### PR TITLE
fixing the beacon cursor still being available when out of fuel

### DIFF
--- a/CustomMap.cpp
+++ b/CustomMap.cpp
@@ -307,7 +307,7 @@ HOOK_METHOD(StarMap, MouseMove, (int x, int y) -> void)
 
     super(x, y);
 
-    if (bChoosingNewSector)
+    if (bChoosingNewSector || outOfFuel)
     {
         potentialLoc = (Location *)NULL; 
         return;


### PR DESCRIPTION
1.13 rewrote some beacon cursor system, it forgot to take into account the out of fuel scenario.