### PR TITLE
added preIgniteChargers config option

### DIFF
--- a/CustomOptions.h
+++ b/CustomOptions.h
@@ -61,6 +61,8 @@ public:
 
     Setting<bool> showScrapCollectorScrap;
 
+    Setting<bool> preIgniteChargers;
+
     Setting<std::string> dismissSound;
 
     Defaults defaults;

--- a/CustomWeapons.cpp
+++ b/CustomWeapons.cpp
@@ -372,6 +372,23 @@ HOOK_METHOD(ProjectileFactory, SpendMissiles, () -> int)
     return super();
 }
 
+// Charger pre-ignition
+HOOK_METHOD(ProjectileFactory, ForceCoolup, () -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> ProjectileFactory::ForceCoolup -> Begin (CustomWeapons.cpp)\n")
+
+    if (CustomOptionsManager::GetInstance()->preIgniteChargers.currentValue)
+    {
+        if (powered) {
+            cooldown.first = cooldown.second;
+            chargeLevel = std::max(1, this->blueprint->chargeLevels);
+        }
+        return;
+    }
+    
+    super();
+}
+
 // Weapon Types:
 // 0: LASER
 // 1: MISSILES

--- a/Mod Files/data/hyperspace.xml
+++ b/Mod Files/data/hyperspace.xml
@@ -78,6 +78,8 @@ Note: it is recommended you make a folder like `data/scripts/` or `scripts/` but
 
 <infinite enabled="false"/>
 
+<preIgniteChargers enabled="true"/> <!-- If enabled, charger type weapons will gain all their charges when pre-ignited instead of just one -->
+
 <dismissSound enabled="true" sound="airLoss"/>
 
 <!-- Discord rich presence integration -->

--- a/Resources.cpp
+++ b/Resources.cpp
@@ -450,6 +450,13 @@ void Global::InitializeResources(ResourceControl *resources)
                 customOptions->showScrapCollectorScrap.defaultValue = EventsParser::ParseBoolean(enabled);
                 customOptions->showScrapCollectorScrap.currentValue = EventsParser::ParseBoolean(enabled);
             }
+            
+            if (strcmp(node->name(), "preIgniteChargers") == 0)
+            {
+                auto enabled = node->first_attribute("enabled")->value();
+                customOptions->preIgniteChargers.defaultValue = EventsParser::ParseBoolean(enabled);
+                customOptions->preIgniteChargers.currentValue = EventsParser::ParseBoolean(enabled);
+            }
 
             if (strcmp(node->name(), "alternateOxygenRendering") == 0)
             {


### PR DESCRIPTION
Since you can use [a bug](https://youtu.be/cMVlkQhF3Kw?list=PLGCAaPvQJtQIs8zDUss4zGuUKOJtC0HvT) to pre-ignite chargers with all their charges, it makes sense to just make it work that way normally.