### PR TITLE
Make downgrade.bat work when run as administrator

### DIFF
--- a/Release Files/Windows - Extract these files into where FTLGame.exe is/downgrade.bat
+++ b/Release Files/Windows - Extract these files into where FTLGame.exe is/downgrade.bat
@@ -1,3 +1,5 @@
+@pushd %~dp0
 copy FTLGame.exe FTLGame_orig.exe
 "%CD%/patch/flips.exe" -a "%CD%/patch/patch.bps" "%CD%/FTLGame.exe"
-pause
+@pause
+@popd


### PR DESCRIPTION
When a batch file is run as an administrator through the windows right click menu, it is started with the current working directory set to C:\Windows\System32.  To work around this, change directory to the path of the batch file at the top of the file.