### PR TITLE
Ship achievement fixes

### DIFF
--- a/CustomShipSelect.cpp
+++ b/CustomShipSelect.cpp
@@ -1115,6 +1115,16 @@ void CustomShipSelect::UpdateFilteredAchievements()
     }
 }
 
+bool CustomShipSelect::ShowAchievementsForShip(int currentShipId, int currentType)
+{
+    if (currentShipId >= 100)
+    {
+        ShipButtonDefinition *def = &GetShipButtonDefinition(currentShipId - 100);
+        return showShipAchievements && def->showShipAchievements && !(hideMissingShipAchievements && def->shipAchievements[currentType].empty());
+    }
+    return showShipAchievements;
+}
+
 void CustomShipSelect::OnRender(bool renderSelect)
 {
     if (shipSelect->tutorial.bOpen)
@@ -2281,7 +2291,7 @@ HOOK_METHOD_PRIORITY(ShipBuilder, OnRender, 1000, () -> void)
 
     auto customSel = CustomShipSelect::GetInstance();
     
-    bool showShipAchievements = isVanillaShip ? customSel->showShipAchievements : customSel->showShipAchievements && customSel->GetShipButtonDefinition(currentShipId - 100).showShipAchievements;
+    bool showShipAchievements = customSel->ShowAchievementsForShip(currentShipId, currentType);
 
     if (Global::forceDlc)
     {
@@ -2733,7 +2743,7 @@ HOOK_METHOD(ShipBuilder, MouseMove, (int x, int y) -> void)
     ShipButtonDefinition *shipButtonDef = nullptr;
     std::string finalName;
 
-    bool showShipAchievements = currentShipId < 100 ? customSel->showShipAchievements : customSel->showShipAchievements && customSel->GetShipButtonDefinition(currentShipId - 100).showShipAchievements;
+    bool showShipAchievements = customSel->ShowAchievementsForShip(currentShipId, currentType);
 
     if (currentShipId >= 100)
     {
@@ -2947,7 +2957,7 @@ HOOK_METHOD(MenuScreen, Open, () -> void)
                 int maxCount = std::min(int(customShipAchievements.size()),3);
                 for (auto i=0; i<maxCount; ++i)
                 {
-                    shipAchievements.push_back({customShipAchievements[i], Point(742.5 - 30.5*maxCount + 71*i, 362), 64});
+                    shipAchievements.push_back({customShipAchievements[i], Point(727.5 - 30.5*maxCount + 71*i, 362), 64});
                 }
                 for (auto i=maxCount; i<3; ++i) // need to insert dummies so that the victory and quest achievements render correctly
                 {
@@ -2993,7 +3003,7 @@ HOOK_METHOD_PRIORITY(MenuScreen, OnRender, 1000, () -> void)
     {
         auto customSel = CustomShipSelect::GetInstance();
         int currentShipId = G_->GetCApp()->menu.shipBuilder.currentShipId;
-        bool specificShipAchievements = currentShipId < 100 ? true : customSel->GetShipButtonDefinition(currentShipId - 100).showShipAchievements;
+        bool specificShipAchievements = currentShipId < 100 || customSel->GetShipButtonDefinition(currentShipId - 100).showShipAchievements;
         if ((!SM_EX(G_->GetWorld()->playerShip->shipManager)->isNewShip || CustomShipSelect::GetInstance()->showShipAchievements || CustomShipSelect::GetInstance()->shipAchievementsToggle) && specificShipAchievements)
         {
             super();

--- a/CustomShipSelect.cpp
+++ b/CustomShipSelect.cpp
@@ -3010,19 +3010,21 @@ HOOK_METHOD_PRIORITY(MenuScreen, OnRender, 1000, () -> void)
 
             if (!bShowControls && !G_->GetTutorialManager()->Running())
             {
-                if (shipAchievements.empty() || shipAchievements[0].dimension != 64)
+                if (confirmDialog.bOpen)
+                {
+                    CSurface::GL_SetColorTint(COLOR_TINT);
+                }
+
+                // todo: checking !confirmDialog.bOpen is a hacky solution keep this from drawing
+                //       on top of the "return to hangar" prompt, this function needs to be
+                //       reverse-engineered and re-implemented to fix properly
+                if (!confirmDialog.bOpen && (shipAchievements.empty() || shipAchievements[0].dimension != 64))
                 {
                     //CSurface::GL_SetColor(g_defaultTextButtonColors[1]);
                     CSurface::GL_SetColor(COLOR_BUTTON_ON);
                     freetype::easy_printCenter(13, 742, 387, G_->GetTextLibrary()->GetText("hangar_no_ship_achievements"));
                 }
-
                 // todo: add "ACHIEVEMENTS DISABLED" overlay for seeded runs
-
-                if (confirmDialog.bOpen)
-                {
-                    CSurface::GL_SetColorTint(COLOR_TINT);
-                }
 
                 CSurface::GL_BlitPixelImageWide(seedBox,
                                         statusPosition.x + 66,

--- a/CustomShipSelect.h
+++ b/CustomShipSelect.h
@@ -205,6 +205,8 @@ public:
     int CountUnlockedShips(int variant);
 
     void UpdateFilteredAchievements();
+    
+    bool ShowAchievementsForShip(int currentShipId, int currentType);
 
 
     bool IsOpen()
@@ -398,6 +400,7 @@ public:
 
     bool showShipAchievements = false;
     bool shipAchievementsToggle = false;
+    bool hideMissingShipAchievements = false;
     std::string shipAchievementsTitle = "hangar_achievements_title_default";
 
     std::vector<std::pair<Point, std::string>> customAnimDefs = std::vector<std::pair<Point, std::string>>();

--- a/HSVersion.h
+++ b/HSVersion.h
@@ -7,7 +7,7 @@ Change the version numbers here
 */
 #define HS_VER_MAJOR 1
 #define HS_VER_MINOR 7
-#define HS_VER_PATCH 0
+#define HS_VER_PATCH 1
 
 #define BUILD_IDENTIFIER_HASH "unknown_build"
 #define BUILD_BRANCH ""

--- a/Mod Files/data/hyperspace.xml
+++ b/Mod Files/data/hyperspace.xml
@@ -15,7 +15,7 @@
     <version>^0.9.2</version> A major match, allows minor & patch to be changed (upwards) but not major, in this case 0.10.0 would match as would 0.9.5 but not 1.0.0.
     If you fail to specify a match character and just do <version>0.9.2</version> this will be considered the same as `^` above but will also generate a warning message in FTL_HS.log.
 -->  
-<version>^1.7.0</version>
+<version>^1.7.1</version>
 
 <!-- Hyperspace defaults
 

--- a/Mod Files/data/hyperspace.xml
+++ b/Mod Files/data/hyperspace.xml
@@ -261,8 +261,9 @@ If the chance attribute is set to 1 or above, every time the main menu is loaded
 
 <!-- Show ship achievements on menu for custom ships instead of custom victories -->
 <!-- Set toggle = true to be able to toggle between ship achievements and victories -->
+<!-- Set hideIfMissing = true to hide ship achievements for ships that have none -->
 
-<showShipAchievements enabled="true" toggle="false" id="hangar_achievements_title_default"/>
+<showShipAchievements enabled="true" toggle="false" hideIfMissing="false" id="hangar_achievements_title_default"/>
 
 <!-- Enable seeded runs -->
 <!-- Can also control whether unlocks, achievements, or metavariable changes are allowed during a seeded run -->

--- a/Mod Files/data/text-de.xml.append
+++ b/Mod Files/data/text-de.xml.append
@@ -25,7 +25,7 @@
   <mod:setValue>FTL: Hyperspace</mod:setValue>
 </mod:findName>
 <mod:findName type="text" name="version" language="de">
-  <mod:setValue>\1 (Hyperspace 1.7.0)</mod:setValue>
+  <mod:setValue>\1 (Hyperspace 1.7.1)</mod:setValue>
 </mod:findName>
 <mod:findName type="text" name="fire_chance" language="de">
   <mod:setValue>Feuerchance: \1%</mod:setValue>

--- a/Mod Files/data/text_misc.xml.append
+++ b/Mod Files/data/text_misc.xml.append
@@ -9,7 +9,7 @@
 </mod:findName>
 
 <mod:findName type="text" name="version">
-  <mod:setValue>\1 (Hyperspace 1.7.0)</mod:setValue>
+  <mod:setValue>\1 (Hyperspace 1.7.1)</mod:setValue>
 </mod:findName>
 
 <mod:findName type="text" name="fire_chance">

--- a/Mod Files/mod-appendix/metadata.xml
+++ b/Mod Files/mod-appendix/metadata.xml
@@ -30,7 +30,7 @@
 			2.4.1 Hi-res Bkgs
 			1.0 for FTL 1.03.1
 	-->
-	<version><![CDATA[ 1.7.0 ]]></version>
+	<version><![CDATA[ 1.7.1 ]]></version>
 
 
 	<description>

--- a/Resources.cpp
+++ b/Resources.cpp
@@ -556,7 +556,11 @@ void Global::InitializeResources(ResourceControl *resources)
                 }
                 if (node->first_attribute("toggle"))
                 {
-                    customShipManager->shipAchievementsToggle = EventsParser::ParseBoolean(node->first_attribute("enabled")->value());
+                    customShipManager->shipAchievementsToggle = EventsParser::ParseBoolean(node->first_attribute("toggle")->value());
+                }
+                if (node->first_attribute("hideIfMissing"))
+                {
+                    customShipManager->hideMissingShipAchievements = EventsParser::ParseBoolean(node->first_attribute("hideIfMissing")->value());
                 }
                 if (node->first_attribute("id"))
                 {


### PR DESCRIPTION
- Update version to 1.7.1
- Fix `toggle` attribute reading from `enabled` attribute in `showShipAchievements`
- Add `hideIfMissing` attribute to `showShipAchievements`
- Fixed offset for custom ship achievements in ESC menu
- Fixed "no ship achievements" text drawing over "return to hangar" prompt in ESC menu