### PR TITLE
Expose ShipManager::current_target

### DIFF
--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -876,7 +876,8 @@ playerVariableType playerVariables;
 %immutable ShipManager::ship;
 //%rename("%s") ShipManager::statusMessages;
 //%rename("%s") ShipManager::bGameOver;
-////%rename("%s") ShipManager::current_target; // Probably just use `Hyperspace.ships.enemy` instead?
+%immutable ShipManager::current_target;
+%rename("%s") ShipManager::current_target; 
 %immutable ShipManager::jump_timer;
 %rename("%s") ShipManager::jump_timer;
 //%immutable ShipManager::fuel_count;


### PR DESCRIPTION
This PR exposes ShipManager::current_target as an immutable member variable in lua.

```lua
local otherShip = Hyperspace.Global.GetInstance():GetShipManager(1 - ShipManager.iShipId)
```
is currently a relatively common idiom for getting the other `ShipManager` in a symmetric fashion (such as within a callback with a `ShipManager` argument. `ShipManager.current_target` would just be a neater way of expressing this.