### PR TITLE
fix thruster loading

### DIFF
--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -1014,7 +1014,7 @@ HOOK_METHOD(Ship, OnInit, (ShipBlueprint* bp) -> void)
     LOG_HOOK("HOOK_METHOD -> Ship::OnInit -> Begin (CustomShips.cpp)\n")
     super(bp);
 
-    char *xmltext = G_->GetResources()->LoadFile("data/" + bp->imgFile + ".xml");
+    char *xmltext = G_->GetResources()->LoadFile("data/" + bp->layoutFile + ".xml");
     if (xmltext)
     {
         bool hasThrusters = false;


### PR DESCRIPTION
Thruster animations were loading from the layout xml using the name of the ship's image files rather than the name of its layout file.