### PR TITLE
[Translation] Overwrite nameless-one with appropriate text as ship name in ja

### DIFF
--- a/Mod Files/data/text-ja.xml.append
+++ b/Mod Files/data/text-ja.xml.append
@@ -36,6 +36,9 @@
 <mod:findName type="text" name="stun_chance" language="ja">
   <mod:setValue>スタン発生率：\1%</mod:setValue> <!-- \1 is blueprint stunChance * 10, \2 is low/medium/high -->
 </mod:findName>
+<mod:findName type="text" name="nameless_one" language="ja">
+  <mod:setValue>名無し</mod:setValue> <!-- Vanilla text "名もなきクルー" does not fit as a ship name. "名無し" is at least suitable for both ship and crew names. -->
+</mod:findName>
 
 <text name="free_missile_chance" language="ja">ミサイルを消費しない確率：\1%</text>  
 <text name="erosion_chance" language="ja">発症率：\1%</text>  


### PR DESCRIPTION
Vanilla text "名もなきクルー" does not fit as a ship name. "名無し" is at least suitable for both ship and crew names.