### PR TITLE
Update CustomAugments.cpp

### DIFF
--- a/CustomAugments.cpp
+++ b/CustomAugments.cpp
@@ -500,17 +500,6 @@ HOOK_METHOD(ShipObject, GetAugmentationCount, () -> int)
 
     return count;
 }
-HOOK_METHOD(ShipObject, AddAugmentation, (const std::string& name) -> void)
-{
-    super(name);
-
-    /*
-    ShipManager* ship = G_->GetShipManager(this);
-    if (ship != nullptr)
-    {
-        auto sm = SM_EX(ship);
-    }*/
-}
 HOOK_METHOD(ShipObject, RemoveAugmentation, (const std::string& name) -> void)
 {
     super(name);


### PR DESCRIPTION
Removed HOOK_METHOD for AddAugmentation because the hook is bad and was breaking stuff (if you got a 4th augment it would just disappear rather than getting the over capacity screen).

The hook itself should be changed to return bool or char rather than void (in case we actually want to extend AddAugmentation later on), but this change fixes the bug.