### PR TITLE
add shortcut to access the CApp instance in lua

### DIFF
--- a/Misc.cpp
+++ b/Misc.cpp
@@ -14,6 +14,19 @@
 #include "EnumClassHash.h"
 #include "TemporalSystem.h"
 
+// Set the global CApp variable for Lua
+
+CApp *Global_CApp = nullptr;
+
+HOOK_METHOD(CApp, OnInit, () -> int)
+{
+    LOG_HOOK("HOOK_METHOD -> CApp::OnInit -> Begin (Misc.cpp)\n")
+    Global_CApp = this;
+    return super();
+}
+
+
+
 // Plays airlock sound when crew have been "dismissed"
 
 HOOK_METHOD(CrewEquipBox, RemoveItem, () -> int)

--- a/Misc.h
+++ b/Misc.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "Global.h"
+
+// Only exists to expose to lua as a shortcut for accessing the CApp instance
+extern CApp *Global_CApp;

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -23,6 +23,7 @@
 #include "StatBoost.h"
 #include "ShipUnlocks.h"
 #include "CustomShips.h"
+#include "Misc.h"
 %}
 
 %feature("flatnested");
@@ -208,6 +209,7 @@ namespace std {
 
 %apply const std::string& {std::string* GetName()};
 
+%rename("App") Global_CApp;
 %rename("Blueprints") Global_BlueprintManager_Blueprints; 
 %rename("Sounds") Global_SoundControl_Sounds;
 %rename("Animations") Global_AnimationControl_Animations;
@@ -218,6 +220,7 @@ namespace std {
 %rename("Settings") Global_Settings_Settings;
 %rename("Mouse") Global_MouseControl_Mouse;
 
+%immutable Global_CApp;
 %immutable Global_BlueprintManager_Blueprints;
 %immutable Global_SoundControl_Sounds;
 %immutable Global_AnimationControl_Animations;
@@ -3714,3 +3717,4 @@ playerVariableType playerVariables;
 %include "StatBoost.h"
 %include "ShipUnlocks.h"
 %include "CommandConsole.h"
+%include "Misc.h"


### PR DESCRIPTION
Allows modders to shorten `Hyperspace.Global.GetInstance():GetCApp()` to just `Hyperspace.App`.