### PR TITLE
Expose sector number

### DIFF
--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -599,6 +599,8 @@ playerVariableType playerVariables;
 // TODO: We might be able to allow access to the `sectors` vector and maybe allow rendering secret sectors onto the map but instead just jumping to them when they're clicked?
 ////%rename("%s") StarMap::sectors; // also there is lastSectors, not sure what they're for yet
 // TODO: Not sure what scrapCollected, dronesCollected, fuelCollected, weaponFound, droneFound maps do, does the game record what was found at each node? Can't find calls to it internally.
+%immutable StarMap::worldLevel; //Sector number (Sector 1 has worldLevel = 0, Sector 2 has worldLevel = 1, etc.)
+%rename("%s") StarMap::worldLevel;
 
 /*
 ////%rename("%s") StarMap::ReverseBossPath;


### PR DESCRIPTION
Exposed `StarMap::worldLevel`.

`worldLevel` is equal to the current sector number minus one. Sector One has a `worldLevel` of 0, Sector Two has a `worldLevel` of 1, and so on.

The current sector number can be obtained as follows:
```lua
function GetCurrentSectorNumber()
    return Hyperspace.Global.GetInstance():GetCApp().world.starMap.worldLevel + 1
end
```