### PR TITLE
add callback to set seed

### DIFF
--- a/lua/InternalEvents.h
+++ b/lua/InternalEvents.h
@@ -18,6 +18,9 @@ struct InternalEvents
         ON_TICK, // We'll use CApp::OnLoop for this ticking
         // function main_menu()
         MAIN_MENU, // We'll use MainMenu::Open for this
+
+        // function get_run_seed(bool isCustomSeed, int seed) return isCustomSeed, seed
+        GET_RUN_SEED,
         
         // function on_key_down(SDLKey key) return Chain
         ON_KEY_DOWN,

--- a/wiki/Lua-Defines-module.md
+++ b/wiki/Lua-Defines-module.md
@@ -62,6 +62,7 @@ _**NOTE:** Currently internal events do not expect any arguments or return value
 | :--- | --- | --- | --- | --- |
 | 1.2.0 | ON_TICK | `None` | `None` | Run code every in-game tick (frame), use in combination with other events to turn logic on and off in your code that runs every tick |
 | 1.2.0 | MAIN_MENU | `None` | `None` | Run code when the main menu opens |
+| 1.10.0 | GET_RUN_SEED | `bool isCustomSeed`, `int seed` | `bool isCustomSeed`, `int seed` | Run code when the seed for the run is set |
 | 1.4.0 | ON_KEY_DOWN | [`Defines.SDL`](#sdl-keys)` Key` | `None` | Detect keyboard key is pressed |
 | 1.4.0 | ON_KEY_UP | [`Defines.SDL`](#sdl-keys)` Key` | `None` | Detect keyboard key is unpressed |
 | 1.4.0 | ON_MOUSE_MOVE | `int x`, `int y`, `int xdiff`, `int ydiff`, `bool holdingLMB`, `bool holdingRMB`, `bool holdingMMB` | `None` | Detect mouse movement |


### PR DESCRIPTION
`GET_RUN_SEED` can be used to intercept and change the seed when you start a run.