### PR TITLE
add SET_BONUS_POWER callback

### DIFF
--- a/Misc.cpp
+++ b/Misc.cpp
@@ -1213,11 +1213,9 @@ HOOK_METHOD(ShipSystem, SetBonusPower, (int amount, int permanentPower) -> void)
     auto context = G_->getLuaContext();
     SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pShipSystem, 0);
     lua_pushinteger(context->GetLua(), amount);
-    lua_pushinteger(context->GetLua(), permanentPower);
-    bool preempt = context->getLibScript()->call_on_internal_chain_event_callbacks(InternalEvents::SET_BONUS_POWER, 3, 2);
-    if (lua_isnumber(context->GetLua(), -2)) amount = static_cast<int>(lua_tonumber(context->GetLua(), -2));
-    if (lua_isnumber(context->GetLua(), -1)) permanentPower = static_cast<int>(lua_tonumber(context->GetLua(), -1));
-    lua_pop(context->GetLua(), 3);
+    bool preempt = context->getLibScript()->call_on_internal_chain_event_callbacks(InternalEvents::SET_BONUS_POWER, 2, 1);
+    if (lua_isnumber(context->GetLua(), -1)) amount = static_cast<int>(lua_tonumber(context->GetLua(), -1));
+    lua_pop(context->GetLua(), 2);
     
     if (!preempt) super(amount, permanentPower);
 }
@@ -1228,11 +1226,9 @@ HOOK_METHOD(WeaponSystem, SetBonusPower, (int amount, int permanentPower) -> voi
     auto context = G_->getLuaContext();
     SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pWeaponSystem, 0);
     lua_pushinteger(context->GetLua(), amount);
-    lua_pushinteger(context->GetLua(), permanentPower);
-    bool preempt = context->getLibScript()->call_on_internal_chain_event_callbacks(InternalEvents::SET_BONUS_POWER, 3, 2);
-    if (lua_isnumber(context->GetLua(), -2)) amount = static_cast<int>(lua_tonumber(context->GetLua(), -2));
-    if (lua_isnumber(context->GetLua(), -1)) permanentPower = static_cast<int>(lua_tonumber(context->GetLua(), -1));
-    lua_pop(context->GetLua(), 3);
+    bool preempt = context->getLibScript()->call_on_internal_chain_event_callbacks(InternalEvents::SET_BONUS_POWER, 2, 1);
+    if (lua_isnumber(context->GetLua(), -1)) amount = static_cast<int>(lua_tonumber(context->GetLua(), -1));
+    lua_pop(context->GetLua(), 2);
     
     if (!preempt) super(amount, permanentPower);
 }
@@ -1243,11 +1239,9 @@ HOOK_METHOD(DroneSystem, SetBonusPower, (int amount, int permanentPower) -> void
     auto context = G_->getLuaContext();
     SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pDroneSystem, 0);
     lua_pushinteger(context->GetLua(), amount);
-    lua_pushinteger(context->GetLua(), permanentPower);
-    bool preempt = context->getLibScript()->call_on_internal_chain_event_callbacks(InternalEvents::SET_BONUS_POWER, 3, 2);
-    if (lua_isnumber(context->GetLua(), -2)) amount = static_cast<int>(lua_tonumber(context->GetLua(), -2));
-    if (lua_isnumber(context->GetLua(), -1)) permanentPower = static_cast<int>(lua_tonumber(context->GetLua(), -1));
-    lua_pop(context->GetLua(), 3);
+    bool preempt = context->getLibScript()->call_on_internal_chain_event_callbacks(InternalEvents::SET_BONUS_POWER, 2, 1);
+    if (lua_isnumber(context->GetLua(), -1)) amount = static_cast<int>(lua_tonumber(context->GetLua(), -1));
+    lua_pop(context->GetLua(), 2);
     
     if (!preempt) super(amount, permanentPower);
 }

--- a/Misc.cpp
+++ b/Misc.cpp
@@ -545,6 +545,8 @@ void LuaLibScript::LoadTypeInfo()
     types.pShipEvent = SWIG_TypeQuery(this->m_Lua, "ShipEvent *");
     types.pShipManager = SWIG_TypeQuery(this->m_Lua, "ShipManager *");
     types.pShipSystem = SWIG_TypeQuery(this->m_Lua, "ShipSystem *");
+    types.pWeaponSystem = SWIG_TypeQuery(this->m_Lua, "WeaponSystem *");
+    types.pDroneSystem = SWIG_TypeQuery(this->m_Lua, "DroneSystem *");
     types.pWeaponBlueprint = SWIG_TypeQuery(this->m_Lua, "WeaponBlueprint *");
     types.pRoom = SWIG_TypeQuery(this->m_Lua, "Room *");
     types.pChoiceBox = SWIG_TypeQuery(this->m_Lua, "ChoiceBox *");
@@ -1202,6 +1204,52 @@ HOOK_METHOD(ShipManager, GetDodgeFactor, () -> int)
     }
     lua_pop(context->GetLua(), 2);
     return ret;
+}
+
+HOOK_METHOD(ShipSystem, SetBonusPower, (int amount, int permanentPower) -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> ShipSystem::SetBonusPower -> Begin (Misc.cpp)\n")
+
+    auto context = G_->getLuaContext();
+    SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pShipSystem, 0);
+    lua_pushinteger(context->GetLua(), amount);
+    lua_pushinteger(context->GetLua(), permanentPower);
+    bool preempt = context->getLibScript()->call_on_internal_chain_event_callbacks(InternalEvents::SET_BONUS_POWER, 3, 2);
+    if (lua_isnumber(context->GetLua(), -2)) amount = static_cast<int>(lua_tonumber(context->GetLua(), -2));
+    if (lua_isnumber(context->GetLua(), -1)) permanentPower = static_cast<int>(lua_tonumber(context->GetLua(), -1));
+    lua_pop(context->GetLua(), 3);
+    
+    if (!preempt) super(amount, permanentPower);
+}
+HOOK_METHOD(WeaponSystem, SetBonusPower, (int amount, int permanentPower) -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> WeaponSystem::SetBonusPower -> Begin (Misc.cpp)\n")
+
+    auto context = G_->getLuaContext();
+    SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pWeaponSystem, 0);
+    lua_pushinteger(context->GetLua(), amount);
+    lua_pushinteger(context->GetLua(), permanentPower);
+    bool preempt = context->getLibScript()->call_on_internal_chain_event_callbacks(InternalEvents::SET_BONUS_POWER, 3, 2);
+    if (lua_isnumber(context->GetLua(), -2)) amount = static_cast<int>(lua_tonumber(context->GetLua(), -2));
+    if (lua_isnumber(context->GetLua(), -1)) permanentPower = static_cast<int>(lua_tonumber(context->GetLua(), -1));
+    lua_pop(context->GetLua(), 3);
+    
+    if (!preempt) super(amount, permanentPower);
+}
+HOOK_METHOD(DroneSystem, SetBonusPower, (int amount, int permanentPower) -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> DroneSystem::SetBonusPower -> Begin (Misc.cpp)\n")
+
+    auto context = G_->getLuaContext();
+    SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pDroneSystem, 0);
+    lua_pushinteger(context->GetLua(), amount);
+    lua_pushinteger(context->GetLua(), permanentPower);
+    bool preempt = context->getLibScript()->call_on_internal_chain_event_callbacks(InternalEvents::SET_BONUS_POWER, 3, 2);
+    if (lua_isnumber(context->GetLua(), -2)) amount = static_cast<int>(lua_tonumber(context->GetLua(), -2));
+    if (lua_isnumber(context->GetLua(), -1)) permanentPower = static_cast<int>(lua_tonumber(context->GetLua(), -1));
+    lua_pop(context->GetLua(), 3);
+    
+    if (!preempt) super(amount, permanentPower);
 }
 
 HOOK_METHOD(ShipManager, JumpArrive, () -> void)

--- a/lua/InternalEvents.h
+++ b/lua/InternalEvents.h
@@ -56,6 +56,9 @@ struct InternalEvents
         // function get_dodge_factor(ShipManager& ship, int value) return Chain, value
         GET_DODGE_FACTOR,
 
+        // function set_bonus_power(ShipSystem& system, int amount, int permanentPower) return Chain, amount, permanentPower
+        SET_BONUS_POWER,
+
         // function projectile_initialize(Projectile& projectile, WeaponBlueprint &bp)
         PROJECTILE_INITIALIZE,
         // function projectile_fire(Projectile& projectile, ProjectileFactory &weapon)

--- a/lua/InternalEvents.h
+++ b/lua/InternalEvents.h
@@ -56,7 +56,7 @@ struct InternalEvents
         // function get_dodge_factor(ShipManager& ship, int value) return Chain, value
         GET_DODGE_FACTOR,
 
-        // function set_bonus_power(ShipSystem& system, int amount, int permanentPower) return Chain, amount, permanentPower
+        // function set_bonus_power(ShipSystem& system, int amount) return Chain, amount
         SET_BONUS_POWER,
 
         // function projectile_initialize(Projectile& projectile, WeaponBlueprint &bp)

--- a/lua/LuaLibScript.h
+++ b/lua/LuaLibScript.h
@@ -148,6 +148,8 @@ class LuaLibScript
             swig_type_info *pShipEvent;
             swig_type_info *pShipManager;
             swig_type_info *pShipSystem;
+            swig_type_info *pWeaponSystem;
+            swig_type_info *pDroneSystem;
             swig_type_info *pWeaponBlueprint;
             swig_type_info *pRoom;
             swig_type_info *pChoiceBox;

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -1588,7 +1588,7 @@ playerVariableType playerVariables;
 %rename("%s") ShipSystem::SystemIdToName;
 %rename("%s") ShipSystem::UpgradeSystem;
 //%rename("%s") ShipSystem::selectedState;
-//%rename("%s") ShipSystem::_shipObj;
+%rename("%s") ShipSystem::_shipObj;
 %rename("%s") ShipSystem::fDamage;
 %rename("%s") ShipSystem::pLoc;
 %rename("%s") ShipSystem::fMaxDamage;

--- a/wiki/Lua-Defines-module.md
+++ b/wiki/Lua-Defines-module.md
@@ -75,7 +75,7 @@ _**NOTE:** Currently internal events do not expect any arguments or return value
 | 1.3.0 | CREW_LOOP | `CrewMember crew` | `None` | While unpaused, run code every in-game tick for each crew member |
 | 1.4.0 | SHIP_LOOP | `ShipManager ship` | `None` | While unpaused, run code every in-game tick for each ship |
 | 1.8.0 | GET_DODGE_FACTOR | `ShipManager ship`, `int value` | `Defines.Chain` chain, `int` value | Can be used to alter the dodge factor for the given ship |
-| 1.13.0 | SET_BONUS_POWER | `ShipSystem system`, `int amount`, `int permanentPower` | `Defines.Chain` chain, `int` amount, `int` permanentPower | Can be used to alter the bonus power for the given system |
+| 1.13.0 | SET_BONUS_POWER | `ShipSystem system`, `int amount` | `Defines.Chain` chain, `int` amount | Can be used to alter the bonus power for the given system |
 | 1.10.0 | ON_WAIT | `ShipManager ship` | `None` | Run code every time the ship waits (Spending a jump cycle without moving beacons, either when out of fuel or at last stand) |
 | N/A | ~~ON_INIT~~ | ~~`None`~~ | ~~`None`~~ | ~~Run code on the start of a run (and loading a run), currently handled by `script.on_init` this internal event will potentially replace it~~ |
 | N/A | ~~ON_LOAD~~ | ~~`None`~~ | ~~`None`~~ | ~~Run code after the game is loaded (currently after hyperspace.xml is initialized but might change to on main menu loading so all Lua is ready first), currently handled by `script.on_load` this internal event will potentially replace it~~ |

--- a/wiki/Lua-Defines-module.md
+++ b/wiki/Lua-Defines-module.md
@@ -75,6 +75,7 @@ _**NOTE:** Currently internal events do not expect any arguments or return value
 | 1.3.0 | CREW_LOOP | `CrewMember crew` | `None` | While unpaused, run code every in-game tick for each crew member |
 | 1.4.0 | SHIP_LOOP | `ShipManager ship` | `None` | While unpaused, run code every in-game tick for each ship |
 | 1.8.0 | GET_DODGE_FACTOR | `ShipManager ship`, `int value` | `Defines.Chain` chain, `int` value | Can be used to alter the dodge factor for the given ship |
+| 1.13.0 | SET_BONUS_POWER | `ShipSystem system`, `int amount`, `int permanentPower` | `Defines.Chain` chain, `int` amount, `int` permanentPower | Can be used to alter the bonus power for the given system |
 | 1.10.0 | ON_WAIT | `ShipManager ship` | `None` | Run code every time the ship waits (Spending a jump cycle without moving beacons, either when out of fuel or at last stand) |
 | N/A | ~~ON_INIT~~ | ~~`None`~~ | ~~`None`~~ | ~~Run code on the start of a run (and loading a run), currently handled by `script.on_init` this internal event will potentially replace it~~ |
 | N/A | ~~ON_LOAD~~ | ~~`None`~~ | ~~`None`~~ | ~~Run code after the game is loaded (currently after hyperspace.xml is initialized but might change to on main menu loading so all Lua is ready first), currently handled by `script.on_load` this internal event will potentially replace it~~ |

--- a/wiki/Lua-Hyperspace-Module.md
+++ b/wiki/Lua-Hyperspace-Module.md
@@ -600,7 +600,7 @@ These are called either under `Hyperspace.ShipSystem` or an existing object (for
 ### Fields
 
 - ~~`int` `.selectedState`~~
-- ~~`ShipObject` `._shipObj`~~
+- `ShipObject` `._shipObj`
 - `float` `.fDamage`
 - `Point` `.pLoc`
 - `float` `.fMaxDamage`


### PR DESCRIPTION
Can be used to dynamically alter the bonus power for systems. Also exposed `ShipSystem::_shipObj` so that the system's `ShipManager` can be accessed inside the callback.