### PR TITLE
Added constructor callbacks

### DIFF
--- a/CrewMember_Extend.cpp
+++ b/CrewMember_Extend.cpp
@@ -62,6 +62,11 @@ HOOK_METHOD_PRIORITY(CrewMember, constructor, 900, (CrewBlueprint& blueprint, in
 	ex->orig = this;
 
     HS_MAKE_TABLE(this)
+
+    auto context = G_->getLuaContext();
+    SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pCrewMember, 0);
+    context->getLibScript()->call_on_internal_event_callbacks(InternalEvents::CONSTRUCT_CREWMEMBER, 1);
+    lua_pop(context->GetLua(), 1);
 }
 
 HOOK_METHOD(CrewMember, destructor, () -> void)

--- a/CustomDrones.cpp
+++ b/CustomDrones.cpp
@@ -1221,6 +1221,12 @@ HOOK_METHOD(SpaceDrone, constructor, (int iShipId, int selfId, DroneBlueprint *b
     LOG_HOOK("HOOK_METHOD -> SpaceDrone::constructor -> Begin (CustomDrones.cpp)\n")
     super(iShipId, selfId, blueprint);
     HS_MAKE_TABLE(this)
+    
+    //Push base class data only, to avoid garbage data (Derived class constructor not yet called)
+    auto context = G_->getLuaContext();
+    SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pSpaceDrone, 0);
+    context->getLibScript()->call_on_internal_event_callbacks(InternalEvents::CONSTRUCT_SPACEDRONE, 1);
+    lua_pop(context->GetLua(), 1);
 }
 
 HOOK_METHOD(SpaceDrone, destructor, () -> void)

--- a/CustomWeapons.cpp
+++ b/CustomWeapons.cpp
@@ -627,6 +627,11 @@ HOOK_METHOD(ProjectileFactory, constructor, (const WeaponBlueprint* bp, int ship
             weaponVisual.SetFireTime(def->fireTime);
         }
     }
+    
+    auto context = G_->getLuaContext();
+    SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pProjectileFactory, 0);
+    context->getLibScript()->call_on_internal_event_callbacks(InternalEvents::CONSTRUCT_PROJECTILE_FACTORY, 1);
+    lua_pop(context->GetLua(), 1);
 }
 
 HOOK_METHOD(ProjectileFactory, destructor, () -> void)

--- a/Projectile_Extend.cpp
+++ b/Projectile_Extend.cpp
@@ -22,6 +22,11 @@ HOOK_METHOD_PRIORITY(Projectile, constructor, 900, (Pointf position, int ownerId
 	ex->orig = this;
 
     HS_MAKE_TABLE(this)
+    //Push base class data only, to avoid garbage data (Derived class constructor not yet called)
+    auto context = G_->getLuaContext();
+    SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pProjectile[0], 0);
+    context->getLibScript()->call_on_internal_event_callbacks(InternalEvents::CONSTRUCT_PROJECTILE, 1);
+    lua_pop(context->GetLua(), 1);
 }
 
 HOOK_METHOD(Projectile, destructor, () -> void)

--- a/Room_Extend.cpp
+++ b/Room_Extend.cpp
@@ -24,6 +24,11 @@ HOOK_METHOD_PRIORITY(Room, constructor, 900, (int shipId, int x, int y, int w, i
 	ex->orig = this;
 
     HS_MAKE_TABLE(this)
+
+    auto context = G_->getLuaContext();
+    SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pRoom, 0);
+    context->getLibScript()->call_on_internal_event_callbacks(InternalEvents::CONSTRUCT_ROOM, 1);
+    lua_pop(context->GetLua(), 1);
 }
 
 HOOK_METHOD(Room, destructor, () -> void)

--- a/ShipManager_Extend.cpp
+++ b/ShipManager_Extend.cpp
@@ -25,6 +25,11 @@ HOOK_METHOD_PRIORITY(ShipManager, constructor, 900, (int iShipId) -> void)
 	ex->orig = this;
 
     HS_MAKE_TABLE(this)
+
+    auto context = G_->getLuaContext();
+    SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pShipManager, 0);
+    context->getLibScript()->call_on_internal_event_callbacks(InternalEvents::CONSTRUCT_SHIP_MANAGER, 1);
+    lua_pop(context->GetLua(), 1);
 }
 
 HOOK_METHOD(ShipManager, destructor, () -> void)

--- a/System_Extend.cpp
+++ b/System_Extend.cpp
@@ -25,6 +25,12 @@ HOOK_METHOD_PRIORITY(ShipSystem, constructor, 900, (int systemId, int roomId, in
 	ex->orig = this;
 
     HS_MAKE_TABLE(this)
+
+    //Push base class data only, to avoid garbage data (Derived class constructor not yet called)
+    auto context = G_->getLuaContext();
+    SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pShipSystem, 0);
+    context->getLibScript()->call_on_internal_event_callbacks(InternalEvents::CONSTRUCT_SHIP_SYSTEM, 1);
+    lua_pop(context->GetLua(), 1);
 }
 
 HOOK_METHOD_PRIORITY(ShipSystem, destructor, 900, () -> void)

--- a/lua/InternalEvents.h
+++ b/lua/InternalEvents.h
@@ -125,6 +125,24 @@ struct InternalEvents
         ShipManager::JumpLeave
         */
 
+
+        //Constructor Events
+
+        //function construct_crewmember(CrewMember& crew)
+        CONSTRUCT_CREWMEMBER,
+        //function construct_spacedrone(SpaceDrone& drone)
+        CONSTRUCT_SPACEDRONE,
+        //function construct_projectile_factory(ProjectileFactory& weapon)
+        CONSTRUCT_PROJECTILE_FACTORY,
+        //function construct_projectile(Projectile& projectile)
+        CONSTRUCT_PROJECTILE,
+        //function construct_room(Room& room)
+        CONSTRUCT_ROOM,
+        //function construct_ship_manager(ShipManager& ship)
+        CONSTRUCT_SHIP_MANAGER,
+        //function construct_ship_system(ShipSystem& system)
+        CONSTRUCT_SHIP_SYSTEM,
+
         UNKNOWN_MAX // Must always be last, used to check for bounds of enum input value
     };
 };

--- a/lua/LuaLibScript.cpp
+++ b/lua/LuaLibScript.cpp
@@ -40,7 +40,9 @@ void LuaLibScript::LoadTypeInfo()
     types.pShipManager = SWIG_TypeQuery(this->m_Lua, "ShipManager *");
     types.pShipSystem = SWIG_TypeQuery(this->m_Lua, "ShipSystem *");
     types.pWeaponBlueprint = SWIG_TypeQuery(this->m_Lua, "WeaponBlueprint *");
+    types.pRoom = SWIG_TypeQuery(this->m_Lua, "Room *");
 
+    types.pSpaceDrone = SWIG_TypeQuery(this->m_Lua, "SpaceDrone *");
     // todo: fix the derived types to make them work (probably need to expose them in hyperspace.i)
     types.pSpaceDroneTypes[0] = SWIG_TypeQuery(this->m_Lua, "DefenseDrone *");
     types.pSpaceDroneTypes[1] = SWIG_TypeQuery(this->m_Lua, "CombatDrone *");

--- a/lua/LuaLibScript.h
+++ b/lua/LuaLibScript.h
@@ -149,8 +149,10 @@ class LuaLibScript
             swig_type_info *pShipManager;
             swig_type_info *pShipSystem;
             swig_type_info *pWeaponBlueprint;
+            swig_type_info *pRoom;
 
             swig_type_info *pShipSystemTypes[21];
+            swig_type_info *pSpaceDrone;
             swig_type_info *pSpaceDroneTypes[8];
         };
 


### PR DESCRIPTION
Callbacks for whenever relevant classes are constructed. Intended use for initializing table members with relevant data so their presence does not need to be checked within a repeating callback.