### PR TITLE
Changed add_custom_command to add_custom_target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,19 +277,21 @@ target_sources(
 	lua/swigluarun.h
 )
 
-add_custom_command(
-	OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/lua/swigluarun.h.temp1 ${CMAKE_CURRENT_SOURCE_DIR}/lua/swigluarun.h
-	COMMAND swig -c++ -lua -external-runtime lua/swigluarun.h.temp1
-	COMMAND bash ./processSwigRuntime.sh
-	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+add_custom_target(
+    SWIGRuntime
+    "${SWIG_EXECUTABLE}" -c++ -lua -external-runtime lua/swigluarun.h.temp1
+    COMMAND bash ./processSwigRuntime.sh
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 # TODO: https://stackoverflow.com/a/61814218/3567518
-add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/Version.autogen.hpp.temp ${CMAKE_CURRENT_SOURCE_DIR}/Version.autogen.hpp
-    COMMAND bash ./generateVersion.sh
+add_custom_target(
+    HyperspaceVersion
+    bash ./generateVersion.sh
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+add_dependencies(Hyperspace SWIGRuntime HyperspaceVersion)
 
 target_compile_options(
     Hyperspace PRIVATE


### PR DESCRIPTION
As the custom command requires an output file, CMake seems to update the file modification time when the custom comamnd is run, therefore recompiling every dependent file. Therefore switching to a custom target, which just allows us to run a command before CMake compiles our main target.