### PR TITLE
fix mistake on script module wiki

### DIFF
--- a/wiki/Lua-Script-Module.md
+++ b/wiki/Lua-Script-Module.md
@@ -31,12 +31,8 @@ Actually currently runs on `AcheivementTracker::LoadAchievementDescriptions` (ri
 #### Usage:
 
   ```lua
-  function myModInitializationCode(newGame)
-    if (newGame) then
-      log("My code was run after a new game started")
-    else
-      log("My code was run after a saved game loaded")
-    end
+  function myModInitializationCode()
+    log("My code was run after the game started")
     if not _G["myModLoaded"] then
       _G["myModLoaded"] = true
     end
@@ -62,6 +58,20 @@ Your function will be called once upon starting a new run (and/or loading a run)
 Functions will be called in the order they are registered, lua entry scripts are executed in the order they are defined in the hyperspace.xml, so if your mod was defined before another in Slipstream it'll load before the other mod.
 
 **Warning:** you can accidentally register your function multiple times and it will be called multiple times!
+
+#### Usage:
+
+  ```lua
+  function myModGameStartCode(newGame)
+    if (newGame) then
+      log("My code was run after a new game started")
+    else
+      log("My code was run after a saved game loaded")
+    end
+  end
+
+  script.on_init(myModGameStartCode)
+  ```
 
 <a name="func-on_internal_event"></a>
 ### on\_internal\_event([`InternalEvents`](Lua-Defines-module#internal-events) event, callback)


### PR DESCRIPTION
Accidentally added `script.on_init` stuff under `script.on_load`