### PR TITLE
Exposed clonebay primitives (issue #57)

### DIFF
--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -1110,6 +1110,9 @@ playerVariableType playerVariables;
 %rename("%s") CloneSystem::fTimeGoal;
 %rename("%s") CloneSystem::fDeathTime;
 %rename("%s") CloneSystem::slot;
+%rename("%s") CloneSystem::bottom;
+%rename("%s") CloneSystem::top;
+%rename("%s") CloneSystem::gas;
 
 %nodefaultctors HackingSystem;
 %nodefaultdtors HackingSystem;


### PR DESCRIPTION
Clonebay primitives can now be set, allowing for cabin rotation and other customization in lua

Possible implementation of reversed cabins:
```lua
local function GetTexture(path)
  return Hyperspace.Resources:GetImageId(path)
end
--These exist in the vanilla files, and are the defaults
local top = GetTexture "ship/interior/clone_top.png"
local gas = GetTexture "ship/interior/clone_gas.png"
local bottom = GetTexture "ship/interior/clone_bottom.png"
--Add flipped images to ship/interior folder, these can just be vertically flipped versions of the vanilla images
local flip_top = GetTexture "ship/interior/clone_top_flip.png"
local flip_gas = GetTexture "ship/interior/clone_gas_flip.png"
local flip_bottom = GetTexture "ship/interior/clone_bottom_flip.png"
function flipClonebay(reverse)
  local cloneSys = Hyperspace.ships.player.cloneSystem
  if reverse then
    cloneSys.top = flip_top
    cloneSys.gas = flip_gas
    cloneSys.bottom = flip_bottom
  else
    cloneSys.top = top
    cloneSys.gas = gas
    cloneSys.bottom = bottom
  end
end



```