### PR TITLE
fix buggy return to stations on partitioned ships

### DIFF
--- a/CustomCrew.cpp
+++ b/CustomCrew.cpp
@@ -6776,10 +6776,12 @@ HOOK_METHOD(CrewMember, RestorePosition, () -> bool)
     LOG_HOOK("HOOK_METHOD -> CrewMember::RestorePosition -> Begin (CustomCrew.cpp)\n")
     
     Slot station;
-    if (!bDead && savedPosition.roomId != -1 && (station = FindSlot(savedPosition.roomId, savedPosition.slotId, false), station.roomId > -1) && station.slotId > -1) {
+    if (!bDead && savedPosition.roomId != -1 && (station = FindSlot(savedPosition.roomId, savedPosition.slotId, false), station.roomId > -1) && station.slotId > -1)
+    {
         CrewMember_Extend *ex = CM_EX(this);
         ShipGraph* graph = ShipGraph::GetShipInfo(currentShipId);
-        if (ex->CanTeleportMove(false)) {
+        if (ex->CanTeleportMove(false))
+        {
             // Handle return for stations for crew that can teleport
             SetCurrentTarget((CrewTarget *)NULL, false);
             EmptySlot();
@@ -6795,9 +6797,11 @@ HOOK_METHOD(CrewMember, RestorePosition, () -> bool)
         {
             // Re-implementation of vanilla return to stations code
             Path path = graph->FindPath(Point(x, y), graph->GetSlotWorldPosition(station.slotId, station.roomId), iShipId);
-            if (path.distance != -1.0) {
+            if (path.distance != -1.0)
+            {
                 SetCurrentTarget((CrewTarget *)NULL, false);
-                if (path.doors.empty() || path.doors.front() != blockingDoor) {
+                if (path.doors.empty() || path.doors.front() != blockingDoor)
+                {
                     blockingDoor = (Door *)NULL;
                 }
                 EmptySlot();
@@ -6828,7 +6832,8 @@ HOOK_METHOD(CrewMember, RestorePosition, () -> bool)
                             if (slot == 0) slot = backupRoom.second[0];
                         }
                         path = graph->FindPath(Point(x, y), graph->GetSlotWorldPosition(slot, backupRoom.first), iShipId);
-                        if (path.distance != -1.0) {
+                        if (path.distance != -1.0)
+                        {
                             MoveToRoom(backupRoom.first, slot, true);
                             return true;
                         }

--- a/CustomCrew.cpp
+++ b/CustomCrew.cpp
@@ -6770,3 +6770,73 @@ HOOK_METHOD_PRIORITY(ShipManager, CountPlayerCrew, 9999, () -> int)
     }
     return ret;
 }
+
+HOOK_METHOD(CrewMember, RestorePosition, () -> bool)
+{
+    LOG_HOOK("HOOK_METHOD -> CrewMember::RestorePosition -> Begin (CustomCrew.cpp)\n")
+    
+    Slot station;
+    if (!bDead && savedPosition.roomId != -1 && (station = FindSlot(savedPosition.roomId, savedPosition.slotId, false), station.roomId > -1) && station.slotId > -1) {
+        CrewMember_Extend *ex = CM_EX(this);
+        ShipGraph* graph = ShipGraph::GetShipInfo(currentShipId);
+        if (ex->CanTeleportMove(false)) {
+            // Handle return for stations for crew that can teleport
+            SetCurrentTarget((CrewTarget *)NULL, false);
+            EmptySlot();
+            SetRoomPath(station.slotId, station.roomId);
+            if (graph->GetClosestSlot(Point(x, y), currentShipId, false).roomId != station.roomId)
+            {
+                ex->InitiateTeleport(iShipId, station.roomId, station.slotId);
+                G_->GetSoundControl()->PlaySoundMix("teleport", -1.f, false);
+            }
+            return true;
+        }
+        else
+        {
+            // Re-implementation of vanilla return to stations code
+            Path path = graph->FindPath(Point(x, y), graph->GetSlotWorldPosition(station.slotId, station.roomId), iShipId);
+            if (path.distance != -1.0) {
+                SetCurrentTarget((CrewTarget *)NULL, false);
+                if (path.doors.empty() || path.doors.front() != blockingDoor) {
+                    blockingDoor = (Door *)NULL;
+                }
+                EmptySlot();
+                SetRoomPath(station.slotId, station.roomId);
+                return true;
+            }
+            else
+            {
+                // Use a backup station if a suitable one exists
+                ShipManager *shipManager = G_->GetShipManager(iShipId);
+                std::unordered_map<int, std::vector<std::pair<int, std::vector<int>>>*> stationBackups;
+                if (shipManager && (stationBackups = CustomShipSelect::GetInstance()->GetDefinition(shipManager->myBlueprint.blueprintName).roomStationBackups, stationBackups.find(station.roomId) != stationBackups.end()))
+                {
+                    for (auto backupRoom : *stationBackups.at(station.roomId))
+                    {
+                        int slot = 0;
+                        if (!backupRoom.second.empty())
+                        {
+                            std::vector<int> destRoomFilledSlots = shipManager->ship.vRoomList[backupRoom.first]->filledSlots;
+                            for (int backupSlot : backupRoom.second)
+                            {
+                                if (std::find(destRoomFilledSlots.begin(), destRoomFilledSlots.end(), backupSlot) == destRoomFilledSlots.end())
+                                {
+                                    slot = backupSlot;
+                                    break;
+                                }
+                            }
+                            if (slot == 0) slot = backupRoom.second[0];
+                        }
+                        path = graph->FindPath(Point(x, y), graph->GetSlotWorldPosition(slot, backupRoom.first), iShipId);
+                        if (path.distance != -1.0) {
+                            MoveToRoom(backupRoom.first, slot, true);
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    return false;
+}

--- a/CustomShipSelect.cpp
+++ b/CustomShipSelect.cpp
@@ -564,6 +564,24 @@ bool CustomShipSelect::ParseCustomShipNode(rapidxml::xml_node<char> *node, Custo
 
                     def.roomDefs[roomId] = roomDef;
                 }
+                else if (strcmp(roomNode->name(), "partition") == 0 && roomNode->first_node("rooms") && roomNode->first_node("backups"))
+                {
+                    std::vector<std::pair<int, std::vector<int>>>* backupList = new std::vector<std::pair<int, std::vector<int>>>;
+                    for (auto backupNode = roomNode->first_node("backups")->first_node(); backupNode; backupNode = backupNode->next_sibling())
+                    {
+                        int room = boost::lexical_cast<int>(backupNode->first_attribute("id")->value());
+                        std::vector<int> slots;
+                        for (auto slotNode = backupNode->first_node("slot"); slotNode; slotNode = slotNode->next_sibling())
+                        {
+                            slots.push_back(boost::lexical_cast<int>(slotNode->first_attribute("id")->value()));
+                        }
+                        backupList->push_back(std::make_pair(room, slots));
+                    }
+                    for (auto partitionNode = roomNode->first_node("rooms")->first_node(); partitionNode; partitionNode = partitionNode->next_sibling())
+                    {
+                        def.roomStationBackups[boost::lexical_cast<int>(partitionNode->first_attribute("id")->value())] = backupList;
+                    }
+                }
             }
         }
         if (name == "crew")

--- a/CustomShipSelect.h
+++ b/CustomShipSelect.h
@@ -86,6 +86,7 @@ struct CustomShipDefinition
     int startingScrap = -1;
 
     std::unordered_map<int, RoomDefinition*> roomDefs;
+    std::unordered_map<int, std::vector<std::pair<int, std::vector<int>>>*> roomStationBackups;
     std::vector<std::string> shipIcons;
     ToggleValue<bool> forceAutomated;
 

--- a/Mod Files/data/hyperspace.xml
+++ b/Mod Files/data/hyperspace.xml
@@ -457,6 +457,11 @@ roomAnim render layers:
 3 - draws above crew - can see when room has no vision, but not when you can't actually see the room outline
 4 - draws above everything
 
+<partition> lets you define backup rooms for ships where crew might not always be able to reach their saved stations
+use <rooms> to define the rooms inside the partition, use <backups> to define rooms for saved stations
+you can use <slot> to define specific slots for backup rooms inside <backups>
+define as many partitions as needed
+
 <customReactor> goes inside <customShip>, contains the tags that let you set the prices for upgrading the reactor
 maxLevel attribute sets the maximum level you can upgrade to
 <baseCost> defines the cost of the first 5 levels
@@ -576,6 +581,34 @@ Syntax ->
 				<ionDamageResistChance>10</ionDamageResistChance>
 				<hullDamageResistChance>30</hullDamageResistChance>
 			</room>
+			<partition>
+				<rooms>
+					<room id="1"/>
+					<room id="2"/>
+					<room id="4"/>
+				</rooms>
+				<backups>
+					<room id="3">
+						<slot id="1"/>
+						<slot id="3"/>
+					</room>
+					<room id="5"/>
+				</backups>
+			</partition>
+			<partition>
+				<rooms>
+					<room id="6"/>
+					<room id="8"/>
+					<room id="9"/>
+				</rooms>
+				<backups>
+					<room id="7"/>
+					<room id="10">
+						<slot id="2"/>
+						<slot id="3"/>
+					</room>
+				</backups>
+			</partition>
 		</rooms>
 		<crew>
 			<human room="1" name="Joe"/>


### PR DESCRIPTION
- Crew that can teleport will always return directly to their stations
- Partitions can be defined for ships that have backup stations if a station is unreachable