### PR TITLE
disable starmap on sector jump and fix ship name color

### DIFF
--- a/CustomMap.cpp
+++ b/CustomMap.cpp
@@ -306,6 +306,8 @@ HOOK_METHOD(StarMap, MouseMove, (int x, int y) -> void)
     LOG_HOOK("HOOK_METHOD -> StarMap::MouseMove -> Begin (CustomMap.cpp)\n")
 
     super(x, y);
+
+    if (bChoosingNewSector) return;
     
     bool canJump = false;
     for (auto i : locations)

--- a/CustomMap.cpp
+++ b/CustomMap.cpp
@@ -307,7 +307,11 @@ HOOK_METHOD(StarMap, MouseMove, (int x, int y) -> void)
 
     super(x, y);
 
-    if (bChoosingNewSector) return;
+    if (bChoosingNewSector)
+    {
+        potentialLoc = (Location *)NULL; 
+        return;
+    }
     
     bool canJump = false;
     for (auto i : locations)

--- a/CustomUpgrades.cpp
+++ b/CustomUpgrades.cpp
@@ -63,6 +63,7 @@ void CustomUpgrades::OnRender()
     }
 
     // Draw the ship name
+    CSurface::GL_SetColor(COLOR_WHITE);
     Pointf pos = freetype::easy_printCenter(24, orig->position.x + 310, orig->position.y + 39, G_->GetShipManager(0)->myBlueprint.name.data);
 
     if (allowRename)


### PR DESCRIPTION
Last version added a rewrite of the starmap beacon hitbox detection, this revamp does not disable itself when selecting a new sector, this PR fix this issue.