### PR TITLE
Removed _shortName from FunctionDefinition/Hook

### DIFF
--- a/zhl.cpp
+++ b/zhl.cpp
@@ -135,7 +135,6 @@ const char *Definition::GetLastError() {return g_defLastError;}
 void FunctionDefinition::SetName(const char *name, const char *type)
 {
 	ConvertToUniqueName(_name, name, type);
-	strncpy(_shortName, name, 512);
 }
 
 int Definition::Init()
@@ -321,7 +320,6 @@ const char *FunctionHook_private::GetLastError() {return g_hookLastError;}
 void FunctionHook_private::SetName(const char *name, const char *type)
 {
 	ConvertToUniqueName(_name, name, type);
-	strncpy(_shortName, name, 512);
 }
 
 int FunctionHook_private::Init()

--- a/zhl_internal.h
+++ b/zhl_internal.h
@@ -26,7 +26,6 @@ public:
 class FunctionDefinition : public Definition
 {
 private:
-	char _shortName[128];
 	char _name[256];
 
 	char _sig[512];

--- a/zhl_private.h
+++ b/zhl_private.h
@@ -8,7 +8,6 @@
 class FunctionHook_private
 {
 private:
-	char _shortName[128];
 	char _name[256];
 
 


### PR DESCRIPTION
It is unused. Also the strncpy used a bigger size, which just by luck didn't cause any problems.