### PR TITLE
fix broken access to member methods of SpaceDrone vectors

### DIFF
--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -172,7 +172,9 @@ namespace std {
 %luacode {
     local indexFn = getmetatable(Hyperspace.vector_SpaceDrone)[".instance"].__index
     getmetatable(Hyperspace.vector_SpaceDrone)[".instance"].__index = function(vector, index)
-        return Hyperspace.Get_Drone_Subclass(indexFn(vector, index))
+        local ret = indexFn(vector, index)
+        if type(ret) == "function" then return ret end
+        return Hyperspace.Get_Drone_Subclass(ret)
     end
 }
 


### PR DESCRIPTION
#182 broke the member methods of `SpaceDrone` vectors, this update fixes it.