### PR TITLE
Added hullDamageResistChance which acts like sysDamageResistChance but for hull damage

### DIFF
--- a/CustomShipSelect.cpp
+++ b/CustomShipSelect.cpp
@@ -556,6 +556,10 @@ bool CustomShipSelect::ParseCustomShipNode(rapidxml::xml_node<char> *node, Custo
                         {
                             roomDef->ionDamageResistChance = boost::lexical_cast<float>(roomValue);
                         }
+                        if (roomName == "hullDamageResistChance")
+                        {
+                            roomDef->hullDamageResistChance = boost::lexical_cast<float>(roomValue);
+                        }
                     }
 
                     def.roomDefs[roomId] = roomDef;

--- a/CustomShipSelect.cpp
+++ b/CustomShipSelect.cpp
@@ -548,6 +548,10 @@ bool CustomShipSelect::ParseCustomShipNode(rapidxml::xml_node<char> *node, Custo
                         {
                             roomDef->sensorBlind = EventsParser::ParseBoolean(roomValue);
                         }
+                        if (roomName == "hullDamageResistChance")
+                        {
+                            roomDef->hullDamageResistChance = boost::lexical_cast<float>(roomValue);
+                        }
                         if (roomName == "sysDamageResistChance")
                         {
                             roomDef->sysDamageResistChance = boost::lexical_cast<float>(roomValue);
@@ -555,10 +559,6 @@ bool CustomShipSelect::ParseCustomShipNode(rapidxml::xml_node<char> *node, Custo
                         if (roomName == "ionDamageResistChance")
                         {
                             roomDef->ionDamageResistChance = boost::lexical_cast<float>(roomValue);
-                        }
-                        if (roomName == "hullDamageResistChance")
-                        {
-                            roomDef->hullDamageResistChance = boost::lexical_cast<float>(roomValue);
                         }
                     }
 

--- a/CustomShipSelect.h
+++ b/CustomShipSelect.h
@@ -63,6 +63,7 @@ struct RoomDefinition
 
     float sysDamageResistChance = 0.f;
     float ionDamageResistChance = 0.f;
+    float hullDamageResistChance = 0.f;
 };
 
 struct CrewPlacementDefinition

--- a/CustomShipSelect.h
+++ b/CustomShipSelect.h
@@ -61,9 +61,9 @@ struct RoomDefinition
     std::vector<RoomAnimDef> roomAnims;
     bool sensorBlind = false;
 
+    float hullDamageResistChance = 0.f;
     float sysDamageResistChance = 0.f;
     float ionDamageResistChance = 0.f;
-    float hullDamageResistChance = 0.f;
 };
 
 struct CrewPlacementDefinition

--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -961,7 +961,7 @@ HOOK_METHOD(ShipManager, DamageBeam, (Pointf location1, Pointf location2, Damage
 
     int room1 = ship.GetSelectedRoomId(location1.x, location1.y, true);
     int room2 = ship.GetSelectedRoomId(location2.x, location2.y, true);
-    int willDamage = room1 != room2;
+    bool willDamage = (room1 != room2);
     if (willDamage)
     {
         auto ex = RM_EX(ship.vRoomList[room2]);

--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -961,7 +961,7 @@ HOOK_METHOD(ShipManager, DamageBeam, (Pointf location1, Pointf location2, Damage
 
     int room1 = ship.GetSelectedRoomId(location1.x, location1.y, true);
     int room2 = ship.GetSelectedRoomId(location2.x, location2.y, true);
-    int willDamage = room1 != room2
+    int willDamage = room1 != room2;
     if (willDamage)
     {
         auto ex = RM_EX(ship.vRoomList[room2]);

--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -932,9 +932,9 @@ HOOK_METHOD(ShipManager, DamageSystem, (int roomId, Damage dmg) -> void)
     super(roomId, dmg);
 }
 
-HOOK_METHOD(ShipManager, DamageArea, (Pointf location, Damage dmg, bool forceHit) -> void)
+HOOK_METHOD(ShipManager, DamageHull, (int dmg, bool force) -> void)
 {
-    LOG_HOOK("HOOK_METHOD -> ShipManager::DamageArea -> Begin (CustomDamage.cpp)\n")
+    LOG_HOOK("HOOK_METHOD -> ShipManager::DamageHull -> Begin (CustomDamage.cpp)\n")
 
     int roomId = ship.GetSelectedRoomId(location.x, location.y, true);
     auto ex = RM_EX(ship.vRoomList[roomId]);
@@ -953,34 +953,6 @@ HOOK_METHOD(ShipManager, DamageArea, (Pointf location, Damage dmg, bool forceHit
     }
 
     super(dmg);
-}
-
-HOOK_METHOD(ShipManager, DamageBeam, (Pointf location1, Pointf location2, Damage dmg) -> void)
-{
-    LOG_HOOK("HOOK_METHOD -> ShipManager::DamageBeam -> Begin (CustomDamage.cpp)\n")
-
-    int room1 = ship.GetSelectedRoomId(location1.x, location1.y, true);
-    int room2 = ship.GetSelectedRoomId(location2.x, location2.y, true);
-    int willDamage = room1 != room2
-    if (willDamage)
-    {
-        auto ex = RM_EX(ship.vRoomList[room2]);
-
-        if (random32() % 100 < ex->hullDamageResistChance && dmg.iDamage > 0)
-        {
-            dmg.iSystemDamage = +dmg.iDamage;
-            dmg.iPersDamage = +dmg.iDamage;
-            dmg.iDamage = 0;
-            auto msg = new DamageMessage(1.f, ship.GetRoomCenter(roomId), DamageMessage::MessageType::RESIST);
-            msg->color.r = 255.f / 255.f;
-            msg->color.g = 0.f / 255.f;
-            msg->color.b = 255.f / 255.f;
-            msg->color.a = 1.f;
-            damMessages.push_back(msg);
-        }
-
-        super(dmg);
-    }
 }
 
 HOOK_METHOD(ShipAI, SetStalemate, (bool stalemate) -> void)

--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -911,18 +911,6 @@ HOOK_METHOD(ShipManager, DamageSystem, (int roomId, Damage dmg) -> void)
 
     auto ex = RM_EX(ship.vRoomList[roomId]);
 
-    if (random32() % 100 < ex->hullDamageResistChance && dmg.iDamage > 0)
-    {
-        dmg.iSystemDamage = +dmg.iDamage;
-        dmg.iPersDamage = +dmg.iDamage;
-        dmg.iDamage = 0;
-        auto msg = new DamageMessage(1.f, ship.GetRoomCenter(roomId), DamageMessage::MessageType::RESIST);
-        msg->color.r = 255.f / 255.f;
-        msg->color.g = 0.f / 255.f;
-        msg->color.b = 255.f / 255.f;
-        msg->color.a = 1.f;
-        damMessages.push_back(msg);
-    }
     if (random32() % 100 < ex->sysDamageResistChance && (dmg.iSystemDamage > -dmg.iDamage))
     {
         dmg.iSystemDamage = -dmg.iDamage;
@@ -942,6 +930,55 @@ HOOK_METHOD(ShipManager, DamageSystem, (int roomId, Damage dmg) -> void)
     }
 
     super(roomId, dmg);
+}
+
+HOOK_METHOD(ShipManager, DamageArea, (Pointf location, Damage dmg, bool forceHit) -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> ShipManager::DamageArea -> Begin (CustomDamage.cpp)\n")
+
+    int roomId = ship.GetSelectedRoomId(location.x, location.y, true);
+    auto ex = RM_EX(ship.vRoomList[roomId]);
+
+    if (random32() % 100 < ex->hullDamageResistChance && dmg.iDamage > 0)
+    {
+        dmg.iSystemDamage = +dmg.iDamage;
+        dmg.iPersDamage = +dmg.iDamage;
+        dmg.iDamage = 0;
+        auto msg = new DamageMessage(1.f, ship.GetRoomCenter(roomId), DamageMessage::MessageType::RESIST);
+        msg->color.r = 255.f / 255.f;
+        msg->color.g = 0.f / 255.f;
+        msg->color.b = 255.f / 255.f;
+        msg->color.a = 1.f;
+        damMessages.push_back(msg);
+    }
+
+    super(dmg);
+}
+
+HOOK_METHOD(ShipManager, DamageBeam, (Pointf location1, Pointf location2, Damage dmg) -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> ShipManager::DamageBeam -> Begin (CustomDamage.cpp)\n")
+
+    int room1 = ship.GetSelectedRoomId(location1.x, location1.y, true);
+    int room2 = ship.GetSelectedRoomId(location2.x, location2.y, true);
+    int roomId = room1||room2
+
+    auto ex = RM_EX(ship.vRoomList[roomId]);
+
+    if (random32() % 100 < ex->hullDamageResistChance && dmg.iDamage > 0)
+    {
+        dmg.iSystemDamage = +dmg.iDamage;
+        dmg.iPersDamage = +dmg.iDamage;
+        dmg.iDamage = 0;
+        auto msg = new DamageMessage(1.f, ship.GetRoomCenter(roomId), DamageMessage::MessageType::RESIST);
+        msg->color.r = 255.f / 255.f;
+        msg->color.g = 0.f / 255.f;
+        msg->color.b = 255.f / 255.f;
+        msg->color.a = 1.f;
+        damMessages.push_back(msg);
+    }
+
+    super(dmg);
 }
 
 HOOK_METHOD(ShipAI, SetStalemate, (bool stalemate) -> void)

--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -51,6 +51,7 @@ void ShipManager_Extend::Initialize(bool restarting)
             rex->sensorBlind = i.second->sensorBlind;
             rex->sysDamageResistChance = i.second->sysDamageResistChance;
             rex->ionDamageResistChance = i.second->ionDamageResistChance;
+            rex->hullDamageResistChance = i.second->hullDamageResistChance;
         }
     }
 
@@ -924,6 +925,15 @@ HOOK_METHOD(ShipManager, DamageSystem, (int roomId, Damage dmg) -> void)
         msg->color.r = 40.f / 255.f;
         msg->color.g = 210.f / 255.f;
         msg->color.b = 230.f / 255.f;
+        msg->color.a = 1.f;
+        damMessages.push_back(msg);
+    }
+        if (random32() % 100 < ex->hullDamageResistChance && dmg.iDamage > 0)
+    {
+        dmg.iSystemDamage = +dmg.iDamage;
+        dmg.iPersDamage = +dmg.iDamage;
+        dmg.iDamage = 0;
+        auto msg = new DamageMessage(1.f, ship.GetRoomCenter(roomId), DamageMessage::MessageType::RESIST);
         msg->color.a = 1.f;
         damMessages.push_back(msg);
     }

--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -937,13 +937,12 @@ HOOK_METHOD(ShipManager, DamageArea, (Pointf location, Damage dmg, bool forceHit
     LOG_HOOK("HOOK_METHOD -> ShipManager::DamageArea -> Begin (CustomDamage.cpp)\n")
 
     int roomId = ship.GetSelectedRoomId(location.x, location.y, true);
-    auto ex = RM_EX(ship.vRoomList[roomId]);
     bool resist = false;
 
-    if (random32() % 100 < ex->hullDamageResistChance && dmg.iDamage > 0)
+    if (dmg.iDamage > 0 && random32() % 100 < RM_EX(ship.vRoomList[roomId])->hullDamageResistChance)
     {
-        dmg.iSystemDamage = +dmg.iDamage;
-        dmg.iPersDamage = +dmg.iDamage;
+        dmg.iSystemDamage = dmg.iDamage;
+        dmg.iPersDamage = dmg.iDamage;
         dmg.iDamage = 0;
         resist = true;
     }
@@ -953,9 +952,6 @@ HOOK_METHOD(ShipManager, DamageArea, (Pointf location, Damage dmg, bool forceHit
     if (resist && ret)
     {
         auto msg = new DamageMessage(1.f, ship.GetRoomCenter(roomId), DamageMessage::MessageType::RESIST);
-        msg->color.r = 127.f / 255.f;
-        msg->color.g = 127.f / 255.f;
-        msg->color.b = 127.f / 255.f;
         msg->color.a = 1.f;
         damMessages.push_back(msg);
     }
@@ -969,22 +965,19 @@ HOOK_METHOD(ShipManager, DamageBeam, (Pointf location1, Pointf location2, Damage
 
     int room1 = ship.GetSelectedRoomId(location1.x, location1.y, true);
     int room2 = ship.GetSelectedRoomId(location2.x, location2.y, true);
-    if (room1 != room2)
+    if (dmg.iDamage > 0 && room1 != room2)
     {
         auto ex = room2 != -1 ? RM_EX(ship.vRoomList[room2]) : RM_EX(ship.vRoomList[room1]);
 
-        if (random32() % 100 < ex->hullDamageResistChance && dmg.iDamage > 0)
+        if (random32() % 100 < ex->hullDamageResistChance)
         {
-            dmg.iSystemDamage = +dmg.iDamage;
-            dmg.iPersDamage = +dmg.iDamage;
+            dmg.iSystemDamage = dmg.iDamage;
+            dmg.iPersDamage = dmg.iDamage;
             dmg.iDamage = 0;
-          
+            
             if (room1 > -1)
             {
                 auto msg1 = new DamageMessage(1.f, ship.GetRoomCenter(room1), DamageMessage::MessageType::RESIST);
-                msg1->color.r = 127.f / 255.f;
-                msg1->color.g = 127.f / 255.f;
-                msg1->color.b = 127.f / 255.f;
                 msg1->color.a = 1.f;
                 damMessages.push_back(msg1);
             }

--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -961,24 +961,26 @@ HOOK_METHOD(ShipManager, DamageBeam, (Pointf location1, Pointf location2, Damage
 
     int room1 = ship.GetSelectedRoomId(location1.x, location1.y, true);
     int room2 = ship.GetSelectedRoomId(location2.x, location2.y, true);
-    int roomId = room1||room2
-
-    auto ex = RM_EX(ship.vRoomList[roomId]);
-
-    if (random32() % 100 < ex->hullDamageResistChance && dmg.iDamage > 0)
+    int willDamage = room1 != room2
+    if (willDamage)
     {
-        dmg.iSystemDamage = +dmg.iDamage;
-        dmg.iPersDamage = +dmg.iDamage;
-        dmg.iDamage = 0;
-        auto msg = new DamageMessage(1.f, ship.GetRoomCenter(roomId), DamageMessage::MessageType::RESIST);
-        msg->color.r = 255.f / 255.f;
-        msg->color.g = 0.f / 255.f;
-        msg->color.b = 255.f / 255.f;
-        msg->color.a = 1.f;
-        damMessages.push_back(msg);
-    }
+        auto ex = RM_EX(ship.vRoomList[room2]);
 
-    super(dmg);
+        if (random32() % 100 < ex->hullDamageResistChance && dmg.iDamage > 0)
+        {
+            dmg.iSystemDamage = +dmg.iDamage;
+            dmg.iPersDamage = +dmg.iDamage;
+            dmg.iDamage = 0;
+            auto msg = new DamageMessage(1.f, ship.GetRoomCenter(roomId), DamageMessage::MessageType::RESIST);
+            msg->color.r = 255.f / 255.f;
+            msg->color.g = 0.f / 255.f;
+            msg->color.b = 255.f / 255.f;
+            msg->color.a = 1.f;
+            damMessages.push_back(msg);
+        }
+
+        super(dmg);
+    }
 }
 
 HOOK_METHOD(ShipAI, SetStalemate, (bool stalemate) -> void)

--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -944,12 +944,15 @@ HOOK_METHOD(ShipManager, DamageArea, (Pointf location, Damage dmg, bool forceHit
         dmg.iSystemDamage = +dmg.iDamage;
         dmg.iPersDamage = +dmg.iDamage;
         dmg.iDamage = 0;
-        auto msg = new DamageMessage(1.f, ship.GetRoomCenter(roomId), DamageMessage::MessageType::RESIST);
-        msg->color.r = 255.f / 255.f;
-        msg->color.g = 0.f / 255.f;
-        msg->color.b = 255.f / 255.f;
-        msg->color.a = 1.f;
-        damMessages.push_back(msg);
+        if (whateverVariableHoldsTheEvasionState == Evasion::HIT)
+        {
+            auto msg = new DamageMessage(1.f, ship.GetRoomCenter(roomId), DamageMessage::MessageType::RESIST);
+            msg->color.r = 255.f / 255.f;
+            msg->color.g = 0.f / 255.f;
+            msg->color.b = 255.f / 255.f;
+            msg->color.a = 1.f;
+            damMessages.push_back(msg);
+        }
     }
 
     super(location, dmg, forceHit);
@@ -964,21 +967,32 @@ HOOK_METHOD(ShipManager, DamageBeam, (Pointf location1, Pointf location2, Damage
     bool willDamage = (room1 != room2);
     if (willDamage)
     {
-        auto ex = RM_EX(ship.vRoomList[room2]);
+        auto ex = RM_EX(ship.vRoomList[willDamage]);
 
         if (random32() % 100 < ex->hullDamageResistChance && dmg.iDamage > 0)
         {
             dmg.iSystemDamage = +dmg.iDamage;
             dmg.iPersDamage = +dmg.iDamage;
             dmg.iDamage = 0;
-            auto msg = new DamageMessage(1.f, ship.GetRoomCenter(room2), DamageMessage::MessageType::RESIST);
-            msg->color.r = 255.f / 255.f;
-            msg->color.g = 0.f / 255.f;
-            msg->color.b = 255.f / 255.f;
-            msg->color.a = 1.f;
-            damMessages.push_back(msg);
+            if (room1 != room2)
+            {
+                auto msg1 = new DamageMessage(1.f, ship.GetRoomCenter(room1), DamageMessage::MessageType::RESIST);
+                msg1->color.r = 255.f / 255.f;
+                msg1->color.g = 0.f / 255.f;
+                msg1->color.b = 255.f / 255.f;
+                msg1->color.a = 1.f;
+                damMessages.push_back(msg1);
+            }
+            else
+            {
+                auto msg2 = new DamageMessage(1.f, ship.GetRoomCenter(room2), DamageMessage::MessageType::RESIST);
+                msg2->color.r = 255.f / 255.f;
+                msg2->color.g = 0.f / 255.f;
+                msg2->color.b = 255.f / 255.f;
+                msg2->color.a = 1.f;
+                damMessages.push_back(msg2);
+            }
         }
-
     }
 
     super(location1, location2, dmg);

--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -932,9 +932,9 @@ HOOK_METHOD(ShipManager, DamageSystem, (int roomId, Damage dmg) -> void)
     super(roomId, dmg);
 }
 
-HOOK_METHOD(ShipManager, DamageHull, (int dmg, bool force) -> void)
+HOOK_METHOD(ShipManager, DamageArea, (Pointf location, Damage dmg, bool forceHit) -> void)
 {
-    LOG_HOOK("HOOK_METHOD -> ShipManager::DamageHull -> Begin (CustomDamage.cpp)\n")
+    LOG_HOOK("HOOK_METHOD -> ShipManager::DamageArea -> Begin (CustomDamage.cpp)\n")
 
     int roomId = ship.GetSelectedRoomId(location.x, location.y, true);
     auto ex = RM_EX(ship.vRoomList[roomId]);
@@ -953,6 +953,34 @@ HOOK_METHOD(ShipManager, DamageHull, (int dmg, bool force) -> void)
     }
 
     super(dmg);
+}
+
+HOOK_METHOD(ShipManager, DamageBeam, (Pointf location1, Pointf location2, Damage dmg) -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> ShipManager::DamageBeam -> Begin (CustomDamage.cpp)\n")
+
+    int room1 = ship.GetSelectedRoomId(location1.x, location1.y, true);
+    int room2 = ship.GetSelectedRoomId(location2.x, location2.y, true);
+    int willDamage = room1 != room2
+    if (willDamage)
+    {
+        auto ex = RM_EX(ship.vRoomList[room2]);
+
+        if (random32() % 100 < ex->hullDamageResistChance && dmg.iDamage > 0)
+        {
+            dmg.iSystemDamage = +dmg.iDamage;
+            dmg.iPersDamage = +dmg.iDamage;
+            dmg.iDamage = 0;
+            auto msg = new DamageMessage(1.f, ship.GetRoomCenter(roomId), DamageMessage::MessageType::RESIST);
+            msg->color.r = 255.f / 255.f;
+            msg->color.g = 0.f / 255.f;
+            msg->color.b = 255.f / 255.f;
+            msg->color.a = 1.f;
+            damMessages.push_back(msg);
+        }
+
+        super(dmg);
+    }
 }
 
 HOOK_METHOD(ShipAI, SetStalemate, (bool stalemate) -> void)

--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -911,6 +911,18 @@ HOOK_METHOD(ShipManager, DamageSystem, (int roomId, Damage dmg) -> void)
 
     auto ex = RM_EX(ship.vRoomList[roomId]);
 
+    if (random32() % 100 < ex->hullDamageResistChance && dmg.iDamage > 0)
+    {
+        dmg.iSystemDamage = +dmg.iDamage;
+        dmg.iPersDamage = +dmg.iDamage;
+        dmg.iDamage = 0;
+        auto msg = new DamageMessage(1.f, ship.GetRoomCenter(roomId), DamageMessage::MessageType::RESIST);
+        msg->color.r = 255.f / 255.f;
+        msg->color.g = 0.f / 255.f;
+        msg->color.b = 255.f / 255.f;
+        msg->color.a = 1.f;
+        damMessages.push_back(msg);
+    }
     if (random32() % 100 < ex->sysDamageResistChance && (dmg.iSystemDamage > -dmg.iDamage))
     {
         dmg.iSystemDamage = -dmg.iDamage;
@@ -925,15 +937,6 @@ HOOK_METHOD(ShipManager, DamageSystem, (int roomId, Damage dmg) -> void)
         msg->color.r = 40.f / 255.f;
         msg->color.g = 210.f / 255.f;
         msg->color.b = 230.f / 255.f;
-        msg->color.a = 1.f;
-        damMessages.push_back(msg);
-    }
-        if (random32() % 100 < ex->hullDamageResistChance && dmg.iDamage > 0)
-    {
-        dmg.iSystemDamage = +dmg.iDamage;
-        dmg.iPersDamage = +dmg.iDamage;
-        dmg.iDamage = 0;
-        auto msg = new DamageMessage(1.f, ship.GetRoomCenter(roomId), DamageMessage::MessageType::RESIST);
         msg->color.a = 1.f;
         damMessages.push_back(msg);
     }

--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -952,7 +952,7 @@ HOOK_METHOD(ShipManager, DamageArea, (Pointf location, Damage dmg, bool forceHit
         damMessages.push_back(msg);
     }
 
-    super(dmg);
+    super(location, dmg, forceHit);
 }
 
 HOOK_METHOD(ShipManager, DamageBeam, (Pointf location1, Pointf location2, Damage dmg) -> void)
@@ -971,7 +971,7 @@ HOOK_METHOD(ShipManager, DamageBeam, (Pointf location1, Pointf location2, Damage
             dmg.iSystemDamage = +dmg.iDamage;
             dmg.iPersDamage = +dmg.iDamage;
             dmg.iDamage = 0;
-            auto msg = new DamageMessage(1.f, ship.GetRoomCenter(roomId), DamageMessage::MessageType::RESIST);
+            auto msg = new DamageMessage(1.f, ship.GetRoomCenter(room2), DamageMessage::MessageType::RESIST);
             msg->color.r = 255.f / 255.f;
             msg->color.g = 0.f / 255.f;
             msg->color.b = 255.f / 255.f;
@@ -979,8 +979,9 @@ HOOK_METHOD(ShipManager, DamageBeam, (Pointf location1, Pointf location2, Damage
             damMessages.push_back(msg);
         }
 
-        super(dmg);
     }
+
+    super(location1, location2, dmg);
 }
 
 HOOK_METHOD(ShipAI, SetStalemate, (bool stalemate) -> void)

--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -941,8 +941,8 @@ HOOK_METHOD(ShipManager, DamageArea, (Pointf location, Damage dmg, bool forceHit
 
     if (dmg.iDamage > 0 && random32() % 100 < RM_EX(ship.vRoomList[roomId])->hullDamageResistChance)
     {
-        dmg.iSystemDamage = dmg.iDamage;
-        dmg.iPersDamage = dmg.iDamage;
+        dmg.iSystemDamage += dmg.iDamage;
+        dmg.iPersDamage += dmg.iDamage;
         dmg.iDamage = 0;
         resist = true;
     }
@@ -968,11 +968,10 @@ HOOK_METHOD(ShipManager, DamageBeam, (Pointf location1, Pointf location2, Damage
     if (dmg.iDamage > 0 && room1 != room2)
     {
         auto ex = room2 != -1 ? RM_EX(ship.vRoomList[room2]) : RM_EX(ship.vRoomList[room1]);
-
         if (random32() % 100 < ex->hullDamageResistChance)
         {
-            dmg.iSystemDamage = dmg.iDamage;
-            dmg.iPersDamage = dmg.iDamage;
+            dmg.iSystemDamage += dmg.iDamage;
+            dmg.iPersDamage += dmg.iDamage;
             dmg.iDamage = 0;
             
             if (room1 > -1)

--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -932,30 +932,35 @@ HOOK_METHOD(ShipManager, DamageSystem, (int roomId, Damage dmg) -> void)
     super(roomId, dmg);
 }
 
-HOOK_METHOD(ShipManager, DamageArea, (Pointf location, Damage dmg, bool forceHit) -> void)
+HOOK_METHOD(ShipManager, DamageArea, (Pointf location, Damage dmg, bool forceHit) -> bool)
 {
     LOG_HOOK("HOOK_METHOD -> ShipManager::DamageArea -> Begin (CustomDamage.cpp)\n")
 
     int roomId = ship.GetSelectedRoomId(location.x, location.y, true);
     auto ex = RM_EX(ship.vRoomList[roomId]);
+    bool resist = false;
 
     if (random32() % 100 < ex->hullDamageResistChance && dmg.iDamage > 0)
     {
         dmg.iSystemDamage = +dmg.iDamage;
         dmg.iPersDamage = +dmg.iDamage;
         dmg.iDamage = 0;
-        if (whateverVariableHoldsTheEvasionState == Evasion::HIT)
-        {
-            auto msg = new DamageMessage(1.f, ship.GetRoomCenter(roomId), DamageMessage::MessageType::RESIST);
-            msg->color.r = 255.f / 255.f;
-            msg->color.g = 0.f / 255.f;
-            msg->color.b = 255.f / 255.f;
-            msg->color.a = 1.f;
-            damMessages.push_back(msg);
-        }
+        resist = true;
     }
 
-    super(location, dmg, forceHit);
+    bool ret = super(location, dmg, forceHit);
+
+    if (resist && ret)
+    {
+        auto msg = new DamageMessage(1.f, ship.GetRoomCenter(roomId), DamageMessage::MessageType::RESIST);
+        msg->color.r = 127.f / 255.f;
+        msg->color.g = 127.f / 255.f;
+        msg->color.b = 127.f / 255.f;
+        msg->color.a = 1.f;
+        damMessages.push_back(msg);
+    }
+    
+    return ret;
 }
 
 HOOK_METHOD(ShipManager, DamageBeam, (Pointf location1, Pointf location2, Damage dmg) -> void)
@@ -974,24 +979,17 @@ HOOK_METHOD(ShipManager, DamageBeam, (Pointf location1, Pointf location2, Damage
             dmg.iSystemDamage = +dmg.iDamage;
             dmg.iPersDamage = +dmg.iDamage;
             dmg.iDamage = 0;
-            if (room1 != room2)
+          
+            if (room1 > -1)
             {
                 auto msg1 = new DamageMessage(1.f, ship.GetRoomCenter(room1), DamageMessage::MessageType::RESIST);
-                msg1->color.r = 255.f / 255.f;
-                msg1->color.g = 0.f / 255.f;
-                msg1->color.b = 255.f / 255.f;
+                msg1->color.r = 127.f / 255.f;
+                msg1->color.g = 127.f / 255.f;
+                msg1->color.b = 127.f / 255.f;
                 msg1->color.a = 1.f;
                 damMessages.push_back(msg1);
             }
-            else
-            {
-                auto msg2 = new DamageMessage(1.f, ship.GetRoomCenter(room2), DamageMessage::MessageType::RESIST);
-                msg2->color.r = 255.f / 255.f;
-                msg2->color.g = 0.f / 255.f;
-                msg2->color.b = 255.f / 255.f;
-                msg2->color.a = 1.f;
-                damMessages.push_back(msg2);
-            }
+            
         }
     }
 

--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -969,10 +969,9 @@ HOOK_METHOD(ShipManager, DamageBeam, (Pointf location1, Pointf location2, Damage
 
     int room1 = ship.GetSelectedRoomId(location1.x, location1.y, true);
     int room2 = ship.GetSelectedRoomId(location2.x, location2.y, true);
-    bool willDamage = (room1 != room2);
-    if (willDamage)
+    if (room1 != room2)
     {
-        auto ex = RM_EX(ship.vRoomList[willDamage]);
+        auto ex = room2 != -1 ? RM_EX(ship.vRoomList[room2]) : RM_EX(ship.vRoomList[room1]);
 
         if (random32() % 100 < ex->hullDamageResistChance && dmg.iDamage > 0)
         {

--- a/Mod Files/data/hyperspace.xml
+++ b/Mod Files/data/hyperspace.xml
@@ -563,6 +563,7 @@ Syntax ->
 				</roomAnim>
 				<sysDamageResistChance>50</sysDamageResistChance>
 				<ionDamageResistChance>10</ionDamageResistChance>
+				<hullDamageResistChance>30</hullDamageResistChance>
 			</room>
 		</rooms>
 		<crew>

--- a/Room_Extend.h
+++ b/Room_Extend.h
@@ -157,6 +157,7 @@ struct Room_Extend
 
     float sysDamageResistChance = 0.f;
     float ionDamageResistChance = 0.f;
+    float hullDamageResistChance = 0.f;
 
     int timeDilation = 0;
     TemporalSystem_Wrapper* timeDilationSource = nullptr;

--- a/Room_Extend.h
+++ b/Room_Extend.h
@@ -155,9 +155,9 @@ struct Room_Extend
     std::vector<RoomAnim> roomAnims;
     bool sensorBlind = false;
 
+    float hullDamageResistChance = 0.f;
     float sysDamageResistChance = 0.f;
     float ionDamageResistChance = 0.f;
-    float hullDamageResistChance = 0.f;
 
     int timeDilation = 0;
     TemporalSystem_Wrapper* timeDilationSource = nullptr;

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -1917,6 +1917,7 @@ playerVariableType playerVariables;
 %rename("%s") Room_Extend;
 %rename("%s") Room_Extend::sysDamageResistChance;
 %rename("%s") Room_Extend::ionDamageResistChance;
+%rename("%s") Room_Extend::hullDamageResistChance;
 %rename("%s") Room_Extend::timeDilation;
 
 %nodefaultctor Door;

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -2115,6 +2115,7 @@ playerVariableType playerVariables;
 %rename("%s") RoomDefinition::sensorBlind;
 %rename("%s") RoomDefinition::sysDamageResistChance;
 %rename("%s") RoomDefinition::ionDamageResistChance;
+%rename("%s") RoomDefinition::hullDamageResistChance;
 
 %rename("%s") CrewPlacementDefinition;
 %rename("%s") CrewPlacementDefinition::species;

--- a/wiki/Lua-Hyperspace-Module.md
+++ b/wiki/Lua-Hyperspace-Module.md
@@ -853,6 +853,34 @@ No additional items over base `ShipSystem`
 - `std::string` `.droneImage`
 - `std::string` `.combatIcon`
 
+## Room
+
+### Fields
+- `bool` `.bBlackedOut`
+- `Globals::Rect` `.rect`
+   - **Read-only**
+- `int` `.iRoomId`
+   - **Read-only**
+- [`Room_Extend`](#room_extend) `.extend`
+   - **Read-only**
+
+## Room_Extend
+
+### Fields
+- `float` `.sysDamageResistChance`
+- `float` `.ionDamageResistChance`
+- `float` `.hullDamageResistChance`
+- `int` `.timeDilation`
+
+## RoomDefinition
+
+### Fields
+- `int` `.roomId`
+- `bool` `.sensorBlind`
+- `float` `.sysDamageResistChance`
+- `float` `.ionDamageResistChance`
+- `float` `.hullDamageResistChance`
+
 ## CrewStat
 
 ### Fields


### PR DESCRIPTION
Full support for this new function, the current resist icon is a light gray but changing it to white to be identical to the hull resist icon is trivial (just deleting the r,g and b color codes from the damagearea and damagebeam functions.

People who helped make this possible: doom, pepson, codyfun, chooseche and lizzard. Make sure they are mentioned in the change-log.