### PR TITLE
Fix breaking 1.5.0 on Linux with the version check segfault

### DIFF
--- a/Global.cpp
+++ b/Global.cpp
@@ -40,7 +40,6 @@ void hs_log_file(const char *str...)
     FILE* log = G_->logFile;
     if (log != nullptr)
     {
-        vprintf(str, va);
         vfprintf(log, str, va);
         fflush(G_->logFile);
     }

--- a/HSVersion.h
+++ b/HSVersion.h
@@ -7,7 +7,7 @@ Change the version numbers here
 */
 #define HS_VER_MAJOR 1
 #define HS_VER_MINOR 5
-#define HS_VER_PATCH 0
+#define HS_VER_PATCH 1
 
 #define BUILD_IDENTIFIER_HASH "unknown_build"
 #define BUILD_BRANCH ""


### PR DESCRIPTION
by removing the single line print statement in hs_log_file that actually breaks everything :D
Also updates version to 1.5.1