### PR TITLE
Added __call field to ships metatable

### DIFF
--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -224,11 +224,18 @@ void ErrorMessage(const char* msg);
             elseif key == "enemy" then
                 return Hyperspace.Global.GetInstance():GetShipManager(1)
             else
-                error("Unknown ship " .. key)
+                error("Unknown ship " .. key, 2)
             end
         end,
         __newindex = function(ships, key, value)
-            error("ships is immutable")
+            error("ships is immutable", 2)
+        end,
+        __call = function(ships, shipId)
+            if shipId ~= 0 and shipId ~= 1 then 
+                error("Invalid shipId!", 2)
+            else
+                return Hyperspace.Global.GetInstance():GetShipManager(shipId)
+            end
         end
     })
 }


### PR DESCRIPTION
Added __call field to ships metatable.

Usage:
```lua
Hyperspace.ships(0) --Equivalent to Hyperspace.ships.player
Hyperspace.ships(1) --Equivalent to Hyperspace.ships.enemy

Hyperspace.ships(shipId) --If invalid shipId, throws error, otherwise equivalent to:
Hyperspace.Global.GetInstance():GetShipManager(shipId)
```
