### PR TITLE
Exposed AugmentBlueprint, fixed examples.lua

### DIFF
--- a/Mod Files/examples.lua
+++ b/Mod Files/examples.lua
@@ -42,7 +42,7 @@ function tidePod_renderEffects_before()
             Graphics.CSurface.GL_PushMatrix()
             Graphics.CSurface.GL_Scale(1.1, 1.1, 1.0)
         end
-    else
+    end
 end
 function tidePod_renderEffects_after()
     if mods.hsFun.tideMode then

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -2021,6 +2021,12 @@ playerVariableType playerVariables;
 %rename("%s") BlueprintManager::GetWeaponBlueprint;
 %rename("%s") BlueprintManager::GetBlueprintList;
 
+%nodefaultctor AugmentBlueprint;
+%nodefaultdtor AugmentBlueprint;
+%rename("%s") AugmentBlueprint;
+%rename("%s") AugmentBlueprint::value;
+%rename("%s") AugmentBlueprint::stacking;
+
 %nodefaultctor WeaponBlueprint;
 %nodefaultdtor WeaponBlueprint;
 %rename("%s") WeaponBlueprint;

--- a/wiki/Lua-Hyperspace-Module.md
+++ b/wiki/Lua-Hyperspace-Module.md
@@ -2780,6 +2780,14 @@ Accessed via `Hyperspace.CustomShipUnlocks.instance`
 - [`WeaponBlueprint`](#WeaponBlueprint) `:*GetWeaponBlueprint(std::string name)`
 - `std::vector<std::string> :GetBlueprintList(std::string name)`
 
+## AugmentBlueprint
+
+**Extends [Blueprint](#Blueprint)**
+
+### Fields
+- `float` `.value`
+- `bool` `.stacking`
+
 ## WeaponBlueprint
 
 **Extends [Blueprint](#Blueprint)**


### PR DESCRIPTION
exposing AugmentBlueprint and it's fields, modifying them seems to instantly affect behavior such as with reloaders in the expected ways with the exception of the ROCK_ARMOR, SYSTEM_CASING and ION_ARMOR augments which appears to provide 100% resistance if its value is below 1 and stacking is false.
otherwise works flawlessly, one potential use of modifying could be to store some state in .value if using variables in lua is undesirable


there was an end missing in one function within examples.lua