### PR TITLE
fixing ACH command and adding ACH_LOCK command

### DIFF
--- a/CommandConsole.cpp
+++ b/CommandConsole.cpp
@@ -295,7 +295,7 @@ bool CommandConsole::RunCommand(CommandGui *commandGui, const std::string& cmd)
     }
     if(cmdName == "ACH_LOCK" && command.length() > 8)
     {
-        std::string achName = boost::trim_copy(command.substr(11));
+        std::string achName = boost::trim_copy(command.substr(9));
         CustomAchievementTracker *customAchTrack = CustomAchievementTracker::instance;
         customAchTrack->RemoveAchievement(achName);
 

--- a/CommandConsole.cpp
+++ b/CommandConsole.cpp
@@ -286,7 +286,14 @@ bool CommandConsole::RunCommand(CommandGui *commandGui, const std::string& cmd)
         }
         return true;
     }
-    if(cmdName == "ACH_LOCK" && command.length() > 11)
+    if(cmdName == "ACH" && command.length() > 3)
+    {
+        std::string achName = boost::trim_copy(command.substr(4));
+        CustomAchievementTracker::instance->SetAchievement(achName, false);
+
+        return true;
+    }
+    if(cmdName == "ACH_LOCK" && command.length() > 8)
     {
         std::string achName = boost::trim_copy(command.substr(11));
         CustomAchievementTracker *customAchTrack = CustomAchievementTracker::instance;
@@ -368,19 +375,9 @@ HOOK_METHOD(CommandGui, RunCommand, (std::string& command) -> void)
     {
         super(command);
 
-        std::string cmdName = command.substr(0, command.find(" "));
-        boost::to_upper(cmdName);
-
-        if(cmdName == "GOD")
-        {
+        // This is here instead of in CommandConsole::RunCommand because CommandGui has shipComplete
+        if(command == "GOD")
             PowerManager::GetPowerManager(0)->currentPower.second = CustomShipSelect::GetInstance()->GetDefinition(shipComplete->shipManager->myBlueprint.blueprintName).maxReactorLevel;
-        }
-
-        if(cmdName == "ACH" && command.length() > 4)
-        {
-            std::string achName = boost::trim_copy(command.substr(4));
-            CustomAchievementTracker::instance->SetAchievement(achName, false);
-        }
     }
 }
 

--- a/CommandConsole.cpp
+++ b/CommandConsole.cpp
@@ -4,6 +4,7 @@
 #include "CustomOptions.h"
 #include "CustomEvents.h"
 #include "CustomScoreKeeper.h"
+#include "CustomAchievements.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -285,6 +286,14 @@ bool CommandConsole::RunCommand(CommandGui *commandGui, const std::string& cmd)
         }
         return true;
     }
+    if(cmdName == "ACH_LOCK" && command.length() > 11)
+    {
+        std::string achName = boost::trim_copy(command.substr(11));
+        CustomAchievementTracker *customAchTrack = CustomAchievementTracker::instance;
+        customAchTrack->RemoveAchievement(achName);
+
+        return true;
+    }
 
 
     return false;
@@ -358,8 +367,20 @@ HOOK_METHOD(CommandGui, RunCommand, (std::string& command) -> void)
     if (!CommandConsole::GetInstance()->RunCommand(this, command))
     {
         super(command);
-        if(command == "GOD")
+
+        std::string cmdName = command.substr(0, command.find(" "));
+        boost::to_upper(cmdName);
+
+        if(cmdName == "GOD")
+        {
             PowerManager::GetPowerManager(0)->currentPower.second = CustomShipSelect::GetInstance()->GetDefinition(shipComplete->shipManager->myBlueprint.blueprintName).maxReactorLevel;
+        }
+
+        if(cmdName == "ACH" && command.length() > 4)
+        {
+            std::string achName = boost::trim_copy(command.substr(4));
+            CustomAchievementTracker::instance->SetAchievement(achName, false);
+        }
     }
 }
 

--- a/CustomAchievements.cpp
+++ b/CustomAchievements.cpp
@@ -493,8 +493,10 @@ void CustomAchievementTracker::RemoveAchievement(const std::string &name)
 {
     if (GetAchievementStatus(name) != -1)
     {
+        CustomAchievement &ach = GetAchievement(name);
+        ach.ach.newAchievement = false;
         achievementUnlocks[name] = -1;
-        UpdateAchievements();
+        UpdateAchievement(ach);
     }
 }
 

--- a/CustomAchievements.cpp
+++ b/CustomAchievements.cpp
@@ -489,6 +489,15 @@ void CustomAchievementTracker::SetAchievement(const std::string &name, bool noPo
     }
 }
 
+void CustomAchievementTracker::RemoveAchievement(const std::string &name)
+{
+    if (GetAchievementStatus(name) != -1)
+    {
+        achievementUnlocks[name] = -1;
+        UpdateAchievements();
+    }
+}
+
 void CustomAchievementTracker::ResetFlags()
 {
     for (auto &it : customAchievements)

--- a/CustomAchievements.h
+++ b/CustomAchievements.h
@@ -63,6 +63,7 @@ public:
     void UpdateVariableAchievements(const std::string &varName, int varValue, bool inGame=true);
     bool CheckShipAchievement(CustomAchievement &ach);
     void SetAchievement(const std::string &name, bool noPopup);
+    void RemoveAchievement(const std::string &name);
     std::vector<CAchievement*> GetShipAchievementsCustom(const std::string &ship, int layout, bool showHidden);
     std::vector<CAchievement*> GetShipAchievementsCustom(int shipId, int layout, bool showHidden);
 

--- a/Mod Files/data/hyperspace.xml
+++ b/Mod Files/data/hyperspace.xml
@@ -316,6 +316,7 @@ If the chance attribute is set to 1 or above, every time the main menu is loaded
 EVENT          Run an event.                           Usage: EVENT <event_id>        Example: EVENT FREE_AUG
 LOAD           Loads a ship blueprint.                 Usage: LOAD <ship_id> <str>    Example: LOAD MANTIS_BOMBER 5 (with 5 sector strength)
 ACH            Unlock achievement.                     Usage: ACH <achievement_id>    Example: ACH ACH_SECTOR_8
+ACH_LOCK	   Locks achievement.                      Usage: ACH_LOCK <achievement_id> Example: ACH_LOCK ACH_SECTOR_8
 VICTORY        Forces a Victory and plays Credits.     Usage: VICTORY / CREDITS
 SECTOR         Go to sector type.                      Usage: SECTOR <sector_type>    Example: SECTOR PIRATE_SECTOR
 SCRAP          Add scrap.                              Usage: SCRAP <num_to_add>      Example: SCRAP 500
@@ -341,6 +342,7 @@ DELETECREW     Kills everyone on the enemy ship        Usage: DELETECREW
 SPEED          Changes game speed                      Usage: SPEED <speed>           Example: SPEED 3 (any integer from -2 to 3)
 DAMAGESYS      Damages a system                        Usage: DAMAGESYS <system_name> Example: DAMAGESYS medbay
 SHIP_CUSTOM    Unlocks a customs ship (permanently)    Usage: SHIP_CUSTOM <ship_name> Example: SHIP_CUSTOM PLAYER_SHIP_CUSTOM
+SHIP_CUSTOM_LOCK Locks a customs ship (permanently)    Usage: SHIP_CUSTOM_LOCK <ship_name> Example: SHIP_CUSTOM_LOCK PLAYER_SHIP_CUSTOM
 LOADEVENT      Loads an event using LoadEvent          Usage: LOADEVENT <event_id>
 VARIABLE       Set variable and/or print in FTL_HS.log Usage: VARIABLE <var_id> <n>
 METAVARIABLE   As above but for meta-variables         Usage: METAVARIABLE <var_id> <n>

--- a/Mod Files/data/hyperspace.xml
+++ b/Mod Files/data/hyperspace.xml
@@ -313,42 +313,42 @@ If the chance attribute is set to 1 or above, every time the main menu is loaded
 <!-- Enables command console in game - press \ to use
 
 
-EVENT          Run an event.                           Usage: EVENT <event_id>        Example: EVENT FREE_AUG
-LOAD           Loads a ship blueprint.                 Usage: LOAD <ship_id> <str>    Example: LOAD MANTIS_BOMBER 5 (with 5 sector strength)
-ACH            Unlock achievement.                     Usage: ACH <achievement_id>    Example: ACH ACH_SECTOR_8
-ACH_LOCK	   Locks achievement.                      Usage: ACH_LOCK <achievement_id> Example: ACH_LOCK ACH_SECTOR_8
-VICTORY        Forces a Victory and plays Credits.     Usage: VICTORY / CREDITS
-SECTOR         Go to sector type.                      Usage: SECTOR <sector_type>    Example: SECTOR PIRATE_SECTOR
-SCRAP          Add scrap.                              Usage: SCRAP <num_to_add>      Example: SCRAP 500
-WEAPON         Add a weapon blueprint.                 Usage: WEAPON <weapon_id>      Example: WEAPON LASER_BURST_1
-SHIP           Unlock a ship.                          Usage: SHIP <ship_id>          Example: SHIP PLAYER_SHIP_MANTIS
-DRONES         Add drone parts.                        Usage: DRONES <num_to_add>     Example: DRONES 50
-DRONE          Add a drone blueprint.                  Usage: DRONE <drone_id>        Example: DRONE COMBAT_2
-FUEL           Add fuel.                               Usage: FUEL <num_to_add>       Example: FUEL 50
-MISSILES       Add missiles.                           Usage: MISSILES <num_to_add>   Example: MISSILES 50
-RICH           Add 80 of each resource and 1999 scrap. Usage: RICH
-POOR           Takes away all of your resources        Usage: POOR
-GOD            Fully upgrade every system and reactor. Usage: GOD
-DELETE         Destroys enemy ship.                    Usage: DELETE
-SYS            Add a system.                           Usage: SYS <system_name>       Example: SYS cloaking
-SYS ALL        Add every system.                       Usage: SYS ALL
-AUG            Add an augmentation.                    Usage: AUG <augment_name>      Example: AUG O2_MASKS
-CREW           Add a crew member.                      Usage: CREW [race_name]        Example: CREW slug
-EXIT           Makes your location an exit beacon      Usage: EXIT
-STORE          Creates a store at your location        Usage: STORE [sector]          Example: STORE 3
-KILL           Kills a person on your ship             Usage: KILL <crew_name>        Example: KILL John
-SKILL          Grants full skills to all of your crew  Usage: SKILL
-DELETECREW     Kills everyone on the enemy ship        Usage: DELETECREW
-SPEED          Changes game speed                      Usage: SPEED <speed>           Example: SPEED 3 (any integer from -2 to 3)
-DAMAGESYS      Damages a system                        Usage: DAMAGESYS <system_name> Example: DAMAGESYS medbay
-SHIP_CUSTOM    Unlocks a customs ship (permanently)    Usage: SHIP_CUSTOM <ship_name> Example: SHIP_CUSTOM PLAYER_SHIP_CUSTOM
-SHIP_CUSTOM_LOCK Locks a customs ship (permanently)    Usage: SHIP_CUSTOM_LOCK <ship_name> Example: SHIP_CUSTOM_LOCK PLAYER_SHIP_CUSTOM
-LOADEVENT      Loads an event using LoadEvent          Usage: LOADEVENT <event_id>
-VARIABLE       Set variable and/or print in FTL_HS.log Usage: VARIABLE <var_id> <n>
-METAVARIABLE   As above but for meta-variables         Usage: METAVARIABLE <var_id> <n>
-LUA            Run lua code directly for testing       Usage: LUA <code on one line>  Example: LUA print("Hello World!")
+EVENT              Run an event.                           Usage: EVENT <event_id>        Example: EVENT FREE_AUG
+LOAD               Loads a ship blueprint.                 Usage: LOAD <ship_id> <str>    Example: LOAD MANTIS_BOMBER 5 (with 5 sector strength)
+ACH                Unlock achievement.                     Usage: ACH <achievement_id>    Example: ACH ACH_SECTOR_8
+ACH_LOCK           Locks achievement.                      Usage: ACH_LOCK <achievement_id> Example: ACH_LOCK ACH_SECTOR_8
+VICTORY            Forces a Victory and plays Credits.     Usage: VICTORY / CREDITS
+SECTOR             Go to sector type.                      Usage: SECTOR <sector_type>    Example: SECTOR PIRATE_SECTOR
+SCRAP              Add scrap.                              Usage: SCRAP <num_to_add>      Example: SCRAP 500
+WEAPON             Add a weapon blueprint.                 Usage: WEAPON <weapon_id>      Example: WEAPON LASER_BURST_1
+SHIP               Unlock a ship.                          Usage: SHIP <ship_id>          Example: SHIP PLAYER_SHIP_MANTIS
+DRONES             Add drone parts.                        Usage: DRONES <num_to_add>     Example: DRONES 50
+DRONE              Add a drone blueprint.                  Usage: DRONE <drone_id>        Example: DRONE COMBAT_2
+FUEL               Add fuel.                               Usage: FUEL <num_to_add>       Example: FUEL 50
+MISSILES           Add missiles.                           Usage: MISSILES <num_to_add>   Example: MISSILES 50
+RICH               Add 80 of each resource and 1999 scrap. Usage: RICH
+POOR               Takes away all of your resources        Usage: POOR
+GOD                Fully upgrade every system and reactor. Usage: GOD
+DELETE             Destroys enemy ship.                    Usage: DELETE
+SYS                Add a system.                           Usage: SYS <system_name>       Example: SYS cloaking
+SYS ALL            Add every system.                       Usage: SYS ALL
+AUG                Add an augmentation.                    Usage: AUG <augment_name>      Example: AUG O2_MASKS
+CREW               Add a crew member.                      Usage: CREW [race_name]        Example: CREW slug
+EXIT               Makes your location an exit beacon      Usage: EXIT
+STORE              Creates a store at your location        Usage: STORE [sector]          Example: STORE 3
+KILL               Kills a person on your ship             Usage: KILL <crew_name>        Example: KILL John
+SKILL              Grants full skills to all of your crew  Usage: SKILL
+DELETECREW         Kills everyone on the enemy ship        Usage: DELETECREW
+SPEED              Changes game speed                      Usage: SPEED <speed>           Example: SPEED 3 (any integer from -2 to 3)
+DAMAGESYS          Damages a system                        Usage: DAMAGESYS <system_name> Example: DAMAGESYS medbay
+SHIP_CUSTOM        Unlocks a customs ship (permanently)    Usage: SHIP_CUSTOM <ship_name> Example: SHIP_CUSTOM PLAYER_SHIP_CUSTOM
+SHIP_CUSTOM_LOCK   Locks a customs ship (permanently)      Usage: SHIP_CUSTOM_LOCK <ship_name> Example: SHIP_CUSTOM_LOCK PLAYER_SHIP_CUSTOM
+LOADEVENT          Loads an event using LoadEvent          Usage: LOADEVENT <event_id>
+VARIABLE           Set variable and/or print in FTL_HS.log Usage: VARIABLE <var_id> <n>
+METAVARIABLE       As above but for meta-variables         Usage: METAVARIABLE <var_id> <n>
+LUA                Run lua code directly for testing       Usage: LUA <code on one line>  Example: LUA print("Hello World!")
                                                                                       Example: LUA Hyperspace.Global.GetInstance():GetCApp().world.starMap:ModifyPursuit(-1)
-SQUISHY        Place a message on screen corner        Usage: SQUISHY <some message you'd like to say in support of squishy> Example: SQUISHY Squishy is awesome!
+SQUISHY            Place a message on screen corner        Usage: SQUISHY <some message you'd like to say in support of squishy> Example: SQUISHY Squishy is awesome!
 -->
 
 <console enabled="true"/> 

--- a/Mod Files/data/hyperspace.xml
+++ b/Mod Files/data/hyperspace.xml
@@ -347,7 +347,7 @@ LOADEVENT          Loads an event using LoadEvent          Usage: LOADEVENT <eve
 VARIABLE           Set variable and/or print in FTL_HS.log Usage: VARIABLE <var_id> <n>
 METAVARIABLE       As above but for meta-variables         Usage: METAVARIABLE <var_id> <n>
 LUA                Run lua code directly for testing       Usage: LUA <code on one line>  Example: LUA print("Hello World!")
-                                                                                      Example: LUA Hyperspace.Global.GetInstance():GetCApp().world.starMap:ModifyPursuit(-1)
+                                                                                          Example: LUA Hyperspace.Global.GetInstance():GetCApp().world.starMap:ModifyPursuit(-1)
 SQUISHY            Place a message on screen corner        Usage: SQUISHY <some message you'd like to say in support of squishy> Example: SQUISHY Squishy is awesome!
 -->
 

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -447,7 +447,7 @@ playerVariableType playerVariables;
 %rename("%s") CustomAchievementTracker::UpdateVariableAchievements;
 %rename("%s") CustomAchievementTracker::GetAchievementStatus;
 %rename("%s") CustomAchievementTracker::SetAchievement; // used to award achievements (CheckShipAchievement is automatically called if needed)
-
+// %rename("%s") CustomAchievementTracker::RemoveAchievement; // used to remove achievements, do not expose, the console command `ACH_REMOVE` is enough
 
 %nodefaultctor CustomEventsParser;
 %nodefaultdtor CustomEventsParser;


### PR DESCRIPTION
fixing ACH command and adding ACH_LOCK command.

Created a new method in the achievement tracker to remove achievements. 
`void CustomAchievementTracker::RemoveAchievement(const std::string &name)`

This method should not be exposed to lua, the ACH_LOCK command should be good enough for dev.