### PR TITLE
Properly excluded Discord from the build if disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(Lua REQUIRED) # From vcpkg
 if(UNIX)
     find_package(SDL2 REQUIRED) # From system
 elseif(WIN32)
-    find_package(DiscordRpc REQUIRED) # From vcpkg & our custom find module
     find_package(OpenGL REQUIRED)
 endif()
 
@@ -160,8 +159,6 @@ target_sources(
     CustomWeapons.cpp
     CustomWeapons.h
     Debugging.cpp
-    DiscordIntegration.cpp
-    DiscordIntegration.h
     DroneVTable.cpp
     EnemyShipIcons.cpp
     EnemyShipIcons.h
@@ -314,8 +311,8 @@ if(UNIX)
     target_include_directories(Hyperspace PRIVATE ${SDL2_INCLUDE_DIRS})
     target_link_libraries(Hyperspace PRIVATE ${SDL2_LIBRARIES})
 
-    # Disable Discord integration
-    target_compile_definitions(Hyperspace PRIVATE SKIPDISCORD)
+    # Disable Discord integration by default
+    set(USE_DISCORD_DEFAULT OFF)
 
     # Naming the binary
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)
@@ -331,11 +328,21 @@ if(UNIX)
         set_target_properties(Hyperspace PROPERTIES OUTPUT_NAME "Hyperspace.1.6.12.${name_suffix}")
     endif()
 elseif(WIN32)
-    # Discord
-    target_link_libraries(Hyperspace PRIVATE DiscordRpc::DiscordRpc)
+    # Enable the Discord integration on Windows by default
+    set(USE_DISCORD_DEFAULT ON)
 
     # OpenGL, just raw OpenGL goodness
     target_link_libraries(Hyperspace PRIVATE OpenGL::GL)
 
     target_compile_definitions(Hyperspace PRIVATE BUILD_DLL)
+endif()
+
+option(USE_DISCORD "Enable the Discord Rich Presence integration" ${USE_DISCORD_DEFAULT})
+
+if(USE_DISCORD)
+    find_package(DiscordRpc REQUIRED) # From vcpkg & our custom find module
+
+    target_sources(Hyperspace PRIVATE DiscordIntegration.h DiscordIntegration.cpp)
+    target_compile_definitions(Hyperspace PRIVATE USE_DISCORD)
+    target_link_libraries(Hyperspace PRIVATE DiscordRpc::DiscordRpc)
 endif()

--- a/DiscordIntegration.cpp
+++ b/DiscordIntegration.cpp
@@ -1,5 +1,3 @@
-#ifndef SKIPDISCORD
-
 #include "DiscordIntegration.h"
 #include <ctime>
 #include <boost/algorithm/string.hpp>
@@ -291,5 +289,3 @@ HOOK_METHOD(CApp, OnExit, () -> void)
     DiscordHandler::GetInstance()->Shutdown();
     super();
 }
-
-#endif // WIN32

--- a/Resources.cpp
+++ b/Resources.cpp
@@ -19,7 +19,9 @@
 #include "MainMenu.h"
 #include "CustomBoss.h"
 #include "CustomStore.h"
+#ifdef USE_DISCORD
 #include "DiscordIntegration.h"
+#endif // USE_DISCORD
 #include "CustomDrones.h"
 #include "Seeds.h"
 #include "SaveFile.h"
@@ -688,7 +690,7 @@ void Global::InitializeResources(ResourceControl *resources)
                     }
                 }
             }
-            #ifndef SKIPDISCORD
+            #ifdef USE_DISCORD
             if (strcmp(node->name(), "discord") == 0)
             {
                 auto enabled = EventsParser::ParseBoolean(node->first_attribute("enabled")->value());
@@ -718,7 +720,7 @@ void Global::InitializeResources(ResourceControl *resources)
                     DiscordHandler::GetInstance()->SetLargeImageText(details);
                 }
             }
-            #endif // WIN32
+            #endif // USE_DISCORD
             if (strcmp(node->name(), "saveFile") == 0)
             {
                 SaveFileHandler::instance->ParseSaveFileNode(node);


### PR DESCRIPTION
Previously the Discord library was only searched and linked on Windows builds. But due to the include list of DiscordIntegration.h a linux build required the discord-rpc header file to be present for a successful compilation.

Now the discord library can be enabled or disabled via a CMake option. According to the previous behaviour this option is only enabled by default on Windows builds.