### PR TITLE
fixing RoomAnim::SaveState & RoomAnim::LoadState method

### DIFF
--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -443,18 +443,21 @@ void RoomAnim::SaveState(int fd)
     FileHelper::writeInt(fd, anim.get() != nullptr);
     if (anim)
     {
+        FileHelper::writeString(fd, anim->animName);
         anim->SaveState(fd);
     }
 
     FileHelper::writeInt(fd, tileAnims.size());
     for (Animation &tileAnim : tileAnims)
     {
+        FileHelper::writeString(fd, tileAnim.animName);
         tileAnim.SaveState(fd);
     }
 
     FileHelper::writeInt(fd, wallAnim.get() != nullptr);
     if (wallAnim)
     {
+        FileHelper::writeString(fd, wallAnim->animName);
         wallAnim->SaveState(fd);
     }
 }
@@ -474,21 +477,20 @@ void RoomAnim::LoadState(int fd, Room *room)
 
     if (FileHelper::readInteger(fd))
     {
-        anim.reset(new Animation);
+        anim.reset(new Animation(G_->GetAnimationControl()->GetAnimation(FileHelper::readString(fd))));
         anim->LoadState(fd);
     }
 
     int n = FileHelper::readInteger(fd);
     for (int i=0; i<n; ++i)
     {
-        tileAnims.emplace_back();
-        Animation &tileAnim = tileAnims.back();
-        tileAnim.LoadState(fd);
+        tileAnims.emplace_back(G_->GetAnimationControl()->GetAnimation(FileHelper::readString(fd)));
+        tileAnims.back().LoadState(fd);
     }
 
     if (FileHelper::readInteger(fd))
     {
-        wallAnim.reset(new Animation);
+        wallAnim.reset(new Animation(G_->GetAnimationControl()->GetAnimation(FileHelper::readString(fd))));
         wallAnim->LoadState(fd);
     }
 }


### PR DESCRIPTION
`RoomAnim::SaveState` & `RoomAnim::LoadState` are method meant to save and load the anims in their room.

That method is currently only in use by the erosion system and I guess lacked proper testing as seen in https://github.com/FTL-Hyperspace/FTL-Hyperspace/issues/320.

Inside of those function `Animation::SaveState` & `Animation::LoadState` were in use with the assumption that they would load the animation data, but as the name suggest they only load the state of an animation. Meaning that they would load a state of an animation that was not existing, causing a crash.