### PR TITLE
Custom sound for achievements

### DIFF
--- a/CustomAchievements.h
+++ b/CustomAchievements.h
@@ -12,6 +12,8 @@ struct CustomAchievement
 	TextString secretName;
 	TextString secretDescription;
 
+    std::string sound;
+
 	bool hidden = false;
 
 	void ParseAchievement(rapidxml::xml_node<char> *node, std::string *varName=nullptr);

--- a/CustomAchievements.h
+++ b/CustomAchievements.h
@@ -7,16 +7,16 @@ struct CustomAchievement
     CAchievement ach;
 
     TextString name;
-	TextString description;
+    TextString description;
 
-	TextString secretName;
-	TextString secretDescription;
+    TextString secretName;
+    TextString secretDescription;
 
     std::string sound;
 
-	bool hidden = false;
+    bool hidden = false;
 
-	void ParseAchievement(rapidxml::xml_node<char> *node, std::string *varName=nullptr);
+    void ParseAchievement(rapidxml::xml_node<char> *node, std::string *varName=nullptr);
 };
 
 class CustomAchievementSection

--- a/FTLGameELF32.cpp
+++ b/FTLGameELF32.cpp
@@ -223,14 +223,28 @@ void AchievementTracker::ResetFlags()
 	return execfunc(this);
 }
 
+namespace _func15
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("AchievementTracker::OnLoop", typeid(void (AchievementTracker::*)()), "554889e5415741564154534883ec204989fc", argdata, 1, 6, &func);
+}
+
+void AchievementTracker::OnLoop()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AchievementTracker *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func15::func;
+	return execfunc(this);
+}
+
 AchievementTracker *Global_AchievementTracker_Tracker;
 
-namespace _var15
+namespace _var16
 {
     static VariableDefinition varObj("Global_AchievementTracker_Tracker", "!e8????????89742404c70424(???????\?)e8????????8b44242c8d50f4", &Global_AchievementTracker_Tracker);
 }
 
-namespace _func16
+namespace _func17
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -240,11 +254,11 @@ namespace _func16
 void Animation::constructor(const std::string &_image, int _length, float _time, Pointf _position, int _imageWidth, int _imageHeight, int _stripStartX, int _numFrames)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Animation *this_arg, const std::string &_image_arg, int _length_arg, float _time_arg, Pointf _position_arg, int _imageWidth_arg, int _imageHeight_arg, int _stripStartX_arg, int _numFrames_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func16::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func17::func;
 	return execfunc(this, _image, _length, _time, _position, _imageWidth, _imageHeight, _stripStartX, _numFrames);
 }
 
-namespace _func17
+namespace _func18
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -254,11 +268,11 @@ namespace _func17
 void Animation::OnRender(float opacity, GL_Color color, bool mirror)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Animation *this_arg, float opacity_arg, GL_Color color_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func17::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func18::func;
 	return execfunc(this, opacity, color, mirror);
 }
 
-namespace _func18
+namespace _func19
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -268,11 +282,11 @@ namespace _func18
 void Animation::Update()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Animation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func18::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func19::func;
 	return execfunc(this);
 }
 
-namespace _func19
+namespace _func20
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -282,11 +296,11 @@ namespace _func19
 void Animation::SetCurrentFrame(int frame)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Animation *this_arg, int frame_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func19::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func20::func;
 	return execfunc(this, frame);
 }
 
-namespace _func20
+namespace _func21
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -296,11 +310,11 @@ namespace _func20
 void Animation::Start(bool reset)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Animation *this_arg, bool reset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func20::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func21::func;
 	return execfunc(this, reset);
 }
 
-namespace _func21
+namespace _func22
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -310,11 +324,11 @@ namespace _func21
 void Animation::AddSoundQueue(int frame, const std::string &sound)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Animation *this_arg, int frame_arg, const std::string &sound_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func21::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func22::func;
 	return execfunc(this, frame, sound);
 }
 
-namespace _func22
+namespace _func23
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -324,11 +338,11 @@ namespace _func22
 void Animation::SetAnimationId(GL_Texture *tex)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Animation *this_arg, GL_Texture *tex_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func22::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func23::func;
 	return execfunc(this, tex);
 }
 
-namespace _func23
+namespace _func24
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -338,11 +352,11 @@ namespace _func23
 void Animation::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Animation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func23::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func24::func;
 	return execfunc(this);
 }
 
-namespace _func24
+namespace _func25
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -352,11 +366,11 @@ namespace _func24
 void Animation::StartReverse(bool reset)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Animation *this_arg, bool reset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func24::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func25::func;
 	return execfunc(this, reset);
 }
 
-namespace _func25
+namespace _func26
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -366,11 +380,11 @@ namespace _func25
 void Animation::SetProgress(float progress)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Animation *this_arg, float progress_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func25::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func26::func;
 	return execfunc(this, progress);
 }
 
-namespace _func26
+namespace _func27
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -380,11 +394,11 @@ namespace _func26
 int Animation::RandomStart()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Animation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func26::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func27::func;
 	return execfunc(this);
 }
 
-namespace _func27
+namespace _func28
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -394,11 +408,11 @@ namespace _func27
 void Animation::SaveState(int fd)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Animation *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func27::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func28::func;
 	return execfunc(this, fd);
 }
 
-namespace _func28
+namespace _func29
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -408,11 +422,11 @@ namespace _func28
 bool Animation::Done()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Animation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func28::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func29::func;
 	return execfunc(this);
 }
 
-namespace _func29
+namespace _func30
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -422,11 +436,11 @@ namespace _func29
 void Animation::LoadState(int fd)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Animation *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func29::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func30::func;
 	return execfunc(this, fd);
 }
 
-namespace _func30
+namespace _func31
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -436,18 +450,18 @@ namespace _func30
 Animation AnimationControl::GetAnimation(const std::string &animName)
 {
 	typedef Animation __attribute__((cdecl)) (*custom_arg_funcptr_t)(AnimationControl *this_arg, const std::string &animName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func30::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func31::func;
 	return execfunc(this, animName);
 }
 
 AnimationControl *Global_AnimationControl_Animations;
 
-namespace _var31
+namespace _var32
 {
     static VariableDefinition varObj("Global_AnimationControl_Animations", "!89c6890424c7442404(???????\?)8985d4feffff", &Global_AnimationControl_Animations);
 }
 
-namespace _func32
+namespace _func33
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -457,11 +471,11 @@ namespace _func32
 void AnimationTracker::Update()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func32::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func33::func;
 	return execfunc(this);
 }
 
-namespace _func33
+namespace _func34
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -471,11 +485,11 @@ namespace _func33
 void AnimationTracker::SetLoop(bool loop, float loopDelay)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg, bool loop_arg, float loopDelay_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func33::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func34::func;
 	return execfunc(this, loop, loopDelay);
 }
 
-namespace _func34
+namespace _func35
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -485,11 +499,11 @@ namespace _func34
 void AnimationTracker::Stop(bool resetTime)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg, bool resetTime_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func34::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func35::func;
 	return execfunc(this, resetTime);
 }
 
-namespace _func35
+namespace _func36
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -497,20 +511,6 @@ namespace _func35
 }
 
 void AnimationTracker::Start(float time)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg, float time_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func35::func;
-	return execfunc(this, time);
-}
-
-namespace _func36
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("AnimationTracker::StartReverse", typeid(void (AnimationTracker::*)(float )), "8b44????0f57c9f30f1044????0f2ec8c6401200c640100176??f30f104004f30f11400cc6401101", argdata, 2, 6, &func);
-}
-
-void AnimationTracker::StartReverse(float time)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg, float time_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func36::func;
@@ -521,17 +521,31 @@ namespace _func37
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("AnimationTracker::StartReverse", typeid(void (AnimationTracker::*)(float )), "8b44????0f57c9f30f1044????0f2ec8c6401200c640100176??f30f104004f30f11400cc6401101", argdata, 2, 6, &func);
+}
+
+void AnimationTracker::StartReverse(float time)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg, float time_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func37::func;
+	return execfunc(this, time);
+}
+
+namespace _func38
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("AnimationTracker::Progress", typeid(float (AnimationTracker::*)(float )), "83ec040f57c08b44????f30f104c????8078100074??0f2ec10f28d077??f30f10400cf30f5ec10f2ec2", argdata, 2, 2, &func);
 }
 
 float AnimationTracker::Progress(float speed)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg, float speed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func37::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func38::func;
 	return execfunc(this, speed);
 }
 
-namespace _func38
+namespace _func39
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -541,11 +555,11 @@ namespace _func38
 void AnimationTracker::SetProgress(float time)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg, float time_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func38::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func39::func;
 	return execfunc(this, time);
 }
 
-namespace _func39
+namespace _func40
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -555,11 +569,11 @@ namespace _func39
 float AnimationTracker::GetAlphaLevel(bool reverse)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg, bool reverse_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func39::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func40::func;
 	return execfunc(this, reverse);
 }
 
-namespace _func40
+namespace _func41
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -569,11 +583,11 @@ namespace _func40
 bool ArmamentControl::KeyDown(SDLKey key)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ArmamentControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func40::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func41::func;
 	return execfunc(this, key);
 }
 
-namespace _func41
+namespace _func42
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -583,11 +597,11 @@ namespace _func41
 bool ArmamentControl::Dragging()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ArmamentControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func41::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func42::func;
 	return execfunc(this);
 }
 
-namespace _func42
+namespace _func43
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -597,11 +611,11 @@ namespace _func42
 void ArmamentControl::CreateHolderTab()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ArmamentControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func42::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func43::func;
 	return execfunc(this);
 }
 
-namespace _func43
+namespace _func44
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -611,11 +625,11 @@ namespace _func43
 void ArmamentControl::SetPosition(Point loc)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ArmamentControl *this_arg, Point loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func43::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func44::func;
 	return execfunc(this, loc);
 }
 
-namespace _func44
+namespace _func45
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -625,11 +639,11 @@ namespace _func44
 void ArmamentControl::LinkShip(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ArmamentControl *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func44::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func45::func;
 	return execfunc(this, ship);
 }
 
-namespace _func45
+namespace _func46
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
@@ -639,11 +653,11 @@ namespace _func45
 void ArtilleryBox::constructor(Point pos, ArtillerySystem *sys)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ArtilleryBox *this_arg, Point pos_arg, ArtillerySystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func45::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func46::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func46
+namespace _func47
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -653,11 +667,11 @@ namespace _func46
 void ArtilleryBox::OnRender(bool ignoreStatus)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ArtilleryBox *this_arg, bool ignoreStatus_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func46::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func47::func;
 	return execfunc(this, ignoreStatus);
 }
 
-namespace _func47
+namespace _func48
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -665,20 +679,6 @@ namespace _func47
 }
 
 void ArtillerySystem::Jump()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ArtillerySystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func47::func;
-	return execfunc(this);
-}
-
-namespace _func48
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ArtillerySystem::OnLoop", typeid(void (ArtillerySystem::*)()), ".5589e557565383ec6c8b5d08891c24e8????????891c24e8????????85c0", argdata, 1, 6, &func);
-}
-
-void ArtillerySystem::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ArtillerySystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func48::func;
@@ -689,17 +689,31 @@ namespace _func49
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ArtillerySystem::OnLoop", typeid(void (ArtillerySystem::*)()), ".5589e557565383ec6c8b5d08891c24e8????????891c24e8????????85c0", argdata, 1, 6, &func);
+}
+
+void ArtillerySystem::OnLoop()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ArtillerySystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func49::func;
+	return execfunc(this);
+}
+
+namespace _func50
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("Asteroid::OnUpdate", typeid(void (Asteroid::*)()), "5589e55383ec448b5d0880bbb0000000007415c783f001000000000000", argdata, 1, 6, &func);
 }
 
 void Asteroid::OnUpdate()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Asteroid *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func49::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func50::func;
 	return execfunc(this);
 }
 
-namespace _func50
+namespace _func51
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
@@ -709,11 +723,11 @@ namespace _func50
 void Asteroid::constructor(Pointf pos, int destinationSpace)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Asteroid *this_arg, Pointf pos_arg, int destinationSpace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func50::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func51::func;
 	return execfunc(this, pos, destinationSpace);
 }
 
-namespace _func51
+namespace _func52
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -723,11 +737,11 @@ namespace _func51
 void AsteroidGenerator::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func51::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func52::func;
 	return execfunc(this);
 }
 
-namespace _func52
+namespace _func53
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -737,11 +751,11 @@ namespace _func52
 float AsteroidGenerator::Initialize(int numberOfShips, int shieldCount, bool defense)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg, int numberOfShips_arg, int shieldCount_arg, bool defense_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func52::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func53::func;
 	return execfunc(this, numberOfShips, shieldCount, defense);
 }
 
-namespace _func53
+namespace _func54
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -751,11 +765,11 @@ namespace _func53
 void AsteroidGenerator::SetNumShips(int ships)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg, int ships_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func53::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func54::func;
 	return execfunc(this, ships);
 }
 
-namespace _func54
+namespace _func55
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -765,20 +779,6 @@ namespace _func54
 Projectile *AsteroidGenerator::GetNextAsteroid()
 {
 	typedef Projectile *__attribute__((cdecl)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func54::func;
-	return execfunc(this);
-}
-
-namespace _func55
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("AsteroidGenerator::OnLoop", typeid(void (AsteroidGenerator::*)()), ".5589e557565383ec3c8b5d0880bb880000000075??8d65f45b5e5f5d", argdata, 1, 6, &func);
-}
-
-void AsteroidGenerator::OnLoop()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func55::func;
 	return execfunc(this);
 }
@@ -787,10 +787,10 @@ namespace _func56
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("AsteroidGenerator::GetNextState", typeid(void (AsteroidGenerator::*)()), ".5383ec188b5c24208b437485c074??c743740000000031c0", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("AsteroidGenerator::OnLoop", typeid(void (AsteroidGenerator::*)()), ".5589e557565383ec3c8b5d0880bb880000000075??8d65f45b5e5f5d", argdata, 1, 6, &func);
 }
 
-void AsteroidGenerator::GetNextState()
+void AsteroidGenerator::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func56::func;
@@ -801,10 +801,10 @@ namespace _func57
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("AsteroidGenerator::UpdateState", typeid(void (AsteroidGenerator::*)()), ".5383ec18c70424????????8b5c2420e8????????f30f108380000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("AsteroidGenerator::GetNextState", typeid(void (AsteroidGenerator::*)()), ".5383ec188b5c24208b437485c074??c743740000000031c0", argdata, 1, 6, &func);
 }
 
-void AsteroidGenerator::UpdateState()
+void AsteroidGenerator::GetNextState()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func57::func;
@@ -814,6 +814,20 @@ void AsteroidGenerator::UpdateState()
 namespace _func58
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("AsteroidGenerator::UpdateState", typeid(void (AsteroidGenerator::*)()), ".5383ec18c70424????????8b5c2420e8????????f30f108380000000", argdata, 1, 6, &func);
+}
+
+void AsteroidGenerator::UpdateState()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func58::func;
+	return execfunc(this);
+}
+
+namespace _func59
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("AsteroidGenerator::SaveAsteroids", typeid(bool (AsteroidGenerator::*)(void *)), ".565383ec148b742420f30f1005????????8b5c2424f30f598680000000891c24f30f2cc0", argdata, 2, 2, &func);
 }
@@ -821,11 +835,11 @@ namespace _func58
 bool AsteroidGenerator::SaveAsteroids(void *file)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg, void *file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func58::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func59::func;
 	return execfunc(this, file);
 }
 
-namespace _func59
+namespace _func60
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -835,11 +849,11 @@ namespace _func59
 void AsteroidGenerator::LoadAsteroids(void *file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg, void *file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func59::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func60::func;
 	return execfunc(this, file);
 }
 
-namespace _func60
+namespace _func61
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -847,20 +861,6 @@ namespace _func60
 }
 
 void AugmentEquipBox::RenderIcon()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AugmentEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func60::func;
-	return execfunc(this);
-}
-
-namespace _func61
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("AugmentEquipBox::CheckContents", typeid(void (AugmentEquipBox::*)()), "5589e557565383ec3c8b7d088b477085c0", argdata, 1, 6, &func);
-}
-
-void AugmentEquipBox::CheckContents()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AugmentEquipBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func61::func;
@@ -871,10 +871,10 @@ namespace _func62
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("AugmentEquipBox::RemoveItem", typeid(void (AugmentEquipBox::*)()), "565383ec248b5c24308b437085c0", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("AugmentEquipBox::CheckContents", typeid(void (AugmentEquipBox::*)()), "5589e557565383ec3c8b7d088b477085c0", argdata, 1, 6, &func);
 }
 
-void AugmentEquipBox::RemoveItem()
+void AugmentEquipBox::CheckContents()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AugmentEquipBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func62::func;
@@ -884,6 +884,20 @@ void AugmentEquipBox::RemoveItem()
 namespace _func63
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("AugmentEquipBox::RemoveItem", typeid(void (AugmentEquipBox::*)()), "565383ec248b5c24308b437085c0", argdata, 1, 6, &func);
+}
+
+void AugmentEquipBox::RemoveItem()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AugmentEquipBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func63::func;
+	return execfunc(this);
+}
+
+namespace _func64
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("AugmentStoreBox::constructor", typeid(void (AugmentStoreBox::*)(ShipManager *, const AugmentBlueprint *)), "5557565383ec2c8d44241a8b5c24408d7c241c8b742448", argdata, 3, 6, &func);
 }
@@ -891,11 +905,11 @@ namespace _func63
 void AugmentStoreBox::constructor(ShipManager *ship, const AugmentBlueprint *bp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(AugmentStoreBox *this_arg, ShipManager *ship_arg, const AugmentBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func63::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func64::func;
 	return execfunc(this, ship, bp);
 }
 
-namespace _func64
+namespace _func65
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
@@ -905,11 +919,11 @@ namespace _func64
 void BatteryBox::constructor(Point pos, BatterySystem *sys)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BatteryBox *this_arg, Point pos_arg, BatterySystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func64::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func65::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func65
+namespace _func66
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -919,11 +933,11 @@ namespace _func65
 void BeamWeapon::OnRenderSpecific(int spaceId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BeamWeapon *this_arg, int spaceId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func65::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func66::func;
 	return execfunc(this, spaceId);
 }
 
-namespace _func66
+namespace _func67
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff, 0x2ff, 0x2ff, 0x1ff, 0x1ff, 0x1ff};
@@ -933,11 +947,11 @@ namespace _func66
 void BeamWeapon::constructor(Pointf _position, int _ownerId, int _targetId, Pointf _target, Pointf _target2, int _length, Targetable *_targetable, float heading)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BeamWeapon *this_arg, Pointf _position_arg, int _ownerId_arg, int _targetId_arg, Pointf _target_arg, Pointf _target2_arg, int _length_arg, Targetable *_targetable_arg, float heading_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func66::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func67::func;
 	return execfunc(this, _position, _ownerId, _targetId, _target, _target2, _length, _targetable, heading);
 }
 
-namespace _func67
+namespace _func68
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -947,11 +961,11 @@ namespace _func67
 void BeamWeapon::OnUpdate()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BeamWeapon *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func67::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func68::func;
 	return execfunc(this);
 }
 
-namespace _func68
+namespace _func69
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -961,11 +975,11 @@ namespace _func68
 void BeamWeapon::CollisionCheck(Collideable *other)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BeamWeapon *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func68::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func69::func;
 	return execfunc(this, other);
 }
 
-namespace _func69
+namespace _func70
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -975,11 +989,11 @@ namespace _func69
 void Blueprint::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Blueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func69::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func70::func;
 	return execfunc(this);
 }
 
-namespace _func70
+namespace _func71
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -989,11 +1003,11 @@ namespace _func70
 std::string Blueprint::GetNameShort()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(Blueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func70::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func71::func;
 	return execfunc(this);
 }
 
-namespace _func71
+namespace _func72
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -1003,11 +1017,11 @@ namespace _func71
 std::vector<std::string> BlueprintManager::GetBlueprintList(const std::string &name)
 {
 	typedef std::vector<std::string> __attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func71::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func72::func;
 	return execfunc(this, name);
 }
 
-namespace _func72
+namespace _func73
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -1017,11 +1031,11 @@ namespace _func72
 ShipBlueprint *BlueprintManager::GetShipBlueprint(const std::string &name, int sector)
 {
 	typedef ShipBlueprint *__attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg, int sector_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func72::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func73::func;
 	return execfunc(this, name, sector);
 }
 
-namespace _func73
+namespace _func74
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1031,11 +1045,11 @@ namespace _func73
 DroneBlueprint *BlueprintManager::GetDroneBlueprint(const std::string &name)
 {
 	typedef DroneBlueprint *__attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func73::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func74::func;
 	return execfunc(this, name);
 }
 
-namespace _func74
+namespace _func75
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1045,11 +1059,11 @@ namespace _func74
 float BlueprintManager::GetAugmentValue(const std::string &name)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func74::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func75::func;
 	return execfunc(this, name);
 }
 
-namespace _func75
+namespace _func76
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1059,11 +1073,11 @@ namespace _func75
 ItemBlueprint *BlueprintManager::GetItemBlueprint(const std::string &name)
 {
 	typedef ItemBlueprint *__attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func75::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func76::func;
 	return execfunc(this, name);
 }
 
-namespace _func76
+namespace _func77
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1073,11 +1087,11 @@ namespace _func76
 AugmentBlueprint *BlueprintManager::GetAugmentBlueprint(const std::string &name)
 {
 	typedef AugmentBlueprint *__attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func76::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func77::func;
 	return execfunc(this, name);
 }
 
-namespace _func77
+namespace _func78
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -1087,11 +1101,11 @@ namespace _func77
 WeaponBlueprint BlueprintManager::ProcessWeaponBlueprint(rapidxml::xml_node<char> *node)
 {
 	typedef WeaponBlueprint __attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func77::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func78::func;
 	return execfunc(this, node);
 }
 
-namespace _func78
+namespace _func79
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -1101,11 +1115,11 @@ namespace _func78
 Description BlueprintManager::ProcessDescription(rapidxml::xml_node<char> *node)
 {
 	typedef Description __attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func78::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func79::func;
 	return execfunc(this, node);
 }
 
-namespace _func79
+namespace _func80
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -1115,11 +1129,11 @@ namespace _func79
 EffectsBlueprint BlueprintManager::ProcessEffectsBlueprint(rapidxml::xml_node<char> *node)
 {
 	typedef EffectsBlueprint __attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func79::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func80::func;
 	return execfunc(this, node);
 }
 
-namespace _func80
+namespace _func81
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -1129,11 +1143,11 @@ namespace _func80
 CrewBlueprint BlueprintManager::GetCrewBlueprint(const std::string &name)
 {
 	typedef CrewBlueprint __attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func80::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func81::func;
 	return execfunc(this, name);
 }
 
-namespace _func81
+namespace _func82
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1143,11 +1157,11 @@ namespace _func81
 WeaponBlueprint *BlueprintManager::GetWeaponBlueprint(const std::string &name)
 {
 	typedef WeaponBlueprint *__attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func81::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func82::func;
 	return execfunc(this, name);
 }
 
-namespace _func82
+namespace _func83
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -1157,11 +1171,11 @@ namespace _func82
 std::vector<AugmentBlueprint*> BlueprintManager::GetRandomAugment(int count, bool demo_lock)
 {
 	typedef std::vector<AugmentBlueprint*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, int count_arg, bool demo_lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func82::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func83::func;
 	return execfunc(this, count, demo_lock);
 }
 
-namespace _func83
+namespace _func84
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1171,11 +1185,11 @@ namespace _func83
 SystemBlueprint *BlueprintManager::GetSystemBlueprint(const std::string &name)
 {
 	typedef SystemBlueprint *__attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func83::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func84::func;
 	return execfunc(this, name);
 }
 
-namespace _func84
+namespace _func85
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -1185,11 +1199,11 @@ namespace _func84
 std::string BlueprintManager::GetUnusedCrewName(bool *isMale_ret)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, bool *isMale_ret_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func84::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func85::func;
 	return execfunc(this, isMale_ret);
 }
 
-namespace _func85
+namespace _func86
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -1199,11 +1213,11 @@ namespace _func85
 std::string BlueprintManager::GetCrewName(bool *isMale_ret)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, bool *isMale_ret_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func85::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func86::func;
 	return execfunc(this, isMale_ret);
 }
 
-namespace _func86
+namespace _func87
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -1213,11 +1227,11 @@ namespace _func86
 std::vector<WeaponBlueprint*> BlueprintManager::GetRandomWeapon(int count, bool demo_lock)
 {
 	typedef std::vector<WeaponBlueprint*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, int count_arg, bool demo_lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func86::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func87::func;
 	return execfunc(this, count, demo_lock);
 }
 
-namespace _func87
+namespace _func88
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -1227,11 +1241,11 @@ namespace _func87
 std::vector<DroneBlueprint*> BlueprintManager::GetRandomDrone(int count, bool demo_lock)
 {
 	typedef std::vector<DroneBlueprint*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, int count_arg, bool demo_lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func87::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func88::func;
 	return execfunc(this, count, demo_lock);
 }
 
-namespace _func88
+namespace _func89
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -1241,11 +1255,11 @@ namespace _func88
 ShipBlueprint BlueprintManager::ProcessShipBlueprint(rapidxml::xml_node<char> *node)
 {
 	typedef ShipBlueprint __attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func88::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func89::func;
 	return execfunc(this, node);
 }
 
-namespace _func89
+namespace _func90
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -1255,11 +1269,11 @@ namespace _func89
 DroneBlueprint BlueprintManager::ProcessDroneBlueprint(rapidxml::xml_node<char> *node)
 {
 	typedef DroneBlueprint __attribute__((cdecl)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func89::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func90::func;
 	return execfunc(this, node);
 }
 
-namespace _func90
+namespace _func91
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1269,18 +1283,18 @@ namespace _func90
 GL_Texture *BlueprintManager::GetSkillIcon(int skill, bool outline)
 {
 	typedef GL_Texture *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int skill_arg, bool outline_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func90::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func91::func;
 	return execfunc(skill, outline);
 }
 
 BlueprintManager *Global_BlueprintManager_Blueprints;
 
-namespace _var91
+namespace _var92
 {
     static VariableDefinition varObj("Global_BlueprintManager_Blueprints", "!c7442408ffffffff895c2404c70424(???????\?)e8????????c74424080000000089342489442404", &Global_BlueprintManager_Blueprints);
 }
 
-namespace _func92
+namespace _func93
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1290,11 +1304,11 @@ namespace _func92
 void BoarderPodDrone::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func92::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func93::func;
 	return execfunc(this);
 }
 
-namespace _func93
+namespace _func94
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -1304,11 +1318,11 @@ namespace _func93
 void BoarderPodDrone::constructor(int _iShipId, int _selfId, const DroneBlueprint &_bp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg, int _iShipId_arg, int _selfId_arg, const DroneBlueprint &_bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func93::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func94::func;
 	return execfunc(this, _iShipId, _selfId, _bp);
 }
 
-namespace _func94
+namespace _func95
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1318,18 +1332,18 @@ namespace _func94
 void BoarderPodDrone::SetMovementTarget(Targetable *target)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func94::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func95::func;
 	return execfunc(this, target);
 }
 
-namespace _func95
+namespace _func96
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("BoarderPodDrone::_DO_NOT_HOOK_1", typeid(void (BoarderPodDrone::*)()), "5531c089e55383ec24", argdata, 0, 4, &func);
 }
 
-namespace _func96
+namespace _func97
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1339,11 +1353,11 @@ namespace _func96
 bool BoarderPodDrone::CanBeDeployed()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func96::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func97::func;
 	return execfunc(this);
 }
 
-namespace _func97
+namespace _func98
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1353,11 +1367,11 @@ namespace _func97
 void BoarderPodDrone::SetDeployed(bool _deployed)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg, bool _deployed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func97::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func98::func;
 	return execfunc(this, _deployed);
 }
 
-namespace _func98
+namespace _func99
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -1367,11 +1381,11 @@ namespace _func98
 CollisionResponse BoarderPodDrone::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((cdecl)) (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func98::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func99::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func99
+namespace _func100
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1381,11 +1395,11 @@ namespace _func99
 void BombProjectile::OnUpdate()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BombProjectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func99::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func100::func;
 	return execfunc(this);
 }
 
-namespace _func100
+namespace _func101
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1395,11 +1409,11 @@ namespace _func100
 void BombProjectile::CollisionCheck(Collideable *other)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BombProjectile *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func100::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func101::func;
 	return execfunc(this, other);
 }
 
-namespace _func101
+namespace _func102
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff, 0x2ff};
@@ -1409,11 +1423,11 @@ namespace _func101
 void BombProjectile::constructor(Pointf _position, int _ownerId, int _targetId, Pointf _target)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BombProjectile *this_arg, Pointf _position_arg, int _ownerId_arg, int _targetId_arg, Pointf _target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func101::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func102::func;
 	return execfunc(this, _position, _ownerId, _targetId, _target);
 }
 
-namespace _func102
+namespace _func103
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1423,11 +1437,11 @@ namespace _func102
 void BossShip::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func102::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func103::func;
 	return execfunc(this);
 }
 
-namespace _func103
+namespace _func104
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1437,11 +1451,11 @@ namespace _func103
 bool BossShip::IncomingFire()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func103::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func104::func;
 	return execfunc(this);
 }
 
-namespace _func104
+namespace _func105
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1451,11 +1465,11 @@ namespace _func104
 void BossShip::constructor(SpaceManager *space)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BossShip *this_arg, SpaceManager *space_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func104::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func105::func;
 	return execfunc(this, space);
 }
 
-namespace _func105
+namespace _func106
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1465,11 +1479,11 @@ namespace _func105
 void BossShip::ClearLocation()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func105::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func106::func;
 	return execfunc(this);
 }
 
-namespace _func106
+namespace _func107
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1479,11 +1493,11 @@ namespace _func106
 bool BossShip::Defeated()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func106::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func107::func;
 	return execfunc(this);
 }
 
-namespace _func107
+namespace _func108
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1493,11 +1507,11 @@ namespace _func107
 LocationEvent *BossShip::GetSubEvent()
 {
 	typedef LocationEvent *__attribute__((cdecl)) (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func107::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func108::func;
 	return execfunc(this);
 }
 
-namespace _func108
+namespace _func109
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1507,11 +1521,11 @@ namespace _func108
 void BossShip::StartStage()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func108::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func109::func;
 	return execfunc(this);
 }
 
-namespace _func109
+namespace _func110
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1521,11 +1535,11 @@ namespace _func109
 void BossShip::SaveBoss(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BossShip *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func109::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func110::func;
 	return execfunc(this, file);
 }
 
-namespace _func110
+namespace _func111
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1535,11 +1549,11 @@ namespace _func110
 LocationEvent *BossShip::GetEvent()
 {
 	typedef LocationEvent *__attribute__((cdecl)) (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func110::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func111::func;
 	return execfunc(this);
 }
 
-namespace _func111
+namespace _func112
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1549,11 +1563,11 @@ namespace _func111
 void BossShip::LoadBoss(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BossShip *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func111::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func112::func;
 	return execfunc(this, file);
 }
 
-namespace _func112
+namespace _func113
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1563,11 +1577,11 @@ namespace _func112
 void BossShip::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func112::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func113::func;
 	return execfunc(this);
 }
 
-namespace _func113
+namespace _func114
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -1577,11 +1591,11 @@ namespace _func113
 void Button::SetLocation(const Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Button *this_arg, const Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func113::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func114::func;
 	return execfunc(this, pos);
 }
 
-namespace _func114
+namespace _func115
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff};
@@ -1591,11 +1605,11 @@ namespace _func114
 void Button::OnInit(const std::string &img, Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Button *this_arg, const std::string &img_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func114::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func115::func;
 	return execfunc(this, img, pos);
 }
 
-namespace _func115
+namespace _func116
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1605,11 +1619,11 @@ namespace _func115
 void Button::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Button *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func115::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func116::func;
 	return execfunc(this);
 }
 
-namespace _func116
+namespace _func117
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1619,11 +1633,11 @@ namespace _func116
 void Button::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Button *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func116::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func117::func;
 	return execfunc(this);
 }
 
-namespace _func117
+namespace _func118
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1631,20 +1645,6 @@ namespace _func117
 }
 
 void Button::SetInactiveImage(GL_Texture *texture)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Button *this_arg, GL_Texture *texture_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func117::func;
-	return execfunc(this, texture);
-}
-
-namespace _func118
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("Button::SetActiveImage", typeid(void (Button::*)(GL_Texture *)), "8b4424048b54240839504c", argdata, 2, 6, &func);
-}
-
-void Button::SetActiveImage(GL_Texture *texture)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Button *this_arg, GL_Texture *texture_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func118::func;
@@ -1655,17 +1655,31 @@ namespace _func119
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("Button::SetActiveImage", typeid(void (Button::*)(GL_Texture *)), "8b4424048b54240839504c", argdata, 2, 6, &func);
+}
+
+void Button::SetActiveImage(GL_Texture *texture)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Button *this_arg, GL_Texture *texture_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func119::func;
+	return execfunc(this, texture);
+}
+
+namespace _func120
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("Button::SetImageBase", typeid(void (Button::*)(const std::string &)), "5557565383ec2c8b7c24448d5c241c891c248b742440897c2404", argdata, 2, 6, &func);
 }
 
 void Button::SetImageBase(const std::string &imageBase)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Button *this_arg, const std::string &imageBase_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func119::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func120::func;
 	return execfunc(this, imageBase);
 }
 
-namespace _func120
+namespace _func121
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -1675,11 +1689,11 @@ namespace _func120
 void CAchievement::OnRender(Point pos, int selected, bool showNew)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CAchievement *this_arg, Point pos_arg, int selected_arg, bool showNew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func120::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func121::func;
 	return execfunc(this, pos, selected, showNew);
 }
 
-namespace _func121
+namespace _func122
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1689,11 +1703,11 @@ namespace _func121
 void CAchievement::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CAchievement *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func121::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func122::func;
 	return execfunc(this);
 }
 
-namespace _func122
+namespace _func123
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1703,11 +1717,11 @@ namespace _func122
 void CApp::OnRequestExit()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func122::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func123::func;
 	return execfunc(this);
 }
 
-namespace _func123
+namespace _func124
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1717,11 +1731,11 @@ namespace _func123
 void CApp::OnExit()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func123::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func124::func;
 	return execfunc(this);
 }
 
-namespace _func124
+namespace _func125
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -1731,11 +1745,11 @@ namespace _func124
 void CApp::OnMButtonDown(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func124::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func125::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func125
+namespace _func126
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1745,11 +1759,11 @@ namespace _func125
 void CApp::OnTextInput(int ch)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg, int ch_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func125::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func126::func;
 	return execfunc(this, ch);
 }
 
-namespace _func126
+namespace _func127
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1759,11 +1773,11 @@ namespace _func126
 void CApp::OnTextEvent(CEvent::TextEvent textEvent)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg, CEvent::TextEvent textEvent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func126::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func127::func;
 	return execfunc(this, textEvent);
 }
 
-namespace _func127
+namespace _func128
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1773,11 +1787,11 @@ namespace _func127
 void CApp::OnInputFocus()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func127::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func128::func;
 	return execfunc(this);
 }
 
-namespace _func128
+namespace _func129
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1787,11 +1801,11 @@ namespace _func128
 void CApp::OnInputBlur()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func128::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func129::func;
 	return execfunc(this);
 }
 
-namespace _func129
+namespace _func130
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -1799,20 +1813,6 @@ namespace _func129
 }
 
 void CApp::OnRButtonUp(int x, int y)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func129::func;
-	return execfunc(this, x, y);
-}
-
-namespace _func130
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CApp::OnRButtonDown", typeid(void (CApp::*)(int , int )), ".5383ec288b5c24308b4424348b542438", argdata, 3, 6, &func);
-}
-
-void CApp::OnRButtonDown(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func130::func;
@@ -1823,10 +1823,10 @@ namespace _func131
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CApp::OnLButtonUp", typeid(void (CApp::*)(int , int )), ".5383ec288b5c24308b4424348b542438", argdata, 3, 6, &func);
+	static FunctionDefinition funcObj("CApp::OnRButtonDown", typeid(void (CApp::*)(int , int )), ".5383ec288b5c24308b4424348b542438", argdata, 3, 6, &func);
 }
 
-void CApp::OnLButtonUp(int x, int y)
+void CApp::OnRButtonDown(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func131::func;
@@ -1837,10 +1837,10 @@ namespace _func132
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CApp::OnLButtonDown", typeid(void (CApp::*)(int , int )), ".5383ec288b5c24308b4424348b542438", argdata, 3, 6, &func);
+	static FunctionDefinition funcObj("CApp::OnLButtonUp", typeid(void (CApp::*)(int , int )), ".5383ec288b5c24308b4424348b542438", argdata, 3, 6, &func);
 }
 
-void CApp::OnLButtonDown(int x, int y)
+void CApp::OnLButtonUp(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func132::func;
@@ -1850,6 +1850,20 @@ void CApp::OnLButtonDown(int x, int y)
 namespace _func133
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("CApp::OnLButtonDown", typeid(void (CApp::*)(int , int )), ".5383ec288b5c24308b4424348b542438", argdata, 3, 6, &func);
+}
+
+void CApp::OnLButtonDown(int x, int y)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func133::func;
+	return execfunc(this, x, y);
+}
+
+namespace _func134
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CApp::OnMouseMove", typeid(void (CApp::*)(int , int , int , int , bool , bool , bool )), "57565383ec208b5c24308b4424348b542438", argdata, 8, 6, &func);
 }
@@ -1857,11 +1871,11 @@ namespace _func133
 void CApp::OnMouseMove(int x, int y, int xdiff, int ydiff, bool holdingLMB, bool holdingRMB, bool holdingMMB)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg, int xdiff_arg, int ydiff_arg, bool holdingLMB_arg, bool holdingRMB_arg, bool holdingMMB_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func133::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func134::func;
 	return execfunc(this, x, y, xdiff, ydiff, holdingLMB, holdingRMB, holdingMMB);
 }
 
-namespace _func134
+namespace _func135
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1871,11 +1885,11 @@ namespace _func134
 void CApp::OnKeyUp(SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func134::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func135::func;
 	return execfunc(this, key);
 }
 
-namespace _func135
+namespace _func136
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1885,11 +1899,11 @@ namespace _func135
 void CApp::OnLanguageChange()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func135::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func136::func;
 	return execfunc(this);
 }
 
-namespace _func136
+namespace _func137
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1899,11 +1913,11 @@ namespace _func136
 void CApp::OnKeyDown(SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func136::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func137::func;
 	return execfunc(this, key);
 }
 
-namespace _func137
+namespace _func138
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1913,11 +1927,11 @@ namespace _func137
 void CApp::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func137::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func138::func;
 	return execfunc(this);
 }
 
-namespace _func138
+namespace _func139
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -1927,11 +1941,11 @@ namespace _func138
 void CApp::ParseArgs(int argc, const char **argv)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg, int argc_arg, const char **argv_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func138::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func139::func;
 	return execfunc(this, argc, argv);
 }
 
-namespace _func139
+namespace _func140
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1941,11 +1955,11 @@ namespace _func139
 void CApp::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func139::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func140::func;
 	return execfunc(this);
 }
 
-namespace _func140
+namespace _func141
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -1955,20 +1969,6 @@ namespace _func140
 int CApp::SetupWindow()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func140::func;
-	return execfunc(this);
-}
-
-namespace _func141
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CApp::OnCleanup", typeid(void (CApp::*)()), "565383ec148b5c24208b430c890424", argdata, 1, 6, &func);
-}
-
-void CApp::OnCleanup()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func141::func;
 	return execfunc(this);
 }
@@ -1977,10 +1977,10 @@ namespace _func142
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CApp::GenInputEvents", typeid(void (CApp::*)()), "5383ec188b5c2420e8????????85c00f95??", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CApp::OnCleanup", typeid(void (CApp::*)()), "565383ec148b5c24208b430c890424", argdata, 1, 6, &func);
 }
 
-void CApp::GenInputEvents()
+void CApp::OnCleanup()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func142::func;
@@ -1991,10 +1991,10 @@ namespace _func143
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CApp::OnSuspend", typeid(void (CApp::*)()), "5383ec188b5c2420e8????????8b4308", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CApp::GenInputEvents", typeid(void (CApp::*)()), "5383ec188b5c2420e8????????85c00f95??", argdata, 1, 6, &func);
 }
 
-void CApp::OnSuspend()
+void CApp::GenInputEvents()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func143::func;
@@ -2005,10 +2005,10 @@ namespace _func144
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CApp::OnResume", typeid(void (CApp::*)()), "5383ec188b5c242080??????????0075??807b100074??83c4185b", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CApp::OnSuspend", typeid(void (CApp::*)()), "5383ec188b5c2420e8????????8b4308", argdata, 1, 6, &func);
 }
 
-void CApp::OnResume()
+void CApp::OnSuspend()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func144::func;
@@ -2018,6 +2018,20 @@ void CApp::OnResume()
 namespace _func145
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CApp::OnResume", typeid(void (CApp::*)()), "5383ec188b5c242080??????????0075??807b100074??83c4185b", argdata, 1, 6, &func);
+}
+
+void CApp::OnResume()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func145::func;
+	return execfunc(this);
+}
+
+namespace _func146
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CApp::TranslateMouse", typeid(Point (CApp::*)(int , int )), "565383ec148b5424248b4c24288b44242c8b742420", argdata, 4, 18, &func);
 }
@@ -2025,11 +2039,11 @@ namespace _func145
 Point CApp::TranslateMouse(int x, int y)
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func145::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func146::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func146
+namespace _func147
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -2037,20 +2051,6 @@ namespace _func146
 }
 
 void CApp::UpdateFullScreen()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func146::func;
-	return execfunc(this);
-}
-
-namespace _func147
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CApp::UpdateWindowSettings", typeid(void (CApp::*)()), "56538b44240c????????????00", argdata, 1, 6, &func);
-}
-
-void CApp::UpdateWindowSettings()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func147::func;
@@ -2061,10 +2061,10 @@ namespace _func148
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CApp::OnRender", typeid(void (CApp::*)()), "5589e557565383ec3c8b5d08891c24", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CApp::UpdateWindowSettings", typeid(void (CApp::*)()), "56538b44240c????????????00", argdata, 1, 6, &func);
 }
 
-void CApp::OnRender()
+void CApp::UpdateWindowSettings()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func148::func;
@@ -2075,12 +2075,12 @@ namespace _func149
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CApp::OnInit", typeid(int (CApp::*)()), "5589e557565383ec4c8b5d08c7042400000000", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CApp::OnRender", typeid(void (CApp::*)()), "5589e557565383ec3c8b5d08891c24", argdata, 1, 6, &func);
 }
 
-int CApp::OnInit()
+void CApp::OnRender()
 {
-	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func149::func;
 	return execfunc(this);
 }
@@ -2089,10 +2089,10 @@ namespace _func150
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CApp::OnExecute", typeid(int (CApp::*)()), "5589e557565381ecfc0100008b5d08", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CApp::OnInit", typeid(int (CApp::*)()), "5589e557565383ec4c8b5d08c7042400000000", argdata, 1, 2, &func);
 }
 
-int CApp::OnExecute()
+int CApp::OnInit()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func150::func;
@@ -2102,6 +2102,20 @@ int CApp::OnExecute()
 namespace _func151
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CApp::OnExecute", typeid(int (CApp::*)()), "5589e557565381ecfc0100008b5d08", argdata, 1, 2, &func);
+}
+
+int CApp::OnExecute()
+{
+	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CApp *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func151::func;
+	return execfunc(this);
+}
+
+namespace _func152
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CEvent::OnEvent", typeid(void (CEvent::*)(const InputEvent *)), "5557565383ec3c8b7424548b5c24508b4604f20f104608", argdata, 2, 6, &func);
 }
@@ -2109,11 +2123,11 @@ namespace _func151
 void CEvent::OnEvent(const InputEvent *event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CEvent *this_arg, const InputEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func151::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func152::func;
 	return execfunc(this, event);
 }
 
-namespace _func152
+namespace _func153
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -2123,11 +2137,11 @@ namespace _func152
 float CFPS::GetSpeedFactor()
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(CFPS *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func152::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func153::func;
 	return execfunc(this);
 }
 
-namespace _func153
+namespace _func154
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -2137,18 +2151,18 @@ namespace _func153
 void CFPS::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CFPS *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func153::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func154::func;
 	return execfunc(this);
 }
 
 CFPS *Global_CFPS_FPSControl;
 
-namespace _var154
+namespace _var155
 {
     static VariableDefinition varObj("Global_CFPS_FPSControl", "!83ec2c8b5d08c70424(???????\?)e8????????e8????????884305", &Global_CFPS_FPSControl);
 }
 
-namespace _func155
+namespace _func156
 {
     static void *func = 0;
 	static short argdata[] = {0x4ff};
@@ -2158,11 +2172,11 @@ namespace _func155
 int CSurface::GL_SetColor(GL_Color color)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func155::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func156::func;
 	return execfunc(color);
 }
 
-namespace _func156
+namespace _func157
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -2172,11 +2186,11 @@ namespace _func156
 GL_Color CSurface::GL_GetColor()
 {
 	typedef GL_Color __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func156::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func157::func;
 	return execfunc();
 }
 
-namespace _func157
+namespace _func158
 {
     static void *func = 0;
 	static short argdata[] = {0x4ff};
@@ -2186,11 +2200,11 @@ namespace _func157
 void CSurface::GL_SetColorTint(GL_Color color)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func157::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func158::func;
 	return execfunc(color);
 }
 
-namespace _func158
+namespace _func159
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -2200,20 +2214,6 @@ namespace _func158
 bool CSurface::IsFrameBufferSupported()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func158::func;
-	return execfunc();
-}
-
-namespace _func159
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("CSurface::StartFrame", typeid(void (*)()), "83ec0ce8????????83c40c", argdata, 0, 6, &func);
-}
-
-void CSurface::StartFrame()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func159::func;
 	return execfunc();
 }
@@ -2222,10 +2222,10 @@ namespace _func160
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("CSurface::FinishFrame", typeid(void (*)()), "83ec1ca1????????89442404a1????????890424", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("CSurface::StartFrame", typeid(void (*)()), "83ec0ce8????????83c40c", argdata, 0, 6, &func);
 }
 
-void CSurface::FinishFrame()
+void CSurface::StartFrame()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func160::func;
@@ -2236,10 +2236,10 @@ namespace _func161
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("CSurface::GL_ClearAll", typeid(void (*)()), "0f57c083ec2cc744241400000000f30f1144240cf30f11442408f30f11442404", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("CSurface::FinishFrame", typeid(void (*)()), "83ec1ca1????????89442404a1????????890424", argdata, 0, 6, &func);
 }
 
-void CSurface::GL_ClearAll()
+void CSurface::FinishFrame()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func161::func;
@@ -2250,10 +2250,10 @@ namespace _func162
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("CSurface::GL_ClearColor", typeid(void (*)()), "0f57c083ec1cf30f1144240cf30f11442408f30f11442404f30f110424", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("CSurface::GL_ClearAll", typeid(void (*)()), "0f57c083ec2cc744241400000000f30f1144240cf30f11442408f30f11442404", argdata, 0, 6, &func);
 }
 
-void CSurface::GL_ClearColor()
+void CSurface::GL_ClearAll()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func162::func;
@@ -2263,6 +2263,20 @@ void CSurface::GL_ClearColor()
 namespace _func163
 {
     static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("CSurface::GL_ClearColor", typeid(void (*)()), "0f57c083ec1cf30f1144240cf30f11442408f30f11442404f30f110424", argdata, 0, 6, &func);
+}
+
+void CSurface::GL_ClearColor()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func163::func;
+	return execfunc();
+}
+
+namespace _func164
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CSurface::SetViewPort", typeid(int (*)(int , int , int , int )), "83ec1c8b44242c8944240c8b44242889442408", argdata, 4, 2, &func);
 }
@@ -2270,11 +2284,11 @@ namespace _func163
 int CSurface::SetViewPort(int left, int bottom, int h, int w)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int left_arg, int bottom_arg, int h_arg, int w_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func163::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func164::func;
 	return execfunc(left, bottom, h, w);
 }
 
-namespace _func164
+namespace _func165
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -2284,11 +2298,11 @@ namespace _func164
 void CSurface::GL_PopScissor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func164::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func165::func;
 	return execfunc();
 }
 
-namespace _func165
+namespace _func166
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -2298,11 +2312,11 @@ namespace _func165
 void CSurface::GL_SetStencilMode(GL_StencilMode stencilMode, int ref, int mask)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_StencilMode stencilMode_arg, int ref_arg, int mask_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func165::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func166::func;
 	return execfunc(stencilMode, ref, mask);
 }
 
-namespace _func166
+namespace _func167
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -2312,11 +2326,11 @@ namespace _func166
 void CSurface::GL_PopStencilMode()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func166::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func167::func;
 	return execfunc();
 }
 
-namespace _func167
+namespace _func168
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -2326,11 +2340,11 @@ namespace _func167
 int CSurface::GL_OrthoProjection(float mx1, float mx2, float mx3, float mx4, float mx5, float mx6)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(float mx1_arg, float mx2_arg, float mx3_arg, float mx4_arg, float mx5_arg, float mx6_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func167::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func168::func;
 	return execfunc(mx1, mx2, mx3, mx4, mx5, mx6);
 }
 
-namespace _func168
+namespace _func169
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -2338,20 +2352,6 @@ namespace _func168
 }
 
 int CSurface::GL_LoadIdentity()
-{
-	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func168::func;
-	return execfunc();
-}
-
-namespace _func169
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("CSurface::GL_PushMatrix", typeid(int (*)()), "8b15????????83fa0f76??83ec1cc70424????????", argdata, 0, 2, &func);
-}
-
-int CSurface::GL_PushMatrix()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func169::func;
@@ -2362,10 +2362,10 @@ namespace _func170
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("CSurface::GL_PopMatrix", typeid(int (*)()), "83ec2ca1????????85c00f84????????83e801", argdata, 0, 2, &func);
+	static FunctionDefinition funcObj("CSurface::GL_PushMatrix", typeid(int (*)()), "8b15????????83fa0f76??83ec1cc70424????????", argdata, 0, 2, &func);
 }
 
-int CSurface::GL_PopMatrix()
+int CSurface::GL_PushMatrix()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func170::func;
@@ -2375,25 +2375,25 @@ int CSurface::GL_PopMatrix()
 namespace _func171
 {
     static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CSurface::GL_Rotate2", typeid(void (*)(float , float , float , float )), "81ec0c0100000f57c9f30f10842410010000f30f10942414010000f30f109c2418010000", argdata, 4, 6, &func);
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("CSurface::GL_PopMatrix", typeid(int (*)()), "83ec2ca1????????85c00f84????????83e801", argdata, 0, 2, &func);
 }
 
-void CSurface::GL_Rotate2(float angle, float x, float y, float z)
+int CSurface::GL_PopMatrix()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(float angle_arg, float x_arg, float y_arg, float z_arg);
+	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func171::func;
-	return execfunc(angle, x, y, z);
+	return execfunc();
 }
 
 namespace _func172
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CSurface::GL_Rotate", typeid(void (*)(float , float , float , float )), "81ec0c0100000f57c9f30f10842410010000f30f10942414010000f30f109c2418010000", argdata, 4, 6, &func);
+	static FunctionDefinition funcObj("CSurface::GL_Rotate2", typeid(void (*)(float , float , float , float )), "81ec0c0100000f57c9f30f10842410010000f30f10942414010000f30f109c2418010000", argdata, 4, 6, &func);
 }
 
-void CSurface::GL_Rotate(float angle, float x, float y, float z)
+void CSurface::GL_Rotate2(float angle, float x, float y, float z)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(float angle_arg, float x_arg, float y_arg, float z_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func172::func;
@@ -2403,6 +2403,20 @@ void CSurface::GL_Rotate(float angle, float x, float y, float z)
 namespace _func173
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("CSurface::GL_Rotate", typeid(void (*)(float , float , float , float )), "81ec0c0100000f57c9f30f10842410010000f30f10942414010000f30f109c2418010000", argdata, 4, 6, &func);
+}
+
+void CSurface::GL_Rotate(float angle, float x, float y, float z)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(float angle_arg, float x_arg, float y_arg, float z_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func173::func;
+	return execfunc(angle, x, y, z);
+}
+
+namespace _func174
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CSurface::GL_Scale", typeid(void (*)(float , float , float )), "f30f104c2404b800000000f30f1005????????f30f10542408f30f105c240c", argdata, 3, 6, &func);
 }
@@ -2410,11 +2424,11 @@ namespace _func173
 void CSurface::GL_Scale(float x, float y, float z)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(float x_arg, float y_arg, float z_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func173::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func174::func;
 	return execfunc(x, y, z);
 }
 
-namespace _func174
+namespace _func175
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -2424,11 +2438,11 @@ namespace _func174
 bool CSurface::GL_Translate(float x, float y, float z)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(float x_arg, float y_arg, float z_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func174::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func175::func;
 	return execfunc(x, y, z);
 }
 
-namespace _func175
+namespace _func176
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -2438,11 +2452,11 @@ namespace _func175
 void CSurface::GL_RemoveColorTint()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func175::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func176::func;
 	return execfunc();
 }
 
-namespace _func176
+namespace _func177
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -2452,11 +2466,11 @@ namespace _func176
 GL_Color CSurface::GetColorTint()
 {
 	typedef GL_Color __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func176::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func177::func;
 	return execfunc();
 }
 
-namespace _func177
+namespace _func178
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -2466,11 +2480,11 @@ namespace _func177
 bool CSurface::GL_EnableBlend()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func177::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func178::func;
 	return execfunc();
 }
 
-namespace _func178
+namespace _func179
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -2480,11 +2494,11 @@ namespace _func178
 bool CSurface::GL_DisableBlend()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func178::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func179::func;
 	return execfunc();
 }
 
-namespace _func179
+namespace _func180
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -2494,11 +2508,11 @@ namespace _func179
 void CSurface::GL_ForceAntialias(bool on)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(bool on_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func179::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func180::func;
 	return execfunc(on);
 }
 
-namespace _func180
+namespace _func181
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff};
@@ -2508,11 +2522,11 @@ namespace _func180
 bool CSurface::GL_DrawLine(float x1, float y1, float x2, float y2, float lineWidth, GL_Color color)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(float x1_arg, float y1_arg, float x2_arg, float y2_arg, float lineWidth_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func180::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func181::func;
 	return execfunc(x1, y1, x2, y2, lineWidth, color);
 }
 
-namespace _func181
+namespace _func182
 {
     static void *func = 0;
 	static short argdata[] = {0x2ff, 0x2ff, 0x2ff, 0x4ff};
@@ -2522,11 +2536,11 @@ namespace _func181
 bool CSurface::GL_DrawTriangle(Point vertex1, Point vertex2, Point vertex3, GL_Color color)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Point vertex1_arg, Point vertex2_arg, Point vertex3_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func181::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func182::func;
 	return execfunc(vertex1, vertex2, vertex3, color);
 }
 
-namespace _func182
+namespace _func183
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff};
@@ -2536,11 +2550,11 @@ namespace _func182
 bool CSurface::GL_DrawRect(float x1, float y1, float x2, float y2, GL_Color color)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(float x1_arg, float y1_arg, float x2_arg, float y2_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func182::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func183::func;
 	return execfunc(x1, y1, x2, y2, color);
 }
 
-namespace _func183
+namespace _func184
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -2550,11 +2564,11 @@ namespace _func183
 bool CSurface::GL_DrawRectOutline(int x1, int y1, int x2, int y2, GL_Color color, float lineWidth)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int x1_arg, int y1_arg, int x2_arg, int y2_arg, GL_Color color_arg, float lineWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func183::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func184::func;
 	return execfunc(x1, y1, x2, y2, color, lineWidth);
 }
 
-namespace _func184
+namespace _func185
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -2564,11 +2578,11 @@ namespace _func184
 bool CSurface::GL_BlitImage(GL_Texture *tex, float x, float y, float x2, float y2, float rotation, GL_Color color, bool mirror)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, float x2_arg, float y2_arg, float rotation_arg, GL_Color color_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func184::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func185::func;
 	return execfunc(tex, x, y, x2, y2, rotation, color, mirror);
 }
 
-namespace _func185
+namespace _func186
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -2578,11 +2592,11 @@ namespace _func185
 bool CSurface::GL_BlitPixelImage(GL_Texture *tex, float x, float y, float x2, float y2, float rotation, GL_Color color, bool mirror)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, float x2_arg, float y2_arg, float rotation_arg, GL_Color color_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func185::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func186::func;
 	return execfunc(tex, x, y, x2, y2, rotation, color, mirror);
 }
 
-namespace _func186
+namespace _func187
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -2592,11 +2606,11 @@ namespace _func186
 bool CSurface::GL_BlitImagePartial(GL_Texture *tex, float x, float y, float size_x, float size_y, float start_x, float end_x, float start_y, float end_y, float alpha, GL_Color color, bool mirror)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, float size_x_arg, float size_y_arg, float start_x_arg, float end_x_arg, float start_y_arg, float end_y_arg, float alpha_arg, GL_Color color_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func186::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func187::func;
 	return execfunc(tex, x, y, size_x, size_y, start_x, end_x, start_y, end_y, alpha, color, mirror);
 }
 
-namespace _func187
+namespace _func188
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -2606,11 +2620,11 @@ namespace _func187
 bool CSurface::GL_BlitPixelImageWide(GL_Texture *tex, float x, float y, int x2, int y2, float opacity, GL_Color color, bool mirror)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, int x2_arg, int y2_arg, float opacity_arg, GL_Color color_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func187::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func188::func;
 	return execfunc(tex, x, y, x2, y2, opacity, color, mirror);
 }
 
-namespace _func188
+namespace _func189
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -2620,11 +2634,11 @@ namespace _func188
 void CSurface::GL_BlitMultiImage(GL_Texture *tex, const std::vector<GL_TexVertex> &texVertices, bool antialias)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, const std::vector<GL_TexVertex> &texVertices_arg, bool antialias_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func188::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func189::func;
 	return execfunc(tex, texVertices, antialias);
 }
 
-namespace _func189
+namespace _func190
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -2634,11 +2648,11 @@ namespace _func189
 void CSurface::GL_BlitMultiColorImage(GL_Texture *tex, const std::vector<GL_ColorTexVertex> &texVertices, bool antialias)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, const std::vector<GL_ColorTexVertex> &texVertices_arg, bool antialias_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func189::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func190::func;
 	return execfunc(tex, texVertices, antialias);
 }
 
-namespace _func190
+namespace _func191
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -2648,11 +2662,11 @@ namespace _func190
 void CSurface::GL_RenderPrimitive(GL_Primitive *primitive)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Primitive *primitive_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func190::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func191::func;
 	return execfunc(primitive);
 }
 
-namespace _func191
+namespace _func192
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -2662,11 +2676,11 @@ namespace _func191
 void CSurface::GL_RenderPrimitiveWithAlpha(GL_Primitive *primitive, float alpha)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Primitive *primitive_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func191::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func192::func;
 	return execfunc(primitive, alpha);
 }
 
-namespace _func192
+namespace _func193
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff};
@@ -2676,11 +2690,11 @@ namespace _func192
 void CSurface::GL_RenderPrimitiveWithColor(GL_Primitive *primitive, GL_Color color)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Primitive *primitive_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func192::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func193::func;
 	return execfunc(primitive, color);
 }
 
-namespace _func193
+namespace _func194
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -2690,11 +2704,11 @@ namespace _func193
 void CSurface::GL_DestroyPrimitive(GL_Primitive *primitive)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Primitive *primitive_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func193::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func194::func;
 	return execfunc(primitive);
 }
 
-namespace _func194
+namespace _func195
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff};
@@ -2704,11 +2718,11 @@ namespace _func194
 GL_Primitive *CSurface::GL_CreateRectPrimitive(float x, float y, float w, float h, GL_Color color)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(float x_arg, float y_arg, float w_arg, float h_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func194::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func195::func;
 	return execfunc(x, y, w, h, color);
 }
 
-namespace _func195
+namespace _func196
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -2718,11 +2732,11 @@ namespace _func195
 GL_Primitive *CSurface::GL_CreateRectOutlinePrimitive(int x, int y, int w, int h, GL_Color color, float lineWidth)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int x_arg, int y_arg, int w_arg, int h_arg, GL_Color color_arg, float lineWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func195::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func196::func;
 	return execfunc(x, y, w, h, color, lineWidth);
 }
 
-namespace _func196
+namespace _func197
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff};
@@ -2732,11 +2746,11 @@ namespace _func196
 GL_Primitive *CSurface::GL_CreateMultiRectPrimitive(std::vector<Globals::Rect> &vec, GL_Color color)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(std::vector<Globals::Rect> &vec_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func196::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func197::func;
 	return execfunc(vec, color);
 }
 
-namespace _func197
+namespace _func198
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff, 0x1ff};
@@ -2746,11 +2760,11 @@ namespace _func197
 GL_Primitive *CSurface::GL_CreateMultiLinePrimitive(std::vector<GL_Line> &vec, GL_Color color, float thickness)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(std::vector<GL_Line> &vec_arg, GL_Color color_arg, float thickness_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func197::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func198::func;
 	return execfunc(vec, color, thickness);
 }
 
-namespace _func198
+namespace _func199
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff};
@@ -2760,11 +2774,11 @@ namespace _func198
 GL_Primitive *CSurface::GL_CreatePiePartialPrimitive(int x, int y, float radius, float deg1, float deg2, float thickness, GL_Color color)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int x_arg, int y_arg, float radius_arg, float deg1_arg, float deg2_arg, float thickness_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func198::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func199::func;
 	return execfunc(x, y, radius, deg1, deg2, thickness, color);
 }
 
-namespace _func199
+namespace _func200
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x4ff};
@@ -2774,11 +2788,11 @@ namespace _func199
 GL_Primitive *CSurface::GL_CreateMultiImagePrimitive(GL_Texture *tex, std::vector<GL_TexVertex> *vec, GL_Color color)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, std::vector<GL_TexVertex> *vec_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func199::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func200::func;
 	return execfunc(tex, vec, color);
 }
 
-namespace _func200
+namespace _func201
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -2788,11 +2802,11 @@ namespace _func200
 void CSurface::GL_PushStencilMode()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func200::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func201::func;
 	return execfunc();
 }
 
-namespace _func201
+namespace _func202
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -2802,11 +2816,11 @@ namespace _func201
 void CSurface::AddTexVertices(std::vector<GL_TexVertex> *vec, float x1, float y1, float u1, float v1, float x2, float y2, float u2, float v2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(std::vector<GL_TexVertex> *vec_arg, float x1_arg, float y1_arg, float u1_arg, float v1_arg, float x2_arg, float y2_arg, float u2_arg, float v2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func201::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func202::func;
 	return execfunc(vec, x1, y1, u1, v1, x2, y2, u2, v2);
 }
 
-namespace _func202
+namespace _func203
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x4ff};
@@ -2816,11 +2830,11 @@ namespace _func202
 bool CSurface::GL_DrawCircle(int x, int y, float radius, GL_Color color)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int x_arg, int y_arg, float radius_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func202::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func203::func;
 	return execfunc(x, y, radius, color);
 }
 
-namespace _func203
+namespace _func204
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -2830,11 +2844,11 @@ namespace _func203
 bool CSurface::GL_DrawShield(int x, int y, float a1, float b1, int angle1, int angle2, GL_Color color, float thickness)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int x_arg, int y_arg, float a1_arg, float b1_arg, int angle1_arg, int angle2_arg, GL_Color color_arg, float thickness_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func203::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func204::func;
 	return execfunc(x, y, a1, b1, angle1, angle2, color, thickness);
 }
 
-namespace _func204
+namespace _func205
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff};
@@ -2844,11 +2858,11 @@ namespace _func204
 bool CSurface::GL_DrawLaser(int x, int y, int w, int h, GL_Color color)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int x_arg, int y_arg, int w_arg, int h_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func204::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func205::func;
 	return execfunc(x, y, w, h, color);
 }
 
-namespace _func205
+namespace _func206
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff};
@@ -2858,11 +2872,11 @@ namespace _func205
 GL_Primitive *CSurface::GL_CreateImagePrimitive(GL_Texture *tex, float x, float y, float size_x, float size_y, float rotate, GL_Color color)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, float size_x_arg, float size_y_arg, float rotate_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func205::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func206::func;
 	return execfunc(tex, x, y, size_x, size_y, rotate, color);
 }
 
-namespace _func206
+namespace _func207
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -2872,11 +2886,11 @@ namespace _func206
 GL_Primitive *CSurface::GL_CreatePixelImagePrimitive(GL_Texture *tex, float x, float y, float size_x, float size_y, float rotate, GL_Color color, bool unk)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, float size_x_arg, float size_y_arg, float rotate_arg, GL_Color color_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func206::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func207::func;
 	return execfunc(tex, x, y, size_x, size_y, rotate, color, unk);
 }
 
-namespace _func207
+namespace _func208
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -2886,11 +2900,11 @@ namespace _func207
 void CachedImage::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CachedImage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func207::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func208::func;
 	return execfunc(this);
 }
 
-namespace _func208
+namespace _func209
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -2900,11 +2914,11 @@ namespace _func208
 void CachedImage::SetImagePath(const std::string &imagePath)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CachedImage *this_arg, const std::string &imagePath_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func208::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func209::func;
 	return execfunc(this, imagePath);
 }
 
-namespace _func209
+namespace _func210
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -2914,11 +2928,11 @@ namespace _func209
 void CachedImage::SetPosition(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CachedImage *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func209::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func210::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func210
+namespace _func211
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -2928,11 +2942,11 @@ namespace _func210
 void CachedImage::constructor1(const std::string &path, int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CachedImage *this_arg, const std::string &path_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func210::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func211::func;
 	return execfunc(this, path, x, y);
 }
 
-namespace _func211
+namespace _func212
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -2942,11 +2956,11 @@ namespace _func211
 void CachedImage::constructor2(const std::string &path, CachedImage::Centered centered)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CachedImage *this_arg, const std::string &path_arg, CachedImage::Centered centered_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func211::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func212::func;
 	return execfunc(this, path, centered);
 }
 
-namespace _func212
+namespace _func213
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -2956,11 +2970,11 @@ namespace _func212
 void CachedImage::constructor_copy(const CachedImage &other)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CachedImage *this_arg, const CachedImage &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func212::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func213::func;
 	return execfunc(this, other);
 }
 
-namespace _func213
+namespace _func214
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -2970,11 +2984,11 @@ namespace _func213
 void CachedImage::SetRotation(float _rotation)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CachedImage *this_arg, float _rotation_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func213::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func214::func;
 	return execfunc(this, _rotation);
 }
 
-namespace _func214
+namespace _func215
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -2984,11 +2998,11 @@ namespace _func214
 void CachedImage::SetMirrored(bool _mirrored)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CachedImage *this_arg, bool _mirrored_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func214::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func215::func;
 	return execfunc(this, _mirrored);
 }
 
-namespace _func215
+namespace _func216
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -2998,11 +3012,11 @@ namespace _func215
 void CachedImage::SetScale(float wScale, float hScale)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CachedImage *this_arg, float wScale_arg, float hScale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func215::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func216::func;
 	return execfunc(this, wScale, hScale);
 }
 
-namespace _func216
+namespace _func217
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -3012,11 +3026,11 @@ namespace _func216
 void CachedImage::SetPartial(float x_start, float y_start, float x_size, float y_size)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CachedImage *this_arg, float x_start_arg, float y_start_arg, float x_size_arg, float y_size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func216::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func217::func;
 	return execfunc(this, x_start, y_start, x_size, y_size);
 }
 
-namespace _func217
+namespace _func218
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3026,11 +3040,11 @@ namespace _func217
 void CachedImage::CreatePrimitive()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CachedImage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func217::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func218::func;
 	return execfunc(this);
 }
 
-namespace _func218
+namespace _func219
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -3040,11 +3054,11 @@ namespace _func218
 void CachedPrimitive::OnRender(const GL_Color &color)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CachedPrimitive *this_arg, const GL_Color &color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func218::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func219::func;
 	return execfunc(this, color);
 }
 
-namespace _func219
+namespace _func220
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3054,11 +3068,11 @@ namespace _func219
 void CachedPrimitive::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CachedPrimitive *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func219::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func220::func;
 	return execfunc(this);
 }
 
-namespace _func220
+namespace _func221
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -3068,11 +3082,11 @@ namespace _func220
 void CachedRect::SetPosition(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CachedRect *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func220::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func221::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func221
+namespace _func222
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -3082,11 +3096,11 @@ namespace _func221
 void CachedRect::SetSize(int w, int h)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CachedRect *this_arg, int w_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func221::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func222::func;
 	return execfunc(this, w, h);
 }
 
-namespace _func222
+namespace _func223
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3096,11 +3110,11 @@ namespace _func222
 void ChoiceBox::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ChoiceBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func222::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func223::func;
 	return execfunc(this);
 }
 
-namespace _func223
+namespace _func224
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -3110,11 +3124,11 @@ namespace _func223
 void ChoiceBox::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ChoiceBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func223::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func224::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func224
+namespace _func225
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -3124,11 +3138,11 @@ namespace _func224
 void ChoiceBox::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ChoiceBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func224::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func225::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func225
+namespace _func226
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
@@ -3138,11 +3152,11 @@ namespace _func225
 void CloakingBox::constructor(Point pos, CloakingSystem *sys)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CloakingBox *this_arg, Point pos_arg, CloakingSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func225::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func226::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func226
+namespace _func227
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3152,11 +3166,11 @@ namespace _func226
 void CloakingSystem::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CloakingSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func226::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func227::func;
 	return execfunc(this);
 }
 
-namespace _func227
+namespace _func228
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3166,11 +3180,11 @@ namespace _func227
 void CloakingSystem::FiredWeapon()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CloakingSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func227::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func228::func;
 	return execfunc(this);
 }
 
-namespace _func228
+namespace _func229
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
@@ -3180,11 +3194,11 @@ namespace _func228
 void CloneBox::constructor(Point pos, CloneSystem *sys)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CloneBox *this_arg, Point pos_arg, CloneSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func228::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func229::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func229
+namespace _func230
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3194,11 +3208,11 @@ namespace _func229
 void CloneSystem::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CloneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func229::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func230::func;
 	return execfunc(this);
 }
 
-namespace _func230
+namespace _func231
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -3208,11 +3222,11 @@ namespace _func230
 void CombatAI::UpdateMindControl(bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatAI *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func230::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func231::func;
 	return execfunc(this, unk);
 }
 
-namespace _func231
+namespace _func232
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3222,11 +3236,11 @@ namespace _func231
 void CombatAI::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func231::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func232::func;
 	return execfunc(this);
 }
 
-namespace _func232
+namespace _func233
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3236,11 +3250,11 @@ namespace _func232
 void CombatControl::RenderTarget()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func232::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func233::func;
 	return execfunc(this);
 }
 
-namespace _func233
+namespace _func234
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3250,20 +3264,6 @@ namespace _func233
 ShipManager *CombatControl::GetCurrentTarget()
 {
 	typedef ShipManager *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func233::func;
-	return execfunc(this);
-}
-
-namespace _func234
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CombatControl::CurrentTargetIsBoss", typeid(char (CombatControl::*)()), "8b4424048b80b805000085c074??8b10", argdata, 1, 2, &func);
-}
-
-char CombatControl::CurrentTargetIsBoss()
-{
-	typedef char __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func234::func;
 	return execfunc(this);
 }
@@ -3272,10 +3272,10 @@ namespace _func235
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CombatControl::CanTargetSelf", typeid(char (CombatControl::*)()), "5589e557565383ec4c8b75088b86a4000000", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CombatControl::CurrentTargetIsBoss", typeid(char (CombatControl::*)()), "8b4424048b80b805000085c074??8b10", argdata, 1, 2, &func);
 }
 
-char CombatControl::CanTargetSelf()
+char CombatControl::CurrentTargetIsBoss()
 {
 	typedef char __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func235::func;
@@ -3286,17 +3286,31 @@ namespace _func236
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CombatControl::CanTargetSelf", typeid(char (CombatControl::*)()), "5589e557565383ec4c8b75088b86a4000000", argdata, 1, 2, &func);
+}
+
+char CombatControl::CanTargetSelf()
+{
+	typedef char __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func236::func;
+	return execfunc(this);
+}
+
+namespace _func237
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("CombatControl::OnRenderCombat", typeid(void (CombatControl::*)()), "5589e5565383ec208b5d0880bb240b000000", argdata, 1, 6, &func);
 }
 
 void CombatControl::OnRenderCombat()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func236::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func237::func;
 	return execfunc(this);
 }
 
-namespace _func237
+namespace _func238
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -3306,11 +3320,11 @@ namespace _func237
 void CombatControl::AddEnemyShip(CompleteShip *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg, CompleteShip *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func237::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func238::func;
 	return execfunc(this, ship);
 }
 
-namespace _func238
+namespace _func239
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3320,11 +3334,11 @@ namespace _func238
 void CombatControl::UpdateAiming()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func238::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func239::func;
 	return execfunc(this);
 }
 
-namespace _func239
+namespace _func240
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3334,11 +3348,11 @@ namespace _func239
 bool CombatControl::UpdateTarget()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func239::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func240::func;
 	return execfunc(this);
 }
 
-namespace _func240
+namespace _func241
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff, 0x1ff};
@@ -3348,11 +3362,11 @@ namespace _func240
 void CombatControl::DrawHostileBox(GL_Color color, int stencilBit)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg, GL_Color color_arg, int stencilBit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func240::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func241::func;
 	return execfunc(this, color, stencilBit);
 }
 
-namespace _func241
+namespace _func242
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -3362,11 +3376,11 @@ namespace _func241
 void CombatControl::OnInit(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func241::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func242::func;
 	return execfunc(this, pos);
 }
 
-namespace _func242
+namespace _func243
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3376,11 +3390,11 @@ namespace _func242
 void CombatControl::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func242::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func243::func;
 	return execfunc(this);
 }
 
-namespace _func243
+namespace _func244
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3390,11 +3404,11 @@ namespace _func243
 void CombatControl::SetMouseCursor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func243::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func244::func;
 	return execfunc(this);
 }
 
-namespace _func244
+namespace _func245
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -3404,11 +3418,11 @@ namespace _func244
 std::pair<int, int> CombatControl::GetTeleportationCommand()
 {
 	typedef std::pair<int, int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func244::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func245::func;
 	return execfunc(this);
 }
 
-namespace _func245
+namespace _func246
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3418,11 +3432,11 @@ namespace _func245
 void CombatControl::DisarmAll()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func245::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func246::func;
 	return execfunc(this);
 }
 
-namespace _func246
+namespace _func247
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3432,11 +3446,11 @@ namespace _func246
 bool CombatControl::SelectTarget()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func246::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func247::func;
 	return execfunc(this);
 }
 
-namespace _func247
+namespace _func248
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -3446,11 +3460,11 @@ namespace _func247
 bool CombatControl::MouseRClick(int x, int y)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func247::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func248::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func248
+namespace _func249
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3460,11 +3474,11 @@ namespace _func248
 bool CombatControl::WeaponsArmed()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func248::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func249::func;
 	return execfunc(this);
 }
 
-namespace _func249
+namespace _func250
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -3474,11 +3488,11 @@ namespace _func249
 void CombatControl::KeyDown(SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func249::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func250::func;
 	return execfunc(this, key);
 }
 
-namespace _func250
+namespace _func251
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3486,20 +3500,6 @@ namespace _func250
 }
 
 void CombatControl::DisarmTeleporter()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func250::func;
-	return execfunc(this);
-}
-
-namespace _func251
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CombatControl::constructor", typeid(void (CombatControl::*)()), "5557565381ecbc0000008bb424d0000000", argdata, 1, 6, &func);
-}
-
-void CombatControl::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func251::func;
@@ -3510,10 +3510,10 @@ namespace _func252
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CombatControl::OnRenderSelfAiming", typeid(void (CombatControl::*)()), "5589e55383ec348b5d088d4314", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CombatControl::constructor", typeid(void (CombatControl::*)()), "5557565381ecbc0000008bb424d0000000", argdata, 1, 6, &func);
 }
 
-void CombatControl::OnRenderSelfAiming()
+void CombatControl::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func252::func;
@@ -3523,6 +3523,20 @@ void CombatControl::OnRenderSelfAiming()
 namespace _func253
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CombatControl::OnRenderSelfAiming", typeid(void (CombatControl::*)()), "5589e55383ec348b5d088d4314", argdata, 1, 6, &func);
+}
+
+void CombatControl::OnRenderSelfAiming()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func253::func;
+	return execfunc(this);
+}
+
+namespace _func254
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x4ff};
 	static FunctionDefinition funcObj("CombatControl::RenderShipStatus", typeid(void (CombatControl::*)(Pointf , GL_Color )), "5589e557565381ec9c0000008b5d0c8b75108b7d08", argdata, 3, 6, &func);
 }
@@ -3530,11 +3544,11 @@ namespace _func253
 void CombatControl::RenderShipStatus(Pointf pos, GL_Color color)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg, Pointf pos_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func253::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func254::func;
 	return execfunc(this, pos, color);
 }
 
-namespace _func254
+namespace _func255
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -3544,11 +3558,11 @@ namespace _func254
 std::string CombatControl::GetCrewTooltip(int x, int y)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func254::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func255::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func255
+namespace _func256
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3558,11 +3572,11 @@ namespace _func255
 void CombatControl::Clear()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func255::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func256::func;
 	return execfunc(this);
 }
 
-namespace _func256
+namespace _func257
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -3572,11 +3586,11 @@ namespace _func256
 bool CombatControl::MouseMove(int mX, int mY)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func256::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func257::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func257
+namespace _func258
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -3586,11 +3600,11 @@ namespace _func257
 void CombatControl::MouseClick(int mX, int mY, bool shift)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatControl *this_arg, int mX_arg, int mY_arg, bool shift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func257::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func258::func;
 	return execfunc(this, mX, mY, shift);
 }
 
-namespace _func258
+namespace _func259
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -3600,11 +3614,11 @@ namespace _func258
 void CombatDrone::constructor(int iShipId, int selfId, const DroneBlueprint *bp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatDrone *this_arg, int iShipId_arg, int selfId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func258::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func259::func;
 	return execfunc(this, iShipId, selfId, bp);
 }
 
-namespace _func259
+namespace _func260
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -3614,11 +3628,11 @@ namespace _func259
 void CombatDrone::SetWeaponTarget(Targetable *target)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func259::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func260::func;
 	return execfunc(this, target);
 }
 
-namespace _func260
+namespace _func261
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3628,11 +3642,11 @@ namespace _func260
 void CombatDrone::PickTarget()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CombatDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func260::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func261::func;
 	return execfunc(this);
 }
 
-namespace _func261
+namespace _func262
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -3642,11 +3656,11 @@ namespace _func261
 void CommandGui::RunCommand(std::string &command)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg, std::string &command_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func261::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func262::func;
 	return execfunc(this, command);
 }
 
-namespace _func262
+namespace _func263
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -3656,11 +3670,11 @@ namespace _func262
 Store *CommandGui::CreateNewStore(int sectorNumber)
 {
 	typedef Store *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg, int sectorNumber_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func262::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func263::func;
 	return execfunc(this, sectorNumber);
 }
 
-namespace _func263
+namespace _func264
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -3670,11 +3684,11 @@ namespace _func263
 Point CommandGui::GetWorldCoordinates(Point point, bool fromTarget)
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg, Point point_arg, bool fromTarget_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func263::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func264::func;
 	return execfunc(this, point, fromTarget);
 }
 
-namespace _func264
+namespace _func265
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -3684,11 +3698,11 @@ namespace _func264
 void CommandGui::KeyDown(SDLKey key, bool shiftHeld)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg, SDLKey key_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func264::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func265::func;
 	return execfunc(this, key, shiftHeld);
 }
 
-namespace _func265
+namespace _func266
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3698,11 +3712,11 @@ namespace _func265
 void CommandGui::RenderStatic()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func265::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func266::func;
 	return execfunc(this);
 }
 
-namespace _func266
+namespace _func267
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3712,11 +3726,11 @@ namespace _func266
 void CommandGui::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func266::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func267::func;
 	return execfunc(this);
 }
 
-namespace _func267
+namespace _func268
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -3726,11 +3740,11 @@ namespace _func267
 void CommandGui::AddEnemyShip(CompleteShip *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg, CompleteShip *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func267::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func268::func;
 	return execfunc(this, ship);
 }
 
-namespace _func268
+namespace _func269
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3740,11 +3754,11 @@ namespace _func268
 void CommandGui::Victory()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func268::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func269::func;
 	return execfunc(this);
 }
 
-namespace _func269
+namespace _func270
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3754,11 +3768,11 @@ namespace _func269
 void CommandGui::OnInit()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func269::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func270::func;
 	return execfunc(this);
 }
 
-namespace _func270
+namespace _func271
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -3768,11 +3782,11 @@ namespace _func270
 void CommandGui::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func270::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func271::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func271
+namespace _func272
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -3782,11 +3796,11 @@ namespace _func271
 void CommandGui::LButtonDown(int mX, int mY, bool shiftHeld)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg, int mX_arg, int mY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func271::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func272::func;
 	return execfunc(this, mX, mY, shiftHeld);
 }
 
-namespace _func272
+namespace _func273
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3794,20 +3808,6 @@ namespace _func272
 }
 
 void CommandGui::OnLoop()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func272::func;
-	return execfunc(this);
-}
-
-namespace _func273
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CommandGui::CheckGameover", typeid(void (CommandGui::*)()), "5589e557565383ec5c8b7d08????????????0075??", argdata, 1, 6, &func);
-}
-
-void CommandGui::CheckGameover()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func273::func;
@@ -3818,17 +3818,31 @@ namespace _func274
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CommandGui::CheckGameover", typeid(void (CommandGui::*)()), "5589e557565383ec5c8b7d08????????????0075??", argdata, 1, 6, &func);
+}
+
+void CommandGui::CheckGameover()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func274::func;
+	return execfunc(this);
+}
+
+namespace _func275
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("CommandGui::IsGameOver", typeid(bool (CommandGui::*)()), "5383ec18803d????????008b5c242075??????????????85c0", argdata, 1, 2, &func);
 }
 
 bool CommandGui::IsGameOver()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func274::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func275::func;
 	return execfunc(this);
 }
 
-namespace _func275
+namespace _func276
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -3838,11 +3852,11 @@ namespace _func275
 void CommandGui::NewLocation(const std::string &mainText, std::vector<ChoiceText> *choices, ResourceEvent &resources, bool testingEvents)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg, const std::string &mainText_arg, std::vector<ChoiceText> *choices_arg, ResourceEvent &resources_arg, bool testingEvents_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func275::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func276::func;
 	return execfunc(this, mainText, choices, resources, testingEvents);
 }
 
-namespace _func276
+namespace _func277
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -3852,11 +3866,11 @@ namespace _func276
 void CommandGui::RenderPlayerShip(Point &shipCenter, float jumpScale)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg, Point &shipCenter_arg, float jumpScale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func276::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func277::func;
 	return execfunc(this, shipCenter, jumpScale);
 }
 
-namespace _func277
+namespace _func278
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -3866,25 +3880,25 @@ namespace _func277
 void CommandGui::LButtonUp(int mX, int mY, bool shiftHeld)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg, int mX_arg, int mY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func277::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func278::func;
 	return execfunc(this, mX, mY, shiftHeld);
-}
-
-namespace _func278
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("CompleteShip::DO_NOT_HOOK", typeid(void (CompleteShip::*)()), "!8b48fc8d59ff8958fc89c8e9????????8b48fc8d59ff8958fc89c8eb??6690", argdata, 0, 4, &func);
 }
 
 namespace _func279
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("CompleteShip::DO_NOT_HOOK2", typeid(void (CompleteShip::*)()), "!.8b48fc8d59ff8958fc89c8e9????????8b48fc8d59ff8958fc89c8eb??6690", argdata, 0, 4, &func);
+	static FunctionDefinition funcObj("CompleteShip::DO_NOT_HOOK", typeid(void (CompleteShip::*)()), "!8b48fc8d59ff8958fc89c8e9????????8b48fc8d59ff8958fc89c8eb??6690", argdata, 0, 4, &func);
 }
 
 namespace _func280
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("CompleteShip::DO_NOT_HOOK2", typeid(void (CompleteShip::*)()), "!.8b48fc8d59ff8958fc89c8e9????????8b48fc8d59ff8958fc89c8eb??6690", argdata, 0, 4, &func);
+}
+
+namespace _func281
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3894,11 +3908,11 @@ namespace _func280
 void CompleteShip::PauseLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func280::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func281::func;
 	return execfunc(this);
 }
 
-namespace _func281
+namespace _func282
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -3908,11 +3922,11 @@ namespace _func281
 void CompleteShip::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func281::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func282::func;
 	return execfunc(this);
 }
 
-namespace _func282
+namespace _func283
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -3922,11 +3936,11 @@ namespace _func282
 void CompleteShip::constructor(SpaceManager *space, bool unk, int unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, SpaceManager *space_arg, bool unk_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func282::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func283::func;
 	return execfunc(this, space, unk, unk2);
 }
 
-namespace _func283
+namespace _func284
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -3936,11 +3950,11 @@ namespace _func283
 void CompleteShip::SetShip(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func283::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func284::func;
 	return execfunc(this, ship);
 }
 
-namespace _func284
+namespace _func285
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -3950,11 +3964,11 @@ namespace _func284
 void CompleteShip::OnInit(const ShipBlueprint *blueprint, int unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, const ShipBlueprint *blueprint_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func284::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func285::func;
 	return execfunc(this, blueprint, unk);
 }
 
-namespace _func285
+namespace _func286
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -3964,11 +3978,11 @@ namespace _func285
 void CompleteShip::AddBoarders(int amount, const std::string &race, bool unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int amount_arg, const std::string &race_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func285::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func286::func;
 	return execfunc(this, amount, race, unk2);
 }
 
-namespace _func286
+namespace _func287
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -3978,11 +3992,11 @@ namespace _func286
 CrewMember *CompleteShip::AddCrewMember(const CrewBlueprint *blueprint, bool hostile)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, const CrewBlueprint *blueprint_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func286::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func287::func;
 	return execfunc(this, blueprint, hostile);
 }
 
-namespace _func287
+namespace _func288
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -3992,11 +4006,11 @@ namespace _func287
 CrewMember *CompleteShip::AddCrewMember1(const std::string &race, const std::string &name, bool hostile)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, const std::string &race_arg, const std::string &name_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func287::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func288::func;
 	return execfunc(this, race, name, hostile);
 }
 
-namespace _func288
+namespace _func289
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4006,11 +4020,11 @@ namespace _func288
 Drone *CompleteShip::AddDrone(const DroneBlueprint *blueprint, int unk)
 {
 	typedef Drone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, const DroneBlueprint *blueprint_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func288::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func289::func;
 	return execfunc(this, blueprint, unk);
 }
 
-namespace _func289
+namespace _func290
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4020,11 +4034,11 @@ namespace _func289
 CrewMember *CompleteShip::AddCrewMember2(CrewMember *member, int unk)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, CrewMember *member_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func289::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func290::func;
 	return execfunc(this, member, unk);
 }
 
-namespace _func290
+namespace _func291
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4034,11 +4048,11 @@ namespace _func290
 void CompleteShip::SaveState(int unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func290::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func291::func;
 	return execfunc(this, unk);
 }
 
-namespace _func291
+namespace _func292
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4048,11 +4062,11 @@ namespace _func291
 void CompleteShip::LoadState(int unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func291::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func292::func;
 	return execfunc(this, unk);
 }
 
-namespace _func292
+namespace _func293
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4062,11 +4076,11 @@ namespace _func292
 void CompleteShip::InitiateTeleport(int targetRoom, int command)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int targetRoom_arg, int command_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func292::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func293::func;
 	return execfunc(this, targetRoom, command);
 }
 
-namespace _func293
+namespace _func294
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4076,11 +4090,11 @@ namespace _func293
 void CompleteShip::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func293::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func294::func;
 	return execfunc(this);
 }
 
-namespace _func294
+namespace _func295
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4090,11 +4104,11 @@ namespace _func294
 std::vector<CrewMember*> CompleteShip::GetTeleportingParty()
 {
 	typedef std::vector<CrewMember*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func294::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func295::func;
 	return execfunc(this);
 }
 
-namespace _func295
+namespace _func296
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4104,11 +4118,11 @@ namespace _func295
 void CompleteShip::KillRandomCrew()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func295::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func296::func;
 	return execfunc(this);
 }
 
-namespace _func296
+namespace _func297
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4118,11 +4132,11 @@ namespace _func296
 int CompleteShip::CountCrew(bool boarders)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, bool boarders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func296::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func297::func;
 	return execfunc(this, boarders);
 }
 
-namespace _func297
+namespace _func298
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4132,11 +4146,11 @@ namespace _func297
 void CompleteShip::Jump()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func297::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func298::func;
 	return execfunc(this);
 }
 
-namespace _func298
+namespace _func299
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4146,11 +4160,11 @@ namespace _func298
 void CompleteShip::SetEnemyShip(CompleteShip *other)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, CompleteShip *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func298::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func299::func;
 	return execfunc(this, other);
 }
 
-namespace _func299
+namespace _func300
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4160,11 +4174,11 @@ namespace _func299
 bool CompleteShip::DeadCrew()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func299::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func300::func;
 	return execfunc(this);
 }
 
-namespace _func300
+namespace _func301
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4174,11 +4188,11 @@ namespace _func300
 std::vector<CrewMember*> CompleteShip::TeleportCrew(int roomId, bool intruders)
 {
 	typedef std::vector<CrewMember*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int roomId_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func300::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func301::func;
 	return execfunc(this, roomId, intruders);
 }
 
-namespace _func301
+namespace _func302
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4188,11 +4202,11 @@ namespace _func301
 void CompleteShip::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func301::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func302::func;
 	return execfunc(this);
 }
 
-namespace _func302
+namespace _func303
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4202,11 +4216,11 @@ namespace _func302
 void CompleteShip::OnRenderSpace()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func302::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func303::func;
 	return execfunc(this);
 }
 
-namespace _func303
+namespace _func304
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4216,11 +4230,11 @@ namespace _func303
 void CompleteShip::OnRenderShip(bool unk1, bool unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, bool unk1_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func303::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func304::func;
 	return execfunc(this, unk1, unk2);
 }
 
-namespace _func304
+namespace _func305
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4230,11 +4244,11 @@ namespace _func304
 void ConfirmWindow::SetText(const TextString &text_, int minWidth, bool autoCenter, const TextString &yesText_, const TextString &noText_)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, const TextString &text__arg, int minWidth_arg, bool autoCenter_arg, const TextString &yesText__arg, const TextString &noText__arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func304::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func305::func;
 	return execfunc(this, text_, minWidth, autoCenter, yesText_, noText_);
 }
 
-namespace _func305
+namespace _func306
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4244,11 +4258,11 @@ namespace _func305
 void ConfirmWindow::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func305::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func306::func;
 	return execfunc(this);
 }
 
-namespace _func306
+namespace _func307
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -4258,11 +4272,11 @@ namespace _func306
 void ConfirmWindow::SetPosition(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func306::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func307::func;
 	return execfunc(this, pos);
 }
 
-namespace _func307
+namespace _func308
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4272,11 +4286,11 @@ namespace _func307
 void ConfirmWindow::Open()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func307::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func308::func;
 	return execfunc(this);
 }
 
-namespace _func308
+namespace _func309
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4286,11 +4300,11 @@ namespace _func308
 void ConfirmWindow::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func308::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func309::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func309
+namespace _func310
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4300,11 +4314,11 @@ namespace _func309
 void ConfirmWindow::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func309::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func310::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func310
+namespace _func311
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4312,20 +4326,6 @@ namespace _func310
 }
 
 void ConfirmWindow::constructor()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func310::func;
-	return execfunc(this);
-}
-
-namespace _func311
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ConfirmWindow::Close", typeid(void (ConfirmWindow::*)()), "5383ec188b5c24208b4348890424", argdata, 1, 6, &func);
-}
-
-void ConfirmWindow::Close()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func311::func;
@@ -4336,12 +4336,12 @@ namespace _func312
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ControlButton::OnRender", typeid(void (ControlButton::*)()), "5589e557565383ec6c8b5d08f30f102d????????", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ConfirmWindow::Close", typeid(void (ConfirmWindow::*)()), "5383ec188b5c24208b4348890424", argdata, 1, 6, &func);
 }
 
-void ControlButton::OnRender()
+void ConfirmWindow::Close()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ControlButton *this_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func312::func;
 	return execfunc(this);
 }
@@ -4350,12 +4350,12 @@ namespace _func313
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ControlsScreen::OnInit", typeid(void (ControlsScreen::*)()), "5589e557565381ecbc0000008b45088b80cc040000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ControlButton::OnRender", typeid(void (ControlButton::*)()), "5589e557565383ec6c8b5d08f30f102d????????", argdata, 1, 6, &func);
 }
 
-void ControlsScreen::OnInit()
+void ControlButton::OnRender()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ControlButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func313::func;
 	return execfunc(this);
 }
@@ -4364,10 +4364,10 @@ namespace _func314
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ControlsScreen::OnLoop", typeid(void (ControlsScreen::*)()), "5589e557565331db83ec4c8b45088b4d08", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ControlsScreen::OnInit", typeid(void (ControlsScreen::*)()), "5589e557565381ecbc0000008b45088b80cc040000", argdata, 1, 6, &func);
 }
 
-void ControlsScreen::OnLoop()
+void ControlsScreen::OnInit()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func314::func;
@@ -4378,10 +4378,10 @@ namespace _func315
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ControlsScreen::OnRender", typeid(void (ControlsScreen::*)()), "5589e557565381ec7c0100008b7508", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ControlsScreen::OnLoop", typeid(void (ControlsScreen::*)()), "5589e557565331db83ec4c8b45088b4d08", argdata, 1, 6, &func);
 }
 
-void ControlsScreen::OnRender()
+void ControlsScreen::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func315::func;
@@ -4391,6 +4391,20 @@ void ControlsScreen::OnRender()
 namespace _func316
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ControlsScreen::OnRender", typeid(void (ControlsScreen::*)()), "5589e557565381ec7c0100008b7508", argdata, 1, 6, &func);
+}
+
+void ControlsScreen::OnRender()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func316::func;
+	return execfunc(this);
+}
+
+namespace _func317
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CooldownSystemBox::constructor", typeid(void (CooldownSystemBox::*)(Point , ShipSystem *, bool )), "5557565381ec1c0100008bac24300100008b9c24340100008bb424380100008b84243c0100008bbc2440010000", argdata, 4, 6, &func);
 }
@@ -4398,11 +4412,11 @@ namespace _func316
 void CooldownSystemBox::constructor(Point pos, ShipSystem *sys, bool roundDown)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CooldownSystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, bool roundDown_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func316::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func317::func;
 	return execfunc(this, pos, sys, roundDown);
 }
 
-namespace _func317
+namespace _func318
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4412,11 +4426,11 @@ namespace _func317
 void CooldownSystemBox::OnRender(bool ignoreStatus)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CooldownSystemBox *this_arg, bool ignoreStatus_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func317::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func318::func;
 	return execfunc(this, ignoreStatus);
 }
 
-namespace _func318
+namespace _func319
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4426,11 +4440,11 @@ namespace _func318
 void CreditScreen::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CreditScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func318::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func319::func;
 	return execfunc(this);
 }
 
-namespace _func319
+namespace _func320
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4440,11 +4454,11 @@ namespace _func319
 void CreditScreen::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CreditScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func319::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func320::func;
 	return execfunc(this);
 }
 
-namespace _func320
+namespace _func321
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4454,11 +4468,11 @@ namespace _func320
 void CreditScreen::Start(const std::string &shipName, const std::vector<std::string> &crewNames)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CreditScreen *this_arg, const std::string &shipName_arg, const std::vector<std::string> &crewNames_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func320::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func321::func;
 	return execfunc(this, shipName, crewNames);
 }
 
-namespace _func321
+namespace _func322
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4468,11 +4482,11 @@ namespace _func321
 bool CreditScreen::Done()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CreditScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func321::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func322::func;
 	return execfunc(this);
 }
 
-namespace _func322
+namespace _func323
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4482,11 +4496,11 @@ namespace _func322
 void CrewAI::UpdateDrones()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func322::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func323::func;
 	return execfunc(this);
 }
 
-namespace _func323
+namespace _func324
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4496,11 +4510,11 @@ namespace _func323
 void CrewAI::AssignCrewmembers()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func323::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func324::func;
 	return execfunc(this);
 }
 
-namespace _func324
+namespace _func325
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x3ff, 0x1ff};
@@ -4510,11 +4524,11 @@ namespace _func324
 int CrewAI::PrioritizeTask(CrewTask task, int crewId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg, CrewTask task_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func324::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func325::func;
 	return execfunc(this, task, crewId);
 }
 
-namespace _func325
+namespace _func326
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4524,11 +4538,11 @@ namespace _func325
 void CrewAI::UpdateIntruders()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func325::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func326::func;
 	return execfunc(this);
 }
 
-namespace _func326
+namespace _func327
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4538,11 +4552,11 @@ namespace _func326
 int CrewAI::PrioritizeIntruderRoom(CrewMember *crew, int roomId, int target)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg, CrewMember *crew_arg, int roomId_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func326::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func327::func;
 	return execfunc(this, crew, roomId, target);
 }
 
-namespace _func327
+namespace _func328
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4552,11 +4566,11 @@ namespace _func327
 void CrewAI::UpdateCrewMember(int crewId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func327::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func328::func;
 	return execfunc(this, crewId);
 }
 
-namespace _func328
+namespace _func329
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4564,20 +4578,6 @@ namespace _func328
 }
 
 void CrewAI::CheckForHealing()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func328::func;
-	return execfunc(this);
-}
-
-namespace _func329
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewAI::OnLoop", typeid(void (CrewAI::*)()), "5589e557565383ec4c8b5d088b0389442404", argdata, 1, 6, &func);
-}
-
-void CrewAI::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func329::func;
@@ -4588,10 +4588,10 @@ namespace _func330
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewAI::CheckForProblems", typeid(void (CrewAI::*)()), "5589e557565383ec7c8b7d088b07c6470801", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewAI::OnLoop", typeid(void (CrewAI::*)()), "5589e557565383ec4c8b5d088b0389442404", argdata, 1, 6, &func);
 }
 
-void CrewAI::CheckForProblems()
+void CrewAI::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func330::func;
@@ -4601,6 +4601,20 @@ void CrewAI::CheckForProblems()
 namespace _func331
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CrewAI::CheckForProblems", typeid(void (CrewAI::*)()), "5589e557565383ec7c8b7d088b07c6470801", argdata, 1, 6, &func);
+}
+
+void CrewAI::CheckForProblems()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func331::func;
+	return execfunc(this);
+}
+
+namespace _func332
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CrewAI::DangerRating", typeid(int (CrewAI::*)(int , int )), "5589e557565383ec5c8b75088b4d108b5d0c", argdata, 3, 2, &func);
 }
@@ -4608,11 +4622,11 @@ namespace _func331
 int CrewAI::DangerRating(int roomId, int crewId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg, int roomId_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func331::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func332::func;
 	return execfunc(this, roomId, crewId);
 }
 
-namespace _func332
+namespace _func333
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -4622,11 +4636,11 @@ namespace _func332
 void CrewAnimation::constructor(int shipId, const std::string &race, Pointf unk, bool hostile)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, int shipId_arg, const std::string &race_arg, Pointf unk_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func332::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func333::func;
 	return execfunc(this, shipId, race, unk, hostile);
 }
 
-namespace _func333
+namespace _func334
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4636,25 +4650,25 @@ namespace _func333
 std::string CrewAnimation::GetDeathSound()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func333::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func334::func;
 	return execfunc(this);
-}
-
-namespace _func334
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("DO_NOT_HOOK_MANTISANIMATIONSHOOTINGSOUND", typeid(void (*)()), "5557565381ec0c010000803d????????00", argdata, 0, 4, &func);
 }
 
 namespace _func335
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("DO_NOT_HOOK_ROCKANIMATIONSHOOTINGSOUND", typeid(void (*)()), ".5557565381ec0c010000803d????????00", argdata, 0, 4, &func);
+	static FunctionDefinition funcObj("DO_NOT_HOOK_MANTISANIMATIONSHOOTINGSOUND", typeid(void (*)()), "5557565381ec0c010000803d????????00", argdata, 0, 4, &func);
 }
 
 namespace _func336
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("DO_NOT_HOOK_ROCKANIMATIONSHOOTINGSOUND", typeid(void (*)()), ".5557565381ec0c010000803d????????00", argdata, 0, 4, &func);
+}
+
+namespace _func337
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4664,11 +4678,11 @@ namespace _func336
 std::string CrewAnimation::GetShootingSound()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func336::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func337::func;
 	return execfunc(this);
 }
 
-namespace _func337
+namespace _func338
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4678,11 +4692,11 @@ namespace _func337
 void CrewAnimation::OnRender(float scale, int selectedState, bool outlineOnly)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, float scale_arg, int selectedState_arg, bool outlineOnly_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func337::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func338::func;
 	return execfunc(this, scale, selectedState, outlineOnly);
 }
 
-namespace _func338
+namespace _func339
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4692,11 +4706,11 @@ namespace _func338
 void CrewAnimation::OnRenderProps()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func338::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func339::func;
 	return execfunc(this);
 }
 
-namespace _func339
+namespace _func340
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -4706,11 +4720,11 @@ namespace _func339
 void CrewAnimation::OnInit(const std::string &name, Pointf position, bool enemy)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, const std::string &name_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func339::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func340::func;
 	return execfunc(this, name, position, enemy);
 }
 
-namespace _func340
+namespace _func341
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4720,11 +4734,11 @@ namespace _func340
 void CrewAnimation::SetupStrips()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func340::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func341::func;
 	return execfunc(this);
 }
 
-namespace _func341
+namespace _func342
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4734,11 +4748,11 @@ namespace _func341
 void CrewAnimation::OnUpdate(Pointf position, bool moving, bool fighting, bool repairing, bool dying, bool onFire)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, Pointf position_arg, bool moving_arg, bool fighting_arg, bool repairing_arg, bool dying_arg, bool onFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func341::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func342::func;
 	return execfunc(this, position, moving, fighting, repairing, dying, onFire);
 }
 
-namespace _func342
+namespace _func343
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4748,11 +4762,11 @@ namespace _func342
 void CrewAnimation::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func342::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func343::func;
 	return execfunc(this);
 }
 
-namespace _func343
+namespace _func344
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4762,11 +4776,11 @@ namespace _func343
 bool CrewAnimation::FireShot()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func343::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func344::func;
 	return execfunc(this);
 }
 
-namespace _func344
+namespace _func345
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4776,11 +4790,11 @@ namespace _func344
 int CrewAnimation::GetFiringFrame()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func344::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func345::func;
 	return execfunc(this);
 }
 
-namespace _func345
+namespace _func346
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4790,11 +4804,11 @@ namespace _func345
 void CrewAnimation::RenderIcon(bool border)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, bool border_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func345::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func346::func;
 	return execfunc(this, border);
 }
 
-namespace _func346
+namespace _func347
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4804,11 +4818,11 @@ namespace _func346
 void CrewAnimation::OnUpdateEffects()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func346::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func347::func;
 	return execfunc(this);
 }
 
-namespace _func347
+namespace _func348
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4818,11 +4832,11 @@ namespace _func347
 void CrewBlueprint::RandomSkills(int worldLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func347::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func348::func;
 	return execfunc(this, worldLevel);
 }
 
-namespace _func348
+namespace _func349
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4832,11 +4846,11 @@ namespace _func348
 void CrewBlueprint::RenderSkill(int x, int y, int length, int height, int skill)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int x_arg, int y_arg, int length_arg, int height_arg, int skill_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func348::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func349::func;
 	return execfunc(this, x, y, length, height, skill);
 }
 
-namespace _func349
+namespace _func350
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4846,11 +4860,11 @@ namespace _func349
 void CrewBlueprint::RenderIcon(float opacity)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, float opacity_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func349::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func350::func;
 	return execfunc(this, opacity);
 }
 
-namespace _func350
+namespace _func351
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4860,11 +4874,11 @@ namespace _func350
 void CrewBlueprint::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func350::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func351::func;
 	return execfunc(this);
 }
 
-namespace _func351
+namespace _func352
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4874,11 +4888,11 @@ namespace _func351
 std::string CrewBlueprint::GetNameShort()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func351::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func352::func;
 	return execfunc(this);
 }
 
-namespace _func352
+namespace _func353
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4888,11 +4902,11 @@ namespace _func352
 GL_Color CrewBlueprint::GetCurrentSkillColor(int skill)
 {
 	typedef GL_Color __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int skill_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func352::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func353::func;
 	return execfunc(this, skill);
 }
 
-namespace _func353
+namespace _func354
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -4902,11 +4916,11 @@ namespace _func353
 void CrewBox::constructor(Point pos, CrewMember *crew, int number)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg, Point pos_arg, CrewMember *crew_arg, int number_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func353::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func354::func;
 	return execfunc(this, pos, crew, number);
 }
 
-namespace _func354
+namespace _func355
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4916,11 +4930,11 @@ namespace _func354
 void CrewBox::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func354::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func355::func;
 	return execfunc(this);
 }
 
-namespace _func355
+namespace _func356
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4930,11 +4944,11 @@ namespace _func355
 CrewMember *CrewBox::GetSelected(int mouseX, int mouseY)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg, int mouseX_arg, int mouseY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func355::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func356::func;
 	return execfunc(this, mouseX, mouseY);
 }
 
-namespace _func356
+namespace _func357
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4944,11 +4958,11 @@ namespace _func356
 void CrewBox::OnLoop(bool selected)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg, bool selected_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func356::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func357::func;
 	return execfunc(this, selected);
 }
 
-namespace _func357
+namespace _func358
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4956,20 +4970,6 @@ namespace _func357
 }
 
 void CrewBox::OnRenderSkillLevel()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func357::func;
-	return execfunc(this);
-}
-
-namespace _func358
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewBox::destructor", typeid(void (CrewBox::*)()), "5557565383ec2c8b7424408b8628010000890424", argdata, 1, 6, &func);
-}
-
-void CrewBox::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func358::func;
@@ -4980,12 +4980,12 @@ namespace _func359
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewBox::MouseClick", typeid(bool (CrewBox::*)()), "83ec1c8b5424200fb64268", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CrewBox::destructor", typeid(void (CrewBox::*)()), "5557565383ec2c8b7424408b8628010000890424", argdata, 1, 6, &func);
 }
 
-bool CrewBox::MouseClick()
+void CrewBox::destructor()
 {
-	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func359::func;
 	return execfunc(this);
 }
@@ -4994,12 +4994,12 @@ namespace _func360
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewBox::RenderIcon", typeid(void (CrewBox::*)()), "565383ec348b5c24408b4320", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewBox::MouseClick", typeid(bool (CrewBox::*)()), "83ec1c8b5424200fb64268", argdata, 1, 2, &func);
 }
 
-void CrewBox::RenderIcon()
+bool CrewBox::MouseClick()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func360::func;
 	return execfunc(this);
 }
@@ -5008,10 +5008,10 @@ namespace _func361
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewBox::RenderLabels", typeid(void (CrewBox::*)()), "5589e557565383ec5c8b75088d5dd4", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewBox::RenderIcon", typeid(void (CrewBox::*)()), "565383ec348b5c24408b4320", argdata, 1, 6, &func);
 }
 
-void CrewBox::RenderLabels()
+void CrewBox::RenderIcon()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func361::func;
@@ -5022,10 +5022,10 @@ namespace _func362
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewBox::RenderCloneDying", typeid(void (CrewBox::*)()), "83ec3c8b44244080b80801000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewBox::RenderLabels", typeid(void (CrewBox::*)()), "5589e557565383ec5c8b75088d5dd4", argdata, 1, 6, &func);
 }
 
-void CrewBox::RenderCloneDying()
+void CrewBox::RenderLabels()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func362::func;
@@ -5036,12 +5036,12 @@ namespace _func363
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewControl::OnRender", typeid(void (CrewControl::*)()), "5589e557565381ec8c0000008b5d088b4b3c8b4340", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewBox::RenderCloneDying", typeid(void (CrewBox::*)()), "83ec3c8b44244080b80801000000", argdata, 1, 6, &func);
 }
 
-void CrewControl::OnRender()
+void CrewBox::RenderCloneDying()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func363::func;
 	return execfunc(this);
 }
@@ -5050,10 +5050,10 @@ namespace _func364
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewControl::OnLoop", typeid(void (CrewControl::*)()), "5589e557565383ec4c8b5d088db388000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewControl::OnRender", typeid(void (CrewControl::*)()), "5589e557565381ec8c0000008b5d088b4b3c8b4340", argdata, 1, 6, &func);
 }
 
-void CrewControl::OnLoop()
+void CrewControl::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func364::func;
@@ -5064,10 +5064,10 @@ namespace _func365
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewControl::UpdateCrewBoxes", typeid(void (CrewControl::*)()), "5557565383ec4c8b5c24608d442430", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewControl::OnLoop", typeid(void (CrewControl::*)()), "5589e557565383ec4c8b5d088db388000000", argdata, 1, 6, &func);
 }
 
-void CrewControl::UpdateCrewBoxes()
+void CrewControl::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func365::func;
@@ -5077,6 +5077,20 @@ void CrewControl::UpdateCrewBoxes()
 namespace _func366
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CrewControl::UpdateCrewBoxes", typeid(void (CrewControl::*)()), "5557565383ec4c8b5c24608d442430", argdata, 1, 6, &func);
+}
+
+void CrewControl::UpdateCrewBoxes()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func366::func;
+	return execfunc(this);
+}
+
+namespace _func367
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CrewControl::LinkShip", typeid(void (CrewControl::*)(ShipManager *)), "5383ec188b5c24208b4424248903891c24", argdata, 2, 6, &func);
 }
@@ -5084,11 +5098,11 @@ namespace _func366
 void CrewControl::LinkShip(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func366::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func367::func;
 	return execfunc(this, ship);
 }
 
-namespace _func367
+namespace _func368
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5098,11 +5112,11 @@ namespace _func367
 void CrewControl::MouseMove(int mX, int mY, int wX, int wY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, int wX_arg, int wY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func367::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func368::func;
 	return execfunc(this, mX, mY, wX, wY);
 }
 
-namespace _func368
+namespace _func369
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5112,11 +5126,11 @@ namespace _func368
 void CrewControl::LButton(int mX, int mY, int wX, int wY, bool shiftHeld)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, int wX_arg, int wY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func368::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func369::func;
 	return execfunc(this, mX, mY, wX, wY, shiftHeld);
 }
 
-namespace _func369
+namespace _func370
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5126,11 +5140,11 @@ namespace _func369
 void CrewControl::ClearDeadCrew(std::vector<CrewMember*> *crew)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg, std::vector<CrewMember*> *crew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func369::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func370::func;
 	return execfunc(this, crew);
 }
 
-namespace _func370
+namespace _func371
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5140,11 +5154,11 @@ namespace _func370
 void CrewControl::ClearCrewBoxes()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func370::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func371::func;
 	return execfunc(this);
 }
 
-namespace _func371
+namespace _func372
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -5154,11 +5168,11 @@ namespace _func371
 void CrewControl::SelectPotentialCrew(CrewMember *crew, bool allowTeleportLeaving)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg, CrewMember *crew_arg, bool allowTeleportLeaving_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func371::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func372::func;
 	return execfunc(this, crew, allowTeleportLeaving);
 }
 
-namespace _func372
+namespace _func373
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5168,11 +5182,11 @@ namespace _func372
 void CrewControl::KeyDown(SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func372::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func373::func;
 	return execfunc(this, key);
 }
 
-namespace _func373
+namespace _func374
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5182,11 +5196,11 @@ namespace _func373
 void CrewControl::RButton(int mX, int mY, bool shiftHeld)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func373::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func374::func;
 	return execfunc(this, mX, mY, shiftHeld);
 }
 
-namespace _func374
+namespace _func375
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5196,11 +5210,11 @@ namespace _func374
 void CrewControl::SelectCrew(bool keep_current)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg, bool keep_current_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func374::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func375::func;
 	return execfunc(this, keep_current);
 }
 
-namespace _func375
+namespace _func376
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5210,11 +5224,11 @@ namespace _func375
 void CrewCustomizeBox::CheckContents()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewCustomizeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func375::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func376::func;
 	return execfunc(this);
 }
 
-namespace _func376
+namespace _func377
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5224,11 +5238,11 @@ namespace _func376
 void CrewDrone::constructor(const std::string &type, const std::string &name, int shipId, const DroneBlueprint *blueprint, CrewAnimation *anim)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewDrone *this_arg, const std::string &type_arg, const std::string &name_arg, int shipId_arg, const DroneBlueprint *blueprint_arg, CrewAnimation *anim_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func376::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func377::func;
 	return execfunc(this, type, name, shipId, blueprint, anim);
 }
 
-namespace _func377
+namespace _func378
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5238,11 +5252,11 @@ namespace _func377
 void CrewDrone::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func377::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func378::func;
 	return execfunc(this);
 }
 
-namespace _func378
+namespace _func379
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5252,11 +5266,11 @@ namespace _func378
 bool CrewDrone::ProvidesVision()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func378::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func379::func;
 	return execfunc(this);
 }
 
-namespace _func379
+namespace _func380
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5266,11 +5280,11 @@ namespace _func379
 void CrewDrone::SetCurrentShip(int shipId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewDrone *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func379::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func380::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func380
+namespace _func381
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5280,11 +5294,11 @@ namespace _func380
 void CrewDrone::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func380::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func381::func;
 	return execfunc(this);
 }
 
-namespace _func381
+namespace _func382
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5294,11 +5308,11 @@ namespace _func381
 void CrewEquipBox::RemoveItem()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func381::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func382::func;
 	return execfunc(this);
 }
 
-namespace _func382
+namespace _func383
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -5308,11 +5322,11 @@ namespace _func382
 void CrewEquipBox::constructor(Point pos, ShipManager *ship, int slot)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, Point pos_arg, ShipManager *ship_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func382::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func383::func;
 	return execfunc(this, pos, ship, slot);
 }
 
-namespace _func383
+namespace _func384
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5322,11 +5336,11 @@ namespace _func383
 bool CrewEquipBox::GetConfirmDelete()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func383::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func384::func;
 	return execfunc(this);
 }
 
-namespace _func384
+namespace _func385
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -5336,11 +5350,11 @@ namespace _func384
 void CrewEquipBox::RenderLabels(bool dragging, bool isNew)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, bool dragging_arg, bool isNew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func384::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func385::func;
 	return execfunc(this, dragging, isNew);
 }
 
-namespace _func385
+namespace _func386
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5350,11 +5364,11 @@ namespace _func385
 void CrewEquipBox::OnRender(bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func385::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func386::func;
 	return execfunc(this, unk);
 }
 
-namespace _func386
+namespace _func387
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5364,11 +5378,11 @@ namespace _func386
 void CrewEquipBox::OnTextInput(SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func386::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func387::func;
 	return execfunc(this, key);
 }
 
-namespace _func387
+namespace _func388
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5378,11 +5392,11 @@ namespace _func387
 void CrewEquipBox::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func387::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func388::func;
 	return execfunc(this, event);
 }
 
-namespace _func388
+namespace _func389
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5392,11 +5406,11 @@ namespace _func388
 void CrewEquipBox::MouseClick()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func388::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func389::func;
 	return execfunc(this);
 }
 
-namespace _func389
+namespace _func390
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5406,11 +5420,11 @@ namespace _func389
 void CrewEquipBox::CloseRename()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func389::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func390::func;
 	return execfunc(this);
 }
 
-namespace _func390
+namespace _func391
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5420,11 +5434,11 @@ namespace _func390
 void CrewManifest::OnInit(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func390::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func391::func;
 	return execfunc(this, ship);
 }
 
-namespace _func391
+namespace _func392
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5432,20 +5446,6 @@ namespace _func391
 }
 
 void CrewManifest::OnRender()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func391::func;
-	return execfunc(this);
-}
-
-namespace _func392
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewManifest::Update", typeid(void (CrewManifest::*)()), "565383ec448b7424508d442420", argdata, 1, 6, &func);
-}
-
-void CrewManifest::Update()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func392::func;
@@ -5456,10 +5456,10 @@ namespace _func393
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewManifest::constructor", typeid(void (CrewManifest::*)()), "5557565381ec8c0000008bbc24a00000008d5c24708d7424688d6c2458", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewManifest::Update", typeid(void (CrewManifest::*)()), "565383ec448b7424508d442420", argdata, 1, 6, &func);
 }
 
-void CrewManifest::constructor()
+void CrewManifest::Update()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func393::func;
@@ -5469,25 +5469,25 @@ void CrewManifest::constructor()
 namespace _func394
 {
     static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CrewManifest::OnKeyDown", typeid(void (CrewManifest::*)(SDLKey )), ".57565331db83ec108b7c24208b7424248b57708b477429d0c1f80285c0", argdata, 2, 6, &func);
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CrewManifest::constructor", typeid(void (CrewManifest::*)()), "5557565381ec8c0000008bbc24a00000008d5c24708d7424688d6c2458", argdata, 1, 6, &func);
 }
 
-void CrewManifest::OnKeyDown(SDLKey key)
+void CrewManifest::constructor()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func394::func;
-	return execfunc(this, key);
+	return execfunc(this);
 }
 
 namespace _func395
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CrewManifest::OnKeyUp", typeid(void (CrewManifest::*)(SDLKey )), ".57565331db83ec108b7c24208b7424248b57708b477429d0c1f80285c0", argdata, 2, 6, &func);
+	static FunctionDefinition funcObj("CrewManifest::OnKeyDown", typeid(void (CrewManifest::*)(SDLKey )), ".57565331db83ec108b7c24208b7424248b57708b477429d0c1f80285c0", argdata, 2, 6, &func);
 }
 
-void CrewManifest::OnKeyUp(SDLKey key)
+void CrewManifest::OnKeyDown(SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func395::func;
@@ -5498,10 +5498,10 @@ namespace _func396
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CrewManifest::OnTextInput", typeid(void (CrewManifest::*)(SDLKey )), ".57565331db83ec108b7c24208b7424248b57708b477429d0c1f80285c0", argdata, 2, 6, &func);
+	static FunctionDefinition funcObj("CrewManifest::OnKeyUp", typeid(void (CrewManifest::*)(SDLKey )), ".57565331db83ec108b7c24208b7424248b57708b477429d0c1f80285c0", argdata, 2, 6, &func);
 }
 
-void CrewManifest::OnTextInput(SDLKey key)
+void CrewManifest::OnKeyUp(SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func396::func;
@@ -5512,17 +5512,31 @@ namespace _func397
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("CrewManifest::OnTextInput", typeid(void (CrewManifest::*)(SDLKey )), ".57565331db83ec108b7c24208b7424248b57708b477429d0c1f80285c0", argdata, 2, 6, &func);
+}
+
+void CrewManifest::OnTextInput(SDLKey key)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func397::func;
+	return execfunc(this, key);
+}
+
+namespace _func398
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CrewManifest::OnTextEvent", typeid(void (CrewManifest::*)(CEvent::TextEvent )), ".57565331db83ec108b7c24208b7424248b57708b477429d0c1f80285c0", argdata, 2, 6, &func);
 }
 
 void CrewManifest::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func397::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func398::func;
 	return execfunc(this, event);
 }
 
-namespace _func398
+namespace _func399
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5532,11 +5546,11 @@ namespace _func398
 void CrewManifest::Close()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func398::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func399::func;
 	return execfunc(this);
 }
 
-namespace _func399
+namespace _func400
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -5546,11 +5560,11 @@ namespace _func399
 void CrewManifest::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func399::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func400::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func400
+namespace _func401
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -5560,11 +5574,11 @@ namespace _func400
 void CrewManifest::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func400::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func401::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func401
+namespace _func402
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5574,11 +5588,11 @@ namespace _func401
 void CrewMember::OnRender(bool outlineOnly)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool outlineOnly_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func401::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func402::func;
 	return execfunc(this, outlineOnly);
 }
 
-namespace _func402
+namespace _func403
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5588,11 +5602,11 @@ namespace _func402
 Damage CrewMember::GetRoomDamage()
 {
 	typedef Damage __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func402::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func403::func;
 	return execfunc(this);
 }
 
-namespace _func403
+namespace _func404
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5602,11 +5616,11 @@ namespace _func403
 void CrewMember::StartRepair(Repairable *toRepair)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Repairable *toRepair_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func403::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func404::func;
 	return execfunc(this, toRepair);
 }
 
-namespace _func404
+namespace _func405
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5614,20 +5628,6 @@ namespace _func404
 }
 
 void CrewMember::UpdateRepair()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func404::func;
-	return execfunc(this);
-}
-
-namespace _func405
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::UpdateMovement", typeid(void (CrewMember::*)()), "5589e5565383ec408b5d088b839c00000083783806", argdata, 1, 6, &func);
-}
-
-void CrewMember::UpdateMovement()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func405::func;
@@ -5638,10 +5638,10 @@ namespace _func406
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::OnLoop", typeid(void (CrewMember::*)()), "5589e557565381ec8c0000008b5d0880bbac01000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewMember::UpdateMovement", typeid(void (CrewMember::*)()), "5589e5565383ec408b5d088b839c00000083783806", argdata, 1, 6, &func);
 }
 
-void CrewMember::OnLoop()
+void CrewMember::UpdateMovement()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func406::func;
@@ -5651,6 +5651,20 @@ void CrewMember::OnLoop()
 namespace _func407
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CrewMember::OnLoop", typeid(void (CrewMember::*)()), "5589e557565381ec8c0000008b5d0880bbac01000000", argdata, 1, 6, &func);
+}
+
+void CrewMember::OnLoop()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func407::func;
+	return execfunc(this);
+}
+
+namespace _func408
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CrewMember::GetTooltip", typeid(std::string (CrewMember::*)()), "5589e557565381ec8c0000008b45088d5dd8895c2408", argdata, 2, 18, &func);
 }
@@ -5658,11 +5672,11 @@ namespace _func407
 std::string CrewMember::GetTooltip()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func407::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func408::func;
 	return execfunc(this);
 }
 
-namespace _func408
+namespace _func409
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -5672,11 +5686,11 @@ namespace _func408
 std::string CrewMember::GetSkillTooltip(int skillId, int skillLevel, std::pair<int, int> progress, bool infoScreen)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(int skillId_arg, int skillLevel_arg, std::pair<int, int> progress_arg, bool infoScreen_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func408::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func409::func;
 	return execfunc(skillId, skillLevel, progress, infoScreen);
 }
 
-namespace _func409
+namespace _func410
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5686,11 +5700,11 @@ namespace _func409
 void CrewMember::SetSex(bool male)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool male_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func409::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func410::func;
 	return execfunc(this, male);
 }
 
-namespace _func410
+namespace _func411
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5700,11 +5714,11 @@ namespace _func410
 void CrewMember::CycleColorLayer(int unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func410::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func411::func;
 	return execfunc(this, unk);
 }
 
-namespace _func411
+namespace _func412
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5714,11 +5728,11 @@ namespace _func411
 void CrewMember::constructor(CrewBlueprint &blueprint, int shipId, bool intruder, CrewAnimation *animation)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewBlueprint &blueprint_arg, int shipId_arg, bool intruder_arg, CrewAnimation *animation_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func411::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func412::func;
 	return execfunc(this, blueprint, shipId, intruder, animation);
 }
 
-namespace _func412
+namespace _func413
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5726,20 +5740,6 @@ namespace _func412
 }
 
 bool CrewMember::Functional()
-{
-	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func412::func;
-	return execfunc(this);
-}
-
-namespace _func413
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::CountForVictory", typeid(bool (CrewMember::*)()), "5383ec188b5c24208b03891c24ff9088000000", argdata, 1, 2, &func);
-}
-
-bool CrewMember::CountForVictory()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func413::func;
@@ -5750,10 +5750,10 @@ namespace _func414
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::CanSabotage", typeid(bool (CrewMember::*)()), "8b4424040fb68098000000", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CrewMember::CountForVictory", typeid(bool (CrewMember::*)()), "5383ec188b5c24208b03891c24ff9088000000", argdata, 1, 2, &func);
 }
 
-bool CrewMember::CanSabotage()
+bool CrewMember::CountForVictory()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func414::func;
@@ -5764,10 +5764,10 @@ namespace _func415
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::CanMan", typeid(bool (CrewMember::*)()), "8b54240431c080ba9800000000", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CrewMember::CanSabotage", typeid(bool (CrewMember::*)()), "8b4424040fb68098000000", argdata, 1, 2, &func);
 }
 
-bool CrewMember::CanMan()
+bool CrewMember::CanSabotage()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func415::func;
@@ -5778,10 +5778,10 @@ namespace _func416
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::CanRepair", typeid(bool (CrewMember::*)()), "5383ec188b5c242080bb9800000000", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CrewMember::CanMan", typeid(bool (CrewMember::*)()), "8b54240431c080ba9800000000", argdata, 1, 2, &func);
 }
 
-bool CrewMember::CanRepair()
+bool CrewMember::CanMan()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func416::func;
@@ -5792,10 +5792,10 @@ namespace _func417
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::GetControllable", typeid(bool (CrewMember::*)()), "5331c083ec188b5c24208b530485d2", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CrewMember::CanRepair", typeid(bool (CrewMember::*)()), "5383ec188b5c242080bb9800000000", argdata, 1, 2, &func);
 }
 
-bool CrewMember::GetControllable()
+bool CrewMember::CanRepair()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func417::func;
@@ -5806,10 +5806,10 @@ namespace _func418
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::CanHeal", typeid(bool (CrewMember::*)()), "5383ec188b5c2420f30f1043280f2e432c", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CrewMember::GetControllable", typeid(bool (CrewMember::*)()), "5331c083ec188b5c24208b530485d2", argdata, 1, 2, &func);
 }
 
-bool CrewMember::CanHeal()
+bool CrewMember::GetControllable()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func418::func;
@@ -5820,17 +5820,31 @@ namespace _func419
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CrewMember::CanHeal", typeid(bool (CrewMember::*)()), "5383ec188b5c2420f30f1043280f2e432c", argdata, 1, 2, &func);
+}
+
+bool CrewMember::CanHeal()
+{
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func419::func;
+	return execfunc(this);
+}
+
+namespace _func420
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("CrewMember::Jump", typeid(void (CrewMember::*)()), "!8b4424048b908803000083420c018b108b82cc000000", argdata, 1, 6, &func);
 }
 
 void CrewMember::Jump()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func419::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func420::func;
 	return execfunc(this);
 }
 
-namespace _func420
+namespace _func421
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5840,11 +5854,11 @@ namespace _func420
 bool CrewMember::GetIntruder()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func420::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func421::func;
 	return execfunc(this);
 }
 
-namespace _func421
+namespace _func422
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5854,11 +5868,11 @@ namespace _func421
 void CrewMember::SetOutOfGame()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func421::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func422::func;
 	return execfunc(this);
 }
 
-namespace _func422
+namespace _func423
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5868,11 +5882,11 @@ namespace _func422
 float CrewMember::PositionShift()
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func422::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func423::func;
 	return execfunc(this);
 }
 
-namespace _func423
+namespace _func424
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5882,11 +5896,11 @@ namespace _func423
 void CrewMember::SaveState(int fileHelper)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func423::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func424::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func424
+namespace _func425
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5896,11 +5910,11 @@ namespace _func424
 bool CrewMember::CanTeleport()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func424::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func425::func;
 	return execfunc(this);
 }
 
-namespace _func425
+namespace _func426
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5910,11 +5924,11 @@ namespace _func425
 void CrewMember::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func425::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func426::func;
 	return execfunc(this);
 }
 
-namespace _func426
+namespace _func427
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5924,11 +5938,11 @@ namespace _func426
 void CrewMember::Cleanup()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func426::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func427::func;
 	return execfunc(this);
 }
 
-namespace _func427
+namespace _func428
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5938,11 +5952,11 @@ namespace _func427
 void CrewMember::LoadState(int fileHelper)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func427::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func428::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func428
+namespace _func429
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5952,11 +5966,11 @@ namespace _func428
 void CrewMember::SetCurrentSystem(ShipSystem *sys)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, ShipSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func428::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func429::func;
 	return execfunc(this, sys);
 }
 
-namespace _func429
+namespace _func430
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5966,11 +5980,11 @@ namespace _func429
 bool CrewMember::IsManningArtillery()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func429::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func430::func;
 	return execfunc(this);
 }
 
-namespace _func430
+namespace _func431
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5980,11 +5994,11 @@ namespace _func430
 void CrewMember::IncreaseSkill(int skillId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func430::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func431::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func431
+namespace _func432
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5994,11 +6008,11 @@ namespace _func431
 void CrewMember::CheckSkills()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func431::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func432::func;
 	return execfunc(this);
 }
 
-namespace _func432
+namespace _func433
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6008,11 +6022,11 @@ namespace _func432
 void CrewMember::MasterSkill(int skillId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func432::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func433::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func433
+namespace _func434
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6022,11 +6036,11 @@ namespace _func433
 int CrewMember::GetSkillFromSystem(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func433::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func434::func;
 	return execfunc(systemId);
 }
 
-namespace _func434
+namespace _func435
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6036,11 +6050,11 @@ namespace _func434
 void CrewMember::SetResisted(bool resisted)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool resisted_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func434::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func435::func;
 	return execfunc(this, resisted);
 }
 
-namespace _func435
+namespace _func436
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6050,11 +6064,11 @@ namespace _func435
 bool CrewMember::GetResisted()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func435::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func436::func;
 	return execfunc(this);
 }
 
-namespace _func436
+namespace _func437
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -6064,11 +6078,11 @@ namespace _func436
 void CrewMember::SetSkillProgress(int skillId, int skillLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg, int skillLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func436::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func437::func;
 	return execfunc(this, skillId, skillLevel);
 }
 
-namespace _func437
+namespace _func438
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6078,11 +6092,11 @@ namespace _func437
 int CrewMember::GetSkillLevel(int skillId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func437::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func438::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func438
+namespace _func439
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -6092,11 +6106,11 @@ namespace _func438
 std::pair<int, int> CrewMember::GetSkillProgress(int skillId)
 {
 	typedef std::pair<int, int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func438::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func439::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func439
+namespace _func440
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6106,11 +6120,11 @@ namespace _func439
 float CrewMember::GetSkillModifier(int skillId)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func439::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func440::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func440
+namespace _func441
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6120,11 +6134,11 @@ namespace _func440
 bool CrewMember::BadAtCombat()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func440::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func441::func;
 	return execfunc(this);
 }
 
-namespace _func441
+namespace _func442
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6134,11 +6148,11 @@ namespace _func441
 void CrewMember::EmptySlot()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func441::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func442::func;
 	return execfunc(this);
 }
 
-namespace _func442
+namespace _func443
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6148,11 +6162,11 @@ namespace _func442
 bool CrewMember::NeedsSlot()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func442::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func443::func;
 	return execfunc(this);
 }
 
-namespace _func443
+namespace _func444
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6162,11 +6176,11 @@ namespace _func443
 bool CrewMember::DirectModifyHealth(float health)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func443::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func444::func;
 	return execfunc(this, health);
 }
 
-namespace _func444
+namespace _func445
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6176,11 +6190,11 @@ namespace _func444
 void CrewMember::ModifyHealth(float health)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func444::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func445::func;
 	return execfunc(this, health);
 }
 
-namespace _func445
+namespace _func446
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6190,11 +6204,11 @@ namespace _func445
 bool CrewMember::ApplyDamage(float damage)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func445::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func446::func;
 	return execfunc(this, damage);
 }
 
-namespace _func446
+namespace _func447
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6202,20 +6216,6 @@ namespace _func446
 }
 
 bool CrewMember::RepairingSystem()
-{
-	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func446::func;
-	return execfunc(this);
-}
-
-namespace _func447
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::Sabotaging", typeid(bool (CrewMember::*)()), "5383ec188b5c24208b436885c074??8b10", argdata, 1, 2, &func);
-}
-
-bool CrewMember::Sabotaging()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func447::func;
@@ -6226,10 +6226,10 @@ namespace _func448
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::RepairingFire", typeid(bool (CrewMember::*)()), "8b54240431c08b4a6885c9", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CrewMember::Sabotaging", typeid(bool (CrewMember::*)()), "5383ec188b5c24208b436885c074??8b10", argdata, 1, 2, &func);
 }
 
-bool CrewMember::RepairingFire()
+bool CrewMember::Sabotaging()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func448::func;
@@ -6239,6 +6239,20 @@ bool CrewMember::RepairingFire()
 namespace _func449
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CrewMember::RepairingFire", typeid(bool (CrewMember::*)()), "8b54240431c08b4a6885c9", argdata, 1, 2, &func);
+}
+
+bool CrewMember::RepairingFire()
+{
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func449::func;
+	return execfunc(this);
+}
+
+namespace _func450
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CrewMember::SelectSabotageTarget", typeid(Pointf (CrewMember::*)()), "5589e557565383ec2c8b750c8b5d088b4668", argdata, 2, 18, &func);
 }
@@ -6246,11 +6260,11 @@ namespace _func449
 Pointf CrewMember::SelectSabotageTarget()
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func449::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func450::func;
 	return execfunc(this);
 }
 
-namespace _func450
+namespace _func451
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6260,11 +6274,11 @@ namespace _func450
 void CrewMember::SavePosition()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func450::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func451::func;
 	return execfunc(this);
 }
 
-namespace _func451
+namespace _func452
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6274,11 +6288,11 @@ namespace _func451
 void CrewMember::ClearPosition()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func451::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func452::func;
 	return execfunc(this);
 }
 
-namespace _func452
+namespace _func453
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6288,11 +6302,11 @@ namespace _func452
 Slot CrewMember::GetSavedPosition()
 {
 	typedef Slot __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func452::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func453::func;
 	return execfunc(this);
 }
 
-namespace _func453
+namespace _func454
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff};
@@ -6302,11 +6316,11 @@ namespace _func453
 void CrewMember::SetSavePosition(Slot position)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Slot position_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func453::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func454::func;
 	return execfunc(this, position);
 }
 
-namespace _func454
+namespace _func455
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6316,11 +6330,11 @@ namespace _func454
 void CrewMember::StopRepairing()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func454::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func455::func;
 	return execfunc(this);
 }
 
-namespace _func455
+namespace _func456
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6330,11 +6344,11 @@ namespace _func455
 bool CrewMember::Repairing()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func455::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func456::func;
 	return execfunc(this);
 }
 
-namespace _func456
+namespace _func457
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6344,11 +6358,11 @@ namespace _func456
 void CrewMember::SetFrozen(bool frozen)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool frozen_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func456::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func457::func;
 	return execfunc(this, frozen);
 }
 
-namespace _func457
+namespace _func458
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6358,11 +6372,11 @@ namespace _func457
 void CrewMember::SetFrozenLocation(bool frozenLocation)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool frozenLocation_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func457::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func458::func;
 	return execfunc(this, frozenLocation);
 }
 
-namespace _func458
+namespace _func459
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x3ff};
@@ -6372,11 +6386,11 @@ namespace _func458
 void CrewMember::SetTask(CrewTask task)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewTask task_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func458::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func459::func;
 	return execfunc(this, task);
 }
 
-namespace _func459
+namespace _func460
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -6386,11 +6400,11 @@ namespace _func459
 Slot CrewMember::FindSlot(int roomId, int slotId, bool closeEnough)
 {
 	typedef Slot __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg, int slotId_arg, bool closeEnough_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func459::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func460::func;
 	return execfunc(this, roomId, slotId, closeEnough);
 }
 
-namespace _func460
+namespace _func461
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6400,11 +6414,11 @@ namespace _func460
 bool CrewMember::CheckRoomPath(int roomId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func460::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func461::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func461
+namespace _func462
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -6414,11 +6428,11 @@ namespace _func461
 void CrewMember::SetPosition(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func461::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func462::func;
 	return execfunc(this, pos);
 }
 
-namespace _func462
+namespace _func463
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6428,11 +6442,11 @@ namespace _func462
 void CrewMember::ClearTask()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func462::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func463::func;
 	return execfunc(this);
 }
 
-namespace _func463
+namespace _func464
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6442,11 +6456,11 @@ namespace _func463
 void CrewMember::ClearPath()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func463::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func464::func;
 	return execfunc(this);
 }
 
-namespace _func464
+namespace _func465
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6456,11 +6470,11 @@ namespace _func464
 void CrewMember::SetRoom(int roomId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func464::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func465::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func465
+namespace _func466
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6470,11 +6484,11 @@ namespace _func465
 bool CrewMember::IsBusy()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func465::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func466::func;
 	return execfunc(this);
 }
 
-namespace _func466
+namespace _func467
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6484,20 +6498,6 @@ namespace _func466
 bool CrewMember::OnInit()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func466::func;
-	return execfunc(this);
-}
-
-namespace _func467
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CrewMember::GetFinalGoal", typeid(Point (CrewMember::*)()), "83ec1c8b542424f30f1005????????", argdata, 2, 18, &func);
-}
-
-Point CrewMember::GetFinalGoal()
-{
-	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func467::func;
 	return execfunc(this);
 }
@@ -6506,10 +6506,10 @@ namespace _func468
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CrewMember::GetNextGoal", typeid(Point (CrewMember::*)()), "57565383ec108b7424248b5c2420f30f10461c", argdata, 2, 18, &func);
+	static FunctionDefinition funcObj("CrewMember::GetFinalGoal", typeid(Point (CrewMember::*)()), "83ec1c8b542424f30f1005????????", argdata, 2, 18, &func);
 }
 
-Point CrewMember::GetNextGoal()
+Point CrewMember::GetFinalGoal()
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func468::func;
@@ -6520,17 +6520,31 @@ namespace _func469
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("CrewMember::GetNextGoal", typeid(Point (CrewMember::*)()), "57565383ec108b7424248b5c2420f30f10461c", argdata, 2, 18, &func);
+}
+
+Point CrewMember::GetNextGoal()
+{
+	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func469::func;
+	return execfunc(this);
+}
+
+namespace _func470
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CrewMember::CloseDoorBehind", typeid(void (CrewMember::*)(Door *)), "8b5424088b442404895064", argdata, 2, 6, &func);
 }
 
 void CrewMember::CloseDoorBehind(Door *door)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Door *door_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func469::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func470::func;
 	return execfunc(this, door);
 }
 
-namespace _func470
+namespace _func471
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6540,11 +6554,11 @@ namespace _func470
 float CrewMember::GetMoveSpeed()
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func470::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func471::func;
 	return execfunc(this);
 }
 
-namespace _func471
+namespace _func472
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6554,11 +6568,11 @@ namespace _func471
 void CrewMember::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func471::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func472::func;
 	return execfunc(this);
 }
 
-namespace _func472
+namespace _func473
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6568,11 +6582,11 @@ namespace _func472
 void CrewMember::SetDamageBoost(float damageBoost)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float damageBoost_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func472::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func473::func;
 	return execfunc(this, damageBoost);
 }
 
-namespace _func473
+namespace _func474
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6582,11 +6596,11 @@ namespace _func473
 void CrewMember::SetHealthBoost(int healthBoost)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int healthBoost_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func473::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func474::func;
 	return execfunc(this, healthBoost);
 }
 
-namespace _func474
+namespace _func475
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6596,11 +6610,11 @@ namespace _func474
 void CrewMember::InitializeSkills()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func474::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func475::func;
 	return execfunc(this);
 }
 
-namespace _func475
+namespace _func476
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6610,11 +6624,11 @@ namespace _func475
 void CrewMember::SetCloneReady(bool cloneReady)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool cloneReady_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func475::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func476::func;
 	return execfunc(this, cloneReady);
 }
 
-namespace _func476
+namespace _func477
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6624,11 +6638,11 @@ namespace _func476
 void CrewMember::Kill(bool noClone)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool noClone_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func476::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func477::func;
 	return execfunc(this, noClone);
 }
 
-namespace _func477
+namespace _func478
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6638,11 +6652,11 @@ namespace _func477
 bool CrewMember::NeedFrozenLocation()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func477::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func478::func;
 	return execfunc(this);
 }
 
-namespace _func478
+namespace _func479
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6652,11 +6666,11 @@ namespace _func478
 void CrewMember::CheckForTeleport()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func478::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func479::func;
 	return execfunc(this);
 }
 
-namespace _func479
+namespace _func480
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6666,11 +6680,11 @@ namespace _func479
 void CrewMember::SetCurrentShip(int shipId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func479::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func480::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func480
+namespace _func481
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6680,11 +6694,11 @@ namespace _func480
 void CrewMember::CheckFighting()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func480::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func481::func;
 	return execfunc(this);
 }
 
-namespace _func481
+namespace _func482
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6694,11 +6708,11 @@ namespace _func481
 void CrewMember::SetDeathNumber(int deathNum)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int deathNum_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func481::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func482::func;
 	return execfunc(this, deathNum);
 }
 
-namespace _func482
+namespace _func483
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6708,11 +6722,11 @@ namespace _func482
 void CrewMember::ForceMindControl(bool force)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func482::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func483::func;
 	return execfunc(this, force);
 }
 
-namespace _func483
+namespace _func484
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -6722,11 +6736,11 @@ namespace _func483
 void CrewMember::RenderSkillUpAnimation(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func483::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func484::func;
 	return execfunc(this, pos);
 }
 
-namespace _func484
+namespace _func485
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6734,20 +6748,6 @@ namespace _func484
 }
 
 void CrewMember::Clone()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func484::func;
-	return execfunc(this);
-}
-
-namespace _func485
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::UpdateHealth", typeid(void (CrewMember::*)()), "565383ec448b5c24508b83b0010000", argdata, 1, 6, &func);
-}
-
-void CrewMember::UpdateHealth()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func485::func;
@@ -6758,10 +6758,10 @@ namespace _func486
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::OnRenderPath", typeid(void (CrewMember::*)()), "5383ec288b5c24308b4b0485c9", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewMember::UpdateHealth", typeid(void (CrewMember::*)()), "565383ec448b5c24508b83b0010000", argdata, 1, 6, &func);
 }
 
-void CrewMember::OnRenderPath()
+void CrewMember::UpdateHealth()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func486::func;
@@ -6771,6 +6771,20 @@ void CrewMember::OnRenderPath()
 namespace _func487
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CrewMember::OnRenderPath", typeid(void (CrewMember::*)()), "5383ec288b5c24308b4b0485c9", argdata, 1, 6, &func);
+}
+
+void CrewMember::OnRenderPath()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func487::func;
+	return execfunc(this);
+}
+
+namespace _func488
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CrewMember::SetPath", typeid(bool (CrewMember::*)(Path *)), "5557565383ec3c8b742454f30f1005????????", argdata, 2, 2, &func);
 }
@@ -6778,11 +6792,11 @@ namespace _func487
 bool CrewMember::SetPath(Path *path)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Path *path_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func487::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func488::func;
 	return execfunc(this, path);
 }
 
-namespace _func488
+namespace _func489
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -6792,11 +6806,11 @@ namespace _func488
 void CrewMember::SetRoomPath(int slotId, int roomId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int slotId_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func488::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func489::func;
 	return execfunc(this, slotId, roomId);
 }
 
-namespace _func489
+namespace _func490
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6806,20 +6820,6 @@ namespace _func489
 Point CrewMember::GetLocation()
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func489::func;
-	return execfunc(this);
-}
-
-namespace _func490
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::AtGoal", typeid(bool (CrewMember::*)()), "8b442404f30f1015????????f30f100d????????f30f105818", argdata, 1, 2, &func);
-}
-
-bool CrewMember::AtGoal()
-{
-	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func490::func;
 	return execfunc(this);
 }
@@ -6828,10 +6828,10 @@ namespace _func491
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::AtFinalGoal", typeid(bool (CrewMember::*)()), ".8b442404f30f1015????????f30f2a8890000000f30f104008", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CrewMember::AtGoal", typeid(bool (CrewMember::*)()), "8b442404f30f1015????????f30f100d????????f30f105818", argdata, 1, 2, &func);
 }
 
-bool CrewMember::AtFinalGoal()
+bool CrewMember::AtGoal()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func491::func;
@@ -6842,17 +6842,31 @@ namespace _func492
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CrewMember::AtFinalGoal", typeid(bool (CrewMember::*)()), ".8b442404f30f1015????????f30f2a8890000000f30f104008", argdata, 1, 2, &func);
+}
+
+bool CrewMember::AtFinalGoal()
+{
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func492::func;
+	return execfunc(this);
+}
+
+namespace _func493
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("CrewMember::OnRenderHealth", typeid(void (CrewMember::*)()), "5589e557565381ecac0000008b7d0880bfac01000000", argdata, 1, 6, &func);
 }
 
 void CrewMember::OnRenderHealth()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func492::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func493::func;
 	return execfunc(this);
 }
 
-namespace _func493
+namespace _func494
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6862,11 +6876,11 @@ namespace _func493
 int CrewMember::GetIntegerHealth()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func493::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func494::func;
 	return execfunc(this);
 }
 
-namespace _func494
+namespace _func495
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6876,11 +6890,11 @@ namespace _func494
 int CrewMember::GetRepairingId()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func494::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func495::func;
 	return execfunc(this);
 }
 
-namespace _func495
+namespace _func496
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -6890,11 +6904,11 @@ namespace _func495
 bool CrewMember::WithinRect(int x, int y, int w, int h)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int x_arg, int y_arg, int w_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func495::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func496::func;
 	return execfunc(this, x, y, w, h);
 }
 
-namespace _func496
+namespace _func497
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6904,11 +6918,11 @@ namespace _func496
 std::string CrewMember::GetLongName()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func496::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func497::func;
 	return execfunc(this);
 }
 
-namespace _func497
+namespace _func498
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -6918,11 +6932,11 @@ namespace _func497
 void CrewMember::SetName(TextString *name, bool force)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, TextString *name_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func497::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func498::func;
 	return execfunc(this, name, force);
 }
 
-namespace _func498
+namespace _func499
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6932,11 +6946,11 @@ namespace _func498
 std::string CrewMember::GetName()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func498::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func499::func;
 	return execfunc(this);
 }
 
-namespace _func499
+namespace _func500
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -6946,11 +6960,11 @@ namespace _func499
 void CrewMember::SetCurrentTarget(CrewTarget *target, bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewTarget *target_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func499::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func500::func;
 	return execfunc(this, target, unk);
 }
 
-namespace _func500
+namespace _func501
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6960,11 +6974,11 @@ namespace _func500
 bool CrewMember::GetNewGoal()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func500::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func501::func;
 	return execfunc(this);
 }
 
-namespace _func501
+namespace _func502
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -6974,11 +6988,11 @@ namespace _func501
 bool CrewMember::MoveToRoom(int roomId, int slotId, bool forceMove)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg, int slotId_arg, bool forceMove_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func501::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func502::func;
 	return execfunc(this, roomId, slotId, forceMove);
 }
 
-namespace _func502
+namespace _func503
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6988,11 +7002,11 @@ namespace _func502
 void CrewMember::SetMindControl(bool controlled)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool controlled_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func502::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func503::func;
 	return execfunc(this, controlled);
 }
 
-namespace _func503
+namespace _func504
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7002,11 +7016,11 @@ namespace _func503
 bool CrewMember::RestorePosition()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func503::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func504::func;
 	return execfunc(this);
 }
 
-namespace _func504
+namespace _func505
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7016,11 +7030,11 @@ namespace _func504
 bool CrewMember::ContainsPoint(int x, int y)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func504::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func505::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func505
+namespace _func506
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7030,11 +7044,11 @@ namespace _func505
 void CrewMember::SetMedbay(float health)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func505::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func506::func;
 	return execfunc(this, health);
 }
 
-namespace _func506
+namespace _func507
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7044,11 +7058,11 @@ namespace _func506
 void CrewMember::StartTeleport()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func506::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func507::func;
 	return execfunc(this);
 }
 
-namespace _func507
+namespace _func508
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7058,11 +7072,11 @@ namespace _func507
 void CrewMember::StartTeleportArrive()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func507::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func508::func;
 	return execfunc(this);
 }
 
-namespace _func508
+namespace _func509
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7072,11 +7086,11 @@ namespace _func508
 bool CrewMember::InsideRoom(int roomId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func508::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func509::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func509
+namespace _func510
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7086,11 +7100,11 @@ namespace _func509
 std::string CrewMember::GetUniqueRepairing()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func509::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func510::func;
 	return execfunc(this);
 }
 
-namespace _func510
+namespace _func511
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7100,11 +7114,11 @@ namespace _func510
 void CrewMemberFactory::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func510::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func511::func;
 	return execfunc(this);
 }
 
-namespace _func511
+namespace _func512
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7114,11 +7128,11 @@ namespace _func511
 void CrewMemberFactory::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func511::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func512::func;
 	return execfunc(this);
 }
 
-namespace _func512
+namespace _func513
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7128,11 +7142,11 @@ namespace _func512
 int CrewMemberFactory::CountCloneReadyCrew(bool player)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, bool player_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func512::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func513::func;
 	return execfunc(this, player);
 }
 
-namespace _func513
+namespace _func514
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7142,11 +7156,11 @@ namespace _func513
 void CrewMemberFactory::GetCrewPortraitList(std::vector<CrewMember*> *vec, int teamId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> *vec_arg, int teamId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func513::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func514::func;
 	return execfunc(this, vec, teamId);
 }
 
-namespace _func514
+namespace _func515
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -7156,11 +7170,11 @@ namespace _func514
 void CrewMemberFactory::GetCrewList(std::vector<CrewMember*> *vec, int unk, bool unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> *vec_arg, int unk_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func514::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func515::func;
 	return execfunc(this, vec, unk, unk2);
 }
 
-namespace _func515
+namespace _func516
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7170,11 +7184,11 @@ namespace _func515
 int CrewMemberFactory::GetPlayerCrewCount()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func515::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func516::func;
 	return execfunc(this);
 }
 
-namespace _func516
+namespace _func517
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7184,11 +7198,11 @@ namespace _func516
 int CrewMemberFactory::GetEnemyCloneCount()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func516::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func517::func;
 	return execfunc(this);
 }
 
-namespace _func517
+namespace _func518
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7198,11 +7212,11 @@ namespace _func517
 int CrewMemberFactory::GetCrewCount(bool enemy)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func517::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func518::func;
 	return execfunc(this, enemy);
 }
 
-namespace _func518
+namespace _func519
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7212,11 +7226,11 @@ namespace _func518
 int CrewMemberFactory::GetEnemyCrewCount()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func518::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func519::func;
 	return execfunc(this);
 }
 
-namespace _func519
+namespace _func520
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7226,11 +7240,11 @@ namespace _func519
 bool CrewMemberFactory::IsRace(const std::string &species)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &species_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func519::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func520::func;
 	return execfunc(species);
 }
 
-namespace _func520
+namespace _func521
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7240,11 +7254,11 @@ namespace _func520
 BoarderDrone *CrewMemberFactory::CreateBoarderDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef BoarderDrone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func520::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func521::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func521
+namespace _func522
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7254,11 +7268,11 @@ namespace _func521
 BattleDrone *CrewMemberFactory::CreateBattleDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef BattleDrone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func521::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func522::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func522
+namespace _func523
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7268,11 +7282,11 @@ namespace _func522
 void CrewMemberFactory::GetCloneReadyList(std::vector<CrewMember*> &vec, bool player)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> &vec_arg, bool player_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func522::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func523::func;
 	return execfunc(this, vec, player);
 }
 
-namespace _func523
+namespace _func524
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7282,11 +7296,11 @@ namespace _func523
 RepairDrone *CrewMemberFactory::CreateRepairDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef RepairDrone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func523::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func524::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func524
+namespace _func525
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7296,11 +7310,11 @@ namespace _func524
 std::pair<std::string, bool> CrewMemberFactory::GetRandomFriendlyName(const std::string &race)
 {
 	typedef std::pair<std::string, bool> __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, const std::string &race_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func524::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func525::func;
 	return execfunc(this, race);
 }
 
-namespace _func525
+namespace _func526
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7310,11 +7324,11 @@ namespace _func525
 std::vector<std::string> CrewMemberFactory::GetCrewNames()
 {
 	typedef std::vector<std::string> __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func525::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func526::func;
 	return execfunc(this);
 }
 
-namespace _func526
+namespace _func527
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7324,11 +7338,11 @@ namespace _func526
 void CrewMemberFactory::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func526::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func527::func;
 	return execfunc(this);
 }
 
-namespace _func527
+namespace _func528
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7338,11 +7352,11 @@ namespace _func527
 void CrewMemberFactory::RemoveExcessCrew()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func527::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func528::func;
 	return execfunc(this);
 }
 
-namespace _func528
+namespace _func529
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -7352,18 +7366,18 @@ namespace _func528
 CrewMember *CrewMemberFactory::CreateCrewMember(CrewBlueprint *bp, int shipId, bool intruder)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, CrewBlueprint *bp_arg, int shipId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func528::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func529::func;
 	return execfunc(this, bp, shipId, intruder);
 }
 
 CrewMemberFactory *Global_CrewMemberFactory_Factory;
 
-namespace _var529
+namespace _var530
 {
     static VariableDefinition varObj("Global_CrewMemberFactory_Factory", "!c70424(???????\?)e8????????29c6", &Global_CrewMemberFactory_Factory);
 }
 
-namespace _func530
+namespace _func531
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7373,11 +7387,11 @@ namespace _func530
 bool CrewStoreBox::CanHold()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func530::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func531::func;
 	return execfunc(this);
 }
 
-namespace _func531
+namespace _func532
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -7387,11 +7401,11 @@ namespace _func531
 void CrewStoreBox::constructor(ShipManager *ship, int worldLevel, const std::string &type)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewStoreBox *this_arg, ShipManager *ship_arg, int worldLevel_arg, const std::string &type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func531::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func532::func;
 	return execfunc(this, ship, worldLevel, type);
 }
 
-namespace _func532
+namespace _func533
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7401,11 +7415,11 @@ namespace _func532
 void CrewStoreBox::Purchase()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func532::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func533::func;
 	return execfunc(this);
 }
 
-namespace _func533
+namespace _func534
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7415,11 +7429,11 @@ namespace _func533
 void CrewStoreBox::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewStoreBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func533::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func534::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func534
+namespace _func535
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -7429,11 +7443,11 @@ namespace _func534
 void DamageMessage::constructor(float length, Pointf pos, DamageMessage::MessageType type)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DamageMessage *this_arg, float length_arg, Pointf pos_arg, DamageMessage::MessageType type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func534::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func535::func;
 	return execfunc(this, length, pos, type);
 }
 
-namespace _func535
+namespace _func536
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -7443,11 +7457,11 @@ namespace _func535
 void DamageMessage::constructor2(float length, int amount, Pointf pos, bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DamageMessage *this_arg, float length_arg, int amount_arg, Pointf pos_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func535::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func536::func;
 	return execfunc(this, length, amount, pos, unk);
 }
 
-namespace _func536
+namespace _func537
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7457,11 +7471,11 @@ namespace _func536
 bool DefenseDrone::ValidTargetObject(Targetable *target)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func536::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func537::func;
 	return execfunc(this, target);
 }
 
-namespace _func537
+namespace _func538
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7471,11 +7485,11 @@ namespace _func537
 void DefenseDrone::PickTarget()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func537::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func538::func;
 	return execfunc(this);
 }
 
-namespace _func538
+namespace _func539
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7485,11 +7499,11 @@ namespace _func538
 void DefenseDrone::SetWeaponTarget(Targetable *target)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func538::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func539::func;
 	return execfunc(this, target);
 }
 
-namespace _func539
+namespace _func540
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7499,11 +7513,11 @@ namespace _func539
 std::string DefenseDrone::GetTooltip()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func539::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func540::func;
 	return execfunc(this);
 }
 
-namespace _func540
+namespace _func541
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7513,11 +7527,11 @@ namespace _func540
 void DefenseDrone::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func540::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func541::func;
 	return execfunc(this);
 }
 
-namespace _func541
+namespace _func542
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7527,11 +7541,11 @@ namespace _func541
 Description &Description::copy_assign_2(Description &other)
 {
 	typedef Description &__attribute__((cdecl)) (*custom_arg_funcptr_t)(Description *this_arg, Description &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func541::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func542::func;
 	return execfunc(this, other);
 }
 
-namespace _func542
+namespace _func543
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7541,11 +7555,11 @@ namespace _func542
 Description &Description::copy_assign_1(const Description &other)
 {
 	typedef Description &__attribute__((cdecl)) (*custom_arg_funcptr_t)(Description *this_arg, const Description &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func542::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func543::func;
 	return execfunc(this, other);
 }
 
-namespace _func543
+namespace _func544
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7555,11 +7569,11 @@ namespace _func543
 void Description::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Description *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func543::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func544::func;
 	return execfunc(this);
 }
 
-namespace _func544
+namespace _func545
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7569,11 +7583,11 @@ namespace _func544
 Point Door::GetPosition()
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func544::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func545::func;
 	return execfunc(this);
 }
 
-namespace _func545
+namespace _func546
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7583,11 +7597,11 @@ namespace _func545
 bool Door::ApplyDamage(float amount)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Door *this_arg, float amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func545::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func546::func;
 	return execfunc(this, amount);
 }
 
-namespace _func546
+namespace _func547
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7597,11 +7611,11 @@ namespace _func546
 void Door::FakeOpen()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func546::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func547::func;
 	return execfunc(this);
 }
 
-namespace _func547
+namespace _func548
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7611,11 +7625,11 @@ namespace _func547
 void Door::FakeClose()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func547::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func548::func;
 	return execfunc(this);
 }
 
-namespace _func548
+namespace _func549
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7625,11 +7639,11 @@ namespace _func548
 bool Door::IsSealed(int shipId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Door *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func548::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func549::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func549
+namespace _func550
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7639,11 +7653,11 @@ namespace _func549
 void Door::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func549::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func550::func;
 	return execfunc(this);
 }
 
-namespace _func550
+namespace _func551
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -7653,11 +7667,11 @@ namespace _func550
 void DoorBox::constructor(Point pos, ShipSystem *sys, ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DoorBox *this_arg, Point pos_arg, ShipSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func550::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func551::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func551
+namespace _func552
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7667,18 +7681,18 @@ namespace _func551
 void DroneBlueprint::RenderIcon(float scale)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneBlueprint *this_arg, float scale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func551::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func552::func;
 	return execfunc(this, scale);
 }
 
-namespace _func552
+namespace _func553
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("DroneControl::DO_NOT_HOOK", typeid(void (DroneControl::*)()), "!565383ec148b4424208b5c24248b7424288b400c890424", argdata, 0, 4, &func);
 }
 
-namespace _func553
+namespace _func554
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7688,11 +7702,11 @@ namespace _func553
 TextString DroneControl::HolderLabel()
 {
 	typedef TextString __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func553::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func554::func;
 	return execfunc(this);
 }
 
-namespace _func554
+namespace _func555
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7702,11 +7716,11 @@ namespace _func554
 SDLKey DroneControl::ArmamentHotkey(unsigned int i)
 {
 	typedef SDLKey __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneControl *this_arg, unsigned int i_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func554::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func555::func;
 	return execfunc(this, i);
 }
 
-namespace _func555
+namespace _func556
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7716,11 +7730,11 @@ namespace _func555
 void DroneControl::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func555::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func556::func;
 	return execfunc(this);
 }
 
-namespace _func556
+namespace _func557
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -7730,11 +7744,11 @@ namespace _func556
 void DroneStoreBox::constructor(ShipManager *ship, Equipment *equip, const DroneBlueprint *bp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneStoreBox *this_arg, ShipManager *ship_arg, Equipment *equip_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func556::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func557::func;
 	return execfunc(this, ship, equip, bp);
 }
 
-namespace _func557
+namespace _func558
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7744,11 +7758,11 @@ namespace _func557
 void DroneSystem::RemoveDrone(int slot)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneSystem *this_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func557::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func558::func;
 	return execfunc(this, slot);
 }
 
-namespace _func558
+namespace _func559
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7758,11 +7772,11 @@ namespace _func558
 void DroneSystem::Jump()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func558::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func559::func;
 	return execfunc(this);
 }
 
-namespace _func559
+namespace _func560
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7772,11 +7786,11 @@ namespace _func559
 void DroneSystem::UpdateBonusPower()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func559::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func560::func;
 	return execfunc(this);
 }
 
-namespace _func560
+namespace _func561
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7786,11 +7800,11 @@ namespace _func560
 void DroneSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func560::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func561::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func561
+namespace _func562
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7800,11 +7814,11 @@ namespace _func561
 void DroneSystem::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func561::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func562::func;
 	return execfunc(this);
 }
 
-namespace _func562
+namespace _func563
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102, 0x101};
@@ -7814,11 +7828,11 @@ namespace _func562
 bool DroneSystem::DePowerDrone(Drone *drone, bool unk)
 {
 	typedef bool __attribute__((regparm(3))) (*custom_arg_funcptr_t)(DroneSystem *this_arg, Drone *drone_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func562::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func563::func;
 	return execfunc(this, drone, unk);
 }
 
-namespace _func563
+namespace _func564
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7828,11 +7842,11 @@ namespace _func563
 int DroneSystem::StringToDrone(std::string &name)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func563::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func564::func;
 	return execfunc(name);
 }
 
-namespace _func564
+namespace _func565
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7842,11 +7856,11 @@ namespace _func564
 void DropBox::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DropBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func564::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func565::func;
 	return execfunc(this);
 }
 
-namespace _func565
+namespace _func566
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7856,11 +7870,11 @@ namespace _func565
 int DropBox::GetHeight()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(DropBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func565::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func566::func;
 	return execfunc(this);
 }
 
-namespace _func566
+namespace _func567
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7870,11 +7884,11 @@ namespace _func566
 void EnergyAlien::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EnergyAlien *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func566::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func567::func;
 	return execfunc(this);
 }
 
-namespace _func567
+namespace _func568
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7884,11 +7898,11 @@ namespace _func567
 Damage EnergyAlien::GetRoomDamage()
 {
 	typedef Damage __attribute__((cdecl)) (*custom_arg_funcptr_t)(EnergyAlien *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func567::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func568::func;
 	return execfunc(this);
 }
 
-namespace _func568
+namespace _func569
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7898,11 +7912,11 @@ namespace _func568
 void Equipment::Open()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func568::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func569::func;
 	return execfunc(this);
 }
 
-namespace _func569
+namespace _func570
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7912,11 +7926,11 @@ namespace _func569
 void Equipment::Close()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func569::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func570::func;
 	return execfunc(this);
 }
 
-namespace _func570
+namespace _func571
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7926,11 +7940,11 @@ namespace _func570
 void Equipment::OnInit(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func570::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func571::func;
 	return execfunc(this, ship);
 }
 
-namespace _func571
+namespace _func572
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7940,11 +7954,11 @@ namespace _func571
 void Equipment::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func571::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func572::func;
 	return execfunc(this);
 }
 
-namespace _func572
+namespace _func573
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7954,11 +7968,11 @@ namespace _func572
 void Equipment::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func572::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func573::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func573
+namespace _func574
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7968,11 +7982,11 @@ namespace _func573
 void Equipment::MouseUp(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func573::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func574::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func574
+namespace _func575
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -7982,11 +7996,11 @@ namespace _func574
 void Equipment::AddWeapon(WeaponBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, WeaponBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func574::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func575::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func575
+namespace _func576
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -7996,11 +8010,11 @@ namespace _func575
 void Equipment::AddDrone(DroneBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, DroneBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func575::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func576::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func576
+namespace _func577
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8010,11 +8024,11 @@ namespace _func576
 void Equipment::AddAugment(AugmentBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, AugmentBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func576::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func577::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func577
+namespace _func578
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8024,11 +8038,11 @@ namespace _func577
 void Equipment::AddToCargo(const std::string &name)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func577::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func578::func;
 	return execfunc(this, name);
 }
 
-namespace _func578
+namespace _func579
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8038,11 +8052,11 @@ namespace _func578
 std::vector<std::string> Equipment::GetCargoHold()
 {
 	typedef std::vector<std::string> __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func578::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func579::func;
 	return execfunc(this);
 }
 
-namespace _func579
+namespace _func580
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -8052,11 +8066,11 @@ namespace _func579
 void EquipmentBox::SetPosition(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func579::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func580::func;
 	return execfunc(this, pos);
 }
 
-namespace _func580
+namespace _func581
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8066,11 +8080,11 @@ namespace _func580
 void EquipmentBox::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func580::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func581::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func581
+namespace _func582
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8080,11 +8094,11 @@ namespace _func581
 void EquipmentBox::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func581::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func582::func;
 	return execfunc(this);
 }
 
-namespace _func582
+namespace _func583
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff};
@@ -8094,11 +8108,11 @@ namespace _func582
 void EquipmentBox::AddItem(EquipmentBoxItem item)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, EquipmentBoxItem item_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func582::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func583::func;
 	return execfunc(this, item);
 }
 
-namespace _func583
+namespace _func584
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8106,20 +8120,6 @@ namespace _func583
 }
 
 bool EquipmentBox::CanHoldWeapon()
-{
-	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func583::func;
-	return execfunc(this);
-}
-
-namespace _func584
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("EquipmentBox::CanHoldDrone", typeid(bool (EquipmentBox::*)()), "8b4424048b504c85d28b5050", argdata, 1, 2, &func);
-}
-
-bool EquipmentBox::CanHoldDrone()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func584::func;
@@ -8130,17 +8130,31 @@ namespace _func585
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("EquipmentBox::CanHoldDrone", typeid(bool (EquipmentBox::*)()), "8b4424048b504c85d28b5050", argdata, 1, 2, &func);
+}
+
+bool EquipmentBox::CanHoldDrone()
+{
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func585::func;
+	return execfunc(this);
+}
+
+namespace _func586
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("EquipmentBox::GetType", typeid(int (EquipmentBox::*)()), "8b5424048b4c24088b424c85c0", argdata, 1, 2, &func);
 }
 
 int EquipmentBox::GetType()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func585::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func586::func;
 	return execfunc(this);
 }
 
-namespace _func586
+namespace _func587
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8150,11 +8164,11 @@ namespace _func586
 void EquipmentBox::OnRender(bool isEmpty)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool isEmpty_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func586::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func587::func;
 	return execfunc(this, isEmpty);
 }
 
-namespace _func587
+namespace _func588
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8164,11 +8178,11 @@ namespace _func587
 void EquipmentBox::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func587::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func588::func;
 	return execfunc(this);
 }
 
-namespace _func588
+namespace _func589
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8178,11 +8192,11 @@ namespace _func588
 void EquipmentBox::UpdateBoxImage(bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func588::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func589::func;
 	return execfunc(this, unk);
 }
 
-namespace _func589
+namespace _func590
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8192,11 +8206,11 @@ namespace _func589
 void EquipmentBox::RenderLabels(bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func589::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func590::func;
 	return execfunc(this, unk);
 }
 
-namespace _func590
+namespace _func591
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
@@ -8206,11 +8220,11 @@ namespace _func590
 void EquipmentBox::constructor(Point pos, int slot)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, Point pos_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func590::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func591::func;
 	return execfunc(this, pos, slot);
 }
 
-namespace _func591
+namespace _func592
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8220,11 +8234,11 @@ namespace _func591
 int EquipmentBox::GetItemValue()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func591::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func592::func;
 	return execfunc(this);
 }
 
-namespace _func592
+namespace _func593
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8234,11 +8248,11 @@ namespace _func592
 void EquipmentBox::SetBlueprint(InfoBox *infoBox, bool detailedBox)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, InfoBox *infoBox_arg, bool detailedBox_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func592::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func593::func;
 	return execfunc(this, infoBox, detailedBox);
 }
 
-namespace _func593
+namespace _func594
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8248,11 +8262,11 @@ namespace _func593
 Blueprint *EquipmentBox::GetBlueprint()
 {
 	typedef Blueprint *__attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func593::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func594::func;
 	return execfunc(this);
 }
 
-namespace _func594
+namespace _func595
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8262,11 +8276,11 @@ namespace _func594
 LocationEvent *EventGenerator::GetBaseEvent(const std::string &name, int worldLevel, char ignoreUnique, int seed)
 {
 	typedef LocationEvent *__attribute__((cdecl)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg, int worldLevel_arg, char ignoreUnique_arg, int seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func594::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func595::func;
 	return execfunc(this, name, worldLevel, ignoreUnique, seed);
 }
 
-namespace _func595
+namespace _func596
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8276,11 +8290,11 @@ namespace _func595
 LocationEvent *EventGenerator::CreateEvent(const std::string &name, int worldLevel, bool ignoreUnique)
 {
 	typedef LocationEvent *__attribute__((cdecl)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg, int worldLevel_arg, bool ignoreUnique_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func595::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func596::func;
 	return execfunc(this, name, worldLevel, ignoreUnique);
 }
 
-namespace _func596
+namespace _func597
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8290,11 +8304,11 @@ namespace _func596
 SectorDescription EventGenerator::GetSpecificSector(const std::string &name)
 {
 	typedef SectorDescription __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func596::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func597::func;
 	return execfunc(this, name);
 }
 
-namespace _func597
+namespace _func598
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8304,11 +8318,11 @@ namespace _func597
 std::string EventGenerator::GetImageFromList(const std::string &listName)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &listName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func597::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func598::func;
 	return execfunc(this, listName);
 }
 
-namespace _func598
+namespace _func599
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8318,11 +8332,11 @@ namespace _func598
 SectorDescription EventGenerator::GetSectorDescription(const std::string &type, int level)
 {
 	typedef SectorDescription __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &type_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func598::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func599::func;
 	return execfunc(this, type, level);
 }
 
-namespace _func599
+namespace _func600
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8332,18 +8346,18 @@ namespace _func599
 ShipEvent EventGenerator::GetShipEvent(const std::string &event)
 {
 	typedef ShipEvent __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func599::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func600::func;
 	return execfunc(this, event);
 }
 
 EventGenerator *Global_EventGenerator_Generator;
 
-namespace _var600
+namespace _var601
 {
     static VariableDefinition varObj("Global_EventGenerator_Generator", "!c74424080000000089742404c70424(???????\?)e8????????8b54242c8d4af4", &Global_EventGenerator_Generator);
 }
 
-namespace _func601
+namespace _func602
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8353,11 +8367,11 @@ namespace _func601
 void EventSystem::AddEvent(int id)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventSystem *this_arg, int id_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func601::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func602::func;
 	return execfunc(this, id);
 }
 
-namespace _func602
+namespace _func603
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8367,18 +8381,18 @@ namespace _func602
 bool EventSystem::PollEvent(int id)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventSystem *this_arg, int id_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func602::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func603::func;
 	return execfunc(this, id);
 }
 
 EventSystem *Global_EventSystem_EventManager;
 
-namespace _var603
+namespace _var604
 {
     static VariableDefinition varObj("Global_EventSystem_EventManager", "!c74424040c000000c70424(???????\?)e8????????31c0", &Global_EventSystem_EventManager);
 }
 
-namespace _func604
+namespace _func605
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8388,11 +8402,11 @@ namespace _func604
 RandomAmount EventsParser::PullMinMax(rapidxml::xml_node<char> *node, const std::string &name)
 {
 	typedef RandomAmount __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func604::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func605::func;
 	return execfunc(this, node, name);
 }
 
-namespace _func605
+namespace _func606
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8402,11 +8416,11 @@ namespace _func605
 std::string EventsParser::ProcessEvent(rapidxml::xml_node<char> *node, const std::string &eventName)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &eventName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func605::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func606::func;
 	return execfunc(this, node, eventName);
 }
 
-namespace _func606
+namespace _func607
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8416,11 +8430,11 @@ namespace _func606
 ShipTemplate EventsParser::ProcessShipEvent(rapidxml::xml_node<char> *node)
 {
 	typedef ShipTemplate __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func606::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func607::func;
 	return execfunc(this, node);
 }
 
-namespace _func607
+namespace _func608
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8430,11 +8444,11 @@ namespace _func607
 ResourcesTemplate EventsParser::ProcessModifyItem(ResourcesTemplate &resources, rapidxml::xml_node<char> *node, const std::string &unk)
 {
 	typedef ResourcesTemplate __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg, ResourcesTemplate &resources_arg, rapidxml::xml_node<char> *node_arg, const std::string &unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func607::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func608::func;
 	return execfunc(this, resources, node, unk);
 }
 
-namespace _func608
+namespace _func609
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8444,11 +8458,11 @@ namespace _func608
 void EventsParser::AddAllEvents()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func608::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func609::func;
 	return execfunc(this);
 }
 
-namespace _func609
+namespace _func610
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8458,11 +8472,11 @@ namespace _func609
 void EventsParser::AddEvents(EventGenerator &generator, char *file, const std::string &fileName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg, EventGenerator &generator_arg, char *file_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func609::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func610::func;
 	return execfunc(this, generator, file, fileName);
 }
 
-namespace _func610
+namespace _func611
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8472,11 +8486,11 @@ namespace _func610
 std::vector<std::string> EventsParser::ProcessEventList(rapidxml::xml_node<char> *node, const std::string &listName)
 {
 	typedef std::vector<std::string> __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &listName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func610::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func611::func;
 	return execfunc(this, node, listName);
 }
 
-namespace _func611
+namespace _func612
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8486,18 +8500,18 @@ namespace _func611
 void EventsParser::ProcessBaseNode(rapidxml::xml_node<char> *node, EventGenerator &generator)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, EventGenerator &generator_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func611::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func612::func;
 	return execfunc(this, node, generator);
 }
 
 EventsParser *Global_EventsParser_Parser;
 
-namespace _var612
+namespace _var613
 {
     static VariableDefinition varObj("Global_EventsParser_Parser", "!c70424(???????\?)89442408898554ffffff", &Global_EventsParser_Parser);
 }
 
-namespace _func613
+namespace _func614
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x2ff};
@@ -8507,11 +8521,11 @@ namespace _func613
 void ExplosionAnimation::OnInit(rapidxml::xml_node<char> *node, const std::string &name, Point glowOffset)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &name_arg, Point glowOffset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func613::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func614::func;
 	return execfunc(this, node, name, glowOffset);
 }
 
-namespace _func614
+namespace _func615
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x7ff, 0x1ff};
@@ -8521,11 +8535,11 @@ namespace _func614
 void ExplosionAnimation::OnRender(Globals::Rect *shipRect, ImageDesc shipImage, GL_Primitive *shipImagePrimitive)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg, Globals::Rect *shipRect_arg, ImageDesc shipImage_arg, GL_Primitive *shipImagePrimitive_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func614::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func615::func;
 	return execfunc(this, shipRect, shipImage, shipImagePrimitive);
 }
 
-namespace _func615
+namespace _func616
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8535,11 +8549,11 @@ namespace _func615
 void ExplosionAnimation::LoadGibs()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func615::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func616::func;
 	return execfunc(this);
 }
 
-namespace _func616
+namespace _func617
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8549,11 +8563,11 @@ namespace _func616
 void FTLButton::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(FTLButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func616::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func617::func;
 	return execfunc(this);
 }
 
-namespace _func617
+namespace _func618
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8563,11 +8577,11 @@ namespace _func617
 void FTLButton::MouseMove(int mX, int mY, bool silent)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(FTLButton *this_arg, int mX_arg, int mY_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func617::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func618::func;
 	return execfunc(this, mX, mY, silent);
 }
 
-namespace _func618
+namespace _func619
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8577,11 +8591,11 @@ namespace _func618
 void FileHelper::deleteFile(const std::string &fileName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func618::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func619::func;
 	return execfunc(fileName);
 }
 
-namespace _func619
+namespace _func620
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8589,20 +8603,6 @@ namespace _func619
 }
 
 std::string FileHelper::getResourceFile()
-{
-	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func619::func;
-	return execfunc();
-}
-
-namespace _func620
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("FileHelper::getUserFolder", typeid(std::string (*)()), "5383ec288b5c2430e8????????", argdata, 1, 18, &func);
-}
-
-std::string FileHelper::getUserFolder()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func620::func;
@@ -8613,10 +8613,10 @@ namespace _func621
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("FileHelper::getSaveFile", typeid(std::string (*)()), "57565383ec208b5c24308d74241ce8????????", argdata, 1, 18, &func);
+	static FunctionDefinition funcObj("FileHelper::getUserFolder", typeid(std::string (*)()), "5383ec288b5c2430e8????????", argdata, 1, 18, &func);
 }
 
-std::string FileHelper::getSaveFile()
+std::string FileHelper::getUserFolder()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func621::func;
@@ -8626,6 +8626,20 @@ std::string FileHelper::getSaveFile()
 namespace _func622
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("FileHelper::getSaveFile", typeid(std::string (*)()), "57565383ec208b5c24308d74241ce8????????", argdata, 1, 18, &func);
+}
+
+std::string FileHelper::getSaveFile()
+{
+	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func622::func;
+	return execfunc();
+}
+
+namespace _func623
+{
+    static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("FileHelper::initFileHelper", typeid(void (*)()), "565383ec34c605????????018d5c241f", argdata, 0, 6, &func);
 }
@@ -8633,11 +8647,11 @@ namespace _func622
 void FileHelper::initFileHelper()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func622::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func623::func;
 	return execfunc();
 }
 
-namespace _func623
+namespace _func624
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8647,11 +8661,11 @@ namespace _func623
 bool FileHelper::fileExists(const std::string &fileName)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func623::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func624::func;
 	return execfunc(fileName);
 }
 
-namespace _func624
+namespace _func625
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8661,11 +8675,11 @@ namespace _func624
 void FileHelper::renameFile(const std::string &fileName, const std::string &newName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg, const std::string &newName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func624::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func625::func;
 	return execfunc(fileName, newName);
 }
 
-namespace _func625
+namespace _func626
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8675,11 +8689,11 @@ namespace _func625
 int FileHelper::createBinaryFile(const std::string &fileName)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func625::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func626::func;
 	return execfunc(fileName);
 }
 
-namespace _func626
+namespace _func627
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -8689,20 +8703,6 @@ namespace _func626
 bool FileHelper::saveFileExists()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func626::func;
-	return execfunc();
-}
-
-namespace _func627
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::readSaveFile", typeid(int (*)()), ".5557565383ec3c8d442420894424088d442410", argdata, 0, 2, &func);
-}
-
-int FileHelper::readSaveFile()
-{
-	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func627::func;
 	return execfunc();
 }
@@ -8711,10 +8711,10 @@ namespace _func628
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::readStatsFile", typeid(int (*)()), ".5557565383ec3c8d442420894424088d442410", argdata, 0, 2, &func);
+	static FunctionDefinition funcObj("FileHelper::readSaveFile", typeid(int (*)()), ".5557565383ec3c8d442420894424088d442410", argdata, 0, 2, &func);
 }
 
-int FileHelper::readStatsFile()
+int FileHelper::readSaveFile()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func628::func;
@@ -8725,10 +8725,10 @@ namespace _func629
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::createSaveFile", typeid(int (*)()), ".a1????????a3????????b8????????", argdata, 0, 2, &func);
+	static FunctionDefinition funcObj("FileHelper::readStatsFile", typeid(int (*)()), ".5557565383ec3c8d442420894424088d442410", argdata, 0, 2, &func);
 }
 
-int FileHelper::createSaveFile()
+int FileHelper::readStatsFile()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func629::func;
@@ -8739,10 +8739,10 @@ namespace _func630
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::createStatsFile", typeid(int (*)()), ".a1????????a3????????b8????????", argdata, 0, 2, &func);
+	static FunctionDefinition funcObj("FileHelper::createSaveFile", typeid(int (*)()), ".a1????????a3????????b8????????", argdata, 0, 2, &func);
 }
 
-int FileHelper::createStatsFile()
+int FileHelper::createSaveFile()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func630::func;
@@ -8753,12 +8753,12 @@ namespace _func631
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::deleteSaveFile", typeid(void (*)()), "5383ec18c70424????????e8????????89c3", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("FileHelper::createStatsFile", typeid(int (*)()), ".a1????????a3????????b8????????", argdata, 0, 2, &func);
 }
 
-void FileHelper::deleteSaveFile()
+int FileHelper::createStatsFile()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func631::func;
 	return execfunc();
 }
@@ -8767,10 +8767,10 @@ namespace _func632
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::deleteAllSaveFiles", typeid(void (*)()), "5557565383ec2ce8????????8d74241c8d7c241b", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("FileHelper::deleteSaveFile", typeid(void (*)()), "5383ec18c70424????????e8????????89c3", argdata, 0, 6, &func);
 }
 
-void FileHelper::deleteAllSaveFiles()
+void FileHelper::deleteSaveFile()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func632::func;
@@ -8780,6 +8780,20 @@ void FileHelper::deleteAllSaveFiles()
 namespace _func633
 {
     static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("FileHelper::deleteAllSaveFiles", typeid(void (*)()), "5557565383ec2ce8????????8d74241c8d7c241b", argdata, 0, 6, &func);
+}
+
+void FileHelper::deleteAllSaveFiles()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func633::func;
+	return execfunc();
+}
+
+namespace _func634
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("FileHelper::getPosition", typeid(int (*)(int )), ".a1????????c3", argdata, 1, 2, &func);
 }
@@ -8787,11 +8801,11 @@ namespace _func633
 int FileHelper::getPosition(int file)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func633::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func634::func;
 	return execfunc(file);
 }
 
-namespace _func634
+namespace _func635
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8801,11 +8815,11 @@ namespace _func634
 int FileHelper::readBinaryFile(const std::string &fileName)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func634::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func635::func;
 	return execfunc(fileName);
 }
 
-namespace _func635
+namespace _func636
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8815,11 +8829,11 @@ namespace _func635
 bool FileHelper::writeFloat(int file, float data)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, float data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func635::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func636::func;
 	return execfunc(file, data);
 }
 
-namespace _func636
+namespace _func637
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8829,11 +8843,11 @@ namespace _func636
 bool FileHelper::writeInt(int file, int data)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, int data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func636::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func637::func;
 	return execfunc(file, data);
 }
 
-namespace _func637
+namespace _func638
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8843,11 +8857,11 @@ namespace _func637
 bool FileHelper::writeData(int file, void *data, int len)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, void *data_arg, int len_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func637::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func638::func;
 	return execfunc(file, data, len);
 }
 
-namespace _func638
+namespace _func639
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8857,11 +8871,11 @@ namespace _func638
 bool FileHelper::writeString(int file, const std::string &data)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, const std::string &data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func638::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func639::func;
 	return execfunc(file, data);
 }
 
-namespace _func639
+namespace _func640
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8871,11 +8885,11 @@ namespace _func639
 void FileHelper::closeBinaryFile(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func639::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func640::func;
 	return execfunc(file);
 }
 
-namespace _func640
+namespace _func641
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8885,11 +8899,11 @@ namespace _func640
 std::string FileHelper::readString(int file)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func640::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func641::func;
 	return execfunc(file);
 }
 
-namespace _func641
+namespace _func642
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8899,11 +8913,11 @@ namespace _func641
 float FileHelper::readFloat(int file)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func641::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func642::func;
 	return execfunc(file);
 }
 
-namespace _func642
+namespace _func643
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8913,11 +8927,11 @@ namespace _func642
 int FileHelper::readInteger(int file)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func642::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func643::func;
 	return execfunc(file);
 }
 
-namespace _func643
+namespace _func644
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8927,11 +8941,11 @@ namespace _func643
 bool FileHelper::seekPosition(int file, int pos)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, int pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func643::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func644::func;
 	return execfunc(file, pos);
 }
 
-namespace _func644
+namespace _func645
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8941,11 +8955,11 @@ namespace _func644
 char *FileHelper::readBuffer(int file, int len, bool nullTerminate)
 {
 	typedef char *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, int len_arg, bool nullTerminate_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func644::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func645::func;
 	return execfunc(file, len, nullTerminate);
 }
 
-namespace _func645
+namespace _func646
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8955,11 +8969,11 @@ namespace _func645
 void FileHelper::readData(int file, void *data, int len)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, void *data_arg, int len_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func645::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func646::func;
 	return execfunc(file, data, len);
 }
 
-namespace _func646
+namespace _func647
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8969,11 +8983,11 @@ namespace _func646
 void Fire::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Fire *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func646::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func647::func;
 	return execfunc(this);
 }
 
-namespace _func647
+namespace _func648
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8983,11 +8997,11 @@ namespace _func647
 void Fire::UpdateDeathTimer(int connectedFires)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Fire *this_arg, int connectedFires_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func647::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func648::func;
 	return execfunc(this, connectedFires);
 }
 
-namespace _func648
+namespace _func649
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8997,11 +9011,11 @@ namespace _func648
 void Fire::UpdateStartTimer(int doorLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Fire *this_arg, int doorLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func648::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func649::func;
 	return execfunc(this, doorLevel);
 }
 
-namespace _func649
+namespace _func650
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9011,11 +9025,11 @@ namespace _func649
 void FocusWindow::MouseClick(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(FocusWindow *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func649::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func650::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func650
+namespace _func651
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9025,11 +9039,11 @@ namespace _func650
 void FocusWindow::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(FocusWindow *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func650::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func651::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func651
+namespace _func652
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9039,11 +9053,11 @@ namespace _func651
 void GameOver::OpenText(const std::string &text)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GameOver *this_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func651::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func652::func;
 	return execfunc(this, text);
 }
 
-namespace _func652
+namespace _func653
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9053,11 +9067,11 @@ namespace _func652
 void GameOver::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GameOver *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func652::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func653::func;
 	return execfunc(this);
 }
 
-namespace _func653
+namespace _func654
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9067,11 +9081,11 @@ namespace _func653
 void GameOver::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GameOver *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func653::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func654::func;
 	return execfunc(this);
 }
 
-namespace _func654
+namespace _func655
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -9081,11 +9095,11 @@ namespace _func654
 void GenericButton::SetLocation(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GenericButton *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func654::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func655::func;
 	return execfunc(this, pos);
 }
 
-namespace _func655
+namespace _func656
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9095,11 +9109,11 @@ namespace _func655
 void GenericButton::SetActive(bool active)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GenericButton *this_arg, bool active_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func655::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func656::func;
 	return execfunc(this, active);
 }
 
-namespace _func656
+namespace _func657
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9109,18 +9123,18 @@ namespace _func656
 void GenericButton::MouseMove(int x, int y, bool silent)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GenericButton *this_arg, int x_arg, int y_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func656::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func657::func;
 	return execfunc(this, x, y, silent);
 }
 
-namespace _func657
+namespace _func658
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("GenericButton::__DO_NOT_HOOK", typeid(void (GenericButton::*)()), "f3c36690669066906690669066906690", argdata, 0, 4, &func);
 }
 
-namespace _func658
+namespace _func659
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9128,20 +9142,6 @@ namespace _func658
 }
 
 void GenericButton::OnClick()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GenericButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func658::func;
-	return execfunc(this);
-}
-
-namespace _func659
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("GenericButton::OnRightClick", typeid(void (GenericButton::*)()), ".f3c36690669066906690669066906690", argdata, 1, 6, &func);
-}
-
-void GenericButton::OnRightClick()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GenericButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func659::func;
@@ -9152,10 +9152,10 @@ namespace _func660
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("GenericButton::ResetPrimitives", typeid(void (GenericButton::*)()), ".f3c36690669066906690669066906690", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("GenericButton::OnRightClick", typeid(void (GenericButton::*)()), ".f3c36690669066906690669066906690", argdata, 1, 6, &func);
 }
 
-void GenericButton::ResetPrimitives()
+void GenericButton::OnRightClick()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GenericButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func660::func;
@@ -9165,6 +9165,20 @@ void GenericButton::ResetPrimitives()
 namespace _func661
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("GenericButton::ResetPrimitives", typeid(void (GenericButton::*)()), ".f3c36690669066906690669066906690", argdata, 1, 6, &func);
+}
+
+void GenericButton::ResetPrimitives()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GenericButton *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func661::func;
+	return execfunc(this);
+}
+
+namespace _func662
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("font_text_width", typeid(float (*)(freetype::font_data &, const char *, float )), "5557565383ec4c8b4c24608b6c246485c9", argdata, 3, 2, &func);
 }
@@ -9172,11 +9186,11 @@ namespace _func661
 float __stdcall font_text_width(freetype::font_data &fontData, const char *str, float size)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(freetype::font_data &fontData_arg, const char *str_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func661::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func662::func;
 	return execfunc(fontData, str, size);
 }
 
-namespace _func662
+namespace _func663
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -9186,11 +9200,11 @@ namespace _func662
 int __stdcall random32()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func662::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func663::func;
 	return execfunc();
 }
 
-namespace _func663
+namespace _func664
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9200,11 +9214,11 @@ namespace _func663
 void __stdcall srandom32(unsigned int seed)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(unsigned int seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func663::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func664::func;
 	return execfunc(seed);
 }
 
-namespace _func664
+namespace _func665
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9214,11 +9228,11 @@ namespace _func664
 float __stdcall getSkillBonus(int skill, int level)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(int skill_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func664::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func665::func;
 	return execfunc(skill, level);
 }
 
-namespace _func665
+namespace _func666
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9228,11 +9242,11 @@ namespace _func665
 void __stdcall GenerateReward(ResourceEvent &ref, RewardDesc &reward, int worldLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceEvent &ref_arg, RewardDesc &reward_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func665::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func666::func;
 	return execfunc(ref, reward, worldLevel);
 }
 
-namespace _func666
+namespace _func667
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9242,11 +9256,11 @@ namespace _func666
 void __stdcall GetValue(ResourceEvent &ref, const std::string &type, int level, int worldLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceEvent &ref_arg, const std::string &type_arg, int level_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func666::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func667::func;
 	return execfunc(ref, type, level, worldLevel);
 }
 
-namespace _func667
+namespace _func668
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9256,11 +9270,11 @@ namespace _func667
 void __stdcall sys_graphics_set_window_title(char *title)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(char *title_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func667::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func668::func;
 	return execfunc(title);
 }
 
-namespace _func668
+namespace _func669
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9270,11 +9284,11 @@ namespace _func668
 void __stdcall graphics_clear(float r, float g, float b, float a, float depth, unsigned int stencil)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(float r_arg, float g_arg, float b_arg, float a_arg, float depth_arg, unsigned int stencil_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func668::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func669::func;
 	return execfunc(r, g, b, a, depth, stencil);
 }
 
-namespace _func669
+namespace _func670
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x2ff};
@@ -9284,11 +9298,11 @@ namespace _func669
 Pointf Globals::GetNextPoint(Pointf current, float mag_speed, Pointf dest)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf current_arg, float mag_speed_arg, Pointf dest_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func669::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func670::func;
 	return execfunc(current, mag_speed, dest);
 }
 
-namespace _func670
+namespace _func671
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -9298,11 +9312,11 @@ namespace _func670
 int Globals::GetNextSpaceId()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func670::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func671::func;
 	return execfunc();
 }
 
-namespace _func671
+namespace _func672
 {
     static void *func = 0;
 	static short argdata[] = {0x2ff, 0x2ff, 0x1ff};
@@ -9312,11 +9326,11 @@ namespace _func671
 float Globals::AimAhead(Pointf delta, Pointf vr, float muzzleV)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf delta_arg, Pointf vr_arg, float muzzleV_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func671::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func672::func;
 	return execfunc(delta, vr, muzzleV);
 }
 
-namespace _func672
+namespace _func673
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -9326,39 +9340,39 @@ namespace _func672
 Pointf Globals::GetNextPoint(Pointf current, float mag_speed, float heading)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf current_arg, float mag_speed_arg, float heading_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func672::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func673::func;
 	return execfunc(current, mag_speed, heading);
 }
 
 TextLibrary *Global_Globals_Library;
 
-namespace _var673
+namespace _var674
 {
     static VariableDefinition varObj("Global_Globals_Library", "!c744240c????????895c2408c7442404(???????\?)893c24", &Global_Globals_Library);
 }
 
 int *Globals_GetNextSpaceId_id;
 
-namespace _var674
+namespace _var675
 {
     static VariableDefinition varObj("Globals_GetNextSpaceId_id", "!8b15(???????\?)b8650000008d4a0185d20f45c1", &Globals_GetNextSpaceId_id);
 }
 
 bool *Globals_RNG;
 
-namespace _var675
+namespace _var676
 {
     static VariableDefinition varObj("Globals_RNG", "!803d(???????\?)00c787800000003c000000c78784000000c8000000", &Globals_RNG);
 }
 
 FILE *ftl_log_logfile;
 
-namespace _var676
+namespace _var677
 {
     static VariableDefinition varObj("ftl_log_logfile", "!8974240c895c2408c744240401000000890424e8????????a1(???????\?)890424", &ftl_log_logfile);
 }
 
-namespace _func677
+namespace _func678
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -9368,11 +9382,11 @@ namespace _func677
 void HackBox::constructor(Point pos, HackingSystem *sys, ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(HackBox *this_arg, Point pos_arg, HackingSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func677::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func678::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func678
+namespace _func679
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9382,11 +9396,11 @@ namespace _func678
 void HackingDrone::SetMovementTarget(Targetable *target)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(HackingDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func678::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func679::func;
 	return execfunc(this, target);
 }
 
-namespace _func679
+namespace _func680
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -9396,11 +9410,11 @@ namespace _func679
 CollisionResponse HackingDrone::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((cdecl)) (*custom_arg_funcptr_t)(HackingDrone *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func679::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func680::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func680
+namespace _func681
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9410,20 +9424,6 @@ namespace _func680
 void HackingDrone::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(HackingDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func680::func;
-	return execfunc(this);
-}
-
-namespace _func681
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("HackingSystem::BlowHackingDrone", typeid(void (HackingSystem::*)()), "83ec1c8b44242080b8b001000000", argdata, 1, 6, &func);
-}
-
-void HackingSystem::BlowHackingDrone()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(HackingSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func681::func;
 	return execfunc(this);
 }
@@ -9432,10 +9432,10 @@ namespace _func682
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("HackingSystem::OnLoop", typeid(void (HackingSystem::*)()), "57565383ec308b5c2440891c24e8????????80bbbc01000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("HackingSystem::BlowHackingDrone", typeid(void (HackingSystem::*)()), "83ec1c8b44242080b8b001000000", argdata, 1, 6, &func);
 }
 
-void HackingSystem::OnLoop()
+void HackingSystem::BlowHackingDrone()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(HackingSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func682::func;
@@ -9446,17 +9446,31 @@ namespace _func683
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("HackingSystem::OnLoop", typeid(void (HackingSystem::*)()), "57565383ec308b5c2440891c24e8????????80bbbc01000000", argdata, 1, 6, &func);
+}
+
+void HackingSystem::OnLoop()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(HackingSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func683::func;
+	return execfunc(this);
+}
+
+namespace _func684
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("HackingSystem::SoundLoop", typeid(bool (HackingSystem::*)()), "5383ec??8b5c????80bb980100000075??83c4??31c05b", argdata, 1, 2, &func);
 }
 
 bool HackingSystem::SoundLoop()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(HackingSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func683::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func684::func;
 	return execfunc(this);
 }
 
-namespace _func684
+namespace _func685
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9466,11 +9480,11 @@ namespace _func684
 void InfoBox::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func684::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func685::func;
 	return execfunc(this);
 }
 
-namespace _func685
+namespace _func686
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9480,11 +9494,11 @@ namespace _func685
 void InfoBox::Clear()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func685::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func686::func;
 	return execfunc(this);
 }
 
-namespace _func686
+namespace _func687
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9494,11 +9508,11 @@ namespace _func686
 void InfoBox::SetDescription(Description *desc, int width, int height, InfoBox::ExpandDir dir)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, Description *desc_arg, int width_arg, int height_arg, InfoBox::ExpandDir dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func686::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func687::func;
 	return execfunc(this, desc, width, height, dir);
 }
 
-namespace _func687
+namespace _func688
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9508,11 +9522,11 @@ namespace _func687
 void InfoBox::SetText(const std::string &title, const std::string &text, int width, int height, InfoBox::ExpandDir dir)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const std::string &title_arg, const std::string &text_arg, int width_arg, int height_arg, InfoBox::ExpandDir dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func687::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func688::func;
 	return execfunc(this, title, text, width, height, dir);
 }
 
-namespace _func688
+namespace _func689
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9522,11 +9536,11 @@ namespace _func688
 void InfoBox::SetBlueprintWeapon(const WeaponBlueprint *bp, int status, bool hasWeaponSystem, int yShift)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const WeaponBlueprint *bp_arg, int status_arg, bool hasWeaponSystem_arg, int yShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func688::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func689::func;
 	return execfunc(this, bp, status, hasWeaponSystem, yShift);
 }
 
-namespace _func689
+namespace _func690
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9536,11 +9550,11 @@ namespace _func689
 void InfoBox::SetBlueprintDrone(const DroneBlueprint *bp, int status, bool hasDroneSystem, int yShift)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const DroneBlueprint *bp_arg, int status_arg, bool hasDroneSystem_arg, int yShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func689::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func690::func;
 	return execfunc(this, bp, status, hasDroneSystem, yShift);
 }
 
-namespace _func690
+namespace _func691
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9550,11 +9564,11 @@ namespace _func690
 void InfoBox::SetBlueprint(const ItemBlueprint *bp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const ItemBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func690::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func691::func;
 	return execfunc(this, bp);
 }
 
-namespace _func691
+namespace _func692
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9564,11 +9578,11 @@ namespace _func691
 void InfoBox::SetBlueprintCrew(const CrewBlueprint *bp, int yShift, bool detailedCrew)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const CrewBlueprint *bp_arg, int yShift_arg, bool detailedCrew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func691::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func692::func;
 	return execfunc(this, bp, yShift, detailedCrew);
 }
 
-namespace _func692
+namespace _func693
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9578,11 +9592,11 @@ namespace _func692
 void InfoBox::SetBlueprintAugment(const AugmentBlueprint *bp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const AugmentBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func692::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func693::func;
 	return execfunc(this, bp);
 }
 
-namespace _func693
+namespace _func694
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9592,11 +9606,11 @@ namespace _func693
 bool InfoBox::IsEmpty()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func693::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func694::func;
 	return execfunc(this);
 }
 
-namespace _func694
+namespace _func695
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9606,11 +9620,11 @@ namespace _func694
 int InfoBox::CalcBoxHeight()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func694::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func695::func;
 	return execfunc(this);
 }
 
-namespace _func695
+namespace _func696
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9620,11 +9634,11 @@ namespace _func695
 void InfoBox::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func695::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func696::func;
 	return execfunc(this);
 }
 
-namespace _func696
+namespace _func697
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9634,11 +9648,11 @@ namespace _func696
 void InfoBox::SetSystemId(int systemId, int maxPower, int currentLevel, int upgrade, int yShift, int forceSystemWidth)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, int systemId_arg, int maxPower_arg, int currentLevel_arg, int upgrade_arg, int yShift_arg, int forceSystemWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func696::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func697::func;
 	return execfunc(this, systemId, maxPower, currentLevel, upgrade, yShift, forceSystemWidth);
 }
 
-namespace _func697
+namespace _func698
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9648,25 +9662,25 @@ namespace _func697
 void InfoBox::SetSystem(ShipSystem *system, int upgrade, int yShift, int forceSystemWidth)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, ShipSystem *system_arg, int upgrade_arg, int yShift_arg, int forceSystemWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func697::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func698::func;
 	return execfunc(this, system, upgrade, yShift, forceSystemWidth);
 }
 
 GL_Color *Global_InfoBox_detailsBarOn;
 
-namespace _var698
+namespace _var699
 {
     static VariableDefinition varObj("Global_InfoBox_detailsBarOn", "!b8(???????\?)89fa84d2ba(???????\?)", &Global_InfoBox_detailsBarOn);
 }
 
 GL_Color *Global_InfoBox_detailsBarOff;
 
-namespace _var699
+namespace _var700
 {
     static VariableDefinition varObj("Global_InfoBox_detailsBarOff", "", &Global_InfoBox_detailsBarOff);
 }
 
-namespace _func700
+namespace _func701
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9676,11 +9690,11 @@ namespace _func700
 void InputBox::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InputBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func700::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func701::func;
 	return execfunc(this);
 }
 
-namespace _func701
+namespace _func702
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9690,11 +9704,11 @@ namespace _func701
 void InputBox::TextInput(int ch)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InputBox *this_arg, int ch_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func701::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func702::func;
 	return execfunc(this, ch);
 }
 
-namespace _func702
+namespace _func703
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9704,11 +9718,11 @@ namespace _func702
 void InputBox::TextEvent(CEvent::TextEvent event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InputBox *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func702::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func703::func;
 	return execfunc(this, event);
 }
 
-namespace _func703
+namespace _func704
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9718,11 +9732,11 @@ namespace _func703
 void InputBox::StartInput()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InputBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func703::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func704::func;
 	return execfunc(this);
 }
 
-namespace _func704
+namespace _func705
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9732,11 +9746,11 @@ namespace _func704
 Damage IonDrone::GetRoomDamage()
 {
 	typedef Damage __attribute__((cdecl)) (*custom_arg_funcptr_t)(IonDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func704::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func705::func;
 	return execfunc(this);
 }
 
-namespace _func705
+namespace _func706
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9746,11 +9760,11 @@ namespace _func705
 void IonDrone::constructor(int iShipId, DroneBlueprint *blueprint)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(IonDrone *this_arg, int iShipId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func705::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func706::func;
 	return execfunc(this, iShipId, blueprint);
 }
 
-namespace _func706
+namespace _func707
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -9760,11 +9774,11 @@ namespace _func706
 void IonDroneAnimation::constructor(int iShipId, Pointf position, bool enemy)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(IonDroneAnimation *this_arg, int iShipId_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func706::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func707::func;
 	return execfunc(this, iShipId, position, enemy);
 }
 
-namespace _func707
+namespace _func708
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9774,11 +9788,11 @@ namespace _func707
 void IonDroneAnimation::UpdateShooting()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(IonDroneAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func707::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func708::func;
 	return execfunc(this);
 }
 
-namespace _func708
+namespace _func709
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9788,18 +9802,18 @@ namespace _func708
 void ItemStoreBox::constructor(ShipManager *ship, const std::string &resourceName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ItemStoreBox *this_arg, ShipManager *ship_arg, const std::string &resourceName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func708::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func709::func;
 	return execfunc(this, ship, resourceName);
 }
 
 std::vector<std::string> *Global_OptionsScreen_languageList;
 
-namespace _var709
+namespace _var710
 {
     static VariableDefinition varObj("Global_OptionsScreen_languageList", "!8d348500000000a1(???????\?)", &Global_OptionsScreen_languageList);
 }
 
-namespace _func710
+namespace _func711
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9809,11 +9823,11 @@ namespace _func710
 void LanguageChooser::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(LanguageChooser *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func710::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func711::func;
 	return execfunc(this);
 }
 
-namespace _func711
+namespace _func712
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9823,11 +9837,11 @@ namespace _func711
 void LaserBlast::OnUpdate()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(LaserBlast *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func711::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func712::func;
 	return execfunc(this);
 }
 
-namespace _func712
+namespace _func713
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9837,25 +9851,25 @@ namespace _func712
 void LaserBlast::OnInit()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(LaserBlast *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func712::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func713::func;
 	return execfunc(this);
 }
 
 void **VTable_LaserBlast;
 
-namespace _var713
+namespace _var714
 {
     static VariableDefinition varObj("VTable_LaserBlast", "!e8????????8b8d3cfffffff30f108538ffffff8b4174394170c701(???????\?)c74104(???????\?)", &VTable_LaserBlast);
 }
 
 void **VTable_Targetable_LaserBlast;
 
-namespace _var714
+namespace _var715
 {
     static VariableDefinition varObj("VTable_Targetable_LaserBlast", "", &VTable_Targetable_LaserBlast);
 }
 
-namespace _func715
+namespace _func716
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9865,11 +9879,11 @@ namespace _func715
 void LocationEvent::ClearEvent(bool force)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(LocationEvent *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func715::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func716::func;
 	return execfunc(this, force);
 }
 
-namespace _func716
+namespace _func717
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9879,11 +9893,11 @@ namespace _func716
 void LocationEvent::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(LocationEvent *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func716::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func717::func;
 	return execfunc(this);
 }
 
-namespace _func717
+namespace _func718
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9893,11 +9907,11 @@ namespace _func717
 void LockdownShard::Update()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(LockdownShard *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func717::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func718::func;
 	return execfunc(this);
 }
 
-namespace _func718
+namespace _func719
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9907,11 +9921,11 @@ namespace _func718
 void MainMenu::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func718::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func719::func;
 	return execfunc(this);
 }
 
-namespace _func719
+namespace _func720
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9921,11 +9935,11 @@ namespace _func719
 bool MainMenu::Open()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func719::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func720::func;
 	return execfunc(this);
 }
 
-namespace _func720
+namespace _func721
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9935,11 +9949,11 @@ namespace _func720
 void MainMenu::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MainMenu *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func720::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func721::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func721
+namespace _func722
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9949,11 +9963,11 @@ namespace _func721
 void MainMenu::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func721::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func722::func;
 	return execfunc(this);
 }
 
-namespace _func722
+namespace _func723
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9963,11 +9977,11 @@ namespace _func722
 void MainMenu::MouseClick(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MainMenu *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func722::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func723::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func723
+namespace _func724
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9977,18 +9991,18 @@ namespace _func723
 void MainMenu::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func723::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func724::func;
 	return execfunc(this);
 }
 
-namespace _func724
+namespace _func725
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("MantisAnimation::__DO_NOT_HOOK", typeid(void (MantisAnimation::*)()), "565383ec148b7424208b5c2424893424895c2404e8????????f30f108640050000", argdata, 0, 4, &func);
 }
 
-namespace _func725
+namespace _func726
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9998,18 +10012,18 @@ namespace _func725
 std::string MantisAnimation::GetShootingSound()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func725::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func726::func;
 	return execfunc(this);
 }
 
-namespace _func726
+namespace _func727
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("MantisAnimation::__DO_NOT_HOOK2", typeid(void (MantisAnimation::*)()), "8b44240431d280b8d108000000", argdata, 0, 4, &func);
 }
 
-namespace _func727
+namespace _func728
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10019,18 +10033,18 @@ namespace _func727
 std::string MantisAnimation::GetDeathSound()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func727::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func728::func;
 	return execfunc(this);
 }
 
-namespace _func728
+namespace _func729
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("MantisAnimation::__DO_NOT_HOOK3", typeid(void (MantisAnimation::*)()), "31c080bb9f0900000075??c6839f0900000183c418b8010000005b", argdata, 0, 4, &func);
 }
 
-namespace _func729
+namespace _func730
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10040,20 +10054,6 @@ namespace _func729
 bool MantisAnimation::FireShot()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func729::func;
-	return execfunc(this);
-}
-
-namespace _func730
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("MenuScreen::OnLanguageChange", typeid(void (MenuScreen::*)()), "5589e557565381ec9c0000008b75088b561c", argdata, 1, 6, &func);
-}
-
-void MenuScreen::OnLanguageChange()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func730::func;
 	return execfunc(this);
 }
@@ -10062,10 +10062,10 @@ namespace _func731
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("MenuScreen::OnRender", typeid(void (MenuScreen::*)()), ".5589e557565381ecbc0000008b5d0880bb5c02000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("MenuScreen::OnLanguageChange", typeid(void (MenuScreen::*)()), "5589e557565381ec9c0000008b75088b561c", argdata, 1, 6, &func);
 }
 
-void MenuScreen::OnRender()
+void MenuScreen::OnLanguageChange()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func731::func;
@@ -10076,10 +10076,10 @@ namespace _func732
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("MenuScreen::Open", typeid(void (MenuScreen::*)()), ".5589e557565383ec4c8b7d088d75d88d", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("MenuScreen::OnRender", typeid(void (MenuScreen::*)()), ".5589e557565381ecbc0000008b5d0880bb5c02000000", argdata, 1, 6, &func);
 }
 
-void MenuScreen::Open()
+void MenuScreen::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func732::func;
@@ -10090,10 +10090,10 @@ namespace _func733
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("MenuScreen::constructor", typeid(void (MenuScreen::*)()), ".5557565381ec0c0100008b9c24200100008db424a8000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("MenuScreen::Open", typeid(void (MenuScreen::*)()), ".5589e557565383ec4c8b7d088d75d88d", argdata, 1, 6, &func);
 }
 
-void MenuScreen::constructor()
+void MenuScreen::Open()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func733::func;
@@ -10103,6 +10103,20 @@ void MenuScreen::constructor()
 namespace _func734
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("MenuScreen::constructor", typeid(void (MenuScreen::*)()), ".5557565381ec0c0100008b9c24200100008db424a8000000", argdata, 1, 6, &func);
+}
+
+void MenuScreen::constructor()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func734::func;
+	return execfunc(this);
+}
+
+namespace _func735
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
 	static FunctionDefinition funcObj("MindBox::constructor", typeid(void (MindBox::*)(Point , MindSystem *)), "5557565383ec7c8b9c24900000008d7c243c", argdata, 3, 6, &func);
 }
@@ -10110,11 +10124,11 @@ namespace _func734
 void MindBox::constructor(Point pos, MindSystem *sys)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MindBox *this_arg, Point pos_arg, MindSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func734::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func735::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func735
+namespace _func736
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10124,11 +10138,11 @@ namespace _func735
 void MindSystem::ReleaseCrew()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MindSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func735::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func736::func;
 	return execfunc(this);
 }
 
-namespace _func736
+namespace _func737
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10138,11 +10152,11 @@ namespace _func736
 void MindSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MindSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func736::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func737::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func737
+namespace _func738
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10152,11 +10166,11 @@ namespace _func737
 void MindSystem::SetArmed(int armed)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MindSystem *this_arg, int armed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func737::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func738::func;
 	return execfunc(this, armed);
 }
 
-namespace _func738
+namespace _func739
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10166,11 +10180,11 @@ namespace _func738
 void MindSystem::InitiateMindControl()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MindSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func738::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func739::func;
 	return execfunc(this);
 }
 
-namespace _func739
+namespace _func740
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10180,11 +10194,11 @@ namespace _func739
 void MindSystem::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MindSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func739::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func740::func;
 	return execfunc(this);
 }
 
-namespace _func740
+namespace _func741
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -10194,11 +10208,11 @@ namespace _func740
 void Missile::constructor(Pointf _position, int _ownerId, int _targetId, Pointf _target, float _heading)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Missile *this_arg, Pointf _position_arg, int _ownerId_arg, int _targetId_arg, Pointf _target_arg, float _heading_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func740::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func741::func;
 	return execfunc(this, _position, _ownerId, _targetId, _target, _heading);
 }
 
-namespace _func741
+namespace _func742
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10208,11 +10222,11 @@ namespace _func741
 void MouseControl::SetTooltip(const std::string &tooltip)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func741::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func742::func;
 	return execfunc(this, tooltip);
 }
 
-namespace _func742
+namespace _func743
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10222,11 +10236,11 @@ namespace _func742
 void MouseControl::SetTooltipTitle(const std::string &tooltip)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func742::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func743::func;
 	return execfunc(this, tooltip);
 }
 
-namespace _func743
+namespace _func744
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -10236,11 +10250,11 @@ namespace _func743
 Point MouseControl::MeasureTooltip(int unk)
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func743::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func744::func;
 	return execfunc(this, unk);
 }
 
-namespace _func744
+namespace _func745
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -10250,11 +10264,11 @@ namespace _func744
 void MouseControl::QueueStaticTooltip(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func744::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func745::func;
 	return execfunc(this, pos);
 }
 
-namespace _func745
+namespace _func746
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
@@ -10264,11 +10278,11 @@ namespace _func745
 void MouseControl::RenderTooltip(Point tooltipPoint, bool staticPos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg, Point tooltipPoint_arg, bool staticPos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func745::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func746::func;
 	return execfunc(this, tooltipPoint, staticPos);
 }
 
-namespace _func746
+namespace _func747
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10276,20 +10290,6 @@ namespace _func746
 }
 
 void MouseControl::OnLoop()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func746::func;
-	return execfunc(this);
-}
-
-namespace _func747
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("MouseControl::InstantTooltip", typeid(void (MouseControl::*)()), "8b442404c680d400000001", argdata, 1, 6, &func);
-}
-
-void MouseControl::InstantTooltip()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func747::func;
@@ -10300,10 +10300,10 @@ namespace _func748
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("MouseControl::ResetArmed", typeid(void (MouseControl::*)()), ".8b442404c7401000000000c7401400000000c7401800000000c780e000000000000000c7402000000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("MouseControl::InstantTooltip", typeid(void (MouseControl::*)()), "8b442404c680d400000001", argdata, 1, 6, &func);
 }
 
-void MouseControl::ResetArmed()
+void MouseControl::InstantTooltip()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func748::func;
@@ -10314,10 +10314,10 @@ namespace _func749
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("MouseControl::OnRender", typeid(void (MouseControl::*)()), "5557565381ec3c0100008b9c245001000080bbc900000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("MouseControl::ResetArmed", typeid(void (MouseControl::*)()), ".8b442404c7401000000000c7401400000000c7401800000000c780e000000000000000c7402000000000", argdata, 1, 6, &func);
 }
 
-void MouseControl::OnRender()
+void MouseControl::ResetArmed()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func749::func;
@@ -10328,10 +10328,10 @@ namespace _func750
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("MouseControl::Reset", typeid(void (MouseControl::*)()), ".5383ec288b5c24308d83c0000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("MouseControl::OnRender", typeid(void (MouseControl::*)()), "5557565381ec3c0100008b9c245001000080bbc900000000", argdata, 1, 6, &func);
 }
 
-void MouseControl::Reset()
+void MouseControl::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func750::func;
@@ -10341,6 +10341,20 @@ void MouseControl::Reset()
 namespace _func751
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("MouseControl::Reset", typeid(void (MouseControl::*)()), ".5383ec288b5c24308d83c0000000", argdata, 1, 6, &func);
+}
+
+void MouseControl::Reset()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func751::func;
+	return execfunc(this);
+}
+
+namespace _func752
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("MouseControl::SetDoor", typeid(void (MouseControl::*)(int )), "565383ec148b5c24248b74242083fb01", argdata, 2, 6, &func);
 }
@@ -10348,11 +10362,11 @@ namespace _func751
 void MouseControl::SetDoor(int state)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg, int state_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func751::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func752::func;
 	return execfunc(this, state);
 }
 
-namespace _func752
+namespace _func753
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10362,18 +10376,18 @@ namespace _func752
 void MouseControl::LoadTooltip(const std::string &tooltipName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltipName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func752::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func753::func;
 	return execfunc(this, tooltipName);
 }
 
 MouseControl *Global_MouseControl_Mouse;
 
-namespace _var753
+namespace _var754
 {
     static VariableDefinition varObj("Global_MouseControl_Mouse", "!e8????????e8????????884305c70424(???????\?)", &Global_MouseControl_Mouse);
 }
 
-namespace _func754
+namespace _func755
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10383,11 +10397,11 @@ namespace _func754
 void OptionsScreen::Open(bool mainMenu)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OptionsScreen *this_arg, bool mainMenu_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func754::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func755::func;
 	return execfunc(this, mainMenu);
 }
 
-namespace _func755
+namespace _func756
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10397,11 +10411,11 @@ namespace _func755
 void OptionsScreen::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OptionsScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func755::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func756::func;
 	return execfunc(this);
 }
 
-namespace _func756
+namespace _func757
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10411,18 +10425,18 @@ namespace _func756
 void OptionsScreen::OnInit()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OptionsScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func756::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func757::func;
 	return execfunc(this);
 }
 
 void **VTable_OuterHull;
 
-namespace _var757
+namespace _var758
 {
     static VariableDefinition varObj("VTable_OuterHull", "!8b8d44ffffff8d4168c701(???????\?)", &VTable_OuterHull);
 }
 
-namespace _func758
+namespace _func759
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10432,11 +10446,11 @@ namespace _func758
 void OxygenSystem::UpdateBreach(int roomId, int hasBreach, bool unk3)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, int hasBreach_arg, bool unk3_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func758::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func759::func;
 	return execfunc(this, roomId, hasBreach, unk3);
 }
 
-namespace _func759
+namespace _func760
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -10446,11 +10460,11 @@ namespace _func759
 void OxygenSystem::UpdateAirlock(int roomId, int unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func759::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func760::func;
 	return execfunc(this, roomId, unk);
 }
 
-namespace _func760
+namespace _func761
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10460,11 +10474,11 @@ namespace _func760
 void OxygenSystem::EmptyOxygen(int roomId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func760::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func761::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func761
+namespace _func762
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -10474,11 +10488,11 @@ namespace _func761
 void OxygenSystem::ModifyRoomOxygen(int roomId, float value)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, float value_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func761::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func762::func;
 	return execfunc(this, roomId, value);
 }
 
-namespace _func762
+namespace _func763
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10488,11 +10502,11 @@ namespace _func762
 void OxygenSystem::ComputeAirLoss(int roomId, float value, bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, float value_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func762::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func763::func;
 	return execfunc(this, roomId, value, unk);
 }
 
-namespace _func763
+namespace _func764
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10502,11 +10516,11 @@ namespace _func763
 float OxygenSystem::GetRefillSpeed()
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func763::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func764::func;
 	return execfunc(this);
 }
 
-namespace _func764
+namespace _func765
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10516,11 +10530,11 @@ namespace _func764
 void OxygenSystem::constructor(int numRooms, int roomId, int shipId, int startingPower)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int numRooms_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func764::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func765::func;
 	return execfunc(this, numRooms, roomId, shipId, startingPower);
 }
 
-namespace _func765
+namespace _func766
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10530,11 +10544,11 @@ namespace _func765
 void PDSFire::OnUpdate()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(PDSFire *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func765::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func766::func;
 	return execfunc(this);
 }
 
-namespace _func766
+namespace _func767
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10544,11 +10558,11 @@ namespace _func766
 void PDSFire::CollisionCheck(Collideable *other)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(PDSFire *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func766::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func767::func;
 	return execfunc(this, other);
 }
 
-namespace _func767
+namespace _func768
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x2ff};
@@ -10558,11 +10572,11 @@ namespace _func767
 void PDSFire::constructor(Point pos, int destinationSpace, Pointf destination)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(PDSFire *this_arg, Point pos_arg, int destinationSpace_arg, Pointf destination_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func767::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func768::func;
 	return execfunc(this, pos, destinationSpace, destination);
 }
 
-namespace _func768
+namespace _func769
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -10572,11 +10586,11 @@ namespace _func768
 int Point::RelativeDistance(Point other)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Point *this_arg, Point other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func768::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func769::func;
 	return execfunc(this, other);
 }
 
-namespace _func769
+namespace _func770
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -10586,11 +10600,11 @@ namespace _func769
 int Point::Distance(Point other)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Point *this_arg, Point other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func769::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func770::func;
 	return execfunc(this, other);
 }
 
-namespace _func770
+namespace _func771
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -10600,11 +10614,11 @@ namespace _func770
 void Pointf::constructor(float x, float y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf *this_arg, float x_arg, float y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func770::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func771::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func771
+namespace _func772
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -10614,11 +10628,11 @@ namespace _func771
 float Pointf::RelativeDistance(Pointf other)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf *this_arg, Pointf other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func771::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func772::func;
 	return execfunc(this, other);
 }
 
-namespace _func772
+namespace _func773
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10628,18 +10642,18 @@ namespace _func772
 Pointf Pointf::Normalize()
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func772::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func773::func;
 	return execfunc(this);
 }
 
-namespace _func773
+namespace _func774
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("PowerManager::DO_NOT_HOOK", typeid(void (PowerManager::*)()), "807c????018b54????", argdata, 0, 4, &func);
 }
 
-namespace _func774
+namespace _func775
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10649,11 +10663,11 @@ namespace _func774
 void PowerManager::SetHacked(bool val)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(PowerManager *this_arg, bool val_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func774::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func775::func;
 	return execfunc(this, val);
 }
 
-namespace _func775
+namespace _func776
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10663,11 +10677,11 @@ namespace _func775
 PowerManager *PowerManager::GetPowerManager(int iShipId)
 {
 	typedef PowerManager *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int iShipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func775::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func776::func;
 	return execfunc(iShipId);
 }
 
-namespace _func776
+namespace _func777
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10677,11 +10691,11 @@ namespace _func776
 bool Projectile::ValidTarget()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func776::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func777::func;
 	return execfunc(this);
 }
 
-namespace _func777
+namespace _func778
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10691,11 +10705,11 @@ namespace _func777
 int Projectile::ForceRenderLayer()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func777::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func778::func;
 	return execfunc(this);
 }
 
-namespace _func778
+namespace _func779
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -10705,11 +10719,11 @@ namespace _func778
 CollisionResponse Projectile::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func778::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func779::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func779
+namespace _func780
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10719,11 +10733,11 @@ namespace _func779
 void Projectile::OnUpdate()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func779::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func780::func;
 	return execfunc(this);
 }
 
-namespace _func780
+namespace _func781
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10733,11 +10747,11 @@ namespace _func780
 void Projectile::CollisionCheck(Collideable *other)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func780::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func781::func;
 	return execfunc(this, other);
 }
 
-namespace _func781
+namespace _func782
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff, 0x2ff};
@@ -10747,11 +10761,11 @@ namespace _func781
 void Projectile::constructor(Pointf position, int ownerId, int targetId, Pointf target)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *this_arg, Pointf position_arg, int ownerId_arg, int targetId_arg, Pointf target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func781::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func782::func;
 	return execfunc(this, position, ownerId, targetId, target);
 }
 
-namespace _func782
+namespace _func783
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10761,11 +10775,11 @@ namespace _func782
 void Projectile::Initialize(const WeaponBlueprint &bp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *this_arg, const WeaponBlueprint &bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func782::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func783::func;
 	return execfunc(this, bp);
 }
 
-namespace _func783
+namespace _func784
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10775,11 +10789,11 @@ namespace _func783
 Pointf Projectile::RandomSidePoint(int side)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int side_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func783::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func784::func;
 	return execfunc(side);
 }
 
-namespace _func784
+namespace _func785
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10789,11 +10803,11 @@ namespace _func784
 void Projectile::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func784::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func785::func;
 	return execfunc(this);
 }
 
-namespace _func785
+namespace _func786
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -10803,11 +10817,11 @@ namespace _func785
 void ProjectileFactory::constructor(const WeaponBlueprint *bp, int shipId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, const WeaponBlueprint *bp_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func785::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func786::func;
 	return execfunc(this, bp, shipId);
 }
 
-namespace _func786
+namespace _func787
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10817,11 +10831,11 @@ namespace _func786
 void ProjectileFactory::SelectChargeGoal()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func786::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func787::func;
 	return execfunc(this);
 }
 
-namespace _func787
+namespace _func788
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10831,11 +10845,11 @@ namespace _func787
 bool ProjectileFactory::IsChargedGoal()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func787::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func788::func;
 	return execfunc(this);
 }
 
-namespace _func788
+namespace _func789
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10845,11 +10859,11 @@ namespace _func788
 void ProjectileFactory::SetHacked(int hacked)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, int hacked_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func788::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func789::func;
 	return execfunc(this, hacked);
 }
 
-namespace _func789
+namespace _func790
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10859,11 +10873,11 @@ namespace _func789
 void ProjectileFactory::SetCurrentShip(Targetable *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, Targetable *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func789::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func790::func;
 	return execfunc(this, ship);
 }
 
-namespace _func790
+namespace _func791
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10873,11 +10887,11 @@ namespace _func790
 void ProjectileFactory::SetCooldownModifier(float mod)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float mod_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func790::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func791::func;
 	return execfunc(this, mod);
 }
 
-namespace _func791
+namespace _func792
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10887,11 +10901,11 @@ namespace _func791
 void ProjectileFactory::ForceCoolup()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func791::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func792::func;
 	return execfunc(this);
 }
 
-namespace _func792
+namespace _func793
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10901,11 +10915,11 @@ namespace _func792
 void ProjectileFactory::RenderChargeBar(float unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func792::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func793::func;
 	return execfunc(this, unk);
 }
 
-namespace _func793
+namespace _func794
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10915,11 +10929,11 @@ namespace _func793
 int ProjectileFactory::StringToWeapon(const std::string &str)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &str_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func793::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func794::func;
 	return execfunc(str);
 }
 
-namespace _func794
+namespace _func795
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -10929,11 +10943,11 @@ namespace _func794
 void ProjectileFactory::Fire(std::vector<Pointf> &points, int target)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, std::vector<Pointf> &points_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func794::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func795::func;
 	return execfunc(this, points, target);
 }
 
-namespace _func795
+namespace _func796
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10943,11 +10957,11 @@ namespace _func795
 bool ProjectileFactory::FireNextShot()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func795::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func796::func;
 	return execfunc(this);
 }
 
-namespace _func796
+namespace _func797
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10957,11 +10971,11 @@ namespace _func796
 int ProjectileFactory::SpendMissiles()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func796::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func797::func;
 	return execfunc(this);
 }
 
-namespace _func797
+namespace _func798
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -10971,11 +10985,11 @@ namespace _func797
 void ProjectileFactory::OnRender(float alpha, bool forceVisual)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float alpha_arg, bool forceVisual_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func797::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func798::func;
 	return execfunc(this, alpha, forceVisual);
 }
 
-namespace _func798
+namespace _func799
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10983,20 +10997,6 @@ namespace _func798
 }
 
 void ProjectileFactory::ClearAiming()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func798::func;
-	return execfunc(this);
-}
-
-namespace _func799
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ProjectileFactory::ClearProjectiles", typeid(void (ProjectileFactory::*)()), ".8b4424048b9084040000899088040000", argdata, 1, 6, &func);
-}
-
-void ProjectileFactory::ClearProjectiles()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func799::func;
@@ -11007,17 +11007,31 @@ namespace _func800
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ProjectileFactory::ClearProjectiles", typeid(void (ProjectileFactory::*)()), ".8b4424048b9084040000899088040000", argdata, 1, 6, &func);
+}
+
+void ProjectileFactory::ClearProjectiles()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func800::func;
+	return execfunc(this);
+}
+
+namespace _func801
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("ProjectileFactory::NumTargetsRequired", typeid(int (ProjectileFactory::*)()), "8b5424048b421c83b8fc00000001", argdata, 1, 2, &func);
 }
 
 int ProjectileFactory::NumTargetsRequired()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func800::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func801::func;
 	return execfunc(this);
 }
 
-namespace _func801
+namespace _func802
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11027,11 +11041,11 @@ namespace _func801
 void ProjectileFactory::Update()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func801::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func802::func;
 	return execfunc(this);
 }
 
-namespace _func802
+namespace _func803
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11041,11 +11055,11 @@ namespace _func802
 Projectile *ProjectileFactory::GetProjectile()
 {
 	typedef Projectile *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func802::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func803::func;
 	return execfunc(this);
 }
 
-namespace _func803
+namespace _func804
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11055,11 +11069,11 @@ namespace _func803
 void ProjectileFactory::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func803::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func804::func;
 	return execfunc(this);
 }
 
-namespace _func804
+namespace _func805
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11069,11 +11083,11 @@ namespace _func804
 void ProjectileFactory::SaveProjectile(Projectile *p, int fd)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *p_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func804::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func805::func;
 	return execfunc(p, fd);
 }
 
-namespace _func805
+namespace _func806
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11083,11 +11097,11 @@ namespace _func805
 Projectile *ProjectileFactory::LoadProjectile(int fd)
 {
 	typedef Projectile *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func805::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func806::func;
 	return execfunc(fd);
 }
 
-namespace _func806
+namespace _func807
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11095,20 +11109,6 @@ namespace _func806
 }
 
 void ReactorButton::Accept()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func806::func;
-	return execfunc(this);
-}
-
-namespace _func807
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ReactorButton::OnClick", typeid(void (ReactorButton::*)()), "5589e557565383ec3c8b5d088d75d08b4370", argdata, 1, 6, &func);
-}
-
-void ReactorButton::OnClick()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func807::func;
@@ -11119,10 +11119,10 @@ namespace _func808
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ReactorButton::OnRightClick", typeid(void (ReactorButton::*)()), "5589e557565383ec3c8b5d088d75d08b436c", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ReactorButton::OnClick", typeid(void (ReactorButton::*)()), "5589e557565383ec3c8b5d088d75d08b4370", argdata, 1, 6, &func);
 }
 
-void ReactorButton::OnRightClick()
+void ReactorButton::OnClick()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func808::func;
@@ -11133,24 +11133,38 @@ namespace _func809
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ReactorButton::OnRender", typeid(void (ReactorButton::*)()), "5589e557565381ec0c0300008b4508890424", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ReactorButton::OnRightClick", typeid(void (ReactorButton::*)()), "5589e557565383ec3c8b5d088d75d08b436c", argdata, 1, 6, &func);
 }
 
-void ReactorButton::OnRender()
+void ReactorButton::OnRightClick()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func809::func;
 	return execfunc(this);
 }
 
+namespace _func810
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ReactorButton::OnRender", typeid(void (ReactorButton::*)()), "5589e557565381ec0c0300008b4508890424", argdata, 1, 6, &func);
+}
+
+void ReactorButton::OnRender()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func810::func;
+	return execfunc(this);
+}
+
 void **VTable_RepairAnimation;
 
-namespace _var810
+namespace _var811
 {
     static VariableDefinition varObj("VTable_RepairAnimation", "!0f85150100008d44242889442418c706(???????\?)", &VTable_RepairAnimation);
 }
 
-namespace _func811
+namespace _func812
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -11160,11 +11174,11 @@ namespace _func811
 void RepairStoreBox::constructor(ShipManager *ship, bool repairAll, int price)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(RepairStoreBox *this_arg, ShipManager *ship_arg, bool repairAll_arg, int price_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func811::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func812::func;
 	return execfunc(this, ship, repairAll, price);
 }
 
-namespace _func812
+namespace _func813
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11174,11 +11188,11 @@ namespace _func812
 void ResourceControl::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func812::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func813::func;
 	return execfunc(this);
 }
 
-namespace _func813
+namespace _func814
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -11188,11 +11202,11 @@ namespace _func813
 GL_Primitive *ResourceControl::CreateImagePrimitive(GL_Texture *tex, int unk1, int unk2, int unk3, GL_Color color, float alpha, bool mirror)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg, int unk1_arg, int unk2_arg, int unk3_arg, GL_Color color_arg, float alpha_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func813::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func814::func;
 	return execfunc(this, tex, unk1, unk2, unk3, color, alpha, mirror);
 }
 
-namespace _func814
+namespace _func815
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11202,11 +11216,11 @@ namespace _func814
 void ResourceControl::OnInit(int imageSwappingMode)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, int imageSwappingMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func814::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func815::func;
 	return execfunc(this, imageSwappingMode);
 }
 
-namespace _func815
+namespace _func816
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11216,11 +11230,11 @@ namespace _func815
 char *ResourceControl::LoadFile(const std::string &fileName)
 {
 	typedef char *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func815::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func816::func;
 	return execfunc(this, fileName);
 }
 
-namespace _func816
+namespace _func817
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -11230,11 +11244,11 @@ namespace _func816
 char *ResourceControl::LoadFromResourceFile(const std::string &fileName, std::size_t &fileSize, const std::string *unused_resourceFile)
 {
 	typedef char *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &fileName_arg, std::size_t &fileSize_arg, const std::string *unused_resourceFile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func816::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func817::func;
 	return execfunc(this, fileName, fileSize, unused_resourceFile);
 }
 
-namespace _func817
+namespace _func818
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11244,11 +11258,11 @@ namespace _func817
 GL_Texture *ResourceControl::GetImageId(const std::string &dir)
 {
 	typedef GL_Texture *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func817::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func818::func;
 	return execfunc(this, dir);
 }
 
-namespace _func818
+namespace _func819
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -11258,11 +11272,11 @@ namespace _func818
 int ResourceControl::RenderImage(GL_Texture *tex, int x, int y, int rotation, GL_Color color, float opacity, bool mirror)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float opacity_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func818::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func819::func;
 	return execfunc(this, tex, x, y, rotation, color, opacity, mirror);
 }
 
-namespace _func819
+namespace _func820
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -11272,11 +11286,11 @@ namespace _func819
 int ResourceControl::RenderImageString(std::string &tex, int x, int y, int rotation, GL_Color color, float opacity, bool mirror)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, std::string &tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float opacity_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func819::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func820::func;
 	return execfunc(this, tex, x, y, rotation, color, opacity, mirror);
 }
 
-namespace _func820
+namespace _func821
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -11286,11 +11300,11 @@ namespace _func820
 GL_Primitive *ResourceControl::CreateImagePrimitiveString(const std::string &tex, int x, int y, int rotation, GL_Color color, float alpha, bool mirror)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float alpha_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func820::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func821::func;
 	return execfunc(this, tex, x, y, rotation, color, alpha, mirror);
 }
 
-namespace _func821
+namespace _func822
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11300,11 +11314,11 @@ namespace _func821
 freetype::font_data &ResourceControl::GetFontData(int size, bool ignoreLanguage)
 {
 	typedef freetype::font_data &__attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, int size_arg, bool ignoreLanguage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func821::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func822::func;
 	return execfunc(this, size, ignoreLanguage);
 }
 
-namespace _func822
+namespace _func823
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11314,11 +11328,11 @@ namespace _func822
 ImageDesc ResourceControl::GetImageData(GL_Texture *tex)
 {
 	typedef ImageDesc __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func822::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func823::func;
 	return execfunc(this, tex);
 }
 
-namespace _func823
+namespace _func824
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11328,11 +11342,11 @@ namespace _func823
 bool ResourceControl::ImageExists(const std::string &name)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func823::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func824::func;
 	return execfunc(this, name);
 }
 
-namespace _func824
+namespace _func825
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11342,11 +11356,11 @@ namespace _func824
 bool ResourceControl::PreloadResources(bool unk)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func824::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func825::func;
 	return execfunc(this, unk);
 }
 
-namespace _func825
+namespace _func826
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11356,18 +11370,18 @@ namespace _func825
 void ResourceControl::RenderLoadingBar(float initialProgress, float finalProgress)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, float initialProgress_arg, float finalProgress_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func825::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func826::func;
 	return execfunc(this, initialProgress, finalProgress);
 }
 
 ResourceControl *Global_ResourceControl_GlobalResources;
 
-namespace _var826
+namespace _var827
 {
     static VariableDefinition varObj("Global_ResourceControl_GlobalResources", "!8b45e0890424e8????????c70424(???????\?)", &Global_ResourceControl_GlobalResources);
 }
 
-namespace _func827
+namespace _func828
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -11377,18 +11391,18 @@ namespace _func827
 void RockAnimation::constructor(const std::string &subRace, int iShipId, Pointf position, bool enemy)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(RockAnimation *this_arg, const std::string &subRace_arg, int iShipId_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func827::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func828::func;
 	return execfunc(this, subRace, iShipId, position, enemy);
 }
 
-namespace _func828
+namespace _func829
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK", typeid(void (RockAnimation::*)()), "5557565381ec0c010000803d????????000f85????????e8????????89c7", argdata, 0, 4, &func);
 }
 
-namespace _func829
+namespace _func830
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11398,25 +11412,25 @@ namespace _func829
 std::string RockAnimation::GetShootingSound()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(RockAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func829::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func830::func;
 	return execfunc(this);
-}
-
-namespace _func830
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK2", typeid(void (RockAnimation::*)()), "5383ec288b5c24308d44241f89442408c7442404????????891c24e8????????83c42889d85b", argdata, 0, 4, &func);
 }
 
 namespace _func831
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK3", typeid(void (RockAnimation::*)()), ".5383ec288b5c24308d44241f89442408c7442404????????891c24e8????????83c42889d85b", argdata, 0, 4, &func);
+	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK2", typeid(void (RockAnimation::*)()), "5383ec288b5c24308d44241f89442408c7442404????????891c24e8????????83c42889d85b", argdata, 0, 4, &func);
 }
 
 namespace _func832
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK3", typeid(void (RockAnimation::*)()), ".5383ec288b5c24308d44241f89442408c7442404????????891c24e8????????83c42889d85b", argdata, 0, 4, &func);
+}
+
+namespace _func833
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11426,11 +11440,11 @@ namespace _func832
 std::string RockAnimation::GetDeathSound()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(RockAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func832::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func833::func;
 	return execfunc(this);
 }
 
-namespace _func833
+namespace _func834
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11440,11 +11454,11 @@ namespace _func833
 int Room::GetEmptySlots(bool intruder)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func833::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func834::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func834
+namespace _func835
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11454,11 +11468,11 @@ namespace _func834
 bool Room::Full(bool intruder)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func834::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func835::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func835
+namespace _func836
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11468,18 +11482,18 @@ namespace _func835
 int Room::GetEmptySlot(bool intruder)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func835::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func836::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func836
+namespace _func837
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("Room::DO_NOT_HOOK", typeid(void (Room::*)()), ".56538b5c240c0fb64424148b4c2410", argdata, 0, 4, &func);
 }
 
-namespace _func837
+namespace _func838
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11489,11 +11503,11 @@ namespace _func837
 void Room::FillSlot(int slot, bool intruder)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Room *this_arg, int slot_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func837::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func838::func;
 	return execfunc(this, slot, intruder);
 }
 
-namespace _func838
+namespace _func839
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -11503,11 +11517,11 @@ namespace _func838
 void Room::constructor(int iShipId, int x, int y, int w, int h, int roomId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Room *this_arg, int iShipId_arg, int x_arg, int y_arg, int w_arg, int h_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func838::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func839::func;
 	return execfunc(this, iShipId, x, y, w, h, roomId);
 }
 
-namespace _func839
+namespace _func840
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11517,11 +11531,11 @@ namespace _func839
 void Room::OnRenderFloor(float alpha, bool experimental)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Room *this_arg, float alpha_arg, bool experimental_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func839::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func840::func;
 	return execfunc(this, alpha, experimental);
 }
 
-namespace _func840
+namespace _func841
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11531,11 +11545,11 @@ namespace _func840
 void Room::OnRenderWalls(float alpha)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Room *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func840::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func841::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func841
+namespace _func842
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11545,11 +11559,11 @@ namespace _func841
 void Room::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Room *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func841::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func842::func;
 	return execfunc(this);
 }
 
-namespace _func842
+namespace _func843
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11559,11 +11573,11 @@ namespace _func842
 bool ScoreKeeper::GetShipUnlocked(int shipId, int shipVariant)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int shipId_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func842::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func843::func;
 	return execfunc(this, shipId, shipVariant);
 }
 
-namespace _func843
+namespace _func844
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11573,11 +11587,11 @@ namespace _func843
 std::string ScoreKeeper::GetShipBlueprint(int index)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int index_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func843::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func844::func;
 	return execfunc(this, index);
 }
 
-namespace _func844
+namespace _func845
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11587,11 +11601,11 @@ namespace _func844
 void ScoreKeeper::OnInit()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func844::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func845::func;
 	return execfunc(this);
 }
 
-namespace _func845
+namespace _func846
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11601,11 +11615,11 @@ namespace _func845
 void ScoreKeeper::Save(bool newHighScore)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool newHighScore_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func845::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func846::func;
 	return execfunc(this, newHighScore);
 }
 
-namespace _func846
+namespace _func847
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11615,11 +11629,11 @@ namespace _func846
 void ScoreKeeper::OnRender(bool lastPlaythrough)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool lastPlaythrough_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func846::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func847::func;
 	return execfunc(this, lastPlaythrough);
 }
 
-namespace _func847
+namespace _func848
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
@@ -11629,11 +11643,11 @@ namespace _func847
 void ScoreKeeper::UnlockShip(int shipType, int shipVariant, bool save, bool hidePopup)
 {
 	typedef void __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int shipType_arg, int shipVariant_arg, bool save_arg, bool hidePopup_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func847::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func848::func;
 	return execfunc(this, shipType, shipVariant, save, hidePopup);
 }
 
-namespace _func848
+namespace _func849
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11643,11 +11657,11 @@ namespace _func848
 void ScoreKeeper::SetVictory(bool victory)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool victory_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func848::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func849::func;
 	return execfunc(this, victory);
 }
 
-namespace _func849
+namespace _func850
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11657,11 +11671,11 @@ namespace _func849
 void ScoreKeeper::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func849::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func850::func;
 	return execfunc(this);
 }
 
-namespace _func850
+namespace _func851
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11671,11 +11685,11 @@ namespace _func850
 std::pair<int, int> ScoreKeeper::GetShipId(const std::string &blueprintName)
 {
 	typedef std::pair<int, int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, const std::string &blueprintName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func850::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func851::func;
 	return execfunc(this, blueprintName);
 }
 
-namespace _func851
+namespace _func852
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11685,11 +11699,11 @@ namespace _func851
 void ScoreKeeper::LoadVersionFour(int file, int version)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int file_arg, int version_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func851::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func852::func;
 	return execfunc(this, file, version);
 }
 
-namespace _func852
+namespace _func853
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11699,11 +11713,11 @@ namespace _func852
 void ScoreKeeper::WipeProfile(bool permanent)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool permanent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func852::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func853::func;
 	return execfunc(this, permanent);
 }
 
-namespace _func853
+namespace _func854
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11713,11 +11727,11 @@ namespace _func853
 void ScoreKeeper::MouseClick(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func853::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func854::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func854
+namespace _func855
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11727,11 +11741,11 @@ namespace _func854
 void ScoreKeeper::SetupTopShip(int variant)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int variant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func854::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func855::func;
 	return execfunc(this, variant);
 }
 
-namespace _func855
+namespace _func856
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11741,11 +11755,11 @@ namespace _func855
 void ScoreKeeper::CheckTypes()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func855::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func856::func;
 	return execfunc(this);
 }
 
-namespace _func856
+namespace _func857
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102, 0x101};
@@ -11755,11 +11769,11 @@ namespace _func856
 void ScoreKeeper::AddTopScoreType(TopScore &topScore, int type)
 {
 	typedef void __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, TopScore &topScore_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func856::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func857::func;
 	return execfunc(this, topScore, type);
 }
 
-namespace _func857
+namespace _func858
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11769,11 +11783,11 @@ namespace _func857
 int ScoreKeeper::AddTopScoreList(TopScore &score, std::vector<TopScore> &topScoreList)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, TopScore &score_arg, std::vector<TopScore> &topScoreList_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func857::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func858::func;
 	return execfunc(this, score, topScoreList);
 }
 
-namespace _func858
+namespace _func859
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -11783,11 +11797,11 @@ namespace _func858
 void ScoreKeeper::RenderTopScores(const std::vector<TopScore> &topScoreList, Point position, int newHighScore)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, const std::vector<TopScore> &topScoreList_arg, Point position_arg, int newHighScore_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func858::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func859::func;
 	return execfunc(this, topScoreList, position, newHighScore);
 }
 
-namespace _func859
+namespace _func860
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11797,11 +11811,11 @@ namespace _func859
 void ScoreKeeper::CycleLeft()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func859::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func860::func;
 	return execfunc(this);
 }
 
-namespace _func860
+namespace _func861
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11811,11 +11825,11 @@ namespace _func860
 void ScoreKeeper::CycleRight()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func860::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func861::func;
 	return execfunc(this);
 }
 
-namespace _func861
+namespace _func862
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11825,11 +11839,11 @@ namespace _func861
 void ScoreKeeper::Open(bool fromGameOver)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool fromGameOver_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func861::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func862::func;
 	return execfunc(this, fromGameOver);
 }
 
-namespace _func862
+namespace _func863
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11839,11 +11853,11 @@ namespace _func862
 bool ScoreKeeper::KeyDown(SDLKey key)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func862::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func863::func;
 	return execfunc(this, key);
 }
 
-namespace _func863
+namespace _func864
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11853,11 +11867,11 @@ namespace _func863
 void ScoreKeeper::AddScrapCollected(int scrap)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int scrap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func863::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func864::func;
 	return execfunc(this, scrap);
 }
 
-namespace _func864
+namespace _func865
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11867,11 +11881,11 @@ namespace _func864
 void ScoreKeeper::SaveScores(int file, std::vector<TopScore> &topScores)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int file_arg, std::vector<TopScore> &topScores_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func864::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func865::func;
 	return execfunc(this, file, topScores);
 }
 
-namespace _func865
+namespace _func866
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11881,11 +11895,11 @@ namespace _func865
 void ScoreKeeper::SaveGame(int fd)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func865::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func866::func;
 	return execfunc(this, fd);
 }
 
-namespace _func866
+namespace _func867
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11895,11 +11909,11 @@ namespace _func866
 void ScoreKeeper::LoadGame(int fd)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func866::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func867::func;
 	return execfunc(this, fd);
 }
 
-namespace _func867
+namespace _func868
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11909,11 +11923,11 @@ namespace _func867
 void ScoreKeeper::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func867::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func868::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func868
+namespace _func869
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11923,18 +11937,18 @@ namespace _func868
 void ScoreKeeper::SetSector(int sector)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int sector_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func868::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func869::func;
 	return execfunc(this, sector);
 }
 
 ScoreKeeper *Global_ScoreKeeper_Keeper;
 
-namespace _var869
+namespace _var870
 {
     static VariableDefinition varObj("Global_ScoreKeeper_Keeper", "!c744240401000000c70424(???????\?)e8????????89742408", &Global_ScoreKeeper_Keeper);
 }
 
-namespace _func870
+namespace _func871
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -11944,11 +11958,11 @@ namespace _func870
 char Settings::GetCommandConsole()
 {
 	typedef char __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func870::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func871::func;
 	return execfunc();
 }
 
-namespace _func871
+namespace _func872
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -11958,11 +11972,11 @@ namespace _func871
 bool Settings::GetDlcEnabled()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func871::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func872::func;
 	return execfunc();
 }
 
-namespace _func872
+namespace _func873
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11972,11 +11986,11 @@ namespace _func872
 std::string Settings::GetHotkeyName(const std::string &name)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func872::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func873::func;
 	return execfunc(name);
 }
 
-namespace _func873
+namespace _func874
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11986,11 +12000,11 @@ namespace _func873
 SDLKey Settings::GetHotkey(const std::string &hotkeyName)
 {
 	typedef SDLKey __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &hotkeyName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func873::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func874::func;
 	return execfunc(hotkeyName);
 }
 
-namespace _func874
+namespace _func875
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12000,11 +12014,11 @@ namespace _func874
 void Settings::SetHotkey(const std::string &hotkeyName, SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &hotkeyName_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func874::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func875::func;
 	return execfunc(hotkeyName, key);
 }
 
-namespace _func875
+namespace _func876
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -12012,20 +12026,6 @@ namespace _func875
 }
 
 void Settings::SaveSettings()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func875::func;
-	return execfunc();
-}
-
-namespace _func876
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("Settings::ResetHotkeys", typeid(void (*)()), "5557bf????????565383ec4c8d6c2430", argdata, 0, 6, &func);
-}
-
-void Settings::ResetHotkeys()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func876::func;
@@ -12036,24 +12036,38 @@ namespace _func877
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("Settings::LoadSettings", typeid(void (*)()), "5589e557565381ec9c01000065a114000000", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("Settings::ResetHotkeys", typeid(void (*)()), "5557bf????????565383ec4c8d6c2430", argdata, 0, 6, &func);
 }
 
-void Settings::LoadSettings()
+void Settings::ResetHotkeys()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func877::func;
 	return execfunc();
 }
 
+namespace _func878
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("Settings::LoadSettings", typeid(void (*)()), "5589e557565381ec9c01000065a114000000", argdata, 0, 6, &func);
+}
+
+void Settings::LoadSettings()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func878::func;
+	return execfunc();
+}
+
 SettingValues *Global_Settings_Settings;
 
-namespace _var878
+namespace _var879
 {
     static VariableDefinition varObj("Global_Settings_Settings", "!89c557565383ec2cc744241c(???????\?)", &Global_Settings_Settings);
 }
 
-namespace _func879
+namespace _func880
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12063,11 +12077,11 @@ namespace _func879
 void Shields::SetHackingLevel(int hackingLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func879::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func880::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func880
+namespace _func881
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0xdff, 0x1ff};
@@ -12077,11 +12091,11 @@ namespace _func880
 CollisionResponse Shields::CollisionReal(float x, float y, Damage damage, bool force)
 {
 	typedef CollisionResponse __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg, float x_arg, float y_arg, Damage damage_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func880::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func881::func;
 	return execfunc(this, x, y, damage, force);
 }
 
-namespace _func881
+namespace _func882
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -12091,11 +12105,11 @@ namespace _func881
 void Shields::constructor(int roomId, int shipId, int startingPower, const std::string &shieldFile)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg, int roomId_arg, int shipId_arg, int startingPower_arg, const std::string &shieldFile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func881::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func882::func;
 	return execfunc(this, roomId, shipId, startingPower, shieldFile);
 }
 
-namespace _func882
+namespace _func883
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff};
@@ -12105,11 +12119,11 @@ namespace _func882
 void Shields::SetBaseEllipse(Globals::Ellipse ellipse)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg, Globals::Ellipse ellipse_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func882::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func883::func;
 	return execfunc(this, ellipse);
 }
 
-namespace _func883
+namespace _func884
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12117,20 +12131,6 @@ namespace _func883
 }
 
 void Shields::InstantCharge()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func883::func;
-	return execfunc(this);
-}
-
-namespace _func884
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("Shields::Jump", typeid(void (Shields::*)()), "57565383ec208b5c24308d74241c891c24", argdata, 1, 6, &func);
-}
-
-void Shields::Jump()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func884::func;
@@ -12141,10 +12141,10 @@ namespace _func885
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("Shields::OnLoop", typeid(void (Shields::*)()), "5557565383ec3c8b5c24508d74242c891c24e8????????8d44242a", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("Shields::Jump", typeid(void (Shields::*)()), "57565383ec208b5c24308d74241c891c24", argdata, 1, 6, &func);
 }
 
-void Shields::OnLoop()
+void Shields::Jump()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func885::func;
@@ -12154,6 +12154,20 @@ void Shields::OnLoop()
 namespace _func886
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("Shields::OnLoop", typeid(void (Shields::*)()), "5557565383ec3c8b5c24508d74242c891c24e8????????8d44242a", argdata, 1, 6, &func);
+}
+
+void Shields::OnLoop()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func886::func;
+	return execfunc(this);
+}
+
+namespace _func887
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
 	static FunctionDefinition funcObj("Shields::AddSuperShield", typeid(void (Shields::*)(Point )), "57ba05000000565383ec108b5c24208b7424248b7c2428", argdata, 2, 6, &func);
 }
@@ -12161,11 +12175,11 @@ namespace _func886
 void Shields::AddSuperShield(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func886::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func887::func;
 	return execfunc(this, pos);
 }
 
-namespace _func887
+namespace _func888
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12175,11 +12189,11 @@ namespace _func887
 void Shields::RenderBase(float alpha, float superShieldOverwrite)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg, float alpha_arg, float superShieldOverwrite_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func887::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func888::func;
 	return execfunc(this, alpha, superShieldOverwrite);
 }
 
-namespace _func888
+namespace _func889
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0xdff};
@@ -12189,18 +12203,18 @@ namespace _func888
 CollisionResponse Shields::CollisionTest(float x, float y, Damage damage)
 {
 	typedef CollisionResponse __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg, float x_arg, float y_arg, Damage damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func888::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func889::func;
 	return execfunc(this, x, y, damage);
 }
 
 GL_Color *Global_COLOR_GREEN;
 
-namespace _var889
+namespace _var890
 {
     static VariableDefinition varObj("Global_COLOR_GREEN", "!f30f101d(???????\?)f30f1025????????f30f1015", &Global_COLOR_GREEN);
 }
 
-namespace _func890
+namespace _func891
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -12210,11 +12224,11 @@ namespace _func890
 int Ship::GetSelectedRoomId(int x, int y, bool unk)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int x_arg, int y_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func890::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func891::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func891
+namespace _func892
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff};
@@ -12224,11 +12238,11 @@ namespace _func891
 void Ship::LockdownRoom(int roomId, Pointf pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, Pointf pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func891::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func892::func;
 	return execfunc(this, roomId, pos);
 }
 
-namespace _func892
+namespace _func893
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12238,11 +12252,11 @@ namespace _func892
 bool Ship::RoomLocked(int roomId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func892::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func893::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func893
+namespace _func894
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12252,11 +12266,11 @@ namespace _func893
 bool Ship::DestroyedDone()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func893::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func894::func;
 	return execfunc(this);
 }
 
-namespace _func894
+namespace _func895
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12266,11 +12280,11 @@ namespace _func894
 bool Ship::FullRoom(int roomId, bool intruder)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func894::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func895::func;
 	return execfunc(this, roomId, intruder);
 }
 
-namespace _func895
+namespace _func896
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12280,11 +12294,11 @@ namespace _func895
 int Ship::EmptySlots(int roomId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func895::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func896::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func896
+namespace _func897
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12294,11 +12308,11 @@ namespace _func896
 int Ship::GetAvailableRoomSlot(int roomId, bool intruder)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func896::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func897::func;
 	return execfunc(this, roomId, intruder);
 }
 
-namespace _func897
+namespace _func898
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12308,11 +12322,11 @@ namespace _func897
 void Ship::OnRenderBreaches()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func897::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func898::func;
 	return execfunc(this);
 }
 
-namespace _func898
+namespace _func899
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12322,11 +12336,11 @@ namespace _func898
 void Ship::OnRenderWalls(bool forceView, bool doorControlMode)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, bool forceView_arg, bool doorControlMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func898::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func899::func;
 	return execfunc(this, forceView, doorControlMode);
 }
 
-namespace _func899
+namespace _func900
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12336,11 +12350,11 @@ namespace _func899
 void Ship::OnInit(ShipBlueprint *bp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, ShipBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func899::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func900::func;
 	return execfunc(this, bp);
 }
 
-namespace _func900
+namespace _func901
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12350,11 +12364,11 @@ namespace _func900
 void Ship::OnRenderSparks()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func900::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func901::func;
 	return execfunc(this);
 }
 
-namespace _func901
+namespace _func902
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12364,11 +12378,11 @@ namespace _func901
 void Ship::SetRoomBlackout(int roomId, bool blackout)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool blackout_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func901::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func902::func;
 	return execfunc(this, roomId, blackout);
 }
 
-namespace _func902
+namespace _func903
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12376,20 +12390,6 @@ namespace _func902
 }
 
 void Ship::OnRenderBase(bool unk)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func902::func;
-	return execfunc(this, unk);
-}
-
-namespace _func903
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("Ship::OnRenderFloor", typeid(void (Ship::*)(bool )), "565383ec248b5c24308b74243480bbf002000000", argdata, 2, 6, &func);
-}
-
-void Ship::OnRenderFloor(bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func903::func;
@@ -12400,17 +12400,31 @@ namespace _func904
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("Ship::OnRenderFloor", typeid(void (Ship::*)(bool )), "565383ec248b5c24308b74243480bbf002000000", argdata, 2, 6, &func);
+}
+
+void Ship::OnRenderFloor(bool unk)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func904::func;
+	return execfunc(this, unk);
+}
+
+namespace _func905
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("Ship::OnRenderJump", typeid(void (Ship::*)(float )), "5557565383ec5c8b5c24708b4304890424", argdata, 2, 6, &func);
 }
 
 void Ship::OnRenderJump(float progress)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, float progress_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func904::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func905::func;
 	return execfunc(this, progress);
 }
 
-namespace _func905
+namespace _func906
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12420,11 +12434,11 @@ namespace _func905
 Globals::Ellipse Ship::GetBaseEllipse()
 {
 	typedef Globals::Ellipse __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func905::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func906::func;
 	return execfunc(this);
 }
 
-namespace _func906
+namespace _func907
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12434,11 +12448,11 @@ namespace _func906
 void Ship::SetSelectedRoom(int roomId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func906::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func907::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func907
+namespace _func908
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12448,11 +12462,11 @@ namespace _func907
 void Ship::OnLoop(std::vector<float> &oxygenLevels)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, std::vector<float> &oxygenLevels_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func907::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func908::func;
 	return execfunc(this, oxygenLevels);
 }
 
-namespace _func908
+namespace _func909
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12462,11 +12476,11 @@ namespace _func908
 void Ship::BreachRandomHull(int roomId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func908::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func909::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func909
+namespace _func910
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12476,11 +12490,11 @@ namespace _func909
 int Ship::GetAvailableRoom(int preferred, bool intruder)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int preferred_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func909::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func910::func;
 	return execfunc(this, preferred, intruder);
 }
 
-namespace _func910
+namespace _func911
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12490,11 +12504,11 @@ namespace _func910
 void Ship::BreachSpecificHull(int grid_x, int grid_y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int grid_x_arg, int grid_y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func910::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func911::func;
 	return execfunc(this, grid_x, grid_y);
 }
 
-namespace _func911
+namespace _func912
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12504,41 +12518,41 @@ namespace _func911
 std::vector<Repairable*> Ship::GetHullBreaches(bool onlyDamaged)
 {
 	typedef std::vector<Repairable*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, bool onlyDamaged_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func911::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func912::func;
 	return execfunc(this, onlyDamaged);
-}
-
-namespace _noop912
-{
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_0", "!39d07d0b(c6840d74fefeff01)");
 }
 
 namespace _noop913
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_1", "!39d07d03(c60101)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_0", "!39d07d0b(c6840d74fefeff01)");
 }
 
 namespace _noop914
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_2", "!89d37d03(c60101)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_1", "!39d07d03(c60101)");
 }
 
 namespace _noop915
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_3", "!39c27d0b(c6840d70fefeff01)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_2", "!89d37d03(c60101)");
 }
 
 namespace _noop916
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_4", "!39c27d03(c60101)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_3", "!39c27d0b(c6840d70fefeff01)");
 }
 
 namespace _noop917
 {
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_4", "!39c27d03(c60101)");
+}
+
+namespace _noop918
+{
     static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_5", "!89c37e03(c60101)");
 }
 
-namespace _func918
+namespace _func919
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12548,11 +12562,11 @@ namespace _func918
 void ShipAI::constructor(bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipAI *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func918::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func919::func;
 	return execfunc(this, unk);
 }
 
-namespace _func919
+namespace _func920
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12562,11 +12576,11 @@ namespace _func919
 void ShipAI::SetStalemate(bool stalemate)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipAI *this_arg, bool stalemate_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func919::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func920::func;
 	return execfunc(this, stalemate);
 }
 
-namespace _func920
+namespace _func921
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12576,11 +12590,11 @@ namespace _func920
 void ShipAI::OnLoop(bool hostile)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipAI *this_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func920::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func921::func;
 	return execfunc(this, hostile);
 }
 
-namespace _func921
+namespace _func922
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12590,11 +12604,11 @@ namespace _func921
 std::pair<int, int> ShipAI::GetTeleportCommand()
 {
 	typedef std::pair<int, int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func921::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func922::func;
 	return execfunc(this);
 }
 
-namespace _func922
+namespace _func923
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12604,11 +12618,11 @@ namespace _func922
 void ShipBlueprint::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func922::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func923::func;
 	return execfunc(this);
 }
 
-namespace _func923
+namespace _func924
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12618,11 +12632,11 @@ namespace _func923
 void ShipBuilder::CheckTypes()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func923::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func924::func;
 	return execfunc(this);
 }
 
-namespace _func924
+namespace _func925
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12632,11 +12646,11 @@ namespace _func924
 void ShipBuilder::MouseClick(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func924::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func925::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func925
+namespace _func926
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12646,11 +12660,11 @@ namespace _func925
 void ShipBuilder::SwitchShip(int shipType, int shipVariant)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int shipType_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func925::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func926::func;
 	return execfunc(this, shipType, shipVariant);
 }
 
-namespace _func926
+namespace _func927
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12658,20 +12672,6 @@ namespace _func926
 }
 
 void ShipBuilder::CreateEquipmentBoxes()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func926::func;
-	return execfunc(this);
-}
-
-namespace _func927
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::CreateSystemBoxes", typeid(void (ShipBuilder::*)()), "5557565383ec3c8b6c24508b8dc80e0000", argdata, 1, 6, &func);
-}
-
-void ShipBuilder::CreateSystemBoxes()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func927::func;
@@ -12682,10 +12682,10 @@ namespace _func928
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::SetupShipAchievements", typeid(void (ShipBuilder::*)()), "5589e557565383ec4c8b75088d7dd88d5db8", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CreateSystemBoxes", typeid(void (ShipBuilder::*)()), "5557565383ec3c8b6c24508b8dc80e0000", argdata, 1, 6, &func);
 }
 
-void ShipBuilder::SetupShipAchievements()
+void ShipBuilder::CreateSystemBoxes()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func928::func;
@@ -12696,10 +12696,10 @@ namespace _func929
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::ClearShipAchievements", typeid(void (ShipBuilder::*)()), "8b4424048b9058170000c78064170000ffffffff", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipBuilder::SetupShipAchievements", typeid(void (ShipBuilder::*)()), "5589e557565383ec4c8b75088d7dd88d5db8", argdata, 1, 6, &func);
 }
 
-void ShipBuilder::ClearShipAchievements()
+void ShipBuilder::SetupShipAchievements()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func929::func;
@@ -12709,6 +12709,20 @@ void ShipBuilder::ClearShipAchievements()
 namespace _func930
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ShipBuilder::ClearShipAchievements", typeid(void (ShipBuilder::*)()), "8b4424048b9058170000c78064170000ffffffff", argdata, 1, 6, &func);
+}
+
+void ShipBuilder::ClearShipAchievements()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func930::func;
+	return execfunc(this);
+}
+
+namespace _func931
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipBuilder::SwapType", typeid(void (ShipBuilder::*)(int )), "5383ec188b5c24208b0385c0", argdata, 2, 6, &func);
 }
@@ -12716,11 +12730,11 @@ namespace _func930
 void ShipBuilder::SwapType(int variant)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int variant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func930::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func931::func;
 	return execfunc(this, variant);
 }
 
-namespace _func931
+namespace _func932
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12728,20 +12742,6 @@ namespace _func931
 }
 
 void ShipBuilder::CycleShipNext()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func931::func;
-	return execfunc(this);
-}
-
-namespace _func932
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::CycleShipPrevious", typeid(void (ShipBuilder::*)()), "5756be020000005383ec108b7c24208b8700170000", argdata, 1, 6, &func);
-}
-
-void ShipBuilder::CycleShipPrevious()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func932::func;
@@ -12752,10 +12752,10 @@ namespace _func933
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::Open", typeid(void (ShipBuilder::*)()), "5589e557565381ec2c0300008b4508c6808c17000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CycleShipPrevious", typeid(void (ShipBuilder::*)()), "5756be020000005383ec108b7c24208b8700170000", argdata, 1, 6, &func);
 }
 
-void ShipBuilder::Open()
+void ShipBuilder::CycleShipPrevious()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func933::func;
@@ -12766,10 +12766,10 @@ namespace _func934
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::OnRender", typeid(void (ShipBuilder::*)()), "5589e557565381ecbc0000008b5d0880bb4410000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipBuilder::Open", typeid(void (ShipBuilder::*)()), "5589e557565381ec2c0300008b4508c6808c17000000", argdata, 1, 6, &func);
 }
 
-void ShipBuilder::OnRender()
+void ShipBuilder::Open()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func934::func;
@@ -12780,10 +12780,10 @@ namespace _func935
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::OnLoop", typeid(void (ShipBuilder::*)()), "5589e557565383ec5c8b5d08c70424????????", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipBuilder::OnRender", typeid(void (ShipBuilder::*)()), "5589e557565381ecbc0000008b5d0880bb4410000000", argdata, 1, 6, &func);
 }
 
-void ShipBuilder::OnLoop()
+void ShipBuilder::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func935::func;
@@ -12794,10 +12794,10 @@ namespace _func936
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::constructor", typeid(void (ShipBuilder::*)()), "565383ec348b5c24408d74242c8d430c", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipBuilder::OnLoop", typeid(void (ShipBuilder::*)()), "5589e557565383ec5c8b5d08c70424????????", argdata, 1, 6, &func);
 }
 
-void ShipBuilder::constructor()
+void ShipBuilder::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func936::func;
@@ -12807,6 +12807,20 @@ void ShipBuilder::constructor()
 namespace _func937
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ShipBuilder::constructor", typeid(void (ShipBuilder::*)()), "565383ec348b5c24408d74242c8d430c", argdata, 1, 6, &func);
+}
+
+void ShipBuilder::constructor()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func937::func;
+	return execfunc(this);
+}
+
+namespace _func938
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipBuilder::MouseMove", typeid(void (ShipBuilder::*)(int , int )), "5589e557565381ecac0000008b7d088d873c0e0000", argdata, 3, 6, &func);
 }
@@ -12814,11 +12828,11 @@ namespace _func937
 void ShipBuilder::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func937::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func938::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func938
+namespace _func939
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12828,11 +12842,11 @@ namespace _func938
 void ShipBuilder::OnKeyDown(SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func938::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func939::func;
 	return execfunc(this, key);
 }
 
-namespace _func939
+namespace _func940
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12842,11 +12856,11 @@ namespace _func939
 void ShipButton::constructor(int shipType, int shipVariant)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipButton *this_arg, int shipType_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func939::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func940::func;
 	return execfunc(this, shipType, shipVariant);
 }
 
-namespace _func940
+namespace _func941
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff};
@@ -12856,11 +12870,11 @@ namespace _func940
 void ShipButton::OnInit(const std::string &imgName, Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipButton *this_arg, const std::string &imgName_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func940::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func941::func;
 	return execfunc(this, imgName, pos);
 }
 
-namespace _func941
+namespace _func942
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12870,11 +12884,11 @@ namespace _func941
 void ShipButton::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipButton *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func941::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func942::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func942
+namespace _func943
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12884,11 +12898,11 @@ namespace _func942
 void ShipButton::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func942::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func943::func;
 	return execfunc(this);
 }
 
-namespace _func943
+namespace _func944
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12898,11 +12912,11 @@ namespace _func943
 void ShipEvent::constructor(const ShipEvent &event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipEvent *this_arg, const ShipEvent &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func943::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func944::func;
 	return execfunc(this, event);
 }
 
-namespace _func944
+namespace _func945
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12912,11 +12926,11 @@ namespace _func944
 ShipManager *ShipGenerator::CreateShip(const std::string &name, int sector, ShipEvent &event)
 {
 	typedef ShipManager *__attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &name_arg, int sector_arg, ShipEvent &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func944::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func945::func;
 	return execfunc(name, sector, event);
 }
 
-namespace _func945
+namespace _func946
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12926,11 +12940,11 @@ namespace _func945
 std::vector<int> ShipGenerator::GenerateSystemMaxes(const ShipBlueprint &ship, int level)
 {
 	typedef std::vector<int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(const ShipBlueprint &ship_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func945::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func946::func;
 	return execfunc(ship, level);
 }
 
-namespace _func946
+namespace _func947
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12940,11 +12954,11 @@ namespace _func946
 bool ShipGenerator::UpgradeSystem(ShipManager *ship, std::vector<int> &systemMaxes, unsigned int sysId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, unsigned int sysId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func946::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func947::func;
 	return execfunc(ship, systemMaxes, sysId);
 }
 
-namespace _func947
+namespace _func948
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -12954,20 +12968,6 @@ namespace _func947
 std::vector<int> ShipGenerator::GetPossibleSystemUpgrades(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func947::func;
-	return execfunc(ship, systemMaxes, scrap, type);
-}
-
-namespace _func948
-{
-    static void *func = 0;
-	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades2", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), "5589e55789cf565383ec5c8945acc70000000000c7400400000000c7400800000000", argdata, 5, 18, &func);
-}
-
-std::vector<int> ShipGenerator::GetPossibleSystemUpgrades2(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
-{
-	typedef std::vector<int> __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func948::func;
 	return execfunc(ship, systemMaxes, scrap, type);
 }
@@ -12976,10 +12976,10 @@ namespace _func949
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades0", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".5589e55789cf565383ec5c8945acc70000000000c7400400000000c7400800000000", argdata, 5, 18, &func);
+	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades2", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), "5589e55789cf565383ec5c8945acc70000000000c7400400000000c7400800000000", argdata, 5, 18, &func);
 }
 
-std::vector<int> ShipGenerator::GetPossibleSystemUpgrades0(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
+std::vector<int> ShipGenerator::GetPossibleSystemUpgrades2(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func949::func;
@@ -12990,10 +12990,10 @@ namespace _func950
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades1", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".5589e55789cf565383ec5c8945acc70000000000c7400400000000c7400800000000", argdata, 5, 18, &func);
+	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades0", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".5589e55789cf565383ec5c8945acc70000000000c7400400000000c7400800000000", argdata, 5, 18, &func);
 }
 
-std::vector<int> ShipGenerator::GetPossibleSystemUpgrades1(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
+std::vector<int> ShipGenerator::GetPossibleSystemUpgrades0(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func950::func;
@@ -13003,6 +13003,20 @@ std::vector<int> ShipGenerator::GetPossibleSystemUpgrades1(ShipManager *ship, st
 namespace _func951
 {
     static void *func = 0;
+	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades1", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".5589e55789cf565383ec5c8945acc70000000000c7400400000000c7400800000000", argdata, 5, 18, &func);
+}
+
+std::vector<int> ShipGenerator::GetPossibleSystemUpgrades1(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
+{
+	typedef std::vector<int> __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func951::func;
+	return execfunc(ship, systemMaxes, scrap, type);
+}
+
+namespace _func952
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipGenerator::GetPossibleWeaponList", typeid(std::vector<WeaponBlueprint*> (*)(ShipManager *, const std::string &, int , unsigned int )), "5589e557565383ec5c8b450c890424", argdata, 5, 18, &func);
 }
@@ -13010,11 +13024,11 @@ namespace _func951
 std::vector<WeaponBlueprint*> ShipGenerator::GetPossibleWeaponList(ShipManager *ship, const std::string &weaponList, int scrap, unsigned int flags)
 {
 	typedef std::vector<WeaponBlueprint*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &weaponList_arg, int scrap_arg, unsigned int flags_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func951::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func952::func;
 	return execfunc(ship, weaponList, scrap, flags);
 }
 
-namespace _func952
+namespace _func953
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13024,11 +13038,11 @@ namespace _func952
 std::vector<DroneBlueprint*> ShipGenerator::GetPossibleDroneList(ShipManager *ship, const std::string &droneList, int scrap, unsigned int flags, bool repeat)
 {
 	typedef std::vector<DroneBlueprint*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &droneList_arg, int scrap_arg, unsigned int flags_arg, bool repeat_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func952::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func953::func;
 	return execfunc(ship, droneList, scrap, flags, repeat);
 }
 
-namespace _func953
+namespace _func954
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13038,11 +13052,11 @@ namespace _func953
 std::vector<CrewBlueprint> ShipGenerator::GetPossibleCrewList(ShipManager *ship, const std::string &crewList, unsigned int flags)
 {
 	typedef std::vector<CrewBlueprint> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &crewList_arg, unsigned int flags_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func953::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func954::func;
 	return execfunc(ship, crewList, flags);
 }
 
-namespace _func954
+namespace _func955
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13052,11 +13066,11 @@ namespace _func954
 ShipGraph *ShipGraph::GetShipInfo(int shipId)
 {
 	typedef ShipGraph *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func954::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func955::func;
 	return execfunc(shipId);
 }
 
-namespace _func955
+namespace _func956
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13066,11 +13080,11 @@ namespace _func955
 Point ShipGraph::GetSlotWorldPosition(int slotId, int roomId)
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int slotId_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func955::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func956::func;
 	return execfunc(this, slotId, roomId);
 }
 
-namespace _func956
+namespace _func957
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13080,11 +13094,11 @@ namespace _func956
 Point ShipGraph::GetSlotRenderPosition(int slotId, int roomId, bool intruder)
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int slotId_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func956::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func957::func;
 	return execfunc(this, slotId, roomId, intruder);
 }
 
-namespace _func957
+namespace _func958
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13094,11 +13108,11 @@ namespace _func957
 int ShipGraph::DoorCount(int roomId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func957::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func958::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func958
+namespace _func959
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13108,11 +13122,11 @@ namespace _func958
 std::vector<Door*> ShipGraph::GetDoors(int roomId)
 {
 	typedef std::vector<Door*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func958::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func959::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func959
+namespace _func960
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13122,11 +13136,11 @@ namespace _func959
 bool ShipGraph::IsRoomConnected(int room1, int room2)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room1_arg, int room2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func959::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func960::func;
 	return execfunc(this, room1, room2);
 }
 
-namespace _func960
+namespace _func961
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13136,11 +13150,11 @@ namespace _func960
 Door *ShipGraph::ConnectingDoor(int x1, int y1, int x2, int y2)
 {
 	typedef Door *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x1_arg, int y1_arg, int x2_arg, int y2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func960::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func961::func;
 	return execfunc(this, x1, y1, x2, y2);
 }
 
-namespace _func961
+namespace _func962
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13150,11 +13164,11 @@ namespace _func961
 int ShipGraph::ConnectedGridSquares(int x1, int y1, int x2, int y2)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x1_arg, int y1_arg, int x2_arg, int y2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func961::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func962::func;
 	return execfunc(this, x1, y1, x2, y2);
 }
 
-namespace _func962
+namespace _func963
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x2ff};
@@ -13164,11 +13178,11 @@ namespace _func962
 int ShipGraph::ConnectedGridSquaresPoint(Point p1, Point p2)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func962::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func963::func;
 	return execfunc(this, p1, p2);
 }
 
-namespace _func963
+namespace _func964
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x2ff};
@@ -13178,11 +13192,11 @@ namespace _func963
 Door *ShipGraph::ConnectingDoor(Point p1, Point p2)
 {
 	typedef Door *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func963::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func964::func;
 	return execfunc(this, p1, p2);
 }
 
-namespace _func964
+namespace _func965
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13192,11 +13206,11 @@ namespace _func964
 int ShipGraph::GetNumSlots(int room)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func964::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func965::func;
 	return execfunc(this, room);
 }
 
-namespace _func965
+namespace _func966
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13206,11 +13220,11 @@ namespace _func965
 int ShipGraph::PopClosestDoor(std::vector<int> &doors, std::vector<float> &distances)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, std::vector<int> &doors_arg, std::vector<float> &distances_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func965::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func966::func;
 	return execfunc(this, doors, distances);
 }
 
-namespace _func966
+namespace _func967
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x2ff, 0x1ff};
@@ -13220,11 +13234,11 @@ namespace _func966
 Path ShipGraph::Dijkstra(Point start, Point goal, int shipId)
 {
 	typedef Path __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point start_arg, Point goal_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func966::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func967::func;
 	return execfunc(this, start, goal, shipId);
 }
 
-namespace _func967
+namespace _func968
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x2ff, 0x1ff};
@@ -13234,11 +13248,11 @@ namespace _func967
 Path ShipGraph::FindPath(Point p1, Point p2, int shipId)
 {
 	typedef Path __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func967::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func968::func;
 	return execfunc(this, p1, p2, shipId);
 }
 
-namespace _func968
+namespace _func969
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13248,11 +13262,11 @@ namespace _func968
 float ShipGraph::ConvertToWorldAngle(float ang)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, float ang_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func968::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func969::func;
 	return execfunc(this, ang);
 }
 
-namespace _func969
+namespace _func970
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13262,11 +13276,11 @@ namespace _func969
 float ShipGraph::ConvertToLocalAngle(float ang)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, float ang_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func969::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func970::func;
 	return execfunc(this, ang);
 }
 
-namespace _func970
+namespace _func971
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff};
@@ -13276,11 +13290,11 @@ namespace _func970
 Pointf ShipGraph::ConvertToWorldPosition(Pointf local)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Pointf local_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func970::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func971::func;
 	return execfunc(this, local);
 }
 
-namespace _func971
+namespace _func972
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -13290,11 +13304,11 @@ namespace _func971
 Pointf ShipGraph::ConvertToLocalPosition(Pointf world, bool past)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Pointf world_arg, bool past_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func971::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func972::func;
 	return execfunc(this, world, past);
 }
 
-namespace _func972
+namespace _func973
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13304,11 +13318,11 @@ namespace _func972
 void ShipGraph::ComputeCenter()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func972::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func973::func;
 	return execfunc(this);
 }
 
-namespace _func973
+namespace _func974
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13318,11 +13332,11 @@ namespace _func973
 bool ShipGraph::ContainsPoint(int x, int y)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func973::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func974::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func974
+namespace _func975
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13332,11 +13346,11 @@ namespace _func974
 int ShipGraph::GetSelectedRoom(int x, int y, bool unk)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x_arg, int y_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func974::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func975::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func975
+namespace _func976
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13346,11 +13360,11 @@ namespace _func975
 int ShipGraph::RoomCount()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func975::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func976::func;
 	return execfunc(this);
 }
 
-namespace _func976
+namespace _func977
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13360,11 +13374,11 @@ namespace _func976
 Globals::Rect ShipGraph::GetRoomShape(int room)
 {
 	typedef Globals::Rect __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func976::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func977::func;
 	return execfunc(this, room);
 }
 
-namespace _func977
+namespace _func978
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13374,11 +13388,11 @@ namespace _func977
 float ShipGraph::GetRoomOxygen(int room)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func977::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func978::func;
 	return execfunc(this, room);
 }
 
-namespace _func978
+namespace _func979
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13388,11 +13402,11 @@ namespace _func978
 bool ShipGraph::GetRoomBlackedOut(int room)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func978::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func979::func;
 	return execfunc(this, room);
 }
 
-namespace _func979
+namespace _func980
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -13402,11 +13416,11 @@ namespace _func979
 Slot ShipGraph::GetClosestSlot(Point pos, int shipId, bool intruder)
 {
 	typedef Slot __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point pos_arg, int shipId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func979::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func980::func;
 	return execfunc(this, pos, shipId, intruder);
 }
 
-namespace _func980
+namespace _func981
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13416,11 +13430,11 @@ namespace _func980
 char ShipInfo::AddAugmentation(const std::string &augment)
 {
 	typedef char __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func980::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func981::func;
 	return execfunc(this, augment);
 }
 
-namespace _func981
+namespace _func982
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13430,11 +13444,11 @@ namespace _func981
 bool ShipInfo::HasAugmentation(const std::string &augment)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func981::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func982::func;
 	return execfunc(this, augment);
 }
 
-namespace _func982
+namespace _func983
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13444,11 +13458,11 @@ namespace _func982
 float ShipInfo::GetAugmentationValue(const std::string &augment)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func982::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func983::func;
 	return execfunc(this, augment);
 }
 
-namespace _func983
+namespace _func984
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13458,11 +13472,11 @@ namespace _func983
 int ShipManager::constructor(int shipId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func983::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func984::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func984
+namespace _func985
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13472,11 +13486,11 @@ namespace _func984
 void ShipManager::AddInitialCrew(std::vector<CrewBlueprint> &blueprints)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, std::vector<CrewBlueprint> &blueprints_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func984::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func985::func;
 	return execfunc(this, blueprints);
 }
 
-namespace _func985
+namespace _func986
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13486,11 +13500,11 @@ namespace _func985
 int ShipManager::GetDodgeFactor()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func985::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func986::func;
 	return execfunc(this);
 }
 
-namespace _func986
+namespace _func987
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13500,11 +13514,11 @@ namespace _func986
 void ShipManager::OnRender(bool showInterior, bool doorControlMode)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool showInterior_arg, bool doorControlMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func986::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func987::func;
 	return execfunc(this, showInterior, doorControlMode);
 }
 
-namespace _func987
+namespace _func988
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13514,11 +13528,11 @@ namespace _func987
 int ShipManager::CountCrew(bool boarders)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool boarders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func987::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func988::func;
 	return execfunc(this, boarders);
 }
 
-namespace _func988
+namespace _func989
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13528,11 +13542,11 @@ namespace _func988
 std::vector<CrewMember*> ShipManager::TeleportCrew(int roomId, bool intruders)
 {
 	typedef std::vector<CrewMember*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func988::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func989::func;
 	return execfunc(this, roomId, intruders);
 }
 
-namespace _func989
+namespace _func990
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13542,11 +13556,11 @@ namespace _func989
 int ShipManager::OnInit(ShipBlueprint *bp, int shipLevel)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, ShipBlueprint *bp_arg, int shipLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func989::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func990::func;
 	return execfunc(this, bp, shipLevel);
 }
 
-namespace _func990
+namespace _func991
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13556,11 +13570,11 @@ namespace _func990
 bool ShipManager::HasSystem(int systemId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func990::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func991::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func991
+namespace _func992
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13570,11 +13584,11 @@ namespace _func991
 ShipSystem *ShipManager::GetSystemInRoom(int roomId)
 {
 	typedef ShipSystem *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func991::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func992::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func992
+namespace _func993
 {
     static void *func = 0;
 	static short argdata[] = {0x100};
@@ -13584,18 +13598,18 @@ namespace _func992
 void ShipManager::OnLoop()
 {
 	typedef void __attribute__((regparm(1))) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func992::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func993::func;
 	return execfunc(this);
 }
 
-namespace _func993
+namespace _func994
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("ShipManager::DO_NOT_HOOK", typeid(void (ShipManager::*)()), "5383ec188b4424248b5424208b5c242883f811", argdata, 0, 4, &func);
 }
 
-namespace _func994
+namespace _func995
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13605,11 +13619,11 @@ namespace _func994
 void ShipManager::SetSystemPowerLoss(int systemId, int powerLoss)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int powerLoss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func994::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func995::func;
 	return execfunc(this, systemId, powerLoss);
 }
 
-namespace _func995
+namespace _func996
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13619,11 +13633,11 @@ namespace _func995
 int ShipManager::CreateSystems()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func995::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func996::func;
 	return execfunc(this);
 }
 
-namespace _func996
+namespace _func997
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13633,11 +13647,11 @@ namespace _func996
 int ShipManager::AddSystem(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func996::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func997::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func997
+namespace _func998
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13647,11 +13661,11 @@ namespace _func997
 void ShipManager::UpdateCrewMembers()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func997::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func998::func;
 	return execfunc(this);
 }
 
-namespace _func998
+namespace _func999
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13661,11 +13675,11 @@ namespace _func998
 bool ShipManager::PowerDrone(Drone *drone, int roomId, bool userDriven, bool force)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Drone *drone_arg, int roomId_arg, bool userDriven_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func998::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func999::func;
 	return execfunc(this, drone, roomId, userDriven, force);
 }
 
-namespace _func999
+namespace _func1000
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13675,11 +13689,11 @@ namespace _func999
 void ShipManager::UpdateEnvironment()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func999::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1000::func;
 	return execfunc(this);
 }
 
-namespace _func1000
+namespace _func1001
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13689,11 +13703,11 @@ namespace _func1000
 CrewMember *ShipManager::AddCrewMemberFromBlueprint(CrewBlueprint *bp, int slot, bool init, int roomId, bool intruder)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewBlueprint *bp_arg, int slot_arg, bool init_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1000::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1001::func;
 	return execfunc(this, bp, slot, init, roomId, intruder);
 }
 
-namespace _func1001
+namespace _func1002
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13703,11 +13717,11 @@ namespace _func1001
 CrewMember *ShipManager::AddCrewMemberFromString(const std::string &name, const std::string &race, bool intruder, int roomId, bool init, bool male)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const std::string &name_arg, const std::string &race_arg, bool intruder_arg, int roomId_arg, bool init_arg, bool male_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1001::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1002::func;
 	return execfunc(this, name, race, intruder, roomId, init, male);
 }
 
-namespace _func1002
+namespace _func1003
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13717,11 +13731,11 @@ namespace _func1002
 int ShipManager::GetOxygenPercentage()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1002::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1003::func;
 	return execfunc(this);
 }
 
-namespace _func1003
+namespace _func1004
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0xdff};
@@ -13731,11 +13745,11 @@ namespace _func1003
 bool ShipManager::DamageCrew(CrewMember *crew, Damage dmg)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, Damage dmg_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1003::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1004::func;
 	return execfunc(this, crew, dmg);
 }
 
-namespace _func1004
+namespace _func1005
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13745,11 +13759,11 @@ namespace _func1004
 void ShipManager::RemoveItem(const std::string &name)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1004::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1005::func;
 	return execfunc(this, name);
 }
 
-namespace _func1005
+namespace _func1006
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0xdff, 0x1ff};
@@ -13759,11 +13773,11 @@ namespace _func1005
 bool ShipManager::DamageArea(Pointf location, Damage dmg, bool forceHit)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf location_arg, Damage dmg_arg, bool forceHit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1005::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1006::func;
 	return execfunc(this, location, dmg, forceHit);
 }
 
-namespace _func1006
+namespace _func1007
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x2ff, 0xdff};
@@ -13773,11 +13787,11 @@ namespace _func1006
 bool ShipManager::DamageBeam(Pointf location1, Pointf location2, Damage dmg)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf location1_arg, Pointf location2_arg, Damage dmg_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1006::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1007::func;
 	return execfunc(this, location1, location2, dmg);
 }
 
-namespace _func1007
+namespace _func1008
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13787,11 +13801,11 @@ namespace _func1007
 CrewBlueprint ShipManager::SelectRandomCrew(int seed, const std::string &racePref)
 {
 	typedef CrewBlueprint __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int seed_arg, const std::string &racePref_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1007::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1008::func;
 	return execfunc(this, seed, racePref);
 }
 
-namespace _func1008
+namespace _func1009
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13799,20 +13813,6 @@ namespace _func1008
 }
 
 void ShipManager::ClearStatusAll()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1008::func;
-	return execfunc(this);
-}
-
-namespace _func1009
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipManager::PrepareSuperDrones", typeid(void (ShipManager::*)()), "5557565383ec7c8bbc24900000008b87ec050000", argdata, 1, 6, &func);
-}
-
-void ShipManager::PrepareSuperDrones()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1009::func;
@@ -13823,10 +13823,10 @@ namespace _func1010
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipManager::JumpLeave", typeid(void (ShipManager::*)()), "5631c05383ec248b742430", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipManager::PrepareSuperDrones", typeid(void (ShipManager::*)()), "5557565383ec7c8bbc24900000008b87ec050000", argdata, 1, 6, &func);
 }
 
-void ShipManager::JumpLeave()
+void ShipManager::PrepareSuperDrones()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1010::func;
@@ -13836,6 +13836,20 @@ void ShipManager::JumpLeave()
 namespace _func1011
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ShipManager::JumpLeave", typeid(void (ShipManager::*)()), "5631c05383ec248b742430", argdata, 1, 6, &func);
+}
+
+void ShipManager::JumpLeave()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1011::func;
+	return execfunc(this);
+}
+
+namespace _func1012
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipManager::ModifyScrapCount", typeid(void (ShipManager::*)(int , bool )), "5557565383ec3c8b7424548b5c24508b442458", argdata, 3, 6, &func);
 }
@@ -13843,11 +13857,11 @@ namespace _func1011
 void ShipManager::ModifyScrapCount(int scrap, bool income)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int scrap_arg, bool income_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1011::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1012::func;
 	return execfunc(this, scrap, income);
 }
 
-namespace _func1012
+namespace _func1013
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13857,11 +13871,11 @@ namespace _func1012
 void ShipManager::ModifyMissileCount(int missiles)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int missiles_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1012::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1013::func;
 	return execfunc(this, missiles);
 }
 
-namespace _func1013
+namespace _func1014
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13871,11 +13885,11 @@ namespace _func1013
 int ShipManager::GetMissileCount()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1013::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1014::func;
 	return execfunc(this);
 }
 
-namespace _func1014
+namespace _func1015
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13885,11 +13899,11 @@ namespace _func1014
 void ShipManager::ModifyDroneCount(int drones)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int drones_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1014::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1015::func;
 	return execfunc(this, drones);
 }
 
-namespace _func1015
+namespace _func1016
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13899,11 +13913,11 @@ namespace _func1015
 bool ShipManager::DoSensorsProvide(int vision)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int vision_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1015::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1016::func;
 	return execfunc(this, vision);
 }
 
-namespace _func1016
+namespace _func1017
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13913,11 +13927,11 @@ namespace _func1016
 bool ShipManager::IsCrewFull()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1016::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1017::func;
 	return execfunc(this);
 }
 
-namespace _func1017
+namespace _func1018
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13927,11 +13941,11 @@ namespace _func1017
 bool ShipManager::IsCrewOverFull()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1017::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1018::func;
 	return execfunc(this);
 }
 
-namespace _func1018
+namespace _func1019
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13941,11 +13955,11 @@ namespace _func1018
 CrewDrone *ShipManager::CreateCrewDrone(const DroneBlueprint *bp)
 {
 	typedef CrewDrone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1018::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1019::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1019
+namespace _func1020
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13955,11 +13969,11 @@ namespace _func1019
 SpaceDrone *ShipManager::CreateSpaceDrone(const DroneBlueprint *bp)
 {
 	typedef SpaceDrone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1019::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1020::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1020
+namespace _func1021
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13969,11 +13983,11 @@ namespace _func1020
 bool ShipManager::CommandCrewMoveRoom(CrewMember *crew, int roomId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1020::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1021::func;
 	return execfunc(this, crew, roomId);
 }
 
-namespace _func1021
+namespace _func1022
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13983,11 +13997,11 @@ namespace _func1021
 int ShipManager::GetSystemRoom(int sysId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int sysId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1021::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1022::func;
 	return execfunc(this, sysId);
 }
 
-namespace _func1022
+namespace _func1023
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13997,11 +14011,11 @@ namespace _func1022
 std::vector<ProjectileFactory*> ShipManager::GetWeaponList()
 {
 	typedef std::vector<ProjectileFactory*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1022::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1023::func;
 	return execfunc(this);
 }
 
-namespace _func1023
+namespace _func1024
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14011,11 +14025,11 @@ namespace _func1023
 Drone *ShipManager::AddDrone(const DroneBlueprint *bp, int slot)
 {
 	typedef Drone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1023::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1024::func;
 	return execfunc(this, bp, slot);
 }
 
-namespace _func1024
+namespace _func1025
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14025,11 +14039,11 @@ namespace _func1024
 void ShipManager::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1024::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1025::func;
 	return execfunc(this);
 }
 
-namespace _func1025
+namespace _func1026
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14039,11 +14053,11 @@ namespace _func1025
 int ShipManager::GetSystemPower(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1025::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1026::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1026
+namespace _func1027
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14053,11 +14067,11 @@ namespace _func1026
 int ShipManager::CountCrewShipId(int roomId, int shipId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1026::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1027::func;
 	return execfunc(this, roomId, shipId);
 }
 
-namespace _func1027
+namespace _func1028
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14067,11 +14081,11 @@ namespace _func1027
 ShipSystem *ShipManager::GetSystem(int systemId)
 {
 	typedef ShipSystem *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1027::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1028::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1028
+namespace _func1029
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14081,11 +14095,11 @@ namespace _func1028
 bool ShipManager::DoorsFunction()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1028::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1029::func;
 	return execfunc(this);
 }
 
-namespace _func1029
+namespace _func1030
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14095,11 +14109,11 @@ namespace _func1029
 void ShipManager::ExportShip(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1029::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1030::func;
 	return execfunc(this, file);
 }
 
-namespace _func1030
+namespace _func1031
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14109,11 +14123,11 @@ namespace _func1030
 void ShipManager::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1030::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1031::func;
 	return execfunc(this);
 }
 
-namespace _func1031
+namespace _func1032
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14123,11 +14137,11 @@ namespace _func1031
 void ShipManager::destructor2()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1031::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1032::func;
 	return execfunc(this);
 }
 
-namespace _func1032
+namespace _func1033
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14137,11 +14151,11 @@ namespace _func1032
 void ShipManager::ImportShip(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1032::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1033::func;
 	return execfunc(this, file);
 }
 
-namespace _func1033
+namespace _func1034
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14151,11 +14165,11 @@ namespace _func1033
 void ShipManager::CheckVision()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1033::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1034::func;
 	return execfunc(this);
 }
 
-namespace _func1034
+namespace _func1035
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14165,11 +14179,11 @@ namespace _func1034
 int ShipManager::IsSystemHacked(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1034::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1035::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1035
+namespace _func1036
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -14179,11 +14193,11 @@ namespace _func1035
 CrewMember *ShipManager::GetSelectedCrewPoint(int x, int y, bool intruder)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int x_arg, int y_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1035::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1036::func;
 	return execfunc(this, x, y, intruder);
 }
 
-namespace _func1036
+namespace _func1037
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14193,11 +14207,11 @@ namespace _func1036
 void ShipManager::RenderWeapons()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1036::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1037::func;
 	return execfunc(this);
 }
 
-namespace _func1037
+namespace _func1038
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14207,11 +14221,11 @@ namespace _func1037
 void ShipManager::ClearStatusSystem(int system)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int system_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1037::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1038::func;
 	return execfunc(this, system);
 }
 
-namespace _func1038
+namespace _func1039
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14219,20 +14233,6 @@ namespace _func1038
 }
 
 void ShipManager::ResetScrapLevel()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1038::func;
-	return execfunc(this);
-}
-
-namespace _func1039
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipManager::JumpArrive", typeid(void (ShipManager::*)()), "565383ec248b7424308b86f4030000c786c403000000000000", argdata, 1, 6, &func);
-}
-
-void ShipManager::JumpArrive()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1039::func;
@@ -14243,10 +14243,10 @@ namespace _func1040
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipManager::CheckSpreadDamage", typeid(void (ShipManager::*)()), "5589e557565383ec5c8b7d08c745b000000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipManager::JumpArrive", typeid(void (ShipManager::*)()), "565383ec248b7424308b86f4030000c786c403000000000000", argdata, 1, 6, &func);
 }
 
-void ShipManager::CheckSpreadDamage()
+void ShipManager::JumpArrive()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1040::func;
@@ -14256,6 +14256,20 @@ void ShipManager::CheckSpreadDamage()
 namespace _func1041
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ShipManager::CheckSpreadDamage", typeid(void (ShipManager::*)()), "5589e557565383ec5c8b7d08c745b000000000", argdata, 1, 6, &func);
+}
+
+void ShipManager::CheckSpreadDamage()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1041::func;
+	return execfunc(this);
+}
+
+namespace _func1042
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipManager::ForceDecreaseSystemPower", typeid(bool (ShipManager::*)(int )), "8b4424088b54240483f8ff74??8b8a000400008b048183f8ff74??8b52188b048285c074??8b10c744240801000000894424048b8284000000", argdata, 2, 2, &func);
 }
@@ -14263,11 +14277,11 @@ namespace _func1041
 bool ShipManager::ForceDecreaseSystemPower(int sys)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1041::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1042::func;
 	return execfunc(this, sys);
 }
 
-namespace _func1042
+namespace _func1043
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14277,11 +14291,11 @@ namespace _func1042
 ShieldPower ShipManager::GetShieldPower()
 {
 	typedef ShieldPower __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1042::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1043::func;
 	return execfunc(this);
 }
 
-namespace _func1043
+namespace _func1044
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14291,11 +14305,11 @@ namespace _func1043
 int ShipManager::AddWeapon(const WeaponBlueprint *bp, int slot)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const WeaponBlueprint *bp_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1043::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1044::func;
 	return execfunc(this, bp, slot);
 }
 
-namespace _func1044
+namespace _func1045
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14305,11 +14319,11 @@ namespace _func1044
 void ShipManager::AddEquipmentFromList(std::vector<std::string> *equipmentList)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, std::vector<std::string> *equipmentList_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1044::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1045::func;
 	return execfunc(this, equipmentList);
 }
 
-namespace _func1045
+namespace _func1046
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14319,11 +14333,11 @@ namespace _func1045
 void ShipManager::RenderChargeBars()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1045::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1046::func;
 	return execfunc(this);
 }
 
-namespace _func1046
+namespace _func1047
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14331,20 +14345,6 @@ namespace _func1046
 }
 
 void ShipManager::ExportBattleState(int file)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1046::func;
-	return execfunc(this, file);
-}
-
-namespace _func1047
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipManager::ImportBattleState", typeid(void (ShipManager::*)(int )), "5557565383ec3c8b7424508b5c24548b8600040000", argdata, 2, 6, &func);
-}
-
-void ShipManager::ImportBattleState(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1047::func;
@@ -14355,24 +14355,24 @@ namespace _func1048
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipManager::SystemFunctions", typeid(bool (ShipManager::*)(int )), "8b5424048b4c24088b82000400008b048883f8ff74??8b52188b04828b10894424048b422c", argdata, 2, 2, &func);
+	static FunctionDefinition funcObj("ShipManager::ImportBattleState", typeid(void (ShipManager::*)(int )), "5557565383ec3c8b7424508b5c24548b8600040000", argdata, 2, 6, &func);
 }
 
-bool ShipManager::SystemFunctions(int systemId)
+void ShipManager::ImportBattleState(int file)
 {
-	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1048::func;
-	return execfunc(this, systemId);
+	return execfunc(this, file);
 }
 
 namespace _func1049
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipManager::CanFitSystem", typeid(bool (ShipManager::*)(int )), "57565383ec108b4424248b7c242083f805", argdata, 2, 2, &func);
+	static FunctionDefinition funcObj("ShipManager::SystemFunctions", typeid(bool (ShipManager::*)(int )), "8b5424048b4c24088b82000400008b048883f8ff74??8b52188b04828b10894424048b422c", argdata, 2, 2, &func);
 }
 
-bool ShipManager::CanFitSystem(int systemId)
+bool ShipManager::SystemFunctions(int systemId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1049::func;
@@ -14383,10 +14383,10 @@ namespace _func1050
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipManager::CanFitSubsystem", typeid(bool (ShipManager::*)(int )), "57565383ec108b7c24208b57188b471c", argdata, 2, 2, &func);
+	static FunctionDefinition funcObj("ShipManager::CanFitSystem", typeid(bool (ShipManager::*)(int )), "57565383ec108b4424248b7c242083f805", argdata, 2, 2, &func);
 }
 
-bool ShipManager::CanFitSubsystem(int systemId)
+bool ShipManager::CanFitSystem(int systemId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1050::func;
@@ -14396,6 +14396,20 @@ bool ShipManager::CanFitSubsystem(int systemId)
 namespace _func1051
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("ShipManager::CanFitSubsystem", typeid(bool (ShipManager::*)(int )), "57565383ec108b7c24208b57188b471c", argdata, 2, 2, &func);
+}
+
+bool ShipManager::CanFitSubsystem(int systemId)
+{
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1051::func;
+	return execfunc(this, systemId);
+}
+
+namespace _func1052
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipManager::DamageHull", typeid(int (ShipManager::*)(int , bool )), "565383ec148b5c24208b7424288b03891c24", argdata, 3, 2, &func);
 }
@@ -14403,11 +14417,11 @@ namespace _func1051
 int ShipManager::DamageHull(int dmg, bool force)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int dmg_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1051::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1052::func;
 	return execfunc(this, dmg, force);
 }
 
-namespace _func1052
+namespace _func1053
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0xdff};
@@ -14417,11 +14431,11 @@ namespace _func1052
 void ShipManager::DamageSystem(int systemId, Damage damage)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, Damage damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1052::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1053::func;
 	return execfunc(this, systemId, damage);
 }
 
-namespace _func1053
+namespace _func1054
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14431,11 +14445,11 @@ namespace _func1053
 void ShipManager::StartFire(int roomId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1053::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1054::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1054
+namespace _func1055
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14445,11 +14459,11 @@ namespace _func1054
 CrewMember *ShipManager::FindCrew(const CrewBlueprint *bp)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const CrewBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1054::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1055::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1055
+namespace _func1056
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14459,11 +14473,11 @@ namespace _func1055
 bool ShipManager::GetDodged()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1055::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1056::func;
 	return execfunc(this);
 }
 
-namespace _func1056
+namespace _func1057
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14473,11 +14487,11 @@ namespace _func1056
 void ShipManager::PrepareSuperBarrage()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1056::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1057::func;
 	return execfunc(this);
 }
 
-namespace _func1057
+namespace _func1058
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -14487,11 +14501,11 @@ namespace _func1057
 std::string ShipManager::GetTooltip(int x, int y)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1057::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1058::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1058
+namespace _func1059
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14501,11 +14515,11 @@ namespace _func1058
 bool ShipManager::RestoreCrewPositions()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1058::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1059::func;
 	return execfunc(this);
 }
 
-namespace _func1059
+namespace _func1060
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14515,11 +14529,11 @@ namespace _func1059
 CrewMember *ShipManager::GetCrewmember(int slot, bool present)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int slot_arg, bool present_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1059::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1060::func;
 	return execfunc(this, slot, present);
 }
 
-namespace _func1060
+namespace _func1061
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14529,11 +14543,11 @@ namespace _func1060
 int ShipManager::CanUpgrade(int systemId, int amount)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1060::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1061::func;
 	return execfunc(this, systemId, amount);
 }
 
-namespace _func1061
+namespace _func1062
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14543,11 +14557,11 @@ namespace _func1061
 ShipBlueprint ShipManager::SaveToBlueprint(bool unk)
 {
 	typedef ShipBlueprint __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1061::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1062::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1062
+namespace _func1063
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -14557,11 +14571,11 @@ namespace _func1062
 void ShipManager::CheckCrystalAugment(Pointf pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1062::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1063::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1063
+namespace _func1064
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -14571,11 +14585,11 @@ namespace _func1063
 CollisionResponse ShipManager::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1063::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1064::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func1064
+namespace _func1065
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14585,11 +14599,11 @@ namespace _func1064
 int ShipManager::GetSystemPowerMax(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1064::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1065::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1065
+namespace _func1066
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14599,11 +14613,11 @@ namespace _func1065
 std::vector<Drone*> ShipManager::GetDroneList()
 {
 	typedef std::vector<Drone*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1065::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1066::func;
 	return execfunc(this);
 }
 
-namespace _func1066
+namespace _func1067
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14613,11 +14627,11 @@ namespace _func1066
 int ShipManager::GetDroneCount()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1066::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1067::func;
 	return execfunc(this);
 }
 
-namespace _func1067
+namespace _func1068
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14627,11 +14641,11 @@ namespace _func1067
 void ShipManager::InstantPowerShields()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1067::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1068::func;
 	return execfunc(this);
 }
 
-namespace _func1068
+namespace _func1069
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14641,11 +14655,11 @@ namespace _func1068
 void ShipManager::SetDestroyed()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1068::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1069::func;
 	return execfunc(this);
 }
 
-namespace _func1069
+namespace _func1070
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14655,11 +14669,11 @@ namespace _func1069
 int ShipManager::GetFireCount(int roomId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1069::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1070::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1070
+namespace _func1071
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14669,11 +14683,11 @@ namespace _func1070
 void ShipManager::AddCrewMember(CrewMember *crew, int roomId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1070::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1071::func;
 	return execfunc(this, crew, roomId);
 }
 
-namespace _func1071
+namespace _func1072
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14683,11 +14697,11 @@ namespace _func1071
 std::vector<CrewMember*> ShipManager::GetLeavingCrew(bool intruders)
 {
 	typedef std::vector<CrewMember*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1071::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1072::func;
 	return execfunc(this, intruders);
 }
 
-namespace _func1072
+namespace _func1073
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14697,11 +14711,11 @@ namespace _func1072
 void ShipManager::UpgradeSystem(int id, int amount)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int id_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1072::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1073::func;
 	return execfunc(this, id, amount);
 }
 
-namespace _func1073
+namespace _func1074
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -14711,11 +14725,11 @@ namespace _func1073
 CollisionResponse ShipManager::CollisionShield(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1073::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1074::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func1074
+namespace _func1075
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14725,11 +14739,11 @@ namespace _func1074
 bool ShipManager::IsCloaked()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1074::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1075::func;
 	return execfunc(this);
 }
 
-namespace _func1075
+namespace _func1076
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14739,11 +14753,11 @@ namespace _func1075
 int ShipManager::CountPlayerCrew()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1075::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1076::func;
 	return execfunc(this);
 }
 
-namespace _func1076
+namespace _func1077
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14753,11 +14767,11 @@ namespace _func1076
 void ShipManager::Wait()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1076::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1077::func;
 	return execfunc(this);
 }
 
-namespace _func1077
+namespace _func1078
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14767,11 +14781,11 @@ namespace _func1077
 int ShipObject::HasAugmentation(const std::string &augment)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1077::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1078::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1078
+namespace _func1079
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14781,11 +14795,11 @@ namespace _func1078
 float ShipObject::GetAugmentationValue(const std::string &augment)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1078::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1079::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1079
+namespace _func1080
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14795,11 +14809,11 @@ namespace _func1079
 void ShipObject::RemoveAugmentation(const std::string &augment)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1079::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1080::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1080
+namespace _func1081
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14809,11 +14823,11 @@ namespace _func1080
 int ShipObject::HasEquipment(const std::string &equip)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1080::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1081::func;
 	return execfunc(this, equip);
 }
 
-namespace _func1081
+namespace _func1082
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14823,11 +14837,11 @@ namespace _func1081
 std::vector<std::string> ShipObject::GetAugmentationList()
 {
 	typedef std::vector<std::string> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1081::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1082::func;
 	return execfunc(this);
 }
 
-namespace _func1082
+namespace _func1083
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14837,11 +14851,11 @@ namespace _func1082
 bool ShipObject::AddAugmentation(const std::string &augment)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1082::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1083::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1083
+namespace _func1084
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14851,11 +14865,11 @@ namespace _func1083
 int ShipObject::GetAugmentationCount()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1083::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1084::func;
 	return execfunc(this);
 }
 
-namespace _func1084
+namespace _func1085
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14865,18 +14879,18 @@ namespace _func1084
 void ShipObject::ClearShipInfo()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1084::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1085::func;
 	return execfunc(this);
 }
 
 ShipInfo **Global_ShipObject_ShipInfoList;
 
-namespace _var1085
+namespace _var1086
 {
     static VariableDefinition varObj("Global_ShipObject_ShipInfoList", "!6bc0340305(???????\?)8b4030c3", &Global_ShipObject_ShipInfoList);
 }
 
-namespace _func1086
+namespace _func1087
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102};
@@ -14886,11 +14900,11 @@ namespace _func1086
 void ShipSelect::SelectShip(int shipType)
 {
 	typedef void __attribute__((regparm(2))) (*custom_arg_funcptr_t)(ShipSelect *this_arg, int shipType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1086::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1087::func;
 	return execfunc(this, shipType);
 }
 
-namespace _func1087
+namespace _func1088
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14900,11 +14914,11 @@ namespace _func1087
 void ShipSelect::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1087::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1088::func;
 	return execfunc(this);
 }
 
-namespace _func1088
+namespace _func1089
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14914,11 +14928,11 @@ namespace _func1088
 void ShipSelect::ClearShipButtons()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1088::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1089::func;
 	return execfunc(this);
 }
 
-namespace _func1089
+namespace _func1090
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14928,11 +14942,11 @@ namespace _func1089
 void ShipSelect::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1089::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1090::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1090
+namespace _func1091
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14942,11 +14956,11 @@ namespace _func1090
 void ShipSelect::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1090::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1091::func;
 	return execfunc(this);
 }
 
-namespace _func1091
+namespace _func1092
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14956,11 +14970,11 @@ namespace _func1091
 int ShipSelect::KeyDown(SDLKey key)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1091::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1092::func;
 	return execfunc(this, key);
 }
 
-namespace _func1092
+namespace _func1093
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14970,11 +14984,11 @@ namespace _func1092
 void ShipSelect::MouseClick()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1092::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1093::func;
 	return execfunc(this);
 }
 
-namespace _func1093
+namespace _func1094
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14984,11 +14998,11 @@ namespace _func1093
 void ShipSelect::PreSelectShip(int shipType)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, int shipType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1093::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1094::func;
 	return execfunc(this, shipType);
 }
 
-namespace _func1094
+namespace _func1095
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14998,11 +15012,11 @@ namespace _func1094
 void ShipSelect::Close()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1094::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1095::func;
 	return execfunc(this);
 }
 
-namespace _func1095
+namespace _func1096
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15012,11 +15026,11 @@ namespace _func1095
 int ShipSelect::GetSelectedShip()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1095::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1096::func;
 	return execfunc(this);
 }
 
-namespace _func1096
+namespace _func1097
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -15026,11 +15040,11 @@ namespace _func1096
 void ShipSelect::Open(int currentId, int currentType)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, int currentId_arg, int currentType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1096::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1097::func;
 	return execfunc(this, currentId, currentType);
 }
 
-namespace _func1097
+namespace _func1098
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15040,11 +15054,11 @@ namespace _func1097
 void ShipSelect::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1097::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1098::func;
 	return execfunc(this);
 }
 
-namespace _func1098
+namespace _func1099
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15054,11 +15068,11 @@ namespace _func1098
 void ShipStatus::RenderHealth(bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1098::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1099::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1099
+namespace _func1100
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
@@ -15068,11 +15082,11 @@ namespace _func1099
 void ShipStatus::OnInit(Point unk, float unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipStatus *this_arg, Point unk_arg, float unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1099::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1100::func;
 	return execfunc(this, unk, unk2);
 }
 
-namespace _func1100
+namespace _func1101
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15082,11 +15096,11 @@ namespace _func1100
 void ShipStatus::RenderEvadeOxygen(bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1100::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1101::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1101
+namespace _func1102
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15096,11 +15110,11 @@ namespace _func1101
 void ShipStatus::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1101::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1102::func;
 	return execfunc(this);
 }
 
-namespace _func1102
+namespace _func1103
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102};
@@ -15110,11 +15124,11 @@ namespace _func1102
 void ShipStatus::RenderShields(bool renderText)
 {
 	typedef void __attribute__((regparm(2))) (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool renderText_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1102::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1103::func;
 	return execfunc(this, renderText);
 }
 
-namespace _func1103
+namespace _func1104
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15124,11 +15138,11 @@ namespace _func1103
 void ShipStatus::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1103::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1104::func;
 	return execfunc(this);
 }
 
-namespace _func1104
+namespace _func1105
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15138,11 +15152,11 @@ namespace _func1104
 void ShipSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1104::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1105::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func1105
+namespace _func1106
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15152,11 +15166,11 @@ namespace _func1105
 bool ShipSystem::DamageOverTime(float unk)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, float unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1105::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1106::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1106
+namespace _func1107
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15166,11 +15180,11 @@ namespace _func1106
 void ShipSystem::CheckForRepower()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1106::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1107::func;
 	return execfunc(this);
 }
 
-namespace _func1107
+namespace _func1108
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15180,11 +15194,11 @@ namespace _func1107
 int ShipSystem::NameToSystemId(const std::string &name)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1107::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1108::func;
 	return execfunc(name);
 }
 
-namespace _func1108
+namespace _func1109
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15194,11 +15208,11 @@ namespace _func1108
 int ShipSystem::IsMannedBoost()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1108::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1109::func;
 	return execfunc(this);
 }
 
-namespace _func1109
+namespace _func1110
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15208,11 +15222,11 @@ namespace _func1109
 std::string ShipSystem::SystemIdToName(int systemId)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1109::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1110::func;
 	return execfunc(systemId);
 }
 
-namespace _func1110
+namespace _func1111
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15222,11 +15236,11 @@ namespace _func1110
 void ShipSystem::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1110::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1111::func;
 	return execfunc(this);
 }
 
-namespace _func1111
+namespace _func1112
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15236,11 +15250,11 @@ namespace _func1111
 bool ShipSystem::Ioned(int num)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int num_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1111::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1112::func;
 	return execfunc(this, num);
 }
 
-namespace _func1112
+namespace _func1113
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15250,11 +15264,11 @@ namespace _func1112
 int ShipSystem::SetPowerLoss(int power)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int power_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1112::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1113::func;
 	return execfunc(this, power);
 }
 
-namespace _func1113
+namespace _func1114
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -15264,11 +15278,11 @@ namespace _func1113
 void ShipSystem::constructor(int systemId, int roomId, int shipId, int startingPower)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int systemId_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1113::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1114::func;
 	return execfunc(this, systemId, roomId, shipId, startingPower);
 }
 
-namespace _func1114
+namespace _func1115
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15278,11 +15292,11 @@ namespace _func1114
 int ShipSystem::GetPowerCap()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1114::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1115::func;
 	return execfunc(this);
 }
 
-namespace _func1115
+namespace _func1116
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15292,11 +15306,11 @@ namespace _func1115
 bool ShipSystem::BlockedBoosted(bool countLimit)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool countLimit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1115::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1116::func;
 	return execfunc(this, countLimit);
 }
 
-namespace _func1116
+namespace _func1117
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15306,11 +15320,11 @@ namespace _func1116
 void ShipSystem::SetPowerCap(int cap)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int cap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1116::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1117::func;
 	return execfunc(this, cap);
 }
 
-namespace _func1117
+namespace _func1118
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15320,11 +15334,11 @@ namespace _func1117
 void ShipSystem::LockSystem(int lock)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1117::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1118::func;
 	return execfunc(this, lock);
 }
 
-namespace _func1118
+namespace _func1119
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15334,11 +15348,11 @@ namespace _func1118
 bool ShipSystem::ForceDecreasePower(int powerLoss)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int powerLoss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1118::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1119::func;
 	return execfunc(this, powerLoss);
 }
 
-namespace _func1119
+namespace _func1120
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15348,11 +15362,11 @@ namespace _func1119
 int ShipSystem::GetEffectivePower()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1119::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1120::func;
 	return execfunc(this);
 }
 
-namespace _func1120
+namespace _func1121
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15362,11 +15376,11 @@ namespace _func1120
 int ShipSystem::GetMaxPower()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1120::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1121::func;
 	return execfunc(this);
 }
 
-namespace _func1121
+namespace _func1122
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -15376,11 +15390,11 @@ namespace _func1121
 void ShipSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1121::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1122::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func1122
+namespace _func1123
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15390,11 +15404,11 @@ namespace _func1122
 void ShipSystem::CheckMaxPower()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1122::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1123::func;
 	return execfunc(this);
 }
 
-namespace _func1123
+namespace _func1124
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15404,11 +15418,11 @@ namespace _func1123
 bool ShipSystem::PartialDamage(float amount)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, float amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1123::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1124::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1124
+namespace _func1125
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15418,11 +15432,11 @@ namespace _func1124
 bool ShipSystem::IsSubsystem(int systemType)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int systemType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1124::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1125::func;
 	return execfunc(systemType);
 }
 
-namespace _func1125
+namespace _func1126
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15432,11 +15446,11 @@ namespace _func1125
 void ShipSystem::ClearStatus()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1125::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1126::func;
 	return execfunc(this);
 }
 
-namespace _func1126
+namespace _func1127
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -15446,11 +15460,11 @@ namespace _func1126
 std::string ShipSystem::GetLevelDescription(int systemId, int level, bool tooltip)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(int systemId_arg, int level_arg, bool tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1126::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1127::func;
 	return execfunc(systemId, level, tooltip);
 }
 
-namespace _func1127
+namespace _func1128
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15460,11 +15474,11 @@ namespace _func1127
 void ShipSystem::AddLock(int lock)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1127::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1128::func;
 	return execfunc(this, lock);
 }
 
-namespace _func1128
+namespace _func1129
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15474,11 +15488,11 @@ namespace _func1128
 bool ShipSystem::GetLocked()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1128::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1129::func;
 	return execfunc(this);
 }
 
-namespace _func1129
+namespace _func1130
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15488,11 +15502,11 @@ namespace _func1129
 void ShipSystem::StopHacking()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1129::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1130::func;
 	return execfunc(this);
 }
 
-namespace _func1130
+namespace _func1131
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15500,20 +15514,6 @@ namespace _func1130
 }
 
 void ShipSystem::SaveState(int file)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1130::func;
-	return execfunc(this, file);
-}
-
-namespace _func1131
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipSystem::LoadState", typeid(void (ShipSystem::*)(int )), "565383ec148b7424248b5c2420893424e8????????898308010000", argdata, 2, 6, &func);
-}
-
-void ShipSystem::LoadState(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1131::func;
@@ -15524,17 +15524,31 @@ namespace _func1132
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("ShipSystem::LoadState", typeid(void (ShipSystem::*)(int )), "565383ec148b7424248b5c2420893424e8????????898308010000", argdata, 2, 6, &func);
+}
+
+void ShipSystem::LoadState(int file)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1132::func;
+	return execfunc(this, file);
+}
+
+namespace _func1133
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipSystem::UpgradeSystem", typeid(bool (ShipSystem::*)(int )), "565383ec148b5c24208b7424248b03891c24ff5010", argdata, 2, 2, &func);
 }
 
 bool ShipSystem::UpgradeSystem(int amount)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1132::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1133::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1133
+namespace _func1134
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -15544,11 +15558,11 @@ namespace _func1133
 bool ShipSystem::IncreasePower(int amount, bool force)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1133::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1134::func;
 	return execfunc(this, amount, force);
 }
 
-namespace _func1134
+namespace _func1135
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15558,11 +15572,11 @@ namespace _func1134
 bool ShipSystem::DecreasePower(bool force)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1134::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1135::func;
 	return execfunc(this, force);
 }
 
-namespace _func1135
+namespace _func1136
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -15572,11 +15586,11 @@ namespace _func1135
 bool ShipSystem::PartialRepair(float speed, bool autoRepair)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, float speed_arg, bool autoRepair_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1135::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1136::func;
 	return execfunc(this, speed, autoRepair);
 }
 
-namespace _func1136
+namespace _func1137
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -15586,11 +15600,11 @@ namespace _func1136
 int ShipSystem::RenderPowerBoxes(int x, int y, int width, int height, int gap, int heightMod, bool flash)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int x_arg, int y_arg, int width_arg, int height_arg, int gap_arg, int heightMod_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1136::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1137::func;
 	return execfunc(this, x, y, width, height, gap, heightMod, flash);
 }
 
-namespace _func1137
+namespace _func1138
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15600,11 +15614,11 @@ namespace _func1137
 void ShipSystem::AddDamage(int amount)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1137::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1138::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1138
+namespace _func1139
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15614,11 +15628,11 @@ namespace _func1138
 void ShipSystem::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1138::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1139::func;
 	return execfunc(this);
 }
 
-namespace _func1139
+namespace _func1140
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -15628,11 +15642,11 @@ namespace _func1139
 int ShipSystem::RenderPowerBoxesPlain(int x, int y, int width, int height, int gap, int current, int temp, int max)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int x_arg, int y_arg, int width_arg, int height_arg, int gap_arg, int current_arg, int temp_arg, int max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1139::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1140::func;
 	return execfunc(x, y, width, height, gap, current, temp, max);
 }
 
-namespace _func1140
+namespace _func1141
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -15642,11 +15656,11 @@ namespace _func1140
 void ShipSystem::RenderSystemSymbol(bool forPowerUI, int forceColor)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool forPowerUI_arg, int forceColor_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1140::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1141::func;
 	return execfunc(this, forPowerUI, forceColor);
 }
 
-namespace _func1141
+namespace _func1142
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15656,116 +15670,116 @@ namespace _func1141
 TimerHelper ShipSystem::GetLockTimer()
 {
 	typedef TimerHelper __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1141::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1142::func;
 	return execfunc(this);
 }
 
 GL_Primitive **ShipSystem__lockBlue;
 
-namespace _var1142
+namespace _var1143
 {
     static VariableDefinition varObj("ShipSystem__lockBlue", "!8b3d(???????\?)84d28b8580010000", &ShipSystem__lockBlue);
 }
 
 GL_Primitive **ShipSystem__fireImage;
 
-namespace _var1143
+namespace _var1144
 {
     static VariableDefinition varObj("ShipSystem__fireImage", "!.a1(???????\?)890424", &ShipSystem__fireImage);
 }
 
 GL_Primitive **ShipSystem__lockHack;
 
-namespace _var1144
+namespace _var1145
 {
     static VariableDefinition varObj("ShipSystem__lockHack", "!.a1(???????\?)890424", &ShipSystem__lockHack);
 }
 
 GL_Primitive **ShipSystem__manningBarIon;
 
-namespace _var1145
+namespace _var1146
 {
     static VariableDefinition varObj("ShipSystem__manningBarIon", "!.84c0a1(???????\?)0f4405(???????\?)", &ShipSystem__manningBarIon);
 }
 
 GL_Primitive **ShipSystem__manningBarOff;
 
-namespace _var1146
+namespace _var1147
 {
     static VariableDefinition varObj("ShipSystem__manningBarOff", "", &ShipSystem__manningBarOff);
 }
 
 GL_Primitive **ShipSystem__lockWhite;
 
-namespace _var1147
+namespace _var1148
 {
     static VariableDefinition varObj("ShipSystem__lockWhite", "!.8b3d(???????\?)b9ff000000", &ShipSystem__lockWhite);
 }
 
 GL_Primitive **ShipSystem__sabotageImage;
 
-namespace _var1148
+namespace _var1149
 {
     static VariableDefinition varObj("ShipSystem__sabotageImage", "!.a1(???????\?)890424", &ShipSystem__sabotageImage);
 }
 
 GL_Primitive **ShipSystem__manningOutline;
 
-namespace _var1149
+namespace _var1150
 {
     static VariableDefinition varObj("ShipSystem__manningOutline", "!.a1(???????\?)bef0ffffffbb10000000", &ShipSystem__manningOutline);
 }
 
 GL_Primitive **ShipSystem__manningBarOn;
 
-namespace _var1150
+namespace _var1151
 {
     static VariableDefinition varObj("ShipSystem__manningBarOn", "!.0f85????????a1(???????\?)e9", &ShipSystem__manningBarOn);
 }
 
 GL_Primitive **ShipSystem__manningWhite;
 
-namespace _var1151
+namespace _var1152
 {
     static VariableDefinition varObj("ShipSystem__manningWhite", "!.a1(???????\?)bef0ffffffbb10000000", &ShipSystem__manningWhite);
 }
 
 GL_Primitive **ShipSystem__manningGreen;
 
-namespace _var1152
+namespace _var1153
 {
     static VariableDefinition varObj("ShipSystem__manningGreen", "!.a1(???????\?)bee8ffffffbb18000000", &ShipSystem__manningGreen);
 }
 
 GL_Primitive **ShipSystem__manningYellow;
 
-namespace _var1153
+namespace _var1154
 {
     static VariableDefinition varObj("ShipSystem__manningYellow", "!.a1(???????\?)bee8ffffffbb18000000", &ShipSystem__manningYellow);
 }
 
 GL_Primitive **ShipSystem__glowBlue;
 
-namespace _var1154
+namespace _var1155
 {
     static VariableDefinition varObj("ShipSystem__glowBlue", "!.f30f116c2404e8????????a1(???????\?)890424", &ShipSystem__glowBlue);
 }
 
 GL_Primitive **ShipSystem__glowRed;
 
-namespace _var1155
+namespace _var1156
 {
     static VariableDefinition varObj("ShipSystem__glowRed", "!.f30f116c2404e8????????a1(???????\?)890424", &ShipSystem__glowRed);
 }
 
 GL_Primitive **ShipSystem__glowWhite;
 
-namespace _var1156
+namespace _var1157
 {
     static VariableDefinition varObj("ShipSystem__glowWhite", "!.8b153c114a08c7865801000000000000", &ShipSystem__glowWhite);
 }
 
-namespace _func1157
+namespace _func1158
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -15775,11 +15789,11 @@ namespace _func1157
 int SoundControl::PlaySoundMix(const std::string &soundName, float volume, bool loop)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(SoundControl *this_arg, const std::string &soundName_arg, float volume_arg, bool loop_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1157::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1158::func;
 	return execfunc(this, soundName, volume, loop);
 }
 
-namespace _func1158
+namespace _func1159
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15789,11 +15803,11 @@ namespace _func1158
 void SoundControl::StopPlaylist(int fadeOut)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SoundControl *this_arg, int fadeOut_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1158::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1159::func;
 	return execfunc(this, fadeOut);
 }
 
-namespace _func1159
+namespace _func1160
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15803,11 +15817,11 @@ namespace _func1159
 void SoundControl::StartPlaylist(std::vector<std::string> &playlist)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SoundControl *this_arg, std::vector<std::string> &playlist_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1159::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1160::func;
 	return execfunc(this, playlist);
 }
 
-namespace _func1160
+namespace _func1161
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -15817,18 +15831,18 @@ namespace _func1160
 void SoundControl::UpdateSoundLoop(const std::string &loopId, float count)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SoundControl *this_arg, const std::string &loopId_arg, float count_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1160::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1161::func;
 	return execfunc(this, loopId, count);
 }
 
 SoundControl *Global_SoundControl_Sounds;
 
-namespace _var1161
+namespace _var1162
 {
     static VariableDefinition varObj("Global_SoundControl_Sounds", "!e8????????897c240889742404c70424(???????\?)e8", &Global_SoundControl_Sounds);
 }
 
-namespace _func1162
+namespace _func1163
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -15838,11 +15852,11 @@ namespace _func1162
 float SpaceDrone::UpdateAimingAngle(Pointf location, float percentage, float forceDesired)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Pointf location_arg, float percentage_arg, float forceDesired_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1162::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1163::func;
 	return execfunc(this, location, percentage, forceDesired);
 }
 
-namespace _func1163
+namespace _func1164
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15852,11 +15866,11 @@ namespace _func1163
 void SpaceDrone::SetDeployed(bool deployed)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, bool deployed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1163::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1164::func;
 	return execfunc(this, deployed);
 }
 
-namespace _func1164
+namespace _func1165
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15866,11 +15880,11 @@ namespace _func1164
 void SpaceDrone::SetMovementTarget(Targetable *target)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1164::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1165::func;
 	return execfunc(this, target);
 }
 
-namespace _func1165
+namespace _func1166
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -15880,11 +15894,11 @@ namespace _func1165
 CollisionResponse SpaceDrone::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1165::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1166::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func1166
+namespace _func1167
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15894,11 +15908,11 @@ namespace _func1166
 Projectile *SpaceDrone::GetNextProjectile()
 {
 	typedef Projectile *__attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1166::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1167::func;
 	return execfunc(this);
 }
 
-namespace _func1167
+namespace _func1168
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -15908,11 +15922,11 @@ namespace _func1167
 void SpaceDrone::constructor(int iShipId, int selfId, DroneBlueprint *blueprint)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, int iShipId_arg, int selfId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1167::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1168::func;
 	return execfunc(this, iShipId, selfId, blueprint);
 }
 
-namespace _func1168
+namespace _func1169
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15922,11 +15936,11 @@ namespace _func1168
 void SpaceDrone::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1168::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1169::func;
 	return execfunc(this);
 }
 
-namespace _func1169
+namespace _func1170
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15936,11 +15950,11 @@ namespace _func1169
 void SpaceManager::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1169::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1170::func;
 	return execfunc(this);
 }
 
-namespace _func1170
+namespace _func1171
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15950,11 +15964,11 @@ namespace _func1170
 int SpaceManager::GetScreenShake()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1170::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1171::func;
 	return execfunc(this);
 }
 
-namespace _func1171
+namespace _func1172
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15964,11 +15978,11 @@ namespace _func1171
 void SpaceManager::SaveSpace(int fileHelper)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1171::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1172::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1172
+namespace _func1173
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15978,11 +15992,11 @@ namespace _func1172
 ImageDesc SpaceManager::SwitchBeacon()
 {
 	typedef ImageDesc __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1172::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1173::func;
 	return execfunc(this);
 }
 
-namespace _func1173
+namespace _func1174
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -15992,11 +16006,11 @@ namespace _func1173
 ImageDesc SpaceManager::SwitchPlanet(const std::string &name)
 {
 	typedef ImageDesc __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1173::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1174::func;
 	return execfunc(this, name);
 }
 
-namespace _func1174
+namespace _func1175
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16006,11 +16020,11 @@ namespace _func1174
 void SpaceManager::UpdatePlanetImage()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1174::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1175::func;
 	return execfunc(this);
 }
 
-namespace _func1175
+namespace _func1176
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x7ff, 0x7ff, 0x7ff};
@@ -16020,11 +16034,11 @@ namespace _func1175
 void SpaceManager::SwitchImages(ImageDesc planet, ImageDesc unk1, ImageDesc unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, ImageDesc planet_arg, ImageDesc unk1_arg, ImageDesc unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1175::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1176::func;
 	return execfunc(this, planet, unk1, unk2);
 }
 
-namespace _func1176
+namespace _func1177
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -16034,11 +16048,11 @@ namespace _func1176
 ImageDesc SpaceManager::SwitchBackground(const std::string &name)
 {
 	typedef ImageDesc __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1176::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1177::func;
 	return execfunc(this, name);
 }
 
-namespace _func1177
+namespace _func1178
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -16048,11 +16062,11 @@ namespace _func1177
 void SpaceManager::StartAsteroids(int shieldCount, bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int shieldCount_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1177::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1178::func;
 	return execfunc(this, shieldCount, unk);
 }
 
-namespace _func1178
+namespace _func1179
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -16062,11 +16076,11 @@ namespace _func1178
 void SpaceManager::SetPlanetaryDefense(char state, int target)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, char state_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1178::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1179::func;
 	return execfunc(this, state, target);
 }
 
-namespace _func1179
+namespace _func1180
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16076,11 +16090,11 @@ namespace _func1179
 void SpaceManager::SetPulsarLevel(bool pulsarLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool pulsarLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1179::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1180::func;
 	return execfunc(this, pulsarLevel);
 }
 
-namespace _func1180
+namespace _func1181
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16090,11 +16104,11 @@ namespace _func1180
 bool SpaceManager::DangerousEnvironment()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1180::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1181::func;
 	return execfunc(this);
 }
 
-namespace _func1181
+namespace _func1182
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -16104,11 +16118,11 @@ namespace _func1181
 void SpaceManager::MouseMove(int x, int y, int unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int x_arg, int y_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1181::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1182::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func1182
+namespace _func1183
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -16118,11 +16132,11 @@ namespace _func1182
 SpaceDrone *SpaceManager::GetSelectedDrone(int x, int y, int unk)
 {
 	typedef SpaceDrone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int x_arg, int y_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1182::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1183::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func1183
+namespace _func1184
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16132,11 +16146,11 @@ namespace _func1183
 float SpaceManager::GetFlashOpacity()
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1183::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1184::func;
 	return execfunc(this);
 }
 
-namespace _func1184
+namespace _func1185
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16146,20 +16160,6 @@ namespace _func1184
 GL_Color SpaceManager::GetColorTint()
 {
 	typedef GL_Color __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1184::func;
-	return execfunc(this);
-}
-
-namespace _func1185
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::OnRenderBackground", typeid(void (SpaceManager::*)()), "565383ec448b7424500f2805????????", argdata, 1, 6, &func);
-}
-
-void SpaceManager::OnRenderBackground()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1185::func;
 	return execfunc(this);
 }
@@ -16168,10 +16168,10 @@ namespace _func1186
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::OnRenderFleet", typeid(void (SpaceManager::*)()), "57565383ec508b7c2460", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnRenderBackground", typeid(void (SpaceManager::*)()), "565383ec448b7424500f2805????????", argdata, 1, 6, &func);
 }
 
-void SpaceManager::OnRenderFleet()
+void SpaceManager::OnRenderBackground()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1186::func;
@@ -16182,10 +16182,10 @@ namespace _func1187
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::OnRenderForeground", typeid(void (SpaceManager::*)()), "5557565383ec6c8b9c24800000000f2805????????", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnRenderFleet", typeid(void (SpaceManager::*)()), "57565383ec508b7c2460", argdata, 1, 6, &func);
 }
 
-void SpaceManager::OnRenderForeground()
+void SpaceManager::OnRenderFleet()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1187::func;
@@ -16195,6 +16195,20 @@ void SpaceManager::OnRenderForeground()
 namespace _func1188
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("SpaceManager::OnRenderForeground", typeid(void (SpaceManager::*)()), "5557565383ec6c8b9c24800000000f2805????????", argdata, 1, 6, &func);
+}
+
+void SpaceManager::OnRenderForeground()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1188::func;
+	return execfunc(this);
+}
+
+namespace _func1189
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("SpaceManager::SetDangerZone", typeid(void (SpaceManager::*)(int )), "5557565383ec3c8b4424548b7c245085c0", argdata, 2, 6, &func);
 }
@@ -16202,11 +16216,11 @@ namespace _func1188
 void SpaceManager::SetDangerZone(int fleetType)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fleetType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1188::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1189::func;
 	return execfunc(this, fleetType);
 }
 
-namespace _func1189
+namespace _func1190
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -16216,11 +16230,11 @@ namespace _func1189
 void SpaceManager::OnRenderAsteroids(int fieldLayers, float unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fieldLayers_arg, float unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1189::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1190::func;
 	return execfunc(this, fieldLayers, unk2);
 }
 
-namespace _func1190
+namespace _func1191
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -16230,11 +16244,11 @@ namespace _func1190
 void SpaceManager::OnRenderProjectiles(int iShipId, int layerCommand)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int iShipId_arg, int layerCommand_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1190::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1191::func;
 	return execfunc(this, iShipId, layerCommand);
 }
 
-namespace _func1191
+namespace _func1192
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16242,20 +16256,6 @@ namespace _func1191
 }
 
 void SpaceManager::OnInit()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1191::func;
-	return execfunc(this);
-}
-
-namespace _func1192
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::Restart", typeid(void (SpaceManager::*)()), ".57565383ec108b7424208b168b4604", argdata, 1, 6, &func);
-}
-
-void SpaceManager::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1192::func;
@@ -16266,10 +16266,10 @@ namespace _func1193
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::ClearEnvironment", typeid(void (SpaceManager::*)()), "8b442404c6807402000000c6807502000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::Restart", typeid(void (SpaceManager::*)()), ".57565383ec108b7424208b168b4604", argdata, 1, 6, &func);
 }
 
-void SpaceManager::ClearEnvironment()
+void SpaceManager::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1193::func;
@@ -16280,10 +16280,10 @@ namespace _func1194
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::Clear", typeid(void (SpaceManager::*)()), "57565383ec108b5c24208b839c000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::ClearEnvironment", typeid(void (SpaceManager::*)()), "8b442404c6807402000000c6807502000000", argdata, 1, 6, &func);
 }
 
-void SpaceManager::Clear()
+void SpaceManager::ClearEnvironment()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1194::func;
@@ -16294,10 +16294,10 @@ namespace _func1195
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::ClearProjectiles", typeid(void (SpaceManager::*)()), ".57565383ec108b7424208b168b4604", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::Clear", typeid(void (SpaceManager::*)()), "57565383ec108b5c24208b839c000000", argdata, 1, 6, &func);
 }
 
-void SpaceManager::ClearProjectiles()
+void SpaceManager::Clear()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1195::func;
@@ -16307,25 +16307,25 @@ void SpaceManager::ClearProjectiles()
 namespace _func1196
 {
     static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::UpdateProjectile", typeid(void (SpaceManager::*)(Projectile *)), "555731ff565383ec1c8b5c24348b7424308b03", argdata, 2, 6, &func);
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("SpaceManager::ClearProjectiles", typeid(void (SpaceManager::*)()), ".57565383ec108b7424208b168b4604", argdata, 1, 6, &func);
 }
 
-void SpaceManager::UpdateProjectile(Projectile *proj)
+void SpaceManager::ClearProjectiles()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1196::func;
-	return execfunc(this, proj);
+	return execfunc(this);
 }
 
 namespace _func1197
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::TransferProjectile", typeid(void (SpaceManager::*)(Projectile *)), "565383ec148b5c24248b038b7370", argdata, 2, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::UpdateProjectile", typeid(void (SpaceManager::*)(Projectile *)), "555731ff565383ec1c8b5c24348b7424308b03", argdata, 2, 6, &func);
 }
 
-void SpaceManager::TransferProjectile(Projectile *proj)
+void SpaceManager::UpdateProjectile(Projectile *proj)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1197::func;
@@ -16336,17 +16336,31 @@ namespace _func1198
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("SpaceManager::TransferProjectile", typeid(void (SpaceManager::*)(Projectile *)), "565383ec148b5c24248b038b7370", argdata, 2, 6, &func);
+}
+
+void SpaceManager::TransferProjectile(Projectile *proj)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1198::func;
+	return execfunc(this, proj);
+}
+
+namespace _func1199
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("SpaceManager::AddShip", typeid(void (SpaceManager::*)(ShipManager *)), "5589e557565383ec2c8b5d088b83a00000003b83a4000000", argdata, 2, 6, &func);
 }
 
 void SpaceManager::AddShip(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1198::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1199::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1199
+namespace _func1200
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16356,11 +16370,11 @@ namespace _func1199
 void SpaceManager::AddProjectile(Projectile *proj)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1199::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1200::func;
 	return execfunc(this, proj);
 }
 
-namespace _func1200
+namespace _func1201
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16370,11 +16384,11 @@ namespace _func1200
 void SpaceManager::LoadSpace(int fileHelper)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1200::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1201::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1201
+namespace _func1202
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16382,20 +16396,6 @@ namespace _func1201
 }
 
 void SpaceManager::UpdatePDS()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1201::func;
-	return execfunc(this);
-}
-
-namespace _func1202
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::OnLoopNebulas", typeid(void (SpaceManager::*)()), "5557565331db81ec8c0000008b8424a00000008bbc24a0000000", argdata, 1, 6, &func);
-}
-
-void SpaceManager::OnLoopNebulas()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1202::func;
@@ -16406,10 +16406,10 @@ namespace _func1203
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::OnLoop", typeid(void (SpaceManager::*)()), "5589e557565383ec6c8b75088d860c030000890424", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnLoopNebulas", typeid(void (SpaceManager::*)()), "5557565331db81ec8c0000008b8424a00000008bbc24a0000000", argdata, 1, 6, &func);
 }
 
-void SpaceManager::OnLoop()
+void SpaceManager::OnLoopNebulas()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1203::func;
@@ -16419,25 +16419,25 @@ void SpaceManager::OnLoop()
 namespace _func1204
 {
     static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::SetNebula", typeid(void (SpaceManager::*)(bool )), "5557565381ec9c0000008b9c24b00000008b8424b4000000", argdata, 2, 6, &func);
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("SpaceManager::OnLoop", typeid(void (SpaceManager::*)()), "5589e557565383ec6c8b75088d860c030000890424", argdata, 1, 6, &func);
 }
 
-void SpaceManager::SetNebula(bool state)
+void SpaceManager::OnLoop()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1204::func;
-	return execfunc(this, state);
+	return execfunc(this);
 }
 
 namespace _func1205
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::SetStorm", typeid(void (SpaceManager::*)(bool )), "5383ec288b4424308d5c241cc6802a03000001", argdata, 2, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::SetNebula", typeid(void (SpaceManager::*)(bool )), "5557565381ec9c0000008b9c24b00000008b8424b4000000", argdata, 2, 6, &func);
 }
 
-void SpaceManager::SetStorm(bool state)
+void SpaceManager::SetNebula(bool state)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1205::func;
@@ -16448,10 +16448,10 @@ namespace _func1206
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::SetFireLevel", typeid(void (SpaceManager::*)(bool )), "5557565383ec2c8b7424408d7c241a8b4424448d9ea4020000888674020000", argdata, 2, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::SetStorm", typeid(void (SpaceManager::*)(bool )), "5383ec288b4424308d5c241cc6802a03000001", argdata, 2, 6, &func);
 }
 
-void SpaceManager::SetFireLevel(bool state)
+void SpaceManager::SetStorm(bool state)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1206::func;
@@ -16461,6 +16461,20 @@ void SpaceManager::SetFireLevel(bool state)
 namespace _func1207
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("SpaceManager::SetFireLevel", typeid(void (SpaceManager::*)(bool )), "5557565383ec2c8b7424408d7c241a8b4424448d9ea4020000888674020000", argdata, 2, 6, &func);
+}
+
+void SpaceManager::SetFireLevel(bool state)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1207::func;
+	return execfunc(this, state);
+}
+
+namespace _func1208
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff};
 	static FunctionDefinition funcObj("SpaceStatus::OnInit", typeid(void (SpaceStatus::*)(SpaceManager *, Point )), "55575631f65383ec7c8b9c24????????", argdata, 3, 6, &func);
 }
@@ -16468,11 +16482,11 @@ namespace _func1207
 void SpaceStatus::OnInit(SpaceManager *space, Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg, SpaceManager *space_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1207::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1208::func;
 	return execfunc(this, space, pos);
 }
 
-namespace _func1208
+namespace _func1209
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -16482,11 +16496,11 @@ namespace _func1208
 void SpaceStatus::RenderWarningText(int effect, int textOffset)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg, int effect_arg, int textOffset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1208::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1209::func;
 	return execfunc(this, effect, textOffset);
 }
 
-namespace _func1209
+namespace _func1210
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16496,11 +16510,11 @@ namespace _func1209
 void SpaceStatus::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1209::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1210::func;
 	return execfunc(this);
 }
 
-namespace _func1210
+namespace _func1211
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -16510,11 +16524,11 @@ namespace _func1210
 void SpaceStatus::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1210::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1211::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1211
+namespace _func1212
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -16524,11 +16538,11 @@ namespace _func1211
 void StarMap::SetPosition(Point unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1211::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1212::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1212
+namespace _func1213
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16538,11 +16552,11 @@ namespace _func1212
 void StarMap::KeyDown(int unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1212::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1213::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1213
+namespace _func1214
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16552,11 +16566,11 @@ namespace _func1213
 int StarMap::GetNextDangerMove()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1213::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1214::func;
 	return execfunc(this);
 }
 
-namespace _func1214
+namespace _func1215
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16566,11 +16580,11 @@ namespace _func1214
 void StarMap::Open()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1214::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1215::func;
 	return execfunc(this);
 }
 
-namespace _func1215
+namespace _func1216
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16580,11 +16594,11 @@ namespace _func1215
 void StarMap::Close()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1215::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1216::func;
 	return execfunc(this);
 }
 
-namespace _func1216
+namespace _func1217
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16594,11 +16608,11 @@ namespace _func1216
 void StarMap::SetOpen(bool unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, bool unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1216::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1217::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1217
+namespace _func1218
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16606,20 +16620,6 @@ namespace _func1217
 }
 
 void StarMap::InitMapTitle()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1217::func;
-	return execfunc(this);
-}
-
-namespace _func1218
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::InitNoFuelText", typeid(void (StarMap::*)()), "5557565383ec5c8b6c24708d5c24408d7c243f8b8568040000", argdata, 1, 6, &func);
-}
-
-void StarMap::InitNoFuelText()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1218::func;
@@ -16630,10 +16630,10 @@ namespace _func1219
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::InitBossMessageBox", typeid(void (StarMap::*)()), "5589e557565383ec3c8b5d088bb3cc050000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StarMap::InitNoFuelText", typeid(void (StarMap::*)()), "5557565383ec5c8b6c24708d5c24408d7c243f8b8568040000", argdata, 1, 6, &func);
 }
 
-void StarMap::InitBossMessageBox()
+void StarMap::InitNoFuelText()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1219::func;
@@ -16644,10 +16644,10 @@ namespace _func1220
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::OnLanguageChange", typeid(void (StarMap::*)()), "5383ec188b5c2420891c24e8????????891c24e8????????895c2420", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StarMap::InitBossMessageBox", typeid(void (StarMap::*)()), "5589e557565383ec3c8b5d088bb3cc050000", argdata, 1, 6, &func);
 }
 
-void StarMap::OnLanguageChange()
+void StarMap::InitBossMessageBox()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1220::func;
@@ -16658,17 +16658,31 @@ namespace _func1221
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("StarMap::OnLanguageChange", typeid(void (StarMap::*)()), "5383ec188b5c2420891c24e8????????891c24e8????????895c2420", argdata, 1, 6, &func);
+}
+
+void StarMap::OnLanguageChange()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1221::func;
+	return execfunc(this);
+}
+
+namespace _func1222
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("StarMap::GetRandomSectorChoice", typeid(int (StarMap::*)()), "83ec0c803d????????0075??e8????????89c1", argdata, 1, 2, &func);
 }
 
 int StarMap::GetRandomSectorChoice()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1221::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1222::func;
 	return execfunc(this);
 }
 
-namespace _func1222
+namespace _func1223
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16678,11 +16692,11 @@ namespace _func1222
 void StarMap::NeighboringSector(int unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1222::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1223::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1223
+namespace _func1224
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -16692,11 +16706,11 @@ namespace _func1223
 void StarMap::GetSelectedSector(int unk0, int unk1, int unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg, int unk1_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1223::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1224::func;
 	return execfunc(this, unk0, unk1, unk2);
 }
 
-namespace _func1224
+namespace _func1225
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16706,11 +16720,11 @@ namespace _func1224
 void StarMap::StartSecretSector()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1224::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1225::func;
 	return execfunc(this);
 }
 
-namespace _func1225
+namespace _func1226
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16718,20 +16732,6 @@ namespace _func1225
 }
 
 void StarMap::ReachSector(Sector *unk0)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1225::func;
-	return execfunc(this, unk0);
-}
-
-namespace _func1226
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("StarMap::UpdateSectorMap", typeid(void (StarMap::*)(Sector *)), "5756538b7c24148b74241085ff", argdata, 2, 6, &func);
-}
-
-void StarMap::UpdateSectorMap(Sector *unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1226::func;
@@ -16742,17 +16742,31 @@ namespace _func1227
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("StarMap::UpdateSectorMap", typeid(void (StarMap::*)(Sector *)), "5756538b7c24148b74241085ff", argdata, 2, 6, &func);
+}
+
+void StarMap::UpdateSectorMap(Sector *unk0)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1227::func;
+	return execfunc(this, unk0);
+}
+
+namespace _func1228
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::SaveGame", typeid(void (StarMap::*)(int )), "5557565383ec3c8b6c24508b5c24548b857c060000", argdata, 2, 6, &func);
 }
 
 void StarMap::SaveGame(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1227::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1228::func;
 	return execfunc(this, file);
 }
 
-namespace _func1228
+namespace _func1229
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16760,20 +16774,6 @@ namespace _func1228
 }
 
 void StarMap::InitStatistics()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1228::func;
-	return execfunc(this);
-}
-
-namespace _func1229
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::PrintStatistics", typeid(void (StarMap::*)()), ".f3c38db426000000008dbc2700000000f3c38db4", argdata, 1, 6, &func);
-}
-
-void StarMap::PrintStatistics()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1229::func;
@@ -16784,10 +16784,10 @@ namespace _func1230
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::AnalyzeMap", typeid(void (StarMap::*)()), ".f3c38db426000000008dbc27000000008b442404", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StarMap::PrintStatistics", typeid(void (StarMap::*)()), ".f3c38db426000000008dbc2700000000f3c38db4", argdata, 1, 6, &func);
 }
 
-void StarMap::AnalyzeMap()
+void StarMap::PrintStatistics()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1230::func;
@@ -16797,6 +16797,20 @@ void StarMap::AnalyzeMap()
 namespace _func1231
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("StarMap::AnalyzeMap", typeid(void (StarMap::*)()), ".f3c38db426000000008dbc27000000008b442404", argdata, 1, 6, &func);
+}
+
+void StarMap::AnalyzeMap()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1231::func;
+	return execfunc(this);
+}
+
+namespace _func1232
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::ModifyPursuit", typeid(void (StarMap::*)(int )), "8b4424048b542408019020040000", argdata, 2, 6, &func);
 }
@@ -16804,11 +16818,11 @@ namespace _func1231
 void StarMap::ModifyPursuit(int unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1231::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1232::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1232
+namespace _func1233
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16816,20 +16830,6 @@ namespace _func1232
 }
 
 void StarMap::AtBeacon()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1232::func;
-	return execfunc(this);
-}
-
-namespace _func1233
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::GetWaitLocation", typeid(void (StarMap::*)()), "8b44240480787c00", argdata, 1, 6, &func);
-}
-
-void StarMap::GetWaitLocation()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1233::func;
@@ -16840,10 +16840,10 @@ namespace _func1234
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::StartBeacon", typeid(void (StarMap::*)()), "5631c0538b54240c8b8a18040000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StarMap::GetWaitLocation", typeid(void (StarMap::*)()), "8b44240480787c00", argdata, 1, 6, &func);
 }
 
-void StarMap::StartBeacon()
+void StarMap::GetWaitLocation()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1234::func;
@@ -16853,6 +16853,20 @@ void StarMap::StartBeacon()
 namespace _func1235
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("StarMap::StartBeacon", typeid(void (StarMap::*)()), "5631c0538b54240c8b8a18040000", argdata, 1, 6, &func);
+}
+
+void StarMap::StartBeacon()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1235::func;
+	return execfunc(this);
+}
+
+namespace _func1236
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::LocationsConnected", typeid(bool (StarMap::*)(Location *, Location *)), "538b44240c8b5c24108b48088b500c", argdata, 3, 2, &func);
 }
@@ -16860,11 +16874,11 @@ namespace _func1235
 bool StarMap::LocationsConnected(Location *unk0, Location *unk1)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg, Location *unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1235::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1236::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1236
+namespace _func1237
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -16874,11 +16888,11 @@ namespace _func1236
 Point StarMap::PointToGrid(float x, float y)
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, float x_arg, float y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1236::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1237::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1237
+namespace _func1238
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16888,11 +16902,11 @@ namespace _func1237
 void StarMap::TravelToLocation(Location *unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1237::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1238::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1238
+namespace _func1239
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16902,11 +16916,11 @@ namespace _func1238
 void StarMap::ForceExitBeacon()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1238::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1239::func;
 	return execfunc(this);
 }
 
-namespace _func1239
+namespace _func1240
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16916,11 +16930,11 @@ namespace _func1239
 void StarMap::OnRenderFogEffect()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1239::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1240::func;
 	return execfunc(this);
 }
 
-namespace _func1240
+namespace _func1241
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16928,20 +16942,6 @@ namespace _func1240
 }
 
 void StarMap::LocationHasBoss(Location *unk0)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1240::func;
-	return execfunc(this, unk0);
-}
-
-namespace _func1241
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("StarMap::LocationHasStore", typeid(void (StarMap::*)(Location *)), "56538b5424108b4c240c8b422085c0", argdata, 2, 6, &func);
-}
-
-void StarMap::LocationHasStore(Location *unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1241::func;
@@ -16952,10 +16952,10 @@ namespace _func1242
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("StarMap::LocationHasShip", typeid(void (StarMap::*)(Location *)), "8b4424088b402085c0", argdata, 2, 6, &func);
+	static FunctionDefinition funcObj("StarMap::LocationHasStore", typeid(void (StarMap::*)(Location *)), "56538b5424108b4c240c8b422085c0", argdata, 2, 6, &func);
 }
 
-void StarMap::LocationHasShip(Location *unk0)
+void StarMap::LocationHasStore(Location *unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1242::func;
@@ -16965,25 +16965,25 @@ void StarMap::LocationHasShip(Location *unk0)
 namespace _func1243
 {
     static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::AdvanceWorldLevel", typeid(void (StarMap::*)()), "5557565383ec5c8b7424708b8618040000", argdata, 1, 6, &func);
+	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("StarMap::LocationHasShip", typeid(void (StarMap::*)(Location *)), "8b4424088b402085c0", argdata, 2, 6, &func);
 }
 
-void StarMap::AdvanceWorldLevel()
+void StarMap::LocationHasShip(Location *unk0)
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1243::func;
-	return execfunc(this);
+	return execfunc(this, unk0);
 }
 
 namespace _func1244
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::ReverseBossPath", typeid(void (StarMap::*)()), "56538b5c240c8b8bc4070000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StarMap::AdvanceWorldLevel", typeid(void (StarMap::*)()), "5557565383ec5c8b7424708b8618040000", argdata, 1, 6, &func);
 }
 
-void StarMap::ReverseBossPath()
+void StarMap::AdvanceWorldLevel()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1244::func;
@@ -16994,10 +16994,10 @@ namespace _func1245
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::ForceBossJump", typeid(void (StarMap::*)()), "5756538b5c241080bbbc07000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StarMap::ReverseBossPath", typeid(void (StarMap::*)()), "56538b5c240c8b8bc4070000", argdata, 1, 6, &func);
 }
 
-void StarMap::ForceBossJump()
+void StarMap::ReverseBossPath()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1245::func;
@@ -17008,10 +17008,10 @@ namespace _func1246
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::ClearBoss", typeid(void (StarMap::*)()), "565331db83ec148b7424208b56208b4624c686cc07000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StarMap::ForceBossJump", typeid(void (StarMap::*)()), "5756538b5c241080bbbc07000000", argdata, 1, 6, &func);
 }
 
-void StarMap::ClearBoss()
+void StarMap::ForceBossJump()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1246::func;
@@ -17021,6 +17021,20 @@ void StarMap::ClearBoss()
 namespace _func1247
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("StarMap::ClearBoss", typeid(void (StarMap::*)()), "565331db83ec148b7424208b56208b4624c686cc07000000", argdata, 1, 6, &func);
+}
+
+void StarMap::ClearBoss()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1247::func;
+	return execfunc(this);
+}
+
+namespace _func1248
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::SetBossStage", typeid(void (StarMap::*)(int )), "8b5424088b4424048990f4080000", argdata, 2, 6, &func);
 }
@@ -17028,11 +17042,11 @@ namespace _func1247
 void StarMap::SetBossStage(int stage)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int stage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1247::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1248::func;
 	return execfunc(this, stage);
 }
 
-namespace _func1248
+namespace _func1249
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17040,20 +17054,6 @@ namespace _func1248
 }
 
 void StarMap::CheckGameOver()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1248::func;
-	return execfunc(this);
-}
-
-namespace _func1249
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::RenderLabels", typeid(void (StarMap::*)()), "5589e557565381eccc0000008b7508e8????????", argdata, 1, 6, &func);
-}
-
-void StarMap::RenderLabels()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1249::func;
@@ -17064,10 +17064,10 @@ namespace _func1250
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::DeleteMap", typeid(void (StarMap::*)()), "5557565383ec2c8b7424408bbee8080000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StarMap::RenderLabels", typeid(void (StarMap::*)()), "5589e557565381eccc0000008b7508e8????????", argdata, 1, 6, &func);
 }
 
-void StarMap::DeleteMap()
+void StarMap::RenderLabels()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1250::func;
@@ -17077,6 +17077,20 @@ void StarMap::DeleteMap()
 namespace _func1251
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("StarMap::DeleteMap", typeid(void (StarMap::*)()), "5557565383ec2c8b7424408bbee8080000", argdata, 1, 6, &func);
+}
+
+void StarMap::DeleteMap()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1251::func;
+	return execfunc(this);
+}
+
+namespace _func1252
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::MouseClick", typeid(void (StarMap::*)(int , int )), "5557565383ec2c8b5c244080bb3005000000", argdata, 3, 6, &func);
 }
@@ -17084,11 +17098,11 @@ namespace _func1251
 void StarMap::MouseClick(int unk0, int unk1)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg, int unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1251::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1252::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1252
+namespace _func1253
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17098,11 +17112,11 @@ namespace _func1252
 void StarMap::AddSectorColumn()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1252::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1253::func;
 	return execfunc(this);
 }
 
-namespace _func1253
+namespace _func1254
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17112,11 +17126,11 @@ namespace _func1253
 void StarMap::PushSectorColumn()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1253::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1254::func;
 	return execfunc(this);
 }
 
-namespace _func1254
+namespace _func1255
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17126,11 +17140,11 @@ namespace _func1254
 void StarMap::SelectNewSector(int unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1254::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1255::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1255
+namespace _func1256
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17140,11 +17154,11 @@ namespace _func1255
 void StarMap::GenerateSectorMap()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1255::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1256::func;
 	return execfunc(this);
 }
 
-namespace _func1256
+namespace _func1257
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17154,11 +17168,11 @@ namespace _func1256
 void StarMap::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1256::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1257::func;
 	return execfunc(this);
 }
 
-namespace _func1257
+namespace _func1258
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x4ff};
@@ -17168,11 +17182,11 @@ namespace _func1257
 void StarMap::RenderSectorName(Sector *unk0, GL_Color unk1)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg, GL_Color unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1257::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1258::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1258
+namespace _func1259
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17182,11 +17196,11 @@ namespace _func1258
 void StarMap::UpdateDangerZone()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1258::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1259::func;
 	return execfunc(this);
 }
 
-namespace _func1259
+namespace _func1260
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17196,11 +17210,11 @@ namespace _func1259
 Location *StarMap::GetNewLocation()
 {
 	typedef Location *__attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1259::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1260::func;
 	return execfunc(this);
 }
 
-namespace _func1260
+namespace _func1261
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17210,11 +17224,11 @@ namespace _func1260
 void StarMap::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1260::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1261::func;
 	return execfunc(this);
 }
 
-namespace _func1261
+namespace _func1262
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17224,11 +17238,11 @@ namespace _func1261
 void StarMap::GenerateEvents(bool tutorial)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, bool tutorial_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1261::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1262::func;
 	return execfunc(this, tutorial);
 }
 
-namespace _func1262
+namespace _func1263
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17238,11 +17252,11 @@ namespace _func1262
 void StarMap::AddConnections(Location *unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1262::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1263::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1263
+namespace _func1264
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17252,11 +17266,11 @@ namespace _func1263
 void StarMap::MapConnected()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1263::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1264::func;
 	return execfunc(this);
 }
 
-namespace _func1264
+namespace _func1265
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x2ff};
@@ -17266,11 +17280,11 @@ namespace _func1264
 void StarMap::ConnectLocations(Point unk0, Point unk1)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg, Point unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1264::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1265::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1265
+namespace _func1266
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -17280,11 +17294,11 @@ namespace _func1265
 void StarMap::PopulateGrid(Point unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1265::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1266::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1266
+namespace _func1267
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17294,11 +17308,11 @@ namespace _func1266
 Location *StarMap::PopClosestLoc(std::vector<Location*> &vec, std::map<Location*, int> &map)
 {
 	typedef Location *__attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, std::vector<Location*> &vec_arg, std::map<Location*, int> &map_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1266::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1267::func;
 	return execfunc(this, vec, map);
 }
 
-namespace _func1267
+namespace _func1268
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17308,11 +17322,11 @@ namespace _func1267
 bool StarMap::AddQuest(const std::string &questEvent, bool force)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, const std::string &questEvent_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1267::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1268::func;
 	return execfunc(this, questEvent, force);
 }
 
-namespace _func1268
+namespace _func1269
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17322,11 +17336,11 @@ namespace _func1268
 Location *StarMap::GenerateMap(bool tutorial, bool seed)
 {
 	typedef Location *__attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, bool tutorial_arg, bool seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1268::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1269::func;
 	return execfunc(this, tutorial, seed);
 }
 
-namespace _func1269
+namespace _func1270
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17336,11 +17350,11 @@ namespace _func1269
 Location *StarMap::NewGame(bool unk0)
 {
 	typedef Location *__attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, bool unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1269::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1270::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1270
+namespace _func1271
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -17350,11 +17364,11 @@ namespace _func1270
 std::vector<Location*> StarMap::Dijkstra(Location *start, Location *finish, bool include_unknown)
 {
 	typedef std::vector<Location*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *start_arg, Location *finish_arg, bool include_unknown_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1270::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1271::func;
 	return execfunc(this, start, finish, include_unknown);
 }
 
-namespace _func1271
+namespace _func1272
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17364,11 +17378,11 @@ namespace _func1271
 void StarMap::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1271::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1272::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1272
+namespace _func1273
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -17378,11 +17392,11 @@ namespace _func1272
 void StarMap::OnTouch(TouchAction unk0, int unk1, int unk2, int unk3, int unk4, int unk5)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, TouchAction unk0_arg, int unk1_arg, int unk2_arg, int unk3_arg, int unk4_arg, int unk5_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1272::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1273::func;
 	return execfunc(this, unk0, unk1, unk2, unk3, unk4, unk5);
 }
 
-namespace _func1273
+namespace _func1274
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17392,11 +17406,11 @@ namespace _func1273
 Location *StarMap::LoadGame(int fileHelper)
 {
 	typedef Location *__attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1273::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1274::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1274
+namespace _func1275
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -17406,11 +17420,11 @@ namespace _func1274
 void StarMap::RenderLeftInsetButton(float unk0, float unk1, bool unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, float unk0_arg, float unk1_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1274::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1275::func;
 	return execfunc(this, unk0, unk1, unk2);
 }
 
-namespace _func1275
+namespace _func1276
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17420,11 +17434,11 @@ namespace _func1275
 void StarMap::RenderDistressButtons()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1275::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1276::func;
 	return execfunc(this);
 }
 
-namespace _func1276
+namespace _func1277
 {
     static void *func = 0;
 	static short argdata[] = {0x100};
@@ -17434,11 +17448,11 @@ namespace _func1276
 void StarMap::OnRender()
 {
 	typedef void __attribute__((regparm(1))) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1276::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1277::func;
 	return execfunc(this);
 }
 
-namespace _func1277
+namespace _func1278
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -17448,11 +17462,11 @@ namespace _func1277
 void StarMap::DrawConnection(const Pointf &pos1, const Pointf &pos2, const GL_Color *color)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, const Pointf &pos1_arg, const Pointf &pos2_arg, const GL_Color *color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1277::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1278::func;
 	return execfunc(this, pos1, pos2, color);
 }
 
-namespace _func1278
+namespace _func1279
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17462,11 +17476,11 @@ namespace _func1278
 void StarMap::TurnIntoFleetLocation(Location *loc)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1278::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1279::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1279
+namespace _func1280
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17476,11 +17490,11 @@ namespace _func1279
 std::string StarMap::GetLocationText(const Location *loc)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, const Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1279::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1280::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1280
+namespace _func1281
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17490,11 +17504,11 @@ namespace _func1280
 void StarMap::SetupNoFuel(int seed, const std::string &forceEscape)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int seed_arg, const std::string &forceEscape_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1280::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1281::func;
 	return execfunc(this, seed, forceEscape);
 }
 
-namespace _func1281
+namespace _func1282
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17504,11 +17518,11 @@ namespace _func1281
 void StarMap::GenerateNebulas(const std::vector<std::string> &names)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, const std::vector<std::string> &names_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1281::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1282::func;
 	return execfunc(this, names);
 }
 
-namespace _func1282
+namespace _func1283
 {
     static void *func = 0;
 	static short argdata[] = {0x100};
@@ -17518,11 +17532,11 @@ namespace _func1282
 void StarMap::UpdateBoss()
 {
 	typedef void __attribute__((regparm(1))) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1282::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1283::func;
 	return execfunc(this);
 }
 
-namespace _func1283
+namespace _func1284
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17532,11 +17546,11 @@ namespace _func1283
 StatusEffect StatusEffect::GetNebulaEffect()
 {
 	typedef StatusEffect __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1283::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1284::func;
 	return execfunc();
 }
 
-namespace _func1284
+namespace _func1285
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -17546,11 +17560,11 @@ namespace _func1284
 void Store::OnInit(ShipManager *shopper, Equipment *equip, int worldLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, ShipManager *shopper_arg, Equipment *equip_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1284::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1285::func;
 	return execfunc(this, shopper, equip, worldLevel);
 }
 
-namespace _func1285
+namespace _func1286
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17560,11 +17574,11 @@ namespace _func1285
 void Store::CreateStoreBoxes(int type, Equipment *equip)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, int type_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1285::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1286::func;
 	return execfunc(this, type, equip);
 }
 
-namespace _func1286
+namespace _func1287
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17574,11 +17588,11 @@ namespace _func1286
 bool Store::KeyDown(SDLKey key)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1286::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1287::func;
 	return execfunc(this, key);
 }
 
-namespace _func1287
+namespace _func1288
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17588,11 +17602,11 @@ namespace _func1287
 void Store::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1287::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1288::func;
 	return execfunc(this);
 }
 
-namespace _func1288
+namespace _func1289
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17602,11 +17616,11 @@ namespace _func1288
 void Store::Close()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1288::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1289::func;
 	return execfunc(this);
 }
 
-namespace _func1289
+namespace _func1290
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17616,11 +17630,11 @@ namespace _func1289
 void Store::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1289::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1290::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1290
+namespace _func1291
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17630,11 +17644,11 @@ namespace _func1290
 void Store::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1290::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1291::func;
 	return execfunc(this);
 }
 
-namespace _func1291
+namespace _func1292
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17644,11 +17658,11 @@ namespace _func1291
 void Store::SaveStore(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1291::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1292::func;
 	return execfunc(this, file);
 }
 
-namespace _func1292
+namespace _func1293
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17658,11 +17672,11 @@ namespace _func1292
 void Store::RelinkShip(ShipManager *ship, Equipment *equip)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, ShipManager *ship_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1292::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1293::func;
 	return execfunc(this, ship, equip);
 }
 
-namespace _func1293
+namespace _func1294
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17672,11 +17686,11 @@ namespace _func1293
 bool Store::HasType(int type)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1293::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1294::func;
 	return execfunc(this, type);
 }
 
-namespace _func1294
+namespace _func1295
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17686,11 +17700,11 @@ namespace _func1294
 void Store::Clear()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1294::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1295::func;
 	return execfunc(this);
 }
 
-namespace _func1295
+namespace _func1296
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff};
@@ -17700,11 +17714,11 @@ namespace _func1295
 void Store::InitHeading(int index, Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, int index_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1295::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1296::func;
 	return execfunc(this, index, pos);
 }
 
-namespace _func1296
+namespace _func1297
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -17714,11 +17728,11 @@ namespace _func1296
 void Store::DrawBuySellTabText()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1296::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1297::func;
 	return execfunc();
 }
 
-namespace _func1297
+namespace _func1298
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17728,11 +17742,11 @@ namespace _func1297
 void Store::MouseClick(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1297::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1298::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1298
+namespace _func1299
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17742,11 +17756,11 @@ namespace _func1298
 void Store::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1298::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1299::func;
 	return execfunc(this);
 }
 
-namespace _func1299
+namespace _func1300
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17756,11 +17770,11 @@ namespace _func1299
 void Store::SetPositions()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1299::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1300::func;
 	return execfunc(this);
 }
 
-namespace _func1300
+namespace _func1301
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17770,11 +17784,11 @@ namespace _func1300
 void Store::LoadStore(int file, int worldLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, int file_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1300::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1301::func;
 	return execfunc(this, file, worldLevel);
 }
 
-namespace _func1301
+namespace _func1302
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -17784,11 +17798,11 @@ namespace _func1301
 void Store::SetPosition(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1301::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1302::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1302
+namespace _func1303
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17798,11 +17812,11 @@ namespace _func1302
 void Store::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1302::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1303::func;
 	return execfunc(this);
 }
 
-namespace _func1303
+namespace _func1304
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17812,11 +17826,11 @@ namespace _func1303
 void StoreBox::MouseClick(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1303::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1304::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1304
+namespace _func1305
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17826,11 +17840,11 @@ namespace _func1304
 void StoreBox::Activate()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1304::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1305::func;
 	return execfunc(this);
 }
 
-namespace _func1305
+namespace _func1306
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17840,11 +17854,11 @@ namespace _func1305
 void StoreBox::InitBlueprint(Blueprint *bp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg, Blueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1305::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1306::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1306
+namespace _func1307
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -17854,11 +17868,11 @@ namespace _func1306
 void StoreBox::constructor(const std::string &buttonImage, ShipManager *shopper, Equipment *equip)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg, const std::string &buttonImage_arg, ShipManager *shopper_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1306::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1307::func;
 	return execfunc(this, buttonImage, shopper, equip);
 }
 
-namespace _func1307
+namespace _func1308
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -17868,11 +17882,11 @@ namespace _func1307
 void StoreBox::SetPosition(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1307::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1308::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1308
+namespace _func1309
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17880,20 +17894,6 @@ namespace _func1308
 }
 
 void StoreBox::OnRender()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1308::func;
-	return execfunc(this);
-}
-
-namespace _func1309
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StoreBox::OnLoop", typeid(void (StoreBox::*)()), "5331c083ec188b5c24208b93b800000085d2", argdata, 1, 6, &func);
-}
-
-void StoreBox::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1309::func;
@@ -17904,10 +17904,10 @@ namespace _func1310
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StoreBox::Purchase", typeid(void (StoreBox::*)()), ".5557565383ec2c8d74241c8b5c24408d7c241a", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StoreBox::OnLoop", typeid(void (StoreBox::*)()), "5331c083ec188b5c24208b93b800000085d2", argdata, 1, 6, &func);
 }
 
-void StoreBox::Purchase()
+void StoreBox::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1310::func;
@@ -17917,6 +17917,20 @@ void StoreBox::Purchase()
 namespace _func1311
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("StoreBox::Purchase", typeid(void (StoreBox::*)()), ".5557565383ec2c8d74241c8b5c24408d7c241a", argdata, 1, 6, &func);
+}
+
+void StoreBox::Purchase()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1311::func;
+	return execfunc(this);
+}
+
+namespace _func1312
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("SuperShieldDrone::constructor", typeid(void (SuperShieldDrone::*)(int , int , DroneBlueprint *)), "5557565383ec??8b44????8d????1c8b5c????8d????1a8944????", argdata, 4, 6, &func);
 }
@@ -17924,11 +17938,11 @@ namespace _func1311
 void SuperShieldDrone::constructor(int iShipId, int selfId, DroneBlueprint *blueprint)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SuperShieldDrone *this_arg, int iShipId_arg, int selfId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1311::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1312::func;
 	return execfunc(this, iShipId, selfId, blueprint);
 }
 
-namespace _func1312
+namespace _func1313
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17938,11 +17952,11 @@ namespace _func1312
 void SuperShieldDrone::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SuperShieldDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1312::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1313::func;
 	return execfunc(this);
 }
 
-namespace _func1313
+namespace _func1314
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17952,11 +17966,11 @@ namespace _func1313
 void SystemBox::OnRender(bool ignoreStatus)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemBox *this_arg, bool ignoreStatus_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1313::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1314::func;
 	return execfunc(this, ignoreStatus);
 }
 
-namespace _func1314
+namespace _func1315
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -17966,11 +17980,11 @@ namespace _func1314
 void SystemBox::constructor(Point pos, ShipSystem *sys, bool playerUI)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, bool playerUI_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1314::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1315::func;
 	return execfunc(this, pos, sys, playerUI);
 }
 
-namespace _func1315
+namespace _func1316
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17980,11 +17994,11 @@ namespace _func1315
 void SystemBox::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1315::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1316::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1316
+namespace _func1317
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17994,11 +18008,11 @@ namespace _func1316
 bool SystemBox::MouseClick(bool shift)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemBox *this_arg, bool shift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1316::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1317::func;
 	return execfunc(this, shift);
 }
 
-namespace _func1317
+namespace _func1318
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -18008,11 +18022,11 @@ namespace _func1317
 void SystemBox::KeyDown(SDLKey key, bool shift)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemBox *this_arg, SDLKey key_arg, bool shift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1317::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1318::func;
 	return execfunc(this, key, shift);
 }
 
-namespace _func1318
+namespace _func1319
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18022,11 +18036,11 @@ namespace _func1318
 void SystemControl::CreateSystemBoxes()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1318::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1319::func;
 	return execfunc(this);
 }
 
-namespace _func1319
+namespace _func1320
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18036,11 +18050,11 @@ namespace _func1319
 SystemBox *SystemControl::GetSystemBox(int systemId)
 {
 	typedef SystemBox *__attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemControl *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1319::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1320::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1320
+namespace _func1321
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18050,11 +18064,11 @@ namespace _func1320
 void SystemControl::RenderPowerBar()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1320::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1321::func;
 	return execfunc(this);
 }
 
-namespace _func1321
+namespace _func1322
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18064,25 +18078,25 @@ namespace _func1321
 SystemControl::PowerBars *SystemControl::GetPowerBars(int width, int height, int gap, bool useShieldGap)
 {
 	typedef SystemControl::PowerBars *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int width_arg, int height_arg, int gap_arg, bool useShieldGap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1321::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1322::func;
 	return execfunc(width, height, gap, useShieldGap);
 }
 
 Point *Global_SystemControl_weapon_position;
 
-namespace _var1322
+namespace _var1323
 {
     static VariableDefinition varObj("Global_SystemControl_weapon_position", "!a3(???????\?)8915????????e8????????8b5424448b4424408b4b0c8915????????8b5308a3(???????\?)", &Global_SystemControl_weapon_position);
 }
 
 Point *Global_SystemControl_drone_position;
 
-namespace _var1323
+namespace _var1324
 {
     static VariableDefinition varObj("Global_SystemControl_drone_position", "", &Global_SystemControl_drone_position);
 }
 
-namespace _func1324
+namespace _func1325
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -18092,11 +18106,11 @@ namespace _func1324
 void SystemCustomBox::constructor(Point pos, ShipSystem *sys, ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemCustomBox *this_arg, Point pos_arg, ShipSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1324::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1325::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func1325
+namespace _func1326
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18106,11 +18120,11 @@ namespace _func1325
 void SystemStoreBox::SetExtraData(int droneChoice)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, int droneChoice_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1325::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1326::func;
 	return execfunc(this, droneChoice);
 }
 
-namespace _func1326
+namespace _func1327
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18120,11 +18134,11 @@ namespace _func1326
 void SystemStoreBox::constructor(ShipManager *shopper, Equipment *equip, int sys)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, ShipManager *shopper_arg, Equipment *equip_arg, int sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1326::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1327::func;
 	return execfunc(this, shopper, equip, sys);
 }
 
-namespace _func1327
+namespace _func1328
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18134,11 +18148,11 @@ namespace _func1327
 bool SystemStoreBox::CanHold()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1327::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1328::func;
 	return execfunc(this);
 }
 
-namespace _func1328
+namespace _func1329
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -18148,11 +18162,11 @@ namespace _func1328
 void SystemStoreBox::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1328::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1329::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1329
+namespace _func1330
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18160,20 +18174,6 @@ namespace _func1329
 }
 
 void SystemStoreBox::Activate()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1329::func;
-	return execfunc(this);
-}
-
-namespace _func1330
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SystemStoreBox::Purchase", typeid(void (SystemStoreBox::*)()), "5557565383ec3c8b5c24508d74242c891c24e8????????8b4304", argdata, 1, 6, &func);
-}
-
-void SystemStoreBox::Purchase()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1330::func;
@@ -18184,17 +18184,31 @@ namespace _func1331
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("SystemStoreBox::Purchase", typeid(void (SystemStoreBox::*)()), "5557565383ec3c8b5c24508d74242c891c24e8????????8b4304", argdata, 1, 6, &func);
+}
+
+void SystemStoreBox::Purchase()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1331::func;
+	return execfunc(this);
+}
+
+namespace _func1332
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("TabbedWindow::Close", typeid(void (TabbedWindow::*)()), "5383ec188b5c24208b53408b43288b04908b10", argdata, 1, 6, &func);
 }
 
 void TabbedWindow::Close()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TabbedWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1331::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1332::func;
 	return execfunc(this);
 }
 
-namespace _func1332
+namespace _func1333
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
@@ -18204,11 +18218,11 @@ namespace _func1332
 void TeleportBox::constructor(Point pos, TeleportSystem *sys)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportBox *this_arg, Point pos_arg, TeleportSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1332::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1333::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func1333
+namespace _func1334
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18218,11 +18232,11 @@ namespace _func1333
 void TeleportSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1333::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1334::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func1334
+namespace _func1335
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18232,11 +18246,11 @@ namespace _func1334
 void TeleportSystem::OnRenderFloor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1334::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1335::func;
 	return execfunc(this);
 }
 
-namespace _func1335
+namespace _func1336
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18246,11 +18260,11 @@ namespace _func1335
 void TeleportSystem::constructor(int systemId, int roomId, int shipId, int startingPower)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int systemId_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1335::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1336::func;
 	return execfunc(this, systemId, roomId, shipId, startingPower);
 }
 
-namespace _func1336
+namespace _func1337
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18260,11 +18274,11 @@ namespace _func1336
 float TeleportSystem::GetChargedPercent()
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1336::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1337::func;
 	return execfunc(this);
 }
 
-namespace _func1337
+namespace _func1338
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18274,11 +18288,11 @@ namespace _func1337
 bool TeleportSystem::Charged()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1337::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1338::func;
 	return execfunc(this);
 }
 
-namespace _func1338
+namespace _func1339
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18288,11 +18302,11 @@ namespace _func1338
 void TeleportSystem::ClearCrewLocations()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1338::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1339::func;
 	return execfunc(this);
 }
 
-namespace _func1339
+namespace _func1340
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18302,11 +18316,11 @@ namespace _func1339
 void TeleportSystem::UpdateCrewLocation(int unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1339::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1340::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1340
+namespace _func1341
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18316,11 +18330,11 @@ namespace _func1340
 void TeleportSystem::SetArmed(int armed)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int armed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1340::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1341::func;
 	return execfunc(this, armed);
 }
 
-namespace _func1341
+namespace _func1342
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18330,20 +18344,6 @@ namespace _func1341
 void TeleportSystem::ForceReady()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1341::func;
-	return execfunc(this);
-}
-
-namespace _func1342
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("TeleportSystem::CanSend", typeid(bool (TeleportSystem::*)()), "57565383ec208b5c24308b4b0c", argdata, 1, 2, &func);
-}
-
-bool TeleportSystem::CanSend()
-{
-	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1342::func;
 	return execfunc(this);
 }
@@ -18352,10 +18352,10 @@ namespace _func1343
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("TeleportSystem::CanReceive", typeid(bool (TeleportSystem::*)()), "565383ec148b5c24208b74242480bb9d01000000", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("TeleportSystem::CanSend", typeid(bool (TeleportSystem::*)()), "57565383ec208b5c24308b4b0c", argdata, 1, 2, &func);
 }
 
-bool TeleportSystem::CanReceive()
+bool TeleportSystem::CanSend()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1343::func;
@@ -18366,12 +18366,12 @@ namespace _func1344
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("TeleportSystem::InitiateTeleport", typeid(void (TeleportSystem::*)()), "5383ec288b5c2430891c24", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("TeleportSystem::CanReceive", typeid(bool (TeleportSystem::*)()), "565383ec148b5c24208b74242480bb9d01000000", argdata, 1, 2, &func);
 }
 
-void TeleportSystem::InitiateTeleport()
+bool TeleportSystem::CanReceive()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1344::func;
 	return execfunc(this);
 }
@@ -18380,10 +18380,10 @@ namespace _func1345
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("TeleportSystem::OnLoop", typeid(void (TeleportSystem::*)()), "57565383ec308b5c2440891c24e8????????8b03891c24ff502c84c0", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("TeleportSystem::InitiateTeleport", typeid(void (TeleportSystem::*)()), "5383ec288b5c2430891c24", argdata, 1, 6, &func);
 }
 
-void TeleportSystem::OnLoop()
+void TeleportSystem::InitiateTeleport()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1345::func;
@@ -18394,10 +18394,10 @@ namespace _func1346
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("TeleportSystem::Jump", typeid(void (TeleportSystem::*)()), "5383ec188b5c2420891c24e8????????c7839801000000000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("TeleportSystem::OnLoop", typeid(void (TeleportSystem::*)()), "57565383ec308b5c2440891c24e8????????8b03891c24ff502c84c0", argdata, 1, 6, &func);
 }
 
-void TeleportSystem::Jump()
+void TeleportSystem::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1346::func;
@@ -18408,17 +18408,31 @@ namespace _func1347
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("TeleportSystem::Jump", typeid(void (TeleportSystem::*)()), "5383ec188b5c2420891c24e8????????c7839801000000000000", argdata, 1, 6, &func);
+}
+
+void TeleportSystem::Jump()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1347::func;
+	return execfunc(this);
+}
+
+namespace _func1348
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("TextButton::ResetPrimitives", typeid(void (TextButton::*)()), "565331db83ec148b7424208b449e48", argdata, 1, 6, &func);
 }
 
 void TextButton::ResetPrimitives()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1347::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1348::func;
 	return execfunc(this);
 }
 
-namespace _func1348
+namespace _func1349
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18428,11 +18442,11 @@ namespace _func1348
 int TextButton::GetIdealButtonWidth()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1348::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1349::func;
 	return execfunc(this);
 }
 
-namespace _func1349
+namespace _func1350
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x2ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18442,11 +18456,11 @@ namespace _func1349
 void TextButton::OnInit(Point pos, Point size, int cornerInset, TextString *buttonLabel, int font)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, Point pos_arg, Point size_arg, int cornerInset_arg, TextString *buttonLabel_arg, int font_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1349::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1350::func;
 	return execfunc(this, pos, size, cornerInset, buttonLabel, font);
 }
 
-namespace _func1350
+namespace _func1351
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18456,11 +18470,11 @@ namespace _func1350
 void TextButton::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1350::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1351::func;
 	return execfunc(this);
 }
 
-namespace _func1351
+namespace _func1352
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18470,11 +18484,11 @@ namespace _func1351
 void TextButton::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1351::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1352::func;
 	return execfunc(this);
 }
 
-namespace _func1352
+namespace _func1353
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18484,11 +18498,11 @@ namespace _func1352
 Point TextButton::GetSize()
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1352::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1353::func;
 	return execfunc(this);
 }
 
-namespace _func1353
+namespace _func1354
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18498,11 +18512,11 @@ namespace _func1353
 void TextButton::OnInitRect(Globals::Rect &rect, int cornerInset, TextString &buttonLabel, int font)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, Globals::Rect &rect_arg, int cornerInset_arg, TextString &buttonLabel_arg, int font_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1353::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1354::func;
 	return execfunc(this, rect, cornerInset, buttonLabel, font);
 }
 
-namespace _func1354
+namespace _func1355
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -18512,11 +18526,11 @@ namespace _func1354
 void TextButton::SetBaseImage(const std::string &name, Point pos, int autoWidthMin)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, const std::string &name_arg, Point pos_arg, int autoWidthMin_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1354::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1355::func;
 	return execfunc(this, name, pos, autoWidthMin);
 }
 
-namespace _func1355
+namespace _func1356
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18526,11 +18540,11 @@ namespace _func1355
 void TextButton::SetAutoWidth(bool autoWidth, bool autoRightAlign, int margin, int min)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, bool autoWidth_arg, bool autoRightAlign_arg, int margin_arg, int min_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1355::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1356::func;
 	return execfunc(this, autoWidth, autoRightAlign, margin, min);
 }
 
-namespace _func1356
+namespace _func1357
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18540,11 +18554,11 @@ namespace _func1356
 void TextButton::UpdateAutoWidth()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1356::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1357::func;
 	return execfunc(this);
 }
 
-namespace _func1357
+namespace _func1358
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18554,11 +18568,11 @@ namespace _func1357
 void TextButton::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1357::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1358::func;
 	return execfunc(this);
 }
 
-namespace _func1358
+namespace _func1359
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff};
@@ -18566,20 +18580,6 @@ namespace _func1358
 }
 
 void TextButton::SetInactiveColor(GL_Color color)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1358::func;
-	return execfunc(this, color);
-}
-
-namespace _func1359
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x4ff};
-	static FunctionDefinition funcObj("TextButton::SetActiveColor", typeid(void (TextButton::*)(GL_Color )), ".!8b44240480786400", argdata, 2, 6, &func);
-}
-
-void TextButton::SetActiveColor(GL_Color color)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1359::func;
@@ -18590,10 +18590,10 @@ namespace _func1360
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff};
-	static FunctionDefinition funcObj("TextButton::SetSelectedColor", typeid(void (TextButton::*)(GL_Color )), ".!8b44240480786400", argdata, 2, 6, &func);
+	static FunctionDefinition funcObj("TextButton::SetActiveColor", typeid(void (TextButton::*)(GL_Color )), ".!8b44240480786400", argdata, 2, 6, &func);
 }
 
-void TextButton::SetSelectedColor(GL_Color color)
+void TextButton::SetActiveColor(GL_Color color)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1360::func;
@@ -18604,10 +18604,10 @@ namespace _func1361
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff};
-	static FunctionDefinition funcObj("TextButton::SetTextColor", typeid(void (TextButton::*)(GL_Color )), ".8b44240480786400", argdata, 2, 6, &func);
+	static FunctionDefinition funcObj("TextButton::SetSelectedColor", typeid(void (TextButton::*)(GL_Color )), ".!8b44240480786400", argdata, 2, 6, &func);
 }
 
-void TextButton::SetTextColor(GL_Color color)
+void TextButton::SetSelectedColor(GL_Color color)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1361::func;
@@ -18617,6 +18617,20 @@ void TextButton::SetTextColor(GL_Color color)
 namespace _func1362
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff, 0x4ff};
+	static FunctionDefinition funcObj("TextButton::SetTextColor", typeid(void (TextButton::*)(GL_Color )), ".8b44240480786400", argdata, 2, 6, &func);
+}
+
+void TextButton::SetTextColor(GL_Color color)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1362::func;
+	return execfunc(this, color);
+}
+
+namespace _func1363
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("TextButton::InitPrimitives", typeid(void (TextButton::*)()), "5557565381eccc0000008bb424e0000000807e6400", argdata, 1, 6, &func);
 }
@@ -18624,11 +18638,11 @@ namespace _func1362
 void TextButton::InitPrimitives()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1362::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1363::func;
 	return execfunc(this);
 }
 
-namespace _func1363
+namespace _func1364
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18638,11 +18652,11 @@ namespace _func1363
 void TextInput::constructor(int maxChars, TextInput::AllowedCharType allowedCharType, const std::string &prompt)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg, int maxChars_arg, TextInput::AllowedCharType allowedCharType_arg, const std::string &prompt_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1363::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1364::func;
 	return execfunc(this, maxChars, allowedCharType, prompt);
 }
 
-namespace _func1364
+namespace _func1365
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff};
@@ -18652,11 +18666,11 @@ namespace _func1364
 void TextInput::OnRender(int font, Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg, int font_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1364::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1365::func;
 	return execfunc(this, font, pos);
 }
 
-namespace _func1365
+namespace _func1366
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18666,11 +18680,11 @@ namespace _func1365
 void TextInput::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1365::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1366::func;
 	return execfunc(this);
 }
 
-namespace _func1366
+namespace _func1367
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18680,11 +18694,11 @@ namespace _func1366
 void TextInput::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1366::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1367::func;
 	return execfunc(this, event);
 }
 
-namespace _func1367
+namespace _func1368
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18694,11 +18708,11 @@ namespace _func1367
 bool TextInput::GetActive()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1367::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1368::func;
 	return execfunc(this);
 }
 
-namespace _func1368
+namespace _func1369
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18708,11 +18722,11 @@ namespace _func1368
 std::string TextInput::GetText()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1368::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1369::func;
 	return execfunc(this);
 }
 
-namespace _func1369
+namespace _func1370
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18722,11 +18736,11 @@ namespace _func1369
 void TextInput::Start()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1369::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1370::func;
 	return execfunc(this);
 }
 
-namespace _func1370
+namespace _func1371
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18736,11 +18750,11 @@ namespace _func1370
 void TextInput::Stop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1370::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1371::func;
 	return execfunc(this);
 }
 
-namespace _func1371
+namespace _func1372
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18750,11 +18764,11 @@ namespace _func1371
 int TextInput::SetText(const std::string &text)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1371::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1372::func;
 	return execfunc(this, text);
 }
 
-namespace _func1372
+namespace _func1373
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18764,11 +18778,11 @@ namespace _func1372
 void TextInput::OnTextInput(int asciiChar)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg, int asciiChar_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1372::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1373::func;
 	return execfunc(this, asciiChar);
 }
 
-namespace _func1373
+namespace _func1374
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18778,11 +18792,11 @@ namespace _func1373
 std::string TextLibrary::GetText(const std::string &name, const std::string &lang)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextLibrary *this_arg, const std::string &name_arg, const std::string &lang_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1373::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1374::func;
 	return execfunc(this, name, lang);
 }
 
-namespace _func1374
+namespace _func1375
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18792,11 +18806,11 @@ namespace _func1374
 std::string TextString::GetText()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextString *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1374::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1375::func;
 	return execfunc(this);
 }
 
-namespace _func1375
+namespace _func1376
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18806,11 +18820,11 @@ namespace _func1375
 void TimerHelper::Start(int goal)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TimerHelper *this_arg, int goal_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1375::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1376::func;
 	return execfunc(this, goal);
 }
 
-namespace _func1376
+namespace _func1377
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18820,11 +18834,11 @@ namespace _func1376
 bool TimerHelper::Running()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1376::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1377::func;
 	return execfunc(this);
 }
 
-namespace _func1377
+namespace _func1378
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -18834,11 +18848,11 @@ namespace _func1377
 void TimerHelper::ResetMinMax(int min, int max)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TimerHelper *this_arg, int min_arg, int max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1377::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1378::func;
 	return execfunc(this, min, max);
 }
 
-namespace _func1378
+namespace _func1379
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18848,11 +18862,11 @@ namespace _func1378
 void TimerHelper::SetMaxTime(float max)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TimerHelper *this_arg, float max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1378::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1379::func;
 	return execfunc(this, max);
 }
 
-namespace _func1379
+namespace _func1380
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18860,20 +18874,6 @@ namespace _func1379
 }
 
 void TimerHelper::Stop()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1379::func;
-	return execfunc(this);
-}
-
-namespace _func1380
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("TimerHelper::Update", typeid(void (TimerHelper::*)()), ".5383ec188b5c2420807b1100", argdata, 1, 6, &func);
-}
-
-void TimerHelper::Update()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1380::func;
@@ -18884,17 +18884,31 @@ namespace _func1381
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("TimerHelper::Update", typeid(void (TimerHelper::*)()), ".5383ec188b5c2420807b1100", argdata, 1, 6, &func);
+}
+
+void TimerHelper::Update()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1381::func;
+	return execfunc(this);
+}
+
+namespace _func1382
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("TimerHelper::Done", typeid(bool (TimerHelper::*)()), ".57565383ec108b5c24200fb6431184c0", argdata, 1, 2, &func);
 }
 
 bool TimerHelper::Done()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1381::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1382::func;
 	return execfunc(this);
 }
 
-namespace _func1382
+namespace _func1383
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18904,11 +18918,11 @@ namespace _func1382
 void TutorialManager::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1382::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1383::func;
 	return execfunc(this);
 }
 
-namespace _func1383
+namespace _func1384
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18918,11 +18932,11 @@ namespace _func1383
 bool TutorialManager::Running()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1383::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1384::func;
 	return execfunc(this);
 }
 
-namespace _func1384
+namespace _func1385
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18932,18 +18946,18 @@ namespace _func1384
 void TutorialManager::OnInit(ShipManager *ship, CommandGui *gui, CrewControl *crewControl, Upgrades *upgradesScreen, CombatControl *combatControl, SystemControl *sysControl, TabbedWindow *unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TutorialManager *this_arg, ShipManager *ship_arg, CommandGui *gui_arg, CrewControl *crewControl_arg, Upgrades *upgradesScreen_arg, CombatControl *combatControl_arg, SystemControl *sysControl_arg, TabbedWindow *unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1384::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1385::func;
 	return execfunc(this, ship, gui, crewControl, upgradesScreen, combatControl, sysControl, unk);
 }
 
 TutorialManager *Global_TutorialManager_Tutorial;
 
-namespace _var1385
+namespace _var1386
 {
     static VariableDefinition varObj("Global_TutorialManager_Tutorial", "!c70424(???????\?)e8????????84c075??8383c800000001", &Global_TutorialManager_Tutorial);
 }
 
-namespace _func1386
+namespace _func1387
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -18953,11 +18967,11 @@ namespace _func1386
 void UnlockArrow::constructor(Point pos, int unk1, int unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UnlockArrow *this_arg, Point pos_arg, int unk1_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1386::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1387::func;
 	return execfunc(this, pos, unk1, unk2);
 }
 
-namespace _func1387
+namespace _func1388
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -18967,11 +18981,11 @@ namespace _func1387
 bool UnlockArrow::MouseMove(int x, int y)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(UnlockArrow *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1387::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1388::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1388
+namespace _func1389
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18981,11 +18995,11 @@ namespace _func1388
 void UnlockArrow::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UnlockArrow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1388::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1389::func;
 	return execfunc(this);
 }
 
-namespace _func1389
+namespace _func1390
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
@@ -18995,11 +19009,11 @@ namespace _func1389
 void UpgradeBox::constructorEmpty(Point pos, bool subsystem)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, Point pos_arg, bool subsystem_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1389::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1390::func;
 	return execfunc(this, pos, subsystem);
 }
 
-namespace _func1390
+namespace _func1391
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -19009,11 +19023,11 @@ namespace _func1390
 void UpgradeBox::constructorSystem(ShipManager *ship, ShipSystem *sys, Point pos, bool subsystem)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, ShipManager *ship_arg, ShipSystem *sys_arg, Point pos_arg, bool subsystem_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1390::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1391::func;
 	return execfunc(this, ship, sys, pos, subsystem);
 }
 
-namespace _func1391
+namespace _func1392
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19023,11 +19037,11 @@ namespace _func1391
 void UpgradeBox::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1391::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1392::func;
 	return execfunc(this);
 }
 
-namespace _func1392
+namespace _func1393
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19037,11 +19051,11 @@ namespace _func1392
 void UpgradeBox::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1392::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1393::func;
 	return execfunc(this);
 }
 
-namespace _func1393
+namespace _func1394
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19049,20 +19063,6 @@ namespace _func1393
 }
 
 void UpgradeBox::MouseMove(int mX, int mY)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1393::func;
-	return execfunc(this, mX, mY);
-}
-
-namespace _func1394
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("UpgradeBox::MouseClick", typeid(void (UpgradeBox::*)(int , int )), "5383ec288b5c24308b0385c0", argdata, 3, 6, &func);
-}
-
-void UpgradeBox::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1394::func;
@@ -19073,10 +19073,10 @@ namespace _func1395
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("UpgradeBox::MouseRightClick", typeid(void (UpgradeBox::*)(int , int )), ".565383ec248b5c24308b0385c0", argdata, 3, 6, &func);
+	static FunctionDefinition funcObj("UpgradeBox::MouseClick", typeid(void (UpgradeBox::*)(int , int )), "5383ec288b5c24308b0385c0", argdata, 3, 6, &func);
 }
 
-void UpgradeBox::MouseRightClick(int mX, int mY)
+void UpgradeBox::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1395::func;
@@ -19086,25 +19086,25 @@ void UpgradeBox::MouseRightClick(int mX, int mY)
 namespace _func1396
 {
     static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("UpgradeBox::Undo", typeid(void (UpgradeBox::*)()), "565383ec148b5c24208b431485c0", argdata, 1, 6, &func);
+	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("UpgradeBox::MouseRightClick", typeid(void (UpgradeBox::*)(int , int )), ".565383ec248b5c24308b0385c0", argdata, 3, 6, &func);
 }
 
-void UpgradeBox::Undo()
+void UpgradeBox::MouseRightClick(int mX, int mY)
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1396::func;
-	return execfunc(this);
+	return execfunc(this, mX, mY);
 }
 
 namespace _func1397
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("UpgradeBox::Accept", typeid(void (UpgradeBox::*)()), ".565383ec248b5c24308b0385c0", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("UpgradeBox::Undo", typeid(void (UpgradeBox::*)()), "565383ec148b5c24208b431485c0", argdata, 1, 6, &func);
 }
 
-void UpgradeBox::Accept()
+void UpgradeBox::Undo()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1397::func;
@@ -19114,6 +19114,20 @@ void UpgradeBox::Accept()
 namespace _func1398
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("UpgradeBox::Accept", typeid(void (UpgradeBox::*)()), ".565383ec248b5c24308b0385c0", argdata, 1, 6, &func);
+}
+
+void UpgradeBox::Accept()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1398::func;
+	return execfunc(this);
+}
+
+namespace _func1399
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("Upgrades::OnInit", typeid(void (Upgrades::*)(ShipManager *)), "5557565381eccc0000008b9c24e00000008db424a0000000", argdata, 2, 6, &func);
 }
@@ -19121,11 +19135,11 @@ namespace _func1398
 void Upgrades::OnInit(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1398::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1399::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1399
+namespace _func1400
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19135,11 +19149,11 @@ namespace _func1399
 void Upgrades::ClearUpgradeBoxes()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1399::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1400::func;
 	return execfunc(this);
 }
 
-namespace _func1400
+namespace _func1401
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19149,11 +19163,11 @@ namespace _func1400
 void Upgrades::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1400::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1401::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1401
+namespace _func1402
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19163,11 +19177,11 @@ namespace _func1401
 void Upgrades::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1401::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1402::func;
 	return execfunc(this);
 }
 
-namespace _func1402
+namespace _func1403
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19177,11 +19191,11 @@ namespace _func1402
 void Upgrades::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1402::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1403::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1403
+namespace _func1404
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19191,11 +19205,11 @@ namespace _func1403
 void Upgrades::MouseRightClick(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1403::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1404::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1404
+namespace _func1405
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19203,20 +19217,6 @@ namespace _func1404
 }
 
 void Upgrades::Close()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1404::func;
-	return execfunc(this);
-}
-
-namespace _func1405
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("Upgrades::OnRender", typeid(void (Upgrades::*)()), "5589e557565383ec7c8b5d080f2805????????", argdata, 1, 6, &func);
-}
-
-void Upgrades::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1405::func;
@@ -19227,10 +19227,10 @@ namespace _func1406
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("Upgrades::ConfirmUpgrades", typeid(void (Upgrades::*)()), "5589e5575631f65383ec3c8b7d088b4f248b4720", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("Upgrades::OnRender", typeid(void (Upgrades::*)()), "5589e557565383ec7c8b5d080f2805????????", argdata, 1, 6, &func);
 }
 
-void Upgrades::ConfirmUpgrades()
+void Upgrades::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1406::func;
@@ -19241,12 +19241,12 @@ namespace _func1407
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("WarningMessage::Start", typeid(void (WarningMessage::*)()), "5383ec188b5c2420807b1400", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("Upgrades::ConfirmUpgrades", typeid(void (Upgrades::*)()), "5589e5575631f65383ec3c8b7d088b4f248b4720", argdata, 1, 6, &func);
 }
 
-void WarningMessage::Start()
+void Upgrades::ConfirmUpgrades()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1407::func;
 	return execfunc(this);
 }
@@ -19255,10 +19255,10 @@ namespace _func1408
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("WarningMessage::OnRender", typeid(void (WarningMessage::*)()), "5383ec188b5c2420807b1600", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("WarningMessage::Start", typeid(void (WarningMessage::*)()), "5383ec188b5c2420807b1400", argdata, 1, 6, &func);
 }
 
-void WarningMessage::OnRender()
+void WarningMessage::Start()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1408::func;
@@ -19268,6 +19268,20 @@ void WarningMessage::OnRender()
 namespace _func1409
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("WarningMessage::OnRender", typeid(void (WarningMessage::*)()), "5383ec188b5c2420807b1600", argdata, 1, 6, &func);
+}
+
+void WarningMessage::OnRender()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1409::func;
+	return execfunc(this);
+}
+
+namespace _func1410
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("WarningMessage::RenderWithAlpha", typeid(void (WarningMessage::*)(float )), "5589e557565383ec7c8b5d08807b2800", argdata, 2, 6, &func);
 }
@@ -19275,11 +19289,11 @@ namespace _func1409
 void WarningMessage::RenderWithAlpha(float alpha)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1409::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1410::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func1410
+namespace _func1411
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19289,11 +19303,11 @@ namespace _func1410
 void WarningMessage::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1410::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1411::func;
 	return execfunc(this);
 }
 
-namespace _func1411
+namespace _func1412
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -19303,11 +19317,11 @@ namespace _func1411
 void WarningMessage::InitImage(const std::string &imageName, Point position, float time, bool flash)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &imageName_arg, Point position_arg, float time_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1411::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1412::func;
 	return execfunc(this, imageName, position, time, flash);
 }
 
-namespace _func1412
+namespace _func1413
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -19317,11 +19331,11 @@ namespace _func1412
 void WarningMessage::InitText(const TextString &text, Point position, float time, GL_Color textColor, bool centerText, bool flash)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg, Point position_arg, float time_arg, GL_Color textColor_arg, bool centerText_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1412::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1413::func;
 	return execfunc(this, text, position, time, textColor, centerText, flash);
 }
 
-namespace _func1413
+namespace _func1414
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19331,11 +19345,11 @@ namespace _func1413
 void WarningMessage::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1413::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1414::func;
 	return execfunc(this);
 }
 
-namespace _func1414
+namespace _func1415
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19345,11 +19359,11 @@ namespace _func1414
 void WarningMessage::SetImage(const std::string &imageName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &imageName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1414::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1415::func;
 	return execfunc(this, imageName);
 }
 
-namespace _func1415
+namespace _func1416
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19359,11 +19373,11 @@ namespace _func1415
 void WarningMessage::SetText(const TextString &text)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1415::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1416::func;
 	return execfunc(this, text);
 }
 
-namespace _func1416
+namespace _func1417
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x4ff};
@@ -19373,11 +19387,11 @@ namespace _func1416
 void WarningMessage::SetText(const TextString &text, GL_Color textColor)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg, GL_Color textColor_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1416::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1417::func;
 	return execfunc(this, text, textColor);
 }
 
-namespace _func1417
+namespace _func1418
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -19387,11 +19401,11 @@ namespace _func1417
 void WarningMessage::SetPosition(Point position)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, Point position_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1417::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1418::func;
 	return execfunc(this, position);
 }
 
-namespace _func1418
+namespace _func1419
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19401,11 +19415,11 @@ namespace _func1418
 void WarningMessage::SetLoop(bool loop)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, bool loop_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1418::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1419::func;
 	return execfunc(this, loop);
 }
 
-namespace _func1419
+namespace _func1420
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19415,11 +19429,11 @@ namespace _func1419
 void WarningMessage::SetSound(const std::string &sound)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &sound_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1419::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1420::func;
 	return execfunc(this, sound);
 }
 
-namespace _func1420
+namespace _func1421
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19429,11 +19443,11 @@ namespace _func1420
 bool WeaponAnimation::StartFire()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1420::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1421::func;
 	return execfunc(this);
 }
 
-namespace _func1421
+namespace _func1422
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19443,11 +19457,11 @@ namespace _func1421
 void WeaponAnimation::SetFireTime(float time)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float time_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1421::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1422::func;
 	return execfunc(this, time);
 }
 
-namespace _func1422
+namespace _func1423
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19457,11 +19471,11 @@ namespace _func1422
 Pointf WeaponAnimation::GetSlide()
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1422::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1423::func;
 	return execfunc(this);
 }
 
-namespace _func1423
+namespace _func1424
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19471,11 +19485,11 @@ namespace _func1423
 void WeaponAnimation::Update()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1423::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1424::func;
 	return execfunc(this);
 }
 
-namespace _func1424
+namespace _func1425
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19485,32 +19499,32 @@ namespace _func1424
 void WeaponAnimation::OnRender(float alpha)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1424::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1425::func;
 	return execfunc(this, alpha);
-}
-
-namespace _func1425
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("WeaponBlueprint::__DO_NOT_HOOK", typeid(void (WeaponBlueprint::*)()), "565383ec248b5c24308d74241f8d4304c703????????89742408890424", argdata, 0, 4, &func);
 }
 
 namespace _func1426
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("WeaponBlueprint::__DO_NOT_HOOK2", typeid(void (WeaponBlueprint::*)()), ".565383ec248b5c24308d74241f8d4304c703????????89742408890424", argdata, 0, 4, &func);
+	static FunctionDefinition funcObj("WeaponBlueprint::__DO_NOT_HOOK", typeid(void (WeaponBlueprint::*)()), "565383ec248b5c24308d74241f8d4304c703????????89742408890424", argdata, 0, 4, &func);
 }
 
 namespace _func1427
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("WeaponBlueprint::__DO_NOT_HOOK3", typeid(void (WeaponBlueprint::*)()), ".565383ec248b5c24308d74241f8d4304c703????????89742408890424", argdata, 0, 4, &func);
+	static FunctionDefinition funcObj("WeaponBlueprint::__DO_NOT_HOOK2", typeid(void (WeaponBlueprint::*)()), ".565383ec248b5c24308d74241f8d4304c703????????89742408890424", argdata, 0, 4, &func);
 }
 
 namespace _func1428
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("WeaponBlueprint::__DO_NOT_HOOK3", typeid(void (WeaponBlueprint::*)()), ".565383ec248b5c24308d74241f8d4304c703????????89742408890424", argdata, 0, 4, &func);
+}
+
+namespace _func1429
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19520,11 +19534,11 @@ namespace _func1428
 void WeaponBlueprint::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1428::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1429::func;
 	return execfunc(this);
 }
 
-namespace _func1429
+namespace _func1430
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19534,11 +19548,11 @@ namespace _func1429
 void WeaponBlueprint::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1429::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1430::func;
 	return execfunc(this);
 }
 
-namespace _func1430
+namespace _func1431
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19548,11 +19562,11 @@ namespace _func1430
 std::string WeaponBlueprint::GetDescription(bool tooltip)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg, bool tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1430::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1431::func;
 	return execfunc(this, tooltip);
 }
 
-namespace _func1431
+namespace _func1432
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19562,11 +19576,11 @@ namespace _func1431
 void WeaponBlueprint::RenderIcon(float scale)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg, float scale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1431::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1432::func;
 	return execfunc(this, scale);
 }
 
-namespace _func1432
+namespace _func1433
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19576,11 +19590,11 @@ namespace _func1432
 Point WeaponBlueprint::GetDimensions()
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1432::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1433::func;
 	return execfunc(this);
 }
 
-namespace _func1433
+namespace _func1434
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19590,11 +19604,11 @@ namespace _func1433
 void WeaponBox::RenderBox(bool dragging, bool flashPowerBox)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponBox *this_arg, bool dragging_arg, bool flashPowerBox_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1433::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1434::func;
 	return execfunc(this, dragging, flashPowerBox);
 }
 
-namespace _func1434
+namespace _func1435
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19604,18 +19618,18 @@ namespace _func1434
 std::string WeaponBox::GenerateTooltip()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1434::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1435::func;
 	return execfunc(this);
 }
 
-namespace _func1435
+namespace _func1436
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("WeaponControl::DO_NOT_HOOK", typeid(void (WeaponControl::*)()), "!8b14b0ebb790", argdata, 0, 4, &func);
 }
 
-namespace _func1436
+namespace _func1437
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19625,11 +19639,11 @@ namespace _func1436
 TextString WeaponControl::HolderLabel()
 {
 	typedef TextString __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1436::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1437::func;
 	return execfunc(this);
 }
 
-namespace _func1437
+namespace _func1438
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19639,11 +19653,11 @@ namespace _func1437
 SDLKey WeaponControl::ArmamentHotkey(unsigned int i)
 {
 	typedef SDLKey __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, unsigned int i_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1437::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1438::func;
 	return execfunc(this, i);
 }
 
-namespace _func1438
+namespace _func1439
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19653,11 +19667,11 @@ namespace _func1438
 void WeaponControl::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1438::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1439::func;
 	return execfunc(this);
 }
 
-namespace _func1439
+namespace _func1440
 {
     static void *func = 0;
 	static short argdata[] = {0x2ff, 0x2ff, 0x1ff};
@@ -19667,11 +19681,11 @@ namespace _func1439
 void WeaponControl::RenderBeamAiming(Pointf one, Pointf two, bool bAutoFire)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf one_arg, Pointf two_arg, bool bAutoFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1439::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1440::func;
 	return execfunc(one, two, bAutoFire);
 }
 
-namespace _func1440
+namespace _func1441
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19681,11 +19695,11 @@ namespace _func1440
 void WeaponControl::RenderAiming()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1440::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1441::func;
 	return execfunc(this);
 }
 
-namespace _func1441
+namespace _func1442
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19695,11 +19709,11 @@ namespace _func1441
 void WeaponControl::RenderSelfAiming()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1441::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1442::func;
 	return execfunc(this);
 }
 
-namespace _func1442
+namespace _func1443
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19709,11 +19723,11 @@ namespace _func1442
 void WeaponControl::SetAutofiring(bool on, bool simple)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, bool on_arg, bool simple_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1442::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1443::func;
 	return execfunc(this, on, simple);
 }
 
-namespace _func1443
+namespace _func1444
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -19723,11 +19737,11 @@ namespace _func1443
 void WeaponControl::Fire(std::vector<Pointf> &points, int target, bool autoFire)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, std::vector<Pointf> &points_arg, int target_arg, bool autoFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1443::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1444::func;
 	return execfunc(this, points, target, autoFire);
 }
 
-namespace _func1444
+namespace _func1445
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19737,11 +19751,11 @@ namespace _func1444
 void WeaponControl::OnLanguageChange()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1444::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1445::func;
 	return execfunc(this);
 }
 
-namespace _func1445
+namespace _func1446
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19751,11 +19765,11 @@ namespace _func1445
 void WeaponControl::OnRender(bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1445::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1446::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1446
+namespace _func1447
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -19765,11 +19779,11 @@ namespace _func1446
 bool WeaponControl::LButton(int x, int y, bool holdingShift)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, int x_arg, int y_arg, bool holdingShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1446::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1447::func;
 	return execfunc(this, x, y, holdingShift);
 }
 
-namespace _func1447
+namespace _func1448
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19779,11 +19793,11 @@ namespace _func1447
 void WeaponControl::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1447::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1448::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1448
+namespace _func1449
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19793,11 +19807,11 @@ namespace _func1448
 void WeaponControl::LinkShip(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1448::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1449::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1449
+namespace _func1450
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19807,18 +19821,18 @@ namespace _func1449
 bool WeaponControl::KeyDown(SDLKey key)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1449::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1450::func;
 	return execfunc(this, key);
 }
 
-namespace _func1450
+namespace _func1451
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("WeaponStoreBox::__DO_NOT_HOOK", typeid(void (WeaponStoreBox::*)()), "5557565383ec2c8d44241a8b5c24408d7c241c8b74244c89442408", argdata, 0, 4, &func);
 }
 
-namespace _func1451
+namespace _func1452
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -19828,11 +19842,11 @@ namespace _func1451
 void WeaponStoreBox::constructor(ShipManager *ship, Equipment *equip, const WeaponBlueprint *weaponBp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponStoreBox *this_arg, ShipManager *ship_arg, Equipment *equip_arg, const WeaponBlueprint *weaponBp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1451::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1452::func;
 	return execfunc(this, ship, equip, weaponBp);
 }
 
-namespace _func1452
+namespace _func1453
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19842,11 +19856,11 @@ namespace _func1452
 void WeaponSystem::RemoveWeapon(int slot)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1452::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1453::func;
 	return execfunc(this, slot);
 }
 
-namespace _func1453
+namespace _func1454
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19856,11 +19870,11 @@ namespace _func1453
 void WeaponSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1453::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1454::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func1454
+namespace _func1455
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19870,11 +19884,11 @@ namespace _func1454
 void WeaponSystem::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1454::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1455::func;
 	return execfunc(this);
 }
 
-namespace _func1455
+namespace _func1456
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -19884,11 +19898,11 @@ namespace _func1455
 void WeaponSystemBox::constructor(Point pos, ShipSystem *sys, WeaponControl *weapCtrl)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponSystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, WeaponControl *weapCtrl_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1455::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1456::func;
 	return execfunc(this, pos, sys, weapCtrl);
 }
 
-namespace _func1456
+namespace _func1457
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19898,11 +19912,11 @@ namespace _func1456
 void WindowFrame::Draw(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WindowFrame *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1456::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1457::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1457
+namespace _func1458
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19912,11 +19926,11 @@ namespace _func1457
 void WindowFrame::DrawMask(int unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WindowFrame *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1457::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1458::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1458
+namespace _func1459
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -19926,11 +19940,11 @@ namespace _func1458
 void WindowFrame::constructor(int x, int y, int w, int h)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WindowFrame *this_arg, int x_arg, int y_arg, int w_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1458::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1459::func;
 	return execfunc(this, x, y, w, h);
 }
 
-namespace _func1459
+namespace _func1460
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19940,11 +19954,11 @@ namespace _func1459
 void WindowFrame::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WindowFrame *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1459::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1460::func;
 	return execfunc(this);
 }
 
-namespace _func1460
+namespace _func1461
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19954,11 +19968,11 @@ namespace _func1460
 void WorldManager::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1460::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1461::func;
 	return execfunc(this);
 }
 
-namespace _func1461
+namespace _func1462
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19968,11 +19982,11 @@ namespace _func1461
 int WorldManager::OnInit()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1461::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1462::func;
 	return execfunc(this);
 }
 
-namespace _func1462
+namespace _func1463
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19982,11 +19996,11 @@ namespace _func1462
 CompleteShip *WorldManager::CreateShip(ShipEvent *shipEvent, bool boss)
 {
 	typedef CompleteShip *__attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, ShipEvent *shipEvent_arg, bool boss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1462::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1463::func;
 	return execfunc(this, shipEvent, boss);
 }
 
-namespace _func1463
+namespace _func1464
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19996,11 +20010,11 @@ namespace _func1463
 void WorldManager::CreateLocation(Location *loc)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1463::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1464::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1464
+namespace _func1465
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20010,11 +20024,11 @@ namespace _func1464
 void WorldManager::ClearLocation()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1464::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1465::func;
 	return execfunc(this);
 }
 
-namespace _func1465
+namespace _func1466
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20024,11 +20038,11 @@ namespace _func1465
 void WorldManager::SaveGame()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1465::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1466::func;
 	return execfunc(this);
 }
 
-namespace _func1466
+namespace _func1467
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102};
@@ -20038,11 +20052,11 @@ namespace _func1466
 void WorldManager::CreateChoiceBox(LocationEvent *event)
 {
 	typedef void __attribute__((regparm(2))) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1466::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1467::func;
 	return execfunc(this, event);
 }
 
-namespace _func1467
+namespace _func1468
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20052,11 +20066,11 @@ namespace _func1467
 void WorldManager::CreateChoiceBox0(LocationEvent *event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1467::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1468::func;
 	return execfunc(this, event);
 }
 
-namespace _func1468
+namespace _func1469
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102};
@@ -20066,11 +20080,11 @@ namespace _func1468
 void WorldManager::UpdateLocation(LocationEvent *event)
 {
 	typedef void __attribute__((regparm(2))) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1468::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1469::func;
 	return execfunc(this, event);
 }
 
-namespace _func1469
+namespace _func1470
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20080,11 +20094,11 @@ namespace _func1469
 void WorldManager::UpdateLocation0(LocationEvent *event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1469::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1470::func;
 	return execfunc(this, event);
 }
 
-namespace _func1470
+namespace _func1471
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20094,11 +20108,11 @@ namespace _func1470
 LocationEvent *WorldManager::ModifyResources(LocationEvent *event)
 {
 	typedef LocationEvent *__attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1470::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1471::func;
 	return execfunc(this, event);
 }
 
-namespace _func1471
+namespace _func1472
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -20108,11 +20122,11 @@ namespace _func1471
 void WorldManager::ModifyEnvironment(int envFlag, int envTarget)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, int envFlag_arg, int envTarget_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1471::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1472::func;
 	return execfunc(this, envFlag, envTarget);
 }
 
-namespace _func1472
+namespace _func1473
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20122,11 +20136,11 @@ namespace _func1472
 void WorldManager::CheckStatusEffects(std::vector<StatusEffect> &vec)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, std::vector<StatusEffect> &vec_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1472::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1473::func;
 	return execfunc(this, vec);
 }
 
-namespace _func1473
+namespace _func1474
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -20136,11 +20150,11 @@ namespace _func1473
 void WorldManager::ModifyStatusEffect(StatusEffect effect, ShipManager *target, int targetType)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, StatusEffect effect_arg, ShipManager *target_arg, int targetType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1473::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1474::func;
 	return execfunc(this, effect, target, targetType);
 }
 
-namespace _func1474
+namespace _func1475
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20150,11 +20164,11 @@ namespace _func1474
 void WorldManager::StartGame(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1474::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1475::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1475
+namespace _func1476
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20164,11 +20178,11 @@ namespace _func1475
 void WorldManager::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1475::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1476::func;
 	return execfunc(this);
 }
 
-namespace _func1476
+namespace _func1477
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20178,11 +20192,11 @@ namespace _func1476
 void WorldManager::LoadGame(const std::string &fileName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1476::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1477::func;
 	return execfunc(this, fileName);
 }
 
-namespace _func1477
+namespace _func1478
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20190,20 +20204,6 @@ namespace _func1477
 }
 
 void WorldManager::OnLoop()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1477::func;
-	return execfunc(this);
-}
-
-namespace _func1478
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("WorldManager::PauseLoop", typeid(void (WorldManager::*)()), "5589e557565383ec4c8b75088b068b10", argdata, 1, 6, &func);
-}
-
-void WorldManager::PauseLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1478::func;
@@ -20214,10 +20214,10 @@ namespace _func1479
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("WorldManager::CreateNewGame", typeid(void (WorldManager::*)()), "57565383ec208b7424308d5c241c8d7c241b8b068b4008", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("WorldManager::PauseLoop", typeid(void (WorldManager::*)()), "5589e557565383ec4c8b75088b068b10", argdata, 1, 6, &func);
 }
 
-void WorldManager::CreateNewGame()
+void WorldManager::PauseLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1479::func;
@@ -20228,17 +20228,31 @@ namespace _func1480
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("WorldManager::CreateNewGame", typeid(void (WorldManager::*)()), "57565383ec208b7424308d5c241c8d7c241b8b068b4008", argdata, 1, 6, &func);
+}
+
+void WorldManager::CreateNewGame()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1480::func;
+	return execfunc(this);
+}
+
+namespace _func1481
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("WorldManager::HostileEnvironment", typeid(bool (WorldManager::*)()), "5383ec188b5c24208d4308890424", argdata, 1, 2, &func);
 }
 
 bool WorldManager::HostileEnvironment()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1480::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1481::func;
 	return execfunc(this);
 }
 
-namespace _func1481
+namespace _func1482
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20248,11 +20262,11 @@ namespace _func1481
 bool WorldManager::AddBoarders(BoardingEvent &boardingEvent)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, BoardingEvent &boardingEvent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1481::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1482::func;
 	return execfunc(this, boardingEvent);
 }
 
-namespace _func1482
+namespace _func1483
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20262,11 +20276,11 @@ namespace _func1482
 void WorldManager::CreateStore(LocationEvent *event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1482::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1483::func;
 	return execfunc(this, event);
 }
 
-namespace _func1483
+namespace _func1484
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -20276,11 +20290,11 @@ namespace _func1483
 bool WorldManager::CheckRequirements(LocationEvent *event, bool hidden)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg, bool hidden_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1483::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1484::func;
 	return execfunc(this, event, hidden);
 }
 
-namespace _func1484
+namespace _func1485
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20290,11 +20304,11 @@ namespace _func1484
 void freetype::font_data::init(const void *buffer, int bufferSize, unsigned int h, bool glow)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(freetype::font_data *this_arg, const void *buffer_arg, int bufferSize_arg, unsigned int h_arg, bool glow_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1484::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1485::func;
 	return execfunc(this, buffer, bufferSize, h, glow);
 }
 
-namespace _func1485
+namespace _func1486
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20304,11 +20318,11 @@ namespace _func1485
 void freetype::font_data::init_bitmap(const void *buffer, int bufferSize, int size, int h)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(freetype::font_data *this_arg, const void *buffer_arg, int bufferSize_arg, int size_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1485::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1486::func;
 	return execfunc(this, buffer, bufferSize, size, h);
 }
 
-namespace _func1486
+namespace _func1487
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20318,11 +20332,11 @@ namespace _func1486
 void freetype::font_data::clean()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(freetype::font_data *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1486::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1487::func;
 	return execfunc(this);
 }
 
-namespace _func1487
+namespace _func1488
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20332,11 +20346,11 @@ namespace _func1487
 Pointf freetype::easy_measurePrintLines(int fontSize, float x, float y, int line_length, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1487::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1488::func;
 	return execfunc(fontSize, x, y, line_length, text);
 }
 
-namespace _func1488
+namespace _func1489
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20346,11 +20360,11 @@ namespace _func1488
 int freetype::easy_measureWidth(int fontSize, const std::string &text)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1488::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1489::func;
 	return execfunc(fontSize, text);
 }
 
-namespace _func1489
+namespace _func1490
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20360,11 +20374,11 @@ namespace _func1489
 Pointf freetype::easy_print(int fontSize, float x, float y, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1489::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1490::func;
 	return execfunc(fontSize, x, y, text);
 }
 
-namespace _func1490
+namespace _func1491
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20374,11 +20388,11 @@ namespace _func1490
 Pointf freetype::easy_printRightAlign(int fontSize, float x, float y, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1490::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1491::func;
 	return execfunc(fontSize, x, y, text);
 }
 
-namespace _func1491
+namespace _func1492
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20388,11 +20402,11 @@ namespace _func1491
 Pointf freetype::easy_printNewlinesCentered(int fontSize, float x, float y, int line_length, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1491::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1492::func;
 	return execfunc(fontSize, x, y, line_length, text);
 }
 
-namespace _func1492
+namespace _func1493
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20402,11 +20416,11 @@ namespace _func1492
 Pointf freetype::easy_printAutoNewlines(int fontSize, float x, float y, int line_length, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1492::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1493::func;
 	return execfunc(fontSize, x, y, line_length, text);
 }
 
-namespace _func1493
+namespace _func1494
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20416,11 +20430,11 @@ namespace _func1493
 Pointf freetype::easy_printCenter(int fontSize, float x, float y, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1493::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1494::func;
 	return execfunc(fontSize, x, y, text);
 }
 
-namespace _func1494
+namespace _func1495
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20430,11 +20444,11 @@ namespace _func1494
 void freetype::easy_printAutoShrink(int fontId, float x, float y, int maxWidth, bool centered, const std::string &text)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontId_arg, float x_arg, float y_arg, int maxWidth_arg, bool centered_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1494::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1495::func;
 	return execfunc(fontId, x, y, maxWidth, centered, text);
 }
 
-namespace _func1495
+namespace _func1496
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20444,11 +20458,11 @@ namespace _func1495
 float __stdcall font_height(int font_id, float size)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(int font_id_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1495::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1496::func;
 	return execfunc(font_id, size);
 }
 
-namespace _func1496
+namespace _func1497
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20458,13 +20472,13 @@ namespace _func1496
 float __stdcall font_baseline(int font_id, float size)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(int font_id_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1496::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1497::func;
 	return execfunc(font_id, size);
 }
 
 float *Global_freetype_sil_freetype_outline;
 
-namespace _var1497
+namespace _var1498
 {
     static VariableDefinition varObj("Global_freetype_sil_freetype_outline", "!.f30f5905(???????\?)c744240801000000f30f2dc0", &Global_freetype_sil_freetype_outline);
 }

--- a/FTLGameELF32.h
+++ b/FTLGameELF32.h
@@ -563,6 +563,7 @@ struct AchievementTracker
 	LIBZHL_API void LoadAchievementDescriptions();
 	LIBZHL_API void LoadProfile(int file, int version);
 	LIBZHL_API void OnLanguageChange();
+	LIBZHL_API void OnLoop();
 	LIBZHL_API void ResetFlags();
 	LIBZHL_API void SaveProfile(int file);
 	LIBZHL_API void SetAchievement(const std::string &achievement, bool noPopup, bool sendToServer);

--- a/FTLGameELF64.cpp
+++ b/FTLGameELF64.cpp
@@ -214,14 +214,27 @@ void AchievementTracker::ResetFlags()
 	return execfunc(this);
 }
 
+namespace _func16
+{
+    static void *func = 0;
+	static FunctionDefinition funcObj("AchievementTracker::OnLoop", typeid(void (AchievementTracker::*)()), "415455534889fb4883ec20488b", nullptr, 0, 0, &func);
+}
+
+void AchievementTracker::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(AchievementTracker *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func16::func;
+	return execfunc(this);
+}
+
 AchievementTracker *Global_AchievementTracker_Tracker;
 
-namespace _var16
+namespace _var17
 {
     static VariableDefinition varObj("Global_AchievementTracker_Tracker", "!488d742420bf(???????\?)e8????????488b5424208b44240c", &Global_AchievementTracker_Tracker);
 }
 
-namespace _func17
+namespace _func18
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Animation::destructor", typeid(void (Animation::*)()), "4157415641554989fd415455534883ec18488b8798000000", nullptr, 0, 0, &func);
@@ -230,11 +243,11 @@ namespace _func17
 void Animation::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(Animation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func17::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func18::func;
 	return execfunc(this);
 }
 
-namespace _func18
+namespace _func19
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Animation::constructor", typeid(void (Animation::*)(const std::string &, int , float , Pointf , int , int , int , int )), ".41574989f7be????????", nullptr, 0, 0, &func);
@@ -243,11 +256,11 @@ namespace _func18
 void Animation::constructor(const std::string &_image, int _length, float _time, Pointf _position, int _imageWidth, int _imageHeight, int _stripStartX, int _numFrames)
 {
 	typedef void (*custom_arg_funcptr_t)(Animation *this_arg, const std::string &_image_arg, int _length_arg, float _time_arg, Pointf _position_arg, int _imageWidth_arg, int _imageHeight_arg, int _stripStartX_arg, int _numFrames_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func18::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func19::func;
 	return execfunc(this, _image, _length, _time, _position, _imageWidth, _imageHeight, _stripStartX, _numFrames);
 }
 
-namespace _func19
+namespace _func20
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Animation::SaveState", typeid(void (Animation::*)(int )), ".!5589f5534889fb4883ec080fb6773c", nullptr, 0, 0, &func);
@@ -256,11 +269,11 @@ namespace _func19
 void Animation::SaveState(int fd)
 {
 	typedef void (*custom_arg_funcptr_t)(Animation *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func19::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func20::func;
 	return execfunc(this, fd);
 }
 
-namespace _func20
+namespace _func21
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Animation::SetProgress", typeid(void (Animation::*)(float )), ".f30f105730807f3c00", nullptr, 0, 0, &func);
@@ -269,11 +282,11 @@ namespace _func20
 void Animation::SetProgress(float progress)
 {
 	typedef void (*custom_arg_funcptr_t)(Animation *this_arg, float progress_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func20::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func21::func;
 	return execfunc(this, progress);
 }
 
-namespace _func21
+namespace _func22
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Animation::SetCurrentFrame", typeid(void (Animation::*)(int )), ".8b4708897424fc8d50ff", nullptr, 0, 0, &func);
@@ -282,11 +295,11 @@ namespace _func21
 void Animation::SetCurrentFrame(int frame)
 {
 	typedef void (*custom_arg_funcptr_t)(Animation *this_arg, int frame_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func21::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func22::func;
 	return execfunc(this, frame);
 }
 
-namespace _func22
+namespace _func23
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Animation::Done", typeid(bool (Animation::*)()), ".31c0807f3e00", nullptr, 0, 0, &func);
@@ -295,11 +308,11 @@ namespace _func22
 bool Animation::Done()
 {
 	typedef bool (*custom_arg_funcptr_t)(Animation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func22::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func23::func;
 	return execfunc(this);
 }
 
-namespace _func23
+namespace _func24
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Animation::Update", typeid(void (Animation::*)()), ".41564155415455534889fb4883ec30807f3c00", nullptr, 0, 0, &func);
@@ -308,11 +321,11 @@ namespace _func23
 void Animation::Update()
 {
 	typedef void (*custom_arg_funcptr_t)(Animation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func23::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func24::func;
 	return execfunc(this);
 }
 
-namespace _func24
+namespace _func25
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Animation::RandomStart", typeid(int (Animation::*)()), ".803d????????00534889fb7543", nullptr, 0, 0, &func);
@@ -321,11 +334,11 @@ namespace _func24
 int Animation::RandomStart()
 {
 	typedef int (*custom_arg_funcptr_t)(Animation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func24::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func25::func;
 	return execfunc(this);
 }
 
-namespace _func25
+namespace _func26
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Animation::SetAnimationId", typeid(void (Animation::*)(GL_Texture *)), ".48393774354889f0", nullptr, 0, 0, &func);
@@ -334,11 +347,11 @@ namespace _func25
 void Animation::SetAnimationId(GL_Texture *tex)
 {
 	typedef void (*custom_arg_funcptr_t)(Animation *this_arg, GL_Texture *tex_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func25::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func26::func;
 	return execfunc(this, tex);
 }
 
-namespace _func26
+namespace _func27
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Animation::Start", typeid(void (Animation::*)(bool )), ".534889fb4883ec104084f60f85", nullptr, 0, 0, &func);
@@ -347,11 +360,11 @@ namespace _func26
 void Animation::Start(bool reset)
 {
 	typedef void (*custom_arg_funcptr_t)(Animation *this_arg, bool reset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func26::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func27::func;
 	return execfunc(this, reset);
 }
 
-namespace _func27
+namespace _func28
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Animation::LoadState", typeid(void (Animation::*)(int )), ".5589f5534889fb89f74883ec08", nullptr, 0, 0, &func);
@@ -360,11 +373,11 @@ namespace _func27
 void Animation::LoadState(int fd)
 {
 	typedef void (*custom_arg_funcptr_t)(Animation *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func27::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func28::func;
 	return execfunc(this, fd);
 }
 
-namespace _func28
+namespace _func29
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Animation::StartReverse", typeid(void (Animation::*)(bool )), ".534889fb4883ec104084f67573", nullptr, 0, 0, &func);
@@ -373,11 +386,11 @@ namespace _func28
 void Animation::StartReverse(bool reset)
 {
 	typedef void (*custom_arg_funcptr_t)(Animation *this_arg, bool reset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func28::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func29::func;
 	return execfunc(this, reset);
 }
 
-namespace _func29
+namespace _func30
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Animation::AddSoundQueue", typeid(void (Animation::*)(int , const std::string &)), ".85f6784e488b4f78", nullptr, 0, 0, &func);
@@ -386,11 +399,11 @@ namespace _func29
 void Animation::AddSoundQueue(int frame, const std::string &sound)
 {
 	typedef void (*custom_arg_funcptr_t)(Animation *this_arg, int frame_arg, const std::string &sound_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func29::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func30::func;
 	return execfunc(this, frame, sound);
 }
 
-namespace _func30
+namespace _func31
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Animation::OnRender", typeid(void (Animation::*)(float , GL_Color , bool )), ".4156415541544189f455534889fb4883ec30", nullptr, 0, 0, &func);
@@ -399,11 +412,11 @@ namespace _func30
 void Animation::OnRender(float opacity, GL_Color color, bool mirror)
 {
 	typedef void (*custom_arg_funcptr_t)(Animation *this_arg, float opacity_arg, GL_Color color_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func30::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func31::func;
 	return execfunc(this, opacity, color, mirror);
 }
 
-namespace _func31
+namespace _func32
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("AnimationControl::GetAnimation", typeid(Animation (AnimationControl::*)(const std::string &)), "415741564155415455534883ec6848897c2408", nullptr, 0, 0, &func);
@@ -412,18 +425,18 @@ namespace _func31
 Animation AnimationControl::GetAnimation(const std::string &animName)
 {
 	typedef Animation (*custom_arg_funcptr_t)(AnimationControl *this_arg, const std::string &animName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func31::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func32::func;
 	return execfunc(this, animName);
 }
 
 AnimationControl *Global_AnimationControl_Animations;
 
-namespace _var32
+namespace _var33
 {
     static VariableDefinition varObj("Global_AnimationControl_Animations", "!488d542460488d7c2470be(???????\?)e8????????488b442470", &Global_AnimationControl_Animations);
 }
 
-namespace _func33
+namespace _func34
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("AnimationTracker::Update", typeid(void (AnimationTracker::*)()), "53807f14004889fb", nullptr, 0, 0, &func);
@@ -432,11 +445,11 @@ namespace _func33
 void AnimationTracker::Update()
 {
 	typedef void (*custom_arg_funcptr_t)(AnimationTracker *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func33::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func34::func;
 	return execfunc(this);
 }
 
-namespace _func34
+namespace _func35
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("AnimationTracker::SetLoop", typeid(void (AnimationTracker::*)(bool , float )), "4088770c", nullptr, 0, 0, &func);
@@ -445,11 +458,11 @@ namespace _func34
 void AnimationTracker::SetLoop(bool loop, float loopDelay)
 {
 	typedef void (*custom_arg_funcptr_t)(AnimationTracker *this_arg, bool loop_arg, float loopDelay_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func34::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func35::func;
 	return execfunc(this, loop, loopDelay);
 }
 
-namespace _func35
+namespace _func36
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("AnimationTracker::Stop", typeid(void (AnimationTracker::*)(bool )), "4084f6c6471400", nullptr, 0, 0, &func);
@@ -458,30 +471,17 @@ namespace _func35
 void AnimationTracker::Stop(bool resetTime)
 {
 	typedef void (*custom_arg_funcptr_t)(AnimationTracker *this_arg, bool resetTime_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func35::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func36::func;
 	return execfunc(this, resetTime);
 }
 
-namespace _func36
+namespace _func37
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("AnimationTracker::Start", typeid(void (AnimationTracker::*)(float )), "c6471600c6471401f30f114710", nullptr, 0, 0, &func);
 }
 
 void AnimationTracker::Start(float time)
-{
-	typedef void (*custom_arg_funcptr_t)(AnimationTracker *this_arg, float time_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func36::func;
-	return execfunc(this, time);
-}
-
-namespace _func37
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("AnimationTracker::StartReverse", typeid(void (AnimationTracker::*)(float )), "0f57c9c6471600", nullptr, 0, 0, &func);
-}
-
-void AnimationTracker::StartReverse(float time)
 {
 	typedef void (*custom_arg_funcptr_t)(AnimationTracker *this_arg, float time_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func37::func;
@@ -491,17 +491,30 @@ void AnimationTracker::StartReverse(float time)
 namespace _func38
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("AnimationTracker::StartReverse", typeid(void (AnimationTracker::*)(float )), "0f57c9c6471600", nullptr, 0, 0, &func);
+}
+
+void AnimationTracker::StartReverse(float time)
+{
+	typedef void (*custom_arg_funcptr_t)(AnimationTracker *this_arg, float time_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func38::func;
+	return execfunc(this, time);
+}
+
+namespace _func39
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("AnimationTracker::Progress", typeid(float (AnimationTracker::*)(float )), "807f14000f57c9", nullptr, 0, 0, &func);
 }
 
 float AnimationTracker::Progress(float speed)
 {
 	typedef float (*custom_arg_funcptr_t)(AnimationTracker *this_arg, float speed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func38::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func39::func;
 	return execfunc(this, speed);
 }
 
-namespace _func39
+namespace _func40
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("AnimationTracker::SetProgress", typeid(void (AnimationTracker::*)(float )), "f30f594708", nullptr, 0, 0, &func);
@@ -510,11 +523,11 @@ namespace _func39
 void AnimationTracker::SetProgress(float time)
 {
 	typedef void (*custom_arg_funcptr_t)(AnimationTracker *this_arg, float time_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func39::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func40::func;
 	return execfunc(this, time);
 }
 
-namespace _func40
+namespace _func41
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("AnimationTracker::GetAlphaLevel", typeid(float (AnimationTracker::*)(bool )), "f30f100d????????f30f1015????????f30f594f08", nullptr, 0, 0, &func);
@@ -523,11 +536,11 @@ namespace _func40
 float AnimationTracker::GetAlphaLevel(bool reverse)
 {
 	typedef float (*custom_arg_funcptr_t)(AnimationTracker *this_arg, bool reverse_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func40::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func41::func;
 	return execfunc(this, reverse);
 }
 
-namespace _func41
+namespace _func42
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ArmamentControl::KeyDown", typeid(bool (ArmamentControl::*)(SDLKey )), "415431c94989fc5589f553", nullptr, 0, 0, &func);
@@ -536,11 +549,11 @@ namespace _func41
 bool ArmamentControl::KeyDown(SDLKey key)
 {
 	typedef bool (*custom_arg_funcptr_t)(ArmamentControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func41::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func42::func;
 	return execfunc(this, key);
 }
 
-namespace _func42
+namespace _func43
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ArmamentControl::Dragging", typeid(bool (ArmamentControl::*)()), ".5383bfb0000000ff", nullptr, 0, 0, &func);
@@ -549,11 +562,11 @@ namespace _func42
 bool ArmamentControl::Dragging()
 {
 	typedef bool (*custom_arg_funcptr_t)(ArmamentControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func42::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func43::func;
 	return execfunc(this);
 }
 
-namespace _func43
+namespace _func44
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ArmamentControl::CreateHolderTab", typeid(void (ArmamentControl::*)()), ".4154be????????55534889fb4883ec60", nullptr, 0, 0, &func);
@@ -562,11 +575,11 @@ namespace _func43
 void ArmamentControl::CreateHolderTab()
 {
 	typedef void (*custom_arg_funcptr_t)(ArmamentControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func43::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func44::func;
 	return execfunc(this);
 }
 
-namespace _func44
+namespace _func45
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ArmamentControl::SetPosition", typeid(void (ArmamentControl::*)(Point )), ".55534889fb4883ec08397738", nullptr, 0, 0, &func);
@@ -575,11 +588,11 @@ namespace _func44
 void ArmamentControl::SetPosition(Point loc)
 {
 	typedef void (*custom_arg_funcptr_t)(ArmamentControl *this_arg, Point loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func44::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func45::func;
 	return execfunc(this, loc);
 }
 
-namespace _func45
+namespace _func46
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ArmamentControl::LinkShip", typeid(void (ArmamentControl::*)(ShipManager *)), ".415741564155415455534889fb4883ec3848897718", nullptr, 0, 0, &func);
@@ -588,11 +601,11 @@ namespace _func45
 void ArmamentControl::LinkShip(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(ArmamentControl *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func45::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func46::func;
 	return execfunc(this, ship);
 }
 
-namespace _func46
+namespace _func47
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ArtilleryBox::constructor", typeid(void (ArtilleryBox::*)(Point , ArtillerySystem *)), "55b9010000004889d5534889fb4883ec08", nullptr, 0, 0, &func);
@@ -601,11 +614,11 @@ namespace _func46
 void ArtilleryBox::constructor(Point pos, ArtillerySystem *sys)
 {
 	typedef void (*custom_arg_funcptr_t)(ArtilleryBox *this_arg, Point pos_arg, ArtillerySystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func46::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func47::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func47
+namespace _func48
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ArtilleryBox::OnRender", typeid(void (ArtilleryBox::*)(bool )), "4154400fb6f655534889fb4883ec70", nullptr, 0, 0, &func);
@@ -614,30 +627,17 @@ namespace _func47
 void ArtilleryBox::OnRender(bool ignoreStatus)
 {
 	typedef void (*custom_arg_funcptr_t)(ArtilleryBox *this_arg, bool ignoreStatus_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func47::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func48::func;
 	return execfunc(this, ignoreStatus);
 }
 
-namespace _func48
+namespace _func49
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ArtillerySystem::Jump", typeid(void (ArtillerySystem::*)()), "488b8748020000c7400c00000000", nullptr, 0, 0, &func);
 }
 
 void ArtillerySystem::Jump()
-{
-	typedef void (*custom_arg_funcptr_t)(ArtillerySystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func48::func;
-	return execfunc(this);
-}
-
-namespace _func49
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ArtillerySystem::OnLoop", typeid(void (ArtillerySystem::*)()), ".415455534889fb4883ec70e8????????4889df", nullptr, 0, 0, &func);
-}
-
-void ArtillerySystem::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(ArtillerySystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func49::func;
@@ -647,17 +647,30 @@ void ArtillerySystem::OnLoop()
 namespace _func50
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ArtillerySystem::OnLoop", typeid(void (ArtillerySystem::*)()), ".415455534889fb4883ec70e8????????4889df", nullptr, 0, 0, &func);
+}
+
+void ArtillerySystem::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(ArtillerySystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func50::func;
+	return execfunc(this);
+}
+
+namespace _func51
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Asteroid::OnUpdate", typeid(void (Asteroid::*)()), "534889fb4883ec2080bfc4000000007417", nullptr, 0, 0, &func);
 }
 
 void Asteroid::OnUpdate()
 {
 	typedef void (*custom_arg_funcptr_t)(Asteroid *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func50::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func51::func;
 	return execfunc(this);
 }
 
-namespace _func51
+namespace _func52
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Asteroid::constructor", typeid(void (Asteroid::*)(Pointf , int )), ".4157baffffffff4156415541545589f589d6534889fb4881ecc8010000", nullptr, 0, 0, &func);
@@ -666,11 +679,11 @@ namespace _func51
 void Asteroid::constructor(Pointf pos, int destinationSpace)
 {
 	typedef void (*custom_arg_funcptr_t)(Asteroid *this_arg, Pointf pos_arg, int destinationSpace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func51::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func52::func;
 	return execfunc(this, pos, destinationSpace);
 }
 
-namespace _func52
+namespace _func53
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("AsteroidGenerator::constructor", typeid(void (AsteroidGenerator::*)()), "415741564155415455534889fbbf40000000", nullptr, 0, 0, &func);
@@ -679,11 +692,11 @@ namespace _func52
 void AsteroidGenerator::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func52::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func53::func;
 	return execfunc(this);
 }
 
-namespace _func53
+namespace _func54
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("AsteroidGenerator::Initialize", typeid(float (AsteroidGenerator::*)(int , int , bool )), ".89d0538997b4000000", nullptr, 0, 0, &func);
@@ -692,11 +705,11 @@ namespace _func53
 float AsteroidGenerator::Initialize(int numberOfShips, int shieldCount, bool defense)
 {
 	typedef float (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg, int numberOfShips_arg, int shieldCount_arg, bool defense_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func53::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func54::func;
 	return execfunc(this, numberOfShips, shieldCount, defense);
 }
 
-namespace _func54
+namespace _func55
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("AsteroidGenerator::SetNumShips", typeid(void (AsteroidGenerator::*)(int )), ".89b798000000", nullptr, 0, 0, &func);
@@ -705,11 +718,11 @@ namespace _func54
 void AsteroidGenerator::SetNumShips(int ships)
 {
 	typedef void (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg, int ships_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func54::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func55::func;
 	return execfunc(this, ships);
 }
 
-namespace _func55
+namespace _func56
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("AsteroidGenerator::GetNextAsteroid", typeid(Projectile *(AsteroidGenerator::*)()), ".415741564155415455534889fb4881ec38030000", nullptr, 0, 0, &func);
@@ -718,19 +731,6 @@ namespace _func55
 Projectile *AsteroidGenerator::GetNextAsteroid()
 {
 	typedef Projectile *(*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func55::func;
-	return execfunc(this);
-}
-
-namespace _func56
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("AsteroidGenerator::OnLoop", typeid(void (AsteroidGenerator::*)()), ".415741564155415455534889fb4883ec18", nullptr, 0, 0, &func);
-}
-
-void AsteroidGenerator::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func56::func;
 	return execfunc(this);
 }
@@ -738,10 +738,10 @@ void AsteroidGenerator::OnLoop()
 namespace _func57
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("AsteroidGenerator::GetNextState", typeid(void (AsteroidGenerator::*)()), ".538b879c000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("AsteroidGenerator::OnLoop", typeid(void (AsteroidGenerator::*)()), ".415741564155415455534889fb4883ec18", nullptr, 0, 0, &func);
 }
 
-void AsteroidGenerator::GetNextState()
+void AsteroidGenerator::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func57::func;
@@ -751,10 +751,10 @@ void AsteroidGenerator::GetNextState()
 namespace _func58
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("AsteroidGenerator::UpdateState", typeid(void (AsteroidGenerator::*)()), ".534889fbbf????????e8????????", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("AsteroidGenerator::GetNextState", typeid(void (AsteroidGenerator::*)()), ".538b879c000000", nullptr, 0, 0, &func);
 }
 
-void AsteroidGenerator::UpdateState()
+void AsteroidGenerator::GetNextState()
 {
 	typedef void (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func58::func;
@@ -764,17 +764,30 @@ void AsteroidGenerator::UpdateState()
 namespace _func59
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("AsteroidGenerator::UpdateState", typeid(void (AsteroidGenerator::*)()), ".534889fbbf????????e8????????", nullptr, 0, 0, &func);
+}
+
+void AsteroidGenerator::UpdateState()
+{
+	typedef void (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func59::func;
+	return execfunc(this);
+}
+
+namespace _func60
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("AsteroidGenerator::SaveAsteroids", typeid(bool (AsteroidGenerator::*)(void *)), ".554889fd5389f34883ec08", nullptr, 0, 0, &func);
 }
 
 bool AsteroidGenerator::SaveAsteroids(void *file)
 {
 	typedef bool (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg, void *file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func59::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func60::func;
 	return execfunc(this, file);
 }
 
-namespace _func60
+namespace _func61
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("AsteroidGenerator::LoadAsteroids", typeid(void (AsteroidGenerator::*)(void *)), ".5589f5534889fb89f74883ec08", nullptr, 0, 0, &func);
@@ -783,30 +796,17 @@ namespace _func60
 void AsteroidGenerator::LoadAsteroids(void *file)
 {
 	typedef void (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg, void *file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func60::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func61::func;
 	return execfunc(this, file);
 }
 
-namespace _func61
+namespace _func62
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("AugmentEquipBox::RenderIcon", typeid(void (AugmentEquipBox::*)()), "534889fbe8????????8b435c8b5358", nullptr, 0, 0, &func);
 }
 
 void AugmentEquipBox::RenderIcon()
-{
-	typedef void (*custom_arg_funcptr_t)(AugmentEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func61::func;
-	return execfunc(this);
-}
-
-namespace _func62
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("AugmentEquipBox::CheckContents", typeid(void (AugmentEquipBox::*)()), "41544989fc55534883ec40488bb7a8000000", nullptr, 0, 0, &func);
-}
-
-void AugmentEquipBox::CheckContents()
 {
 	typedef void (*custom_arg_funcptr_t)(AugmentEquipBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func62::func;
@@ -816,10 +816,10 @@ void AugmentEquipBox::CheckContents()
 namespace _func63
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("AugmentEquipBox::RemoveItem", typeid(void (AugmentEquipBox::*)()), "534889fb4883ec204883bfa800000000743d", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("AugmentEquipBox::CheckContents", typeid(void (AugmentEquipBox::*)()), "41544989fc55534883ec40488bb7a8000000", nullptr, 0, 0, &func);
 }
 
-void AugmentEquipBox::RemoveItem()
+void AugmentEquipBox::CheckContents()
 {
 	typedef void (*custom_arg_funcptr_t)(AugmentEquipBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func63::func;
@@ -829,17 +829,30 @@ void AugmentEquipBox::RemoveItem()
 namespace _func64
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("AugmentEquipBox::RemoveItem", typeid(void (AugmentEquipBox::*)()), "534889fb4883ec204883bfa800000000743d", nullptr, 0, 0, &func);
+}
+
+void AugmentEquipBox::RemoveItem()
+{
+	typedef void (*custom_arg_funcptr_t)(AugmentEquipBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func64::func;
+	return execfunc(this);
+}
+
+namespace _func65
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("AugmentStoreBox::constructor", typeid(void (AugmentStoreBox::*)(ShipManager *, const AugmentBlueprint *)), "41544989f4be????????554889d5534889fb", nullptr, 0, 0, &func);
 }
 
 void AugmentStoreBox::constructor(ShipManager *ship, const AugmentBlueprint *bp)
 {
 	typedef void (*custom_arg_funcptr_t)(AugmentStoreBox *this_arg, ShipManager *ship_arg, const AugmentBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func64::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func65::func;
 	return execfunc(this, ship, bp);
 }
 
-namespace _func65
+namespace _func66
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BatteryBox::constructor", typeid(void (BatteryBox::*)(Point , BatterySystem *)), "5531c94889d5534889fb4883ec58", nullptr, 0, 0, &func);
@@ -848,11 +861,11 @@ namespace _func65
 void BatteryBox::constructor(Point pos, BatterySystem *sys)
 {
 	typedef void (*custom_arg_funcptr_t)(BatteryBox *this_arg, Point pos_arg, BatterySystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func65::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func66::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func66
+namespace _func67
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BeamWeapon::OnRenderSpecific", typeid(void (BeamWeapon::*)(int )), "415741564155415455534889fb4883ec6880bf00", nullptr, 0, 0, &func);
@@ -861,11 +874,11 @@ namespace _func66
 void BeamWeapon::OnRenderSpecific(int spaceId)
 {
 	typedef void (*custom_arg_funcptr_t)(BeamWeapon *this_arg, int spaceId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func66::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func67::func;
 	return execfunc(this, spaceId);
 }
 
-namespace _func67
+namespace _func68
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BeamWeapon::constructor", typeid(void (BeamWeapon::*)(Pointf , int , int , Pointf , Pointf , int , Targetable *, float )), ".41564189ce41554154554c89c5534889fb4883ec10", nullptr, 0, 0, &func);
@@ -874,11 +887,11 @@ namespace _func67
 void BeamWeapon::constructor(Pointf _position, int _ownerId, int _targetId, Pointf _target, Pointf _target2, int _length, Targetable *_targetable, float heading)
 {
 	typedef void (*custom_arg_funcptr_t)(BeamWeapon *this_arg, Pointf _position_arg, int _ownerId_arg, int _targetId_arg, Pointf _target_arg, Pointf _target2_arg, int _length_arg, Targetable *_targetable_arg, float heading_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func67::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func68::func;
 	return execfunc(this, _position, _ownerId, _targetId, _target, _target2, _length, _targetable, heading);
 }
 
-namespace _func68
+namespace _func69
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BeamWeapon::OnUpdate", typeid(void (BeamWeapon::*)()), ".41564155415455534889fb4883ec1080bf0003000000", nullptr, 0, 0, &func);
@@ -887,11 +900,11 @@ namespace _func68
 void BeamWeapon::OnUpdate()
 {
 	typedef void (*custom_arg_funcptr_t)(BeamWeapon *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func68::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func69::func;
 	return execfunc(this);
 }
 
-namespace _func69
+namespace _func70
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BeamWeapon::CollisionCheck", typeid(void (BeamWeapon::*)(Collideable *)), ".4157415641554989fd415455534881ecb8010000", nullptr, 0, 0, &func);
@@ -900,11 +913,11 @@ namespace _func69
 void BeamWeapon::CollisionCheck(Collideable *other)
 {
 	typedef void (*custom_arg_funcptr_t)(BeamWeapon *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func69::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func70::func;
 	return execfunc(this, other);
 }
 
-namespace _func70
+namespace _func71
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Blueprint::destructor", typeid(void (Blueprint::*)()), "534889fb4883ec10488b476848c707????????488d78e84881ff????????756f", nullptr, 0, 0, &func);
@@ -913,11 +926,11 @@ namespace _func70
 void Blueprint::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(Blueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func70::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func71::func;
 	return execfunc(this);
 }
 
-namespace _func71
+namespace _func72
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Blueprint::GetNameShort", typeid(std::string (Blueprint::*)()), "53807e2800", nullptr, 0, 0, &func);
@@ -926,11 +939,11 @@ namespace _func71
 std::string Blueprint::GetNameShort()
 {
 	typedef std::string (*custom_arg_funcptr_t)(Blueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func71::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func72::func;
 	return execfunc(this);
 }
 
-namespace _func72
+namespace _func73
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::GetBlueprintList", typeid(std::vector<std::string> (BlueprintManager::*)(const std::string &)), "4157415641554989f54d8dbde8010000", nullptr, 0, 0, &func);
@@ -939,11 +952,11 @@ namespace _func72
 std::vector<std::string> BlueprintManager::GetBlueprintList(const std::string &name)
 {
 	typedef std::vector<std::string> (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func72::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func73::func;
 	return execfunc(this, name);
 }
 
-namespace _func73
+namespace _func74
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::GetShipBlueprint", typeid(ShipBlueprint *(BlueprintManager::*)(const std::string &, int )), "415641554989f541544989fc5589d5534883ec60", nullptr, 0, 0, &func);
@@ -952,11 +965,11 @@ namespace _func73
 ShipBlueprint *BlueprintManager::GetShipBlueprint(const std::string &name, int sector)
 {
 	typedef ShipBlueprint *(*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg, int sector_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func73::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func74::func;
 	return execfunc(this, name, sector);
 }
 
-namespace _func74
+namespace _func75
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::GetWeaponBlueprint", typeid(WeaponBlueprint *(BlueprintManager::*)(const std::string &)), "41554154554889f5be????????534889fb4c8da3e80100004883ec28", nullptr, 0, 0, &func);
@@ -965,11 +978,11 @@ namespace _func74
 WeaponBlueprint *BlueprintManager::GetWeaponBlueprint(const std::string &name)
 {
 	typedef WeaponBlueprint *(*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func74::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func75::func;
 	return execfunc(this, name);
 }
 
-namespace _func75
+namespace _func76
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::GetDroneBlueprint", typeid(DroneBlueprint *(BlueprintManager::*)(const std::string &)), ".41554154554889f5be????????534889fb4c8da3e80100004883ec28", nullptr, 0, 0, &func);
@@ -978,11 +991,11 @@ namespace _func75
 DroneBlueprint *BlueprintManager::GetDroneBlueprint(const std::string &name)
 {
 	typedef DroneBlueprint *(*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func75::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func76::func;
 	return execfunc(this, name);
 }
 
-namespace _func76
+namespace _func77
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::GetAugmentBlueprint", typeid(AugmentBlueprint *(BlueprintManager::*)(const std::string &)), ".41554154554889f5be????????534889fb4c8da3e80100004883ec28", nullptr, 0, 0, &func);
@@ -991,11 +1004,11 @@ namespace _func76
 AugmentBlueprint *BlueprintManager::GetAugmentBlueprint(const std::string &name)
 {
 	typedef AugmentBlueprint *(*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func76::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func77::func;
 	return execfunc(this, name);
 }
 
-namespace _func77
+namespace _func78
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::GetAugmentValue", typeid(float (BlueprintManager::*)(const std::string &)), ".4157488d8798000000", nullptr, 0, 0, &func);
@@ -1004,11 +1017,11 @@ namespace _func77
 float BlueprintManager::GetAugmentValue(const std::string &name)
 {
 	typedef float (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func77::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func78::func;
 	return execfunc(this, name);
 }
 
-namespace _func78
+namespace _func79
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::GetItemBlueprint", typeid(ItemBlueprint *(BlueprintManager::*)(const std::string &)), "4157488d8f90010000", nullptr, 0, 0, &func);
@@ -1017,11 +1030,11 @@ namespace _func78
 ItemBlueprint *BlueprintManager::GetItemBlueprint(const std::string &name)
 {
 	typedef ItemBlueprint *(*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func78::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func79::func;
 	return execfunc(this, name);
 }
 
-namespace _func79
+namespace _func80
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::ProcessWeaponBlueprint", typeid(WeaponBlueprint (BlueprintManager::*)(rapidxml::xml_node<char> *)), "41574156415541544989f4554889d5534889fb4881ecb8000000", nullptr, 0, 0, &func);
@@ -1030,11 +1043,11 @@ namespace _func79
 WeaponBlueprint BlueprintManager::ProcessWeaponBlueprint(rapidxml::xml_node<char> *node)
 {
 	typedef WeaponBlueprint (*custom_arg_funcptr_t)(BlueprintManager *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func79::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func80::func;
 	return execfunc(this, node);
 }
 
-namespace _func80
+namespace _func81
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::ProcessDescription", typeid(Description (BlueprintManager::*)(rapidxml::xml_node<char> *)), "4157be????????415641554154554889fd4c8d6d10", nullptr, 0, 0, &func);
@@ -1043,11 +1056,11 @@ namespace _func80
 Description BlueprintManager::ProcessDescription(rapidxml::xml_node<char> *node)
 {
 	typedef Description (*custom_arg_funcptr_t)(BlueprintManager *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func80::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func81::func;
 	return execfunc(this, node);
 }
 
-namespace _func81
+namespace _func82
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::ProcessEffectsBlueprint", typeid(EffectsBlueprint (BlueprintManager::*)(rapidxml::xml_node<char> *)), "4157415641554989f5be", nullptr, 0, 0, &func);
@@ -1056,11 +1069,11 @@ namespace _func81
 EffectsBlueprint BlueprintManager::ProcessEffectsBlueprint(rapidxml::xml_node<char> *node)
 {
 	typedef EffectsBlueprint (*custom_arg_funcptr_t)(BlueprintManager *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func81::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func82::func;
 	return execfunc(this, node);
 }
 
-namespace _func82
+namespace _func83
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::GetCrewBlueprint", typeid(CrewBlueprint (BlueprintManager::*)(const std::string &)), "41574156415541544989f44d8dac24c8000000", nullptr, 0, 0, &func);
@@ -1069,11 +1082,11 @@ namespace _func82
 CrewBlueprint BlueprintManager::GetCrewBlueprint(const std::string &name)
 {
 	typedef CrewBlueprint (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func82::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func83::func;
 	return execfunc(this, name);
 }
 
-namespace _func83
+namespace _func84
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::GetRandomAugment", typeid(std::vector<AugmentBlueprint*> (BlueprintManager::*)(int , bool )), "488d869800000053", nullptr, 0, 0, &func);
@@ -1082,11 +1095,11 @@ namespace _func83
 std::vector<AugmentBlueprint*> BlueprintManager::GetRandomAugment(int count, bool demo_lock)
 {
 	typedef std::vector<AugmentBlueprint*> (*custom_arg_funcptr_t)(BlueprintManager *this_arg, int count_arg, bool demo_lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func83::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func84::func;
 	return execfunc(this, count, demo_lock);
 }
 
-namespace _func84
+namespace _func85
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::GetSystemBlueprint", typeid(SystemBlueprint *(BlueprintManager::*)(const std::string &)), "4157488d8fc0010000", nullptr, 0, 0, &func);
@@ -1095,30 +1108,17 @@ namespace _func84
 SystemBlueprint *BlueprintManager::GetSystemBlueprint(const std::string &name)
 {
 	typedef SystemBlueprint *(*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func84::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func85::func;
 	return execfunc(this, name);
 }
 
-namespace _func85
+namespace _func86
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::GetUnusedCrewName", typeid(std::string (BlueprintManager::*)(bool *)), "415741564155415455534883ec5848c707", nullptr, 0, 0, &func);
 }
 
 std::string BlueprintManager::GetUnusedCrewName(bool *isMale_ret)
-{
-	typedef std::string (*custom_arg_funcptr_t)(BlueprintManager *this_arg, bool *isMale_ret_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func85::func;
-	return execfunc(this, isMale_ret);
-}
-
-namespace _func86
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("BlueprintManager::GetCrewName", typeid(std::string (BlueprintManager::*)(bool *)), "415741564c8db6f800000041554989d541544989fc55534889f3", nullptr, 0, 0, &func);
-}
-
-std::string BlueprintManager::GetCrewName(bool *isMale_ret)
 {
 	typedef std::string (*custom_arg_funcptr_t)(BlueprintManager *this_arg, bool *isMale_ret_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func86::func;
@@ -1128,17 +1128,30 @@ std::string BlueprintManager::GetCrewName(bool *isMale_ret)
 namespace _func87
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("BlueprintManager::GetCrewName", typeid(std::string (BlueprintManager::*)(bool *)), "415741564c8db6f800000041554989d541544989fc55534889f3", nullptr, 0, 0, &func);
+}
+
+std::string BlueprintManager::GetCrewName(bool *isMale_ret)
+{
+	typedef std::string (*custom_arg_funcptr_t)(BlueprintManager *this_arg, bool *isMale_ret_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func87::func;
+	return execfunc(this, isMale_ret);
+}
+
+namespace _func88
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::GetRandomWeapon", typeid(std::vector<WeaponBlueprint*> (BlueprintManager::*)(int , bool )), "488d463853440fb6c1", nullptr, 0, 0, &func);
 }
 
 std::vector<WeaponBlueprint*> BlueprintManager::GetRandomWeapon(int count, bool demo_lock)
 {
 	typedef std::vector<WeaponBlueprint*> (*custom_arg_funcptr_t)(BlueprintManager *this_arg, int count_arg, bool demo_lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func87::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func88::func;
 	return execfunc(this, count, demo_lock);
 }
 
-namespace _func88
+namespace _func89
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::GetRandomDrone", typeid(std::vector<DroneBlueprint*> (BlueprintManager::*)(int , bool )), "488d466853440fb6c1", nullptr, 0, 0, &func);
@@ -1147,11 +1160,11 @@ namespace _func88
 std::vector<DroneBlueprint*> BlueprintManager::GetRandomDrone(int count, bool demo_lock)
 {
 	typedef std::vector<DroneBlueprint*> (*custom_arg_funcptr_t)(BlueprintManager *this_arg, int count_arg, bool demo_lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func88::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func89::func;
 	return execfunc(this, count, demo_lock);
 }
 
-namespace _func89
+namespace _func90
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::ProcessShipBlueprint", typeid(ShipBlueprint (BlueprintManager::*)(rapidxml::xml_node<char> *)), "415741564989d641554989f5415455534889fb4881ecc8000000", nullptr, 0, 0, &func);
@@ -1160,11 +1173,11 @@ namespace _func89
 ShipBlueprint BlueprintManager::ProcessShipBlueprint(rapidxml::xml_node<char> *node)
 {
 	typedef ShipBlueprint (*custom_arg_funcptr_t)(BlueprintManager *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func89::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func90::func;
 	return execfunc(this, node);
 }
 
-namespace _func90
+namespace _func91
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::ProcessDroneBlueprint", typeid(DroneBlueprint (BlueprintManager::*)(rapidxml::xml_node<char> *)), "415741564989f641554989d54154554889fd534881ec98000000", nullptr, 0, 0, &func);
@@ -1173,11 +1186,11 @@ namespace _func90
 DroneBlueprint BlueprintManager::ProcessDroneBlueprint(rapidxml::xml_node<char> *node)
 {
 	typedef DroneBlueprint (*custom_arg_funcptr_t)(BlueprintManager *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func90::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func91::func;
 	return execfunc(this, node);
 }
 
-namespace _func91
+namespace _func92
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BlueprintManager::GetSkillIcon", typeid(GL_Texture *(*)(int , bool )), "415541544189f4554863ef53400fb6de488d046b", nullptr, 0, 0, &func);
@@ -1186,18 +1199,18 @@ namespace _func91
 GL_Texture *BlueprintManager::GetSkillIcon(int skill, bool outline)
 {
 	typedef GL_Texture *(*custom_arg_funcptr_t)(int skill_arg, bool outline_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func91::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func92::func;
 	return execfunc(skill, outline);
 }
 
 BlueprintManager *Global_BlueprintManager_Blueprints;
 
-namespace _var92
+namespace _var93
 {
     static VariableDefinition varObj("Global_BlueprintManager_Blueprints", "!488d742410baffffffffbf(???????\?)4c8d742430", &Global_BlueprintManager_Blueprints);
 }
 
-namespace _func93
+namespace _func94
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BoarderPodDrone::CanBeDeployed", typeid(bool (BoarderPodDrone::*)()), "534889fb488bbf58010000", nullptr, 0, 0, &func);
@@ -1206,11 +1219,11 @@ namespace _func93
 bool BoarderPodDrone::CanBeDeployed()
 {
 	typedef bool (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func93::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func94::func;
 	return execfunc(this);
 }
 
-namespace _func94
+namespace _func95
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BoarderPodDrone::SetMovementTarget", typeid(void (BoarderPodDrone::*)(Targetable *)), ".534889fb4883ec104885f6", nullptr, 0, 0, &func);
@@ -1219,11 +1232,11 @@ namespace _func94
 void BoarderPodDrone::SetMovementTarget(Targetable *target)
 {
 	typedef void (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func94::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func95::func;
 	return execfunc(this, target);
 }
 
-namespace _func95
+namespace _func96
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BoarderPodDrone::SetDeployed", typeid(void (BoarderPodDrone::*)(bool )), ".5589f5534889fb4883ec08807f1800742f", nullptr, 0, 0, &func);
@@ -1232,11 +1245,11 @@ namespace _func95
 void BoarderPodDrone::SetDeployed(bool _deployed)
 {
 	typedef void (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg, bool _deployed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func95::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func96::func;
 	return execfunc(this, _deployed);
 }
 
-namespace _func96
+namespace _func97
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BoarderPodDrone::CollisionMoving", typeid(CollisionResponse (BoarderPodDrone::*)(Pointf , Pointf , Damage , bool )), ".41554154554889f5534889fb4883ec2880be6804000000", nullptr, 0, 0, &func);
@@ -1245,11 +1258,11 @@ namespace _func96
 CollisionResponse BoarderPodDrone::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func96::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func97::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func97
+namespace _func98
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BoarderPodDrone::OnLoop", typeid(void (BoarderPodDrone::*)()), ".415455534889fb4881ecc0000000", nullptr, 0, 0, &func);
@@ -1258,11 +1271,11 @@ namespace _func97
 void BoarderPodDrone::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func97::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func98::func;
 	return execfunc(this);
 }
 
-namespace _func98
+namespace _func99
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BoarderPodDrone::constructor", typeid(void (BoarderPodDrone::*)(int , int , const DroneBlueprint &)), ".41574989ff415641554989cd415455498dafa8030000", nullptr, 0, 0, &func);
@@ -1271,11 +1284,11 @@ namespace _func98
 void BoarderPodDrone::constructor(int _iShipId, int _selfId, const DroneBlueprint &_bp)
 {
 	typedef void (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg, int _iShipId_arg, int _selfId_arg, const DroneBlueprint &_bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func98::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func99::func;
 	return execfunc(this, _iShipId, _selfId, _bp);
 }
 
-namespace _func99
+namespace _func100
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BombProjectile::OnUpdate", typeid(void (BombProjectile::*)()), "55488daf48010000534889fb4889ef4883ec08", nullptr, 0, 0, &func);
@@ -1284,11 +1297,11 @@ namespace _func99
 void BombProjectile::OnUpdate()
 {
 	typedef void (*custom_arg_funcptr_t)(BombProjectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func99::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func100::func;
 	return execfunc(this);
 }
 
-namespace _func100
+namespace _func101
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BombProjectile::CollisionCheck", typeid(void (BombProjectile::*)(Collideable *)), ".41554154554889f5534889fb4889f74883ec78", nullptr, 0, 0, &func);
@@ -1297,11 +1310,11 @@ namespace _func100
 void BombProjectile::CollisionCheck(Collideable *other)
 {
 	typedef void (*custom_arg_funcptr_t)(BombProjectile *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func100::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func101::func;
 	return execfunc(this, other);
 }
 
-namespace _func101
+namespace _func102
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BombProjectile::constructor", typeid(void (BombProjectile::*)(Pointf , int , int , Pointf )), ".41574989ff41564155415455534881ece8000000", nullptr, 0, 0, &func);
@@ -1310,11 +1323,11 @@ namespace _func101
 void BombProjectile::constructor(Pointf _position, int _ownerId, int _targetId, Pointf _target)
 {
 	typedef void (*custom_arg_funcptr_t)(BombProjectile *this_arg, Pointf _position_arg, int _ownerId_arg, int _targetId_arg, Pointf _target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func101::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func102::func;
 	return execfunc(this, _position, _ownerId, _targetId, _target);
 }
 
-namespace _func102
+namespace _func103
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BossShip::Restart", typeid(void (BossShip::*)()), "c7871402000000000000c7874c02000001000000", nullptr, 0, 0, &func);
@@ -1323,11 +1336,11 @@ namespace _func102
 void BossShip::Restart()
 {
 	typedef void (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func102::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func103::func;
 	return execfunc(this);
 }
 
-namespace _func103
+namespace _func104
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BossShip::IncomingFire", typeid(bool (BossShip::*)()), ".f30f108724020000", nullptr, 0, 0, &func);
@@ -1336,11 +1349,11 @@ namespace _func103
 bool BossShip::IncomingFire()
 {
 	typedef bool (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func103::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func104::func;
 	return execfunc(this);
 }
 
-namespace _func104
+namespace _func105
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BossShip::constructor", typeid(void (BossShip::*)(SpaceManager *)), "!.53b9010000004889fb31d24883c330", nullptr, 0, 0, &func);
@@ -1349,11 +1362,11 @@ namespace _func104
 void BossShip::constructor(SpaceManager *space)
 {
 	typedef void (*custom_arg_funcptr_t)(BossShip *this_arg, SpaceManager *space_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func104::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func105::func;
 	return execfunc(this, space);
 }
 
-namespace _func105
+namespace _func106
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BossShip::ClearLocation", typeid(void (BossShip::*)()), ".534889fb488b7f104885ff740e", nullptr, 0, 0, &func);
@@ -1362,11 +1375,11 @@ namespace _func105
 void BossShip::ClearLocation()
 {
 	typedef void (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func105::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func106::func;
 	return execfunc(this);
 }
 
-namespace _func106
+namespace _func107
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BossShip::Defeated", typeid(bool (BossShip::*)()), ".31c083bf1402000003", nullptr, 0, 0, &func);
@@ -1375,11 +1388,11 @@ namespace _func106
 bool BossShip::Defeated()
 {
 	typedef bool (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func106::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func107::func;
 	return execfunc(this);
 }
 
-namespace _func107
+namespace _func108
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BossShip::GetSubEvent", typeid(LocationEvent *(BossShip::*)()), ".415455534889fb4883ec30", nullptr, 0, 0, &func);
@@ -1388,11 +1401,11 @@ namespace _func107
 LocationEvent *BossShip::GetSubEvent()
 {
 	typedef LocationEvent *(*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func107::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func108::func;
 	return execfunc(this);
 }
 
-namespace _func108
+namespace _func109
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BossShip::StartStage", typeid(void (BossShip::*)()), ".415741564155415455534889fb488d7f304881ecd8010000", nullptr, 0, 0, &func);
@@ -1401,11 +1414,11 @@ namespace _func108
 void BossShip::StartStage()
 {
 	typedef void (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func108::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func109::func;
 	return execfunc(this);
 }
 
-namespace _func109
+namespace _func110
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BossShip::SaveBoss", typeid(void (BossShip::*)(int )), ".41544189f4554889fd538bb714020000", nullptr, 0, 0, &func);
@@ -1414,11 +1427,11 @@ namespace _func109
 void BossShip::SaveBoss(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(BossShip *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func109::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func110::func;
 	return execfunc(this, file);
 }
 
-namespace _func110
+namespace _func111
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BossShip::GetEvent", typeid(LocationEvent *(BossShip::*)()), ".4883ec48488db74c020000", nullptr, 0, 0, &func);
@@ -1427,11 +1440,11 @@ namespace _func110
 LocationEvent *BossShip::GetEvent()
 {
 	typedef LocationEvent *(*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func110::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func111::func;
 	return execfunc(this);
 }
 
-namespace _func111
+namespace _func112
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BossShip::LoadBoss", typeid(void (BossShip::*)(int )), ".4156415541544189f455534889fb89f74883ec10", nullptr, 0, 0, &func);
@@ -1440,11 +1453,11 @@ namespace _func111
 void BossShip::LoadBoss(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(BossShip *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func111::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func112::func;
 	return execfunc(this, file);
 }
 
-namespace _func112
+namespace _func113
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("BossShip::OnLoop", typeid(void (BossShip::*)()), ".4155415455534889fb4883ec28c687d401000001", nullptr, 0, 0, &func);
@@ -1453,11 +1466,11 @@ namespace _func112
 void BossShip::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func112::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func113::func;
 	return execfunc(this);
 }
 
-namespace _func113
+namespace _func114
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Button::SetLocation", typeid(void (Button::*)(const Point )), "8b57084889f08b4f0c48c1f82039f2", nullptr, 0, 0, &func);
@@ -1466,11 +1479,11 @@ namespace _func113
 void Button::SetLocation(const Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(Button *this_arg, const Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func113::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func114::func;
 	return execfunc(this, pos);
 }
 
-namespace _func114
+namespace _func115
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Button::OnInit", typeid(void (Button::*)(const std::string &, Point )), "41544989f4554889d5534889fb4883ec20488d7c2410", nullptr, 0, 0, &func);
@@ -1479,30 +1492,17 @@ namespace _func114
 void Button::OnInit(const std::string &img, Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(Button *this_arg, const std::string &img_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func114::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func115::func;
 	return execfunc(this, img, pos);
 }
 
-namespace _func115
+namespace _func116
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Button::constructor", typeid(void (Button::*)()), "55534889fb488d7f08488d6b284883ec18", nullptr, 0, 0, &func);
 }
 
 void Button::constructor()
-{
-	typedef void (*custom_arg_funcptr_t)(Button *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func115::func;
-	return execfunc(this);
-}
-
-namespace _func116
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Button::OnRender", typeid(void (Button::*)()), "415455534889fb4883ec2048837f6800", nullptr, 0, 0, &func);
-}
-
-void Button::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(Button *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func116::func;
@@ -1512,23 +1512,23 @@ void Button::OnRender()
 namespace _func117
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Button::SetInactiveImage", typeid(void (Button::*)(GL_Texture *)), "483977507412488b07", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Button::OnRender", typeid(void (Button::*)()), "415455534889fb4883ec2048837f6800", nullptr, 0, 0, &func);
 }
 
-void Button::SetInactiveImage(GL_Texture *texture)
+void Button::OnRender()
 {
-	typedef void (*custom_arg_funcptr_t)(Button *this_arg, GL_Texture *texture_arg);
+	typedef void (*custom_arg_funcptr_t)(Button *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func117::func;
-	return execfunc(this, texture);
+	return execfunc(this);
 }
 
 namespace _func118
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Button::SetActiveImage", typeid(void (Button::*)(GL_Texture *)), "483977587412488b07", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Button::SetInactiveImage", typeid(void (Button::*)(GL_Texture *)), "483977507412488b07", nullptr, 0, 0, &func);
 }
 
-void Button::SetActiveImage(GL_Texture *texture)
+void Button::SetInactiveImage(GL_Texture *texture)
 {
 	typedef void (*custom_arg_funcptr_t)(Button *this_arg, GL_Texture *texture_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func118::func;
@@ -1538,17 +1538,30 @@ void Button::SetActiveImage(GL_Texture *texture)
 namespace _func119
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Button::SetActiveImage", typeid(void (Button::*)(GL_Texture *)), "483977587412488b07", nullptr, 0, 0, &func);
+}
+
+void Button::SetActiveImage(GL_Texture *texture)
+{
+	typedef void (*custom_arg_funcptr_t)(Button *this_arg, GL_Texture *texture_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func119::func;
+	return execfunc(this, texture);
+}
+
+namespace _func120
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Button::SetImageBase", typeid(void (Button::*)(const std::string &)), "554889f5534889fb4883ec28488d7c2410", nullptr, 0, 0, &func);
 }
 
 void Button::SetImageBase(const std::string &imageBase)
 {
 	typedef void (*custom_arg_funcptr_t)(Button *this_arg, const std::string &imageBase_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func119::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func120::func;
 	return execfunc(this, imageBase);
 }
 
-namespace _func120
+namespace _func121
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CAchievement::OnRender", typeid(void (CAchievement::*)(Point , int , bool )), "415741564189ce415541544989f45589d5534889fb4883ec78", nullptr, 0, 0, &func);
@@ -1557,11 +1570,11 @@ namespace _func120
 void CAchievement::OnRender(Point pos, int selected, bool showNew)
 {
 	typedef void (*custom_arg_funcptr_t)(CAchievement *this_arg, Point pos_arg, int selected_arg, bool showNew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func120::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func121::func;
 	return execfunc(this, pos, selected, showNew);
 }
 
-namespace _func121
+namespace _func122
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CAchievement::constructor", typeid(void (CAchievement::*)()), "53be????????4889fb4883ec20", nullptr, 0, 0, &func);
@@ -1570,19 +1583,6 @@ namespace _func121
 void CAchievement::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CAchievement *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func121::func;
-	return execfunc(this);
-}
-
-namespace _func122
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CApp::OnRequestExit", typeid(void (CApp::*)()), "!534889fb488b7f104885ff7428", nullptr, 0, 0, &func);
-}
-
-void CApp::OnRequestExit()
-{
-	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func122::func;
 	return execfunc(this);
 }
@@ -1590,10 +1590,10 @@ void CApp::OnRequestExit()
 namespace _func123
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CApp::OnExit", typeid(void (CApp::*)()), ".534889fbe8", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CApp::OnRequestExit", typeid(void (CApp::*)()), "!534889fb488b7f104885ff7428", nullptr, 0, 0, &func);
 }
 
-void CApp::OnExit()
+void CApp::OnRequestExit()
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func123::func;
@@ -1603,17 +1603,30 @@ void CApp::OnExit()
 namespace _func124
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CApp::OnExit", typeid(void (CApp::*)()), ".534889fbe8", nullptr, 0, 0, &func);
+}
+
+void CApp::OnExit()
+{
+	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func124::func;
+	return execfunc(this);
+}
+
+namespace _func125
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CApp::OnMButtonDown", typeid(void (CApp::*)(int , int )), ".80bf????000000", nullptr, 0, 0, &func);
 }
 
 void CApp::OnMButtonDown(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func124::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func125::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func125
+namespace _func126
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CApp::OnTextInput", typeid(void (CApp::*)(int )), ".80bf????000000", nullptr, 0, 0, &func);
@@ -1622,11 +1635,11 @@ namespace _func125
 void CApp::OnTextInput(int ch)
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg, int ch_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func125::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func126::func;
 	return execfunc(this, ch);
 }
 
-namespace _func126
+namespace _func127
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CApp::OnTextEvent", typeid(void (CApp::*)(CEvent::TextEvent )), ".80bf????000000", nullptr, 0, 0, &func);
@@ -1635,30 +1648,17 @@ namespace _func126
 void CApp::OnTextEvent(CEvent::TextEvent textEvent)
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg, CEvent::TextEvent textEvent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func126::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func127::func;
 	return execfunc(this, textEvent);
 }
 
-namespace _func127
+namespace _func128
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CApp::OnInputFocus", typeid(void (CApp::*)()), ".5380bf????000000", nullptr, 0, 0, &func);
 }
 
 void CApp::OnInputFocus()
-{
-	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func127::func;
-	return execfunc(this);
-}
-
-namespace _func128
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CApp::OnInputBlur", typeid(void (CApp::*)()), ".534889fbc687????000000", nullptr, 0, 0, &func);
-}
-
-void CApp::OnInputBlur()
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func128::func;
@@ -1668,23 +1668,23 @@ void CApp::OnInputBlur()
 namespace _func129
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CApp::OnRButtonUp", typeid(void (CApp::*)(int , int )), ".534889fb4883ec102bb7????0000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CApp::OnInputBlur", typeid(void (CApp::*)()), ".534889fbc687????000000", nullptr, 0, 0, &func);
 }
 
-void CApp::OnRButtonUp(int x, int y)
+void CApp::OnInputBlur()
 {
-	typedef void (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
+	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func129::func;
-	return execfunc(this, x, y);
+	return execfunc(this);
 }
 
 namespace _func130
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CApp::OnRButtonDown", typeid(void (CApp::*)(int , int )), ".534889fb4883ec102bb7????0000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CApp::OnRButtonUp", typeid(void (CApp::*)(int , int )), ".534889fb4883ec102bb7????0000", nullptr, 0, 0, &func);
 }
 
-void CApp::OnRButtonDown(int x, int y)
+void CApp::OnRButtonUp(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func130::func;
@@ -1694,10 +1694,10 @@ void CApp::OnRButtonDown(int x, int y)
 namespace _func131
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CApp::OnLButtonUp", typeid(void (CApp::*)(int , int )), ".534889fb4883ec102bb7????0000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CApp::OnRButtonDown", typeid(void (CApp::*)(int , int )), ".534889fb4883ec102bb7????0000", nullptr, 0, 0, &func);
 }
 
-void CApp::OnLButtonUp(int x, int y)
+void CApp::OnRButtonDown(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func131::func;
@@ -1707,10 +1707,10 @@ void CApp::OnLButtonUp(int x, int y)
 namespace _func132
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CApp::OnLButtonDown", typeid(void (CApp::*)(int , int )), ".534889fb4883ec102bb7????0000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CApp::OnLButtonUp", typeid(void (CApp::*)(int , int )), ".534889fb4883ec102bb7????0000", nullptr, 0, 0, &func);
 }
 
-void CApp::OnLButtonDown(int x, int y)
+void CApp::OnLButtonUp(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func132::func;
@@ -1720,17 +1720,30 @@ void CApp::OnLButtonDown(int x, int y)
 namespace _func133
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CApp::OnLButtonDown", typeid(void (CApp::*)(int , int )), ".534889fb4883ec102bb7????0000", nullptr, 0, 0, &func);
+}
+
+void CApp::OnLButtonDown(int x, int y)
+{
+	typedef void (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func133::func;
+	return execfunc(this, x, y);
+}
+
+namespace _func134
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CApp::OnMouseMove", typeid(void (CApp::*)(int , int , int , int , bool , bool , bool )), ".415455534889fb4883ec102bb7????0000", nullptr, 0, 0, &func);
 }
 
 void CApp::OnMouseMove(int x, int y, int xdiff, int ydiff, bool holdingLMB, bool holdingRMB, bool holdingMMB)
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg, int xdiff_arg, int ydiff_arg, bool holdingLMB_arg, bool holdingRMB_arg, bool holdingMMB_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func133::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func134::func;
 	return execfunc(this, x, y, xdiff, ydiff, holdingLMB, holdingRMB, holdingMMB);
 }
 
-namespace _func134
+namespace _func135
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CApp::OnKeyUp", typeid(void (CApp::*)(SDLKey )), ".555389f34883ec3885f6", nullptr, 0, 0, &func);
@@ -1739,11 +1752,11 @@ namespace _func134
 void CApp::OnKeyUp(SDLKey key)
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func134::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func135::func;
 	return execfunc(this, key);
 }
 
-namespace _func135
+namespace _func136
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CApp::OnLanguageChange", typeid(void (CApp::*)()), ".55be????????534889fb4883ec38", nullptr, 0, 0, &func);
@@ -1752,11 +1765,11 @@ namespace _func135
 void CApp::OnLanguageChange()
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func135::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func136::func;
 	return execfunc(this);
 }
 
-namespace _func136
+namespace _func137
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CApp::OnKeyDown", typeid(void (CApp::*)(SDLKey )), ".555389f34883ec4885f6", nullptr, 0, 0, &func);
@@ -1765,11 +1778,11 @@ namespace _func136
 void CApp::OnKeyDown(SDLKey key)
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func136::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func137::func;
 	return execfunc(this, key);
 }
 
-namespace _func137
+namespace _func138
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CApp::constructor", typeid(void (CApp::*)()), ".534889fbe8????????488d7b20", nullptr, 0, 0, &func);
@@ -1778,11 +1791,11 @@ namespace _func137
 void CApp::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func137::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func138::func;
 	return execfunc(this);
 }
 
-namespace _func138
+namespace _func139
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CApp::ParseArgs", typeid(void (CApp::*)(int , const char **)), "!.f3c366666666662e0f1f840000000000", nullptr, 0, 0, &func);
@@ -1791,11 +1804,11 @@ namespace _func138
 void CApp::ParseArgs(int argc, const char **argv)
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg, int argc_arg, const char **argv_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func138::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func139::func;
 	return execfunc(this, argc, argv);
 }
 
-namespace _func139
+namespace _func140
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CApp::OnLoop", typeid(void (CApp::*)()), ".55534889fb", nullptr, 0, 0, &func);
@@ -1804,11 +1817,11 @@ namespace _func139
 void CApp::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func139::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func140::func;
 	return execfunc(this);
 }
 
-namespace _func140
+namespace _func141
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CApp::SetupWindow", typeid(int (CApp::*)()), ".53be0100000031c04889fb", nullptr, 0, 0, &func);
@@ -1817,19 +1830,6 @@ namespace _func140
 int CApp::SetupWindow()
 {
 	typedef int (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func140::func;
-	return execfunc(this);
-}
-
-namespace _func141
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CApp::OnCleanup", typeid(void (CApp::*)()), "!.55534889fb4883ec08488b7f18", nullptr, 0, 0, &func);
-}
-
-void CApp::OnCleanup()
-{
-	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func141::func;
 	return execfunc(this);
 }
@@ -1837,10 +1837,10 @@ void CApp::OnCleanup()
 namespace _func142
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CApp::GenInputEvents", typeid(void (CApp::*)()), ".55534889fb4883ec08", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CApp::OnCleanup", typeid(void (CApp::*)()), "!.55534889fb4883ec08488b7f18", nullptr, 0, 0, &func);
 }
 
-void CApp::GenInputEvents()
+void CApp::OnCleanup()
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func142::func;
@@ -1850,10 +1850,10 @@ void CApp::GenInputEvents()
 namespace _func143
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CApp::OnSuspend", typeid(void (CApp::*)()), ".534889fbe8????????488b7b10", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CApp::GenInputEvents", typeid(void (CApp::*)()), ".55534889fb4883ec08", nullptr, 0, 0, &func);
 }
 
-void CApp::OnSuspend()
+void CApp::GenInputEvents()
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func143::func;
@@ -1863,10 +1863,10 @@ void CApp::OnSuspend()
 namespace _func144
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CApp::OnResume", typeid(void (CApp::*)()), ".5380bf????000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CApp::OnSuspend", typeid(void (CApp::*)()), ".534889fbe8????????488b7b10", nullptr, 0, 0, &func);
 }
 
-void CApp::OnResume()
+void CApp::OnSuspend()
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func144::func;
@@ -1876,36 +1876,36 @@ void CApp::OnResume()
 namespace _func145
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CApp::OnResume", typeid(void (CApp::*)()), ".5380bf????000000", nullptr, 0, 0, &func);
+}
+
+void CApp::OnResume()
+{
+	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func145::func;
+	return execfunc(this);
+}
+
+namespace _func146
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CApp::TranslateMouse", typeid(Point (CApp::*)(int , int )), ".4883ec182bb7????00002b97????0000", nullptr, 0, 0, &func);
 }
 
 Point CApp::TranslateMouse(int x, int y)
 {
 	typedef Point (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func145::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func146::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func146
+namespace _func147
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CApp::UpdateFullScreen", typeid(void (CApp::*)()), ".803d????????007407c3", nullptr, 0, 0, &func);
 }
 
 void CApp::UpdateFullScreen()
-{
-	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func146::func;
-	return execfunc(this);
-}
-
-namespace _func147
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CApp::UpdateWindowSettings", typeid(void (CApp::*)()), ".80bf????000000c787????000000000000", nullptr, 0, 0, &func);
-}
-
-void CApp::UpdateWindowSettings()
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func147::func;
@@ -1915,10 +1915,10 @@ void CApp::UpdateWindowSettings()
 namespace _func148
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CApp::OnRender", typeid(void (CApp::*)()), ".534889fb4883ec30", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CApp::UpdateWindowSettings", typeid(void (CApp::*)()), ".80bf????000000c787????000000000000", nullptr, 0, 0, &func);
 }
 
-void CApp::OnRender()
+void CApp::UpdateWindowSettings()
 {
 	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func148::func;
@@ -1928,12 +1928,12 @@ void CApp::OnRender()
 namespace _func149
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CApp::OnInit", typeid(int (CApp::*)()), ".534889fb31ff4883ec40", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CApp::OnRender", typeid(void (CApp::*)()), ".534889fb4883ec30", nullptr, 0, 0, &func);
 }
 
-int CApp::OnInit()
+void CApp::OnRender()
 {
-	typedef int (*custom_arg_funcptr_t)(CApp *this_arg);
+	typedef void (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func149::func;
 	return execfunc(this);
 }
@@ -1941,10 +1941,10 @@ int CApp::OnInit()
 namespace _func150
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CApp::OnExecute", typeid(int (CApp::*)()), ".415731f641564155415455534889fb", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CApp::OnInit", typeid(int (CApp::*)()), ".534889fb31ff4883ec40", nullptr, 0, 0, &func);
 }
 
-int CApp::OnExecute()
+int CApp::OnInit()
 {
 	typedef int (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func150::func;
@@ -1954,17 +1954,30 @@ int CApp::OnExecute()
 namespace _func151
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CApp::OnExecute", typeid(int (CApp::*)()), ".415731f641564155415455534889fb", nullptr, 0, 0, &func);
+}
+
+int CApp::OnExecute()
+{
+	typedef int (*custom_arg_funcptr_t)(CApp *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func151::func;
+	return execfunc(this);
+}
+
+namespace _func152
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CEvent::OnEvent", typeid(void (CEvent::*)(const InputEvent *)), "415741564155415455534889f34883ec288b4604", nullptr, 0, 0, &func);
 }
 
 void CEvent::OnEvent(const InputEvent *event)
 {
 	typedef void (*custom_arg_funcptr_t)(CEvent *this_arg, const InputEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func151::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func152::func;
 	return execfunc(this, event);
 }
 
-namespace _func152
+namespace _func153
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CFPS::GetSpeedFactor", typeid(float (CFPS::*)()), "f30f104718c3", nullptr, 0, 32, &func);
@@ -1973,11 +1986,11 @@ namespace _func152
 float CFPS::GetSpeedFactor()
 {
 	typedef float (*custom_arg_funcptr_t)(CFPS *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func152::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func153::func;
 	return execfunc(this);
 }
 
-namespace _func153
+namespace _func154
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CFPS::OnLoop", typeid(void (CFPS::*)()), "534889fb4883ec10f20f1015", nullptr, 0, 0, &func);
@@ -1986,37 +1999,24 @@ namespace _func153
 void CFPS::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(CFPS *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func153::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func154::func;
 	return execfunc(this);
 }
 
 CFPS *Global_CFPS_FPSControl;
 
-namespace _var154
+namespace _var155
 {
     static VariableDefinition varObj("Global_CFPS_FPSControl", "!0f28d90f28d0bf(???????\?)f30fc2d1050f54da0f55d00f28ca0f56cb", &Global_CFPS_FPSControl);
 }
 
-namespace _func155
+namespace _func156
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_ClearAll", typeid(void (*)()), "!0f57db31ff", nullptr, 0, 0, &func);
 }
 
 void CSurface::GL_ClearAll()
-{
-	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func155::func;
-	return execfunc();
-}
-
-namespace _func156
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CSurface::GL_ClearColor", typeid(void (*)()), "!.0f57db0f28d30f28cb0f28c3", nullptr, 0, 0, &func);
-}
-
-void CSurface::GL_ClearColor()
 {
 	typedef void (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func156::func;
@@ -2026,17 +2026,30 @@ void CSurface::GL_ClearColor()
 namespace _func157
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CSurface::GL_ClearColor", typeid(void (*)()), "!.0f57db0f28d30f28cb0f28c3", nullptr, 0, 0, &func);
+}
+
+void CSurface::GL_ClearColor()
+{
+	typedef void (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func157::func;
+	return execfunc();
+}
+
+namespace _func158
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::SetViewPort", typeid(int (*)(int , int , int , int )), ".4883ec08e8????????b801000000", nullptr, 0, 0, &func);
 }
 
 int CSurface::SetViewPort(int left, int bottom, int h, int w)
 {
 	typedef int (*custom_arg_funcptr_t)(int left_arg, int bottom_arg, int h_arg, int w_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func157::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func158::func;
 	return execfunc(left, bottom, h, w);
 }
 
-namespace _func158
+namespace _func159
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_PopScissor", typeid(void (*)()), "!.488b0d????????488b15", nullptr, 0, 0, &func);
@@ -2045,11 +2058,11 @@ namespace _func158
 void CSurface::GL_PopScissor()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func158::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func159::func;
 	return execfunc();
 }
 
-namespace _func159
+namespace _func160
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_SetStencilMode", typeid(void (*)(GL_StencilMode , int , int )), ".4883ec1883ff01", nullptr, 0, 0, &func);
@@ -2058,11 +2071,11 @@ namespace _func159
 void CSurface::GL_SetStencilMode(GL_StencilMode stencilMode, int ref, int mask)
 {
 	typedef void (*custom_arg_funcptr_t)(GL_StencilMode stencilMode_arg, int ref_arg, int mask_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func159::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func160::func;
 	return execfunc(stencilMode, ref, mask);
 }
 
-namespace _func160
+namespace _func161
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_PopStencilMode", typeid(void (*)()), ".488b0d????????488b15", nullptr, 0, 0, &func);
@@ -2071,19 +2084,6 @@ namespace _func160
 void CSurface::GL_PopStencilMode()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func160::func;
-	return execfunc();
-}
-
-namespace _func161
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CSurface::GL_LoadIdentity", typeid(int (*)()), "!.0f57d2bf????????0f57c9", nullptr, 0, 0, &func);
-}
-
-int CSurface::GL_LoadIdentity()
-{
-	typedef int (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func161::func;
 	return execfunc();
 }
@@ -2091,10 +2091,10 @@ int CSurface::GL_LoadIdentity()
 namespace _func162
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CSurface::GL_PushMatrix", typeid(int (*)()), ".8b15????????83fa0f", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CSurface::GL_LoadIdentity", typeid(int (*)()), "!.0f57d2bf????????0f57c9", nullptr, 0, 0, &func);
 }
 
-int CSurface::GL_PushMatrix()
+int CSurface::GL_LoadIdentity()
 {
 	typedef int (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func162::func;
@@ -2104,10 +2104,10 @@ int CSurface::GL_PushMatrix()
 namespace _func163
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CSurface::GL_PopMatrix", typeid(int (*)()), ".8b15????????85d20f84", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CSurface::GL_PushMatrix", typeid(int (*)()), ".8b15????????83fa0f", nullptr, 0, 0, &func);
 }
 
-int CSurface::GL_PopMatrix()
+int CSurface::GL_PushMatrix()
 {
 	typedef int (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func163::func;
@@ -2117,17 +2117,30 @@ int CSurface::GL_PopMatrix()
 namespace _func164
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CSurface::GL_PopMatrix", typeid(int (*)()), ".8b15????????85d20f84", nullptr, 0, 0, &func);
+}
+
+int CSurface::GL_PopMatrix()
+{
+	typedef int (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func164::func;
+	return execfunc();
+}
+
+namespace _func165
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_Rotate", typeid(void (*)(float , float , float , float )), ".0f57e44881ecf80000000f2ec4", nullptr, 0, 0, &func);
 }
 
 void CSurface::GL_Rotate(float angle, float x, float y, float z)
 {
 	typedef void (*custom_arg_funcptr_t)(float angle_arg, float x_arg, float y_arg, float z_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func164::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func165::func;
 	return execfunc(angle, x, y, z);
 }
 
-namespace _func165
+namespace _func166
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_Scale", typeid(void (*)(float , float , float )), ".f30f101d????????b8000000000f2ec30f9bc20f45d084d2", nullptr, 0, 0, &func);
@@ -2136,11 +2149,11 @@ namespace _func165
 void CSurface::GL_Scale(float x, float y, float z)
 {
 	typedef void (*custom_arg_funcptr_t)(float x_arg, float y_arg, float z_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func165::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func166::func;
 	return execfunc(x, y, z);
 }
 
-namespace _func166
+namespace _func167
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_Translate", typeid(bool (*)(float , float , float )), ".0f57dbb8000000000f2ec30f9bc20f45d084d2", nullptr, 0, 0, &func);
@@ -2149,11 +2162,11 @@ namespace _func166
 bool CSurface::GL_Translate(float x, float y, float z)
 {
 	typedef bool (*custom_arg_funcptr_t)(float x_arg, float y_arg, float z_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func166::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func167::func;
 	return execfunc(x, y, z);
 }
 
-namespace _func167
+namespace _func168
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_SetColor", typeid(int (*)(GL_Color )), ".4883ec28660fd6442408488b442408660fd64c2408488b542408", nullptr, 0, 0, &func);
@@ -2162,11 +2175,11 @@ namespace _func167
 int CSurface::GL_SetColor(GL_Color color)
 {
 	typedef int (*custom_arg_funcptr_t)(GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func167::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func168::func;
 	return execfunc(color);
 }
 
-namespace _func168
+namespace _func169
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_GetColor", typeid(GL_Color (*)()), ".488b05????????f30f7e05", nullptr, 0, 0, &func);
@@ -2175,11 +2188,11 @@ namespace _func168
 GL_Color CSurface::GL_GetColor()
 {
 	typedef GL_Color (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func168::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func169::func;
 	return execfunc();
 }
 
-namespace _func169
+namespace _func170
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_RemoveColorTint", typeid(void (*)()), ".488b05????????483b05", nullptr, 0, 0, &func);
@@ -2188,11 +2201,11 @@ namespace _func169
 void CSurface::GL_RemoveColorTint()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func169::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func170::func;
 	return execfunc();
 }
 
-namespace _func170
+namespace _func171
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GetColorTint", typeid(GL_Color (*)()), ".488b15????????488b05", nullptr, 0, 0, &func);
@@ -2201,19 +2214,6 @@ namespace _func170
 GL_Color CSurface::GetColorTint()
 {
 	typedef GL_Color (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func170::func;
-	return execfunc();
-}
-
-namespace _func171
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CSurface::GL_EnableBlend", typeid(bool (*)()), "!.ba04000000be03000000bf01000000", nullptr, 0, 0, &func);
-}
-
-bool CSurface::GL_EnableBlend()
-{
-	typedef bool (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func171::func;
 	return execfunc();
 }
@@ -2221,10 +2221,10 @@ bool CSurface::GL_EnableBlend()
 namespace _func172
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CSurface::GL_DisableBlend", typeid(bool (*)()), "!.31d2be01000000bf01000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CSurface::GL_EnableBlend", typeid(bool (*)()), "!.ba04000000be03000000bf01000000", nullptr, 0, 0, &func);
 }
 
-bool CSurface::GL_DisableBlend()
+bool CSurface::GL_EnableBlend()
 {
 	typedef bool (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func172::func;
@@ -2234,17 +2234,30 @@ bool CSurface::GL_DisableBlend()
 namespace _func173
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CSurface::GL_DisableBlend", typeid(bool (*)()), "!.31d2be01000000bf01000000", nullptr, 0, 0, &func);
+}
+
+bool CSurface::GL_DisableBlend()
+{
+	typedef bool (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func173::func;
+	return execfunc();
+}
+
+namespace _func174
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_ForceAntialias", typeid(void (*)(bool )), "!.40883d????????c3", nullptr, 0, 0, &func);
 }
 
 void CSurface::GL_ForceAntialias(bool on)
 {
 	typedef void (*custom_arg_funcptr_t)(bool on_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func173::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func174::func;
 	return execfunc(on);
 }
 
-namespace _func174
+namespace _func175
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_DrawLine", typeid(bool (*)(float , float , float , float , float , GL_Color )), ".4881eca8000000440f28c8660fd62c24", nullptr, 0, 0, &func);
@@ -2253,11 +2266,11 @@ namespace _func174
 bool CSurface::GL_DrawLine(float x1, float y1, float x2, float y2, float lineWidth, GL_Color color)
 {
 	typedef bool (*custom_arg_funcptr_t)(float x1_arg, float y1_arg, float x2_arg, float y2_arg, float lineWidth_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func174::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func175::func;
 	return execfunc(x1, y1, x2, y2, lineWidth, color);
 }
 
-namespace _func175
+namespace _func176
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_DrawTriangle", typeid(bool (*)(Point , Point , Point , GL_Color )), ".4883ec78660fd6442408488b4c2408", nullptr, 0, 0, &func);
@@ -2266,11 +2279,11 @@ namespace _func175
 bool CSurface::GL_DrawTriangle(Point vertex1, Point vertex2, Point vertex3, GL_Color color)
 {
 	typedef bool (*custom_arg_funcptr_t)(Point vertex1_arg, Point vertex2_arg, Point vertex3_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func175::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func176::func;
 	return execfunc(vertex1, vertex2, vertex3, color);
 }
 
-namespace _func176
+namespace _func177
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_DrawRect", typeid(bool (*)(float , float , float , float , GL_Color )), ".4881ec88000000660fd6642408488b542408", nullptr, 0, 0, &func);
@@ -2279,11 +2292,11 @@ namespace _func176
 bool CSurface::GL_DrawRect(float x1, float y1, float x2, float y2, GL_Color color)
 {
 	typedef bool (*custom_arg_funcptr_t)(float x1_arg, float y1_arg, float x2_arg, float y2_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func176::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func177::func;
 	return execfunc(x1, y1, x2, y2, color);
 }
 
-namespace _func177
+namespace _func178
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_DrawRectOutline", typeid(bool (*)(int , int , int , int , GL_Color , float )), ".4881eca8010000660fd64424084c8b442408660fd64c2408", nullptr, 0, 0, &func);
@@ -2292,30 +2305,17 @@ namespace _func177
 bool CSurface::GL_DrawRectOutline(int x1, int y1, int x2, int y2, GL_Color color, float lineWidth)
 {
 	typedef bool (*custom_arg_funcptr_t)(int x1_arg, int y1_arg, int x2_arg, int y2_arg, GL_Color color_arg, float lineWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func177::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func178::func;
 	return execfunc(x1, y1, x2, y2, color, lineWidth);
 }
 
-namespace _func178
+namespace _func179
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_BlitImage", typeid(bool (*)(GL_Texture *, float , float , float , float , float , GL_Color , bool )), ".554889fd534883ec68660fd66c2410", nullptr, 0, 0, &func);
 }
 
 bool CSurface::GL_BlitImage(GL_Texture *tex, float x, float y, float x2, float y2, float rotation, GL_Color color, bool mirror)
-{
-	typedef bool (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, float x2_arg, float y2_arg, float rotation_arg, GL_Color color_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func178::func;
-	return execfunc(tex, x, y, x2, y2, rotation, color, mirror);
-}
-
-namespace _func179
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CSurface::GL_BlitPixelImage", typeid(bool (*)(GL_Texture *, float , float , float , float , float , GL_Color , bool )), ".4154554889fd534883ec60", nullptr, 0, 0, &func);
-}
-
-bool CSurface::GL_BlitPixelImage(GL_Texture *tex, float x, float y, float x2, float y2, float rotation, GL_Color color, bool mirror)
 {
 	typedef bool (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, float x2_arg, float y2_arg, float rotation_arg, GL_Color color_arg, bool mirror_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func179::func;
@@ -2325,17 +2325,30 @@ bool CSurface::GL_BlitPixelImage(GL_Texture *tex, float x, float y, float x2, fl
 namespace _func180
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CSurface::GL_BlitPixelImage", typeid(bool (*)(GL_Texture *, float , float , float , float , float , GL_Color , bool )), ".4154554889fd534883ec60", nullptr, 0, 0, &func);
+}
+
+bool CSurface::GL_BlitPixelImage(GL_Texture *tex, float x, float y, float x2, float y2, float rotation, GL_Color color, bool mirror)
+{
+	typedef bool (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, float x2_arg, float y2_arg, float rotation_arg, GL_Color color_arg, bool mirror_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func180::func;
+	return execfunc(tex, x, y, x2, y2, rotation, color, mirror);
+}
+
+namespace _func181
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_BlitImagePartial", typeid(bool (*)(GL_Texture *, float , float , float , float , float , float , float , float , float , GL_Color , bool )), ".415455534889fb4883ec604084f6f30f11442408", nullptr, 0, 0, &func);
 }
 
 bool CSurface::GL_BlitImagePartial(GL_Texture *tex, float x, float y, float size_x, float size_y, float start_x, float end_x, float start_y, float end_y, float alpha, GL_Color color, bool mirror)
 {
 	typedef bool (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, float size_x_arg, float size_y_arg, float start_x_arg, float end_x_arg, float start_y_arg, float end_y_arg, float alpha_arg, GL_Color color_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func180::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func181::func;
 	return execfunc(tex, x, y, size_x, size_y, start_x, end_x, start_y, end_y, alpha, color, mirror);
 }
 
-namespace _func181
+namespace _func182
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_BlitPixelImageWide", typeid(bool (*)(GL_Texture *, float , float , int , int , float , GL_Color , bool )), ".41574889f841564989fe41554189d54154555389f34881ec88000000", nullptr, 0, 0, &func);
@@ -2344,11 +2357,11 @@ namespace _func181
 bool CSurface::GL_BlitPixelImageWide(GL_Texture *tex, float x, float y, int x2, int y2, float opacity, GL_Color color, bool mirror)
 {
 	typedef bool (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, int x2_arg, int y2_arg, float opacity_arg, GL_Color color_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func181::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func182::func;
 	return execfunc(tex, x, y, x2, y2, opacity, color, mirror);
 }
 
-namespace _func182
+namespace _func183
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_BlitMultiImage", typeid(void (*)(GL_Texture *, const std::vector<GL_TexVertex> &, bool )), ".415641554189d541544989f455534889fb4883ec20", nullptr, 0, 0, &func);
@@ -2357,11 +2370,11 @@ namespace _func182
 void CSurface::GL_BlitMultiImage(GL_Texture *tex, const std::vector<GL_TexVertex> &texVertices, bool antialias)
 {
 	typedef void (*custom_arg_funcptr_t)(GL_Texture *tex_arg, const std::vector<GL_TexVertex> &texVertices_arg, bool antialias_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func182::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func183::func;
 	return execfunc(tex, texVertices, antialias);
 }
 
-namespace _func183
+namespace _func184
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_BlitMultiColorImage", typeid(void (*)(GL_Texture *, const std::vector<GL_ColorTexVertex> &, bool )), ".4156415541544189d4554889f5534889fb4883ec20", nullptr, 0, 0, &func);
@@ -2370,11 +2383,11 @@ namespace _func183
 void CSurface::GL_BlitMultiColorImage(GL_Texture *tex, const std::vector<GL_ColorTexVertex> &texVertices, bool antialias)
 {
 	typedef void (*custom_arg_funcptr_t)(GL_Texture *tex_arg, const std::vector<GL_ColorTexVertex> &texVertices_arg, bool antialias_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func183::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func184::func;
 	return execfunc(tex, texVertices, antialias);
 }
 
-namespace _func184
+namespace _func185
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_RenderPrimitive", typeid(void (*)(GL_Primitive *)), ".534889fb4883ec104885ff", nullptr, 0, 0, &func);
@@ -2383,11 +2396,11 @@ namespace _func184
 void CSurface::GL_RenderPrimitive(GL_Primitive *primitive)
 {
 	typedef void (*custom_arg_funcptr_t)(GL_Primitive *primitive_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func184::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func185::func;
 	return execfunc(primitive);
 }
 
-namespace _func185
+namespace _func186
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_RenderPrimitiveWithAlpha", typeid(void (*)(GL_Primitive *, float )), ".534889fb4883ec104885ff", nullptr, 0, 0, &func);
@@ -2396,11 +2409,11 @@ namespace _func185
 void CSurface::GL_RenderPrimitiveWithAlpha(GL_Primitive *primitive, float alpha)
 {
 	typedef void (*custom_arg_funcptr_t)(GL_Primitive *primitive_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func185::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func186::func;
 	return execfunc(primitive, alpha);
 }
 
-namespace _func186
+namespace _func187
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_RenderPrimitiveWithColor", typeid(void (*)(GL_Primitive *, GL_Color )), ".534889fb4883ec20660fd6442408", nullptr, 0, 0, &func);
@@ -2409,11 +2422,11 @@ namespace _func186
 void CSurface::GL_RenderPrimitiveWithColor(GL_Primitive *primitive, GL_Color color)
 {
 	typedef void (*custom_arg_funcptr_t)(GL_Primitive *primitive_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func186::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func187::func;
 	return execfunc(primitive, color);
 }
 
-namespace _func187
+namespace _func188
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_DestroyPrimitive", typeid(void (*)(GL_Primitive *)), ".4885ff534889fb", nullptr, 0, 0, &func);
@@ -2422,11 +2435,11 @@ namespace _func187
 void CSurface::GL_DestroyPrimitive(GL_Primitive *primitive)
 {
 	typedef void (*custom_arg_funcptr_t)(GL_Primitive *primitive_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func187::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func188::func;
 	return execfunc(primitive);
 }
 
-namespace _func188
+namespace _func189
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_CreateRectPrimitive", typeid(GL_Primitive *(*)(float , float , float , float , GL_Color )), ".53f30f58d0bf30000000f30f58d94883ec40", nullptr, 0, 0, &func);
@@ -2435,11 +2448,11 @@ namespace _func188
 GL_Primitive *CSurface::GL_CreateRectPrimitive(float x, float y, float w, float h, GL_Color color)
 {
 	typedef GL_Primitive *(*custom_arg_funcptr_t)(float x_arg, float y_arg, float w_arg, float h_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func188::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func189::func;
 	return execfunc(x, y, w, h, color);
 }
 
-namespace _func189
+namespace _func190
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_CreateMultiRectPrimitive", typeid(GL_Primitive *(*)(std::vector<Globals::Rect> &, GL_Color )), ".415648be000000000000c01f4989fe4155415455534883ec20", nullptr, 0, 0, &func);
@@ -2448,11 +2461,11 @@ namespace _func189
 GL_Primitive *CSurface::GL_CreateMultiRectPrimitive(std::vector<Globals::Rect> &vec, GL_Color color)
 {
 	typedef GL_Primitive *(*custom_arg_funcptr_t)(std::vector<Globals::Rect> &vec_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func189::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func190::func;
 	return execfunc(vec, color);
 }
 
-namespace _func190
+namespace _func191
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_CreateRectOutlinePrimitive", typeid(GL_Primitive *(*)(int , int , int , int , GL_Color , float )), ".53f30f2adff30f2ae6bf300000004881eca0000000", nullptr, 0, 0, &func);
@@ -2461,11 +2474,11 @@ namespace _func190
 GL_Primitive *CSurface::GL_CreateRectOutlinePrimitive(int x, int y, int w, int h, GL_Color color, float lineWidth)
 {
 	typedef GL_Primitive *(*custom_arg_funcptr_t)(int x_arg, int y_arg, int w_arg, int h_arg, GL_Color color_arg, float lineWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func190::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func191::func;
 	return execfunc(x, y, w, h, color, lineWidth);
 }
 
-namespace _func191
+namespace _func192
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_CreateMultiLinePrimitive", typeid(GL_Primitive *(*)(std::vector<GL_Line> &, GL_Color , float )), ".4157415641554989fd415455534883ec484c8b6708", nullptr, 0, 0, &func);
@@ -2474,11 +2487,11 @@ namespace _func191
 GL_Primitive *CSurface::GL_CreateMultiLinePrimitive(std::vector<GL_Line> &vec, GL_Color color, float thickness)
 {
 	typedef GL_Primitive *(*custom_arg_funcptr_t)(std::vector<GL_Line> &vec_arg, GL_Color color_arg, float thickness_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func191::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func192::func;
 	return execfunc(vec, color, thickness);
 }
 
-namespace _func192
+namespace _func193
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_CreatePiePartialPrimitive", typeid(GL_Primitive *(*)(int , int , float , float , float , float , GL_Color )), ".41564155415455534881ec80020000", nullptr, 0, 0, &func);
@@ -2487,11 +2500,11 @@ namespace _func192
 GL_Primitive *CSurface::GL_CreatePiePartialPrimitive(int x, int y, float radius, float deg1, float deg2, float thickness, GL_Color color)
 {
 	typedef GL_Primitive *(*custom_arg_funcptr_t)(int x_arg, int y_arg, float radius_arg, float deg1_arg, float deg2_arg, float thickness_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func192::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func193::func;
 	return execfunc(x, y, radius, deg1, deg2, thickness, color);
 }
 
-namespace _func193
+namespace _func194
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_CreateMultiImagePrimitive", typeid(GL_Primitive *(*)(GL_Texture *, std::vector<GL_TexVertex> *, GL_Color )), ".415541544989f455534883ec48", nullptr, 0, 0, &func);
@@ -2500,11 +2513,11 @@ namespace _func193
 GL_Primitive *CSurface::GL_CreateMultiImagePrimitive(GL_Texture *tex, std::vector<GL_TexVertex> *vec, GL_Color color)
 {
 	typedef GL_Primitive *(*custom_arg_funcptr_t)(GL_Texture *tex_arg, std::vector<GL_TexVertex> *vec_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func193::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func194::func;
 	return execfunc(tex, vec, color);
 }
 
-namespace _func194
+namespace _func195
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_PushStencilMode", typeid(void (*)()), ".488b05????????483b05", nullptr, 0, 0, &func);
@@ -2513,11 +2526,11 @@ namespace _func194
 void CSurface::GL_PushStencilMode()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func194::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func195::func;
 	return execfunc();
 }
 
-namespace _func195
+namespace _func196
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_SetColorTint", typeid(void (*)(GL_Color )), ".4883ec18488b0d", nullptr, 0, 0, &func);
@@ -2526,11 +2539,11 @@ namespace _func195
 void CSurface::GL_SetColorTint(GL_Color color)
 {
 	typedef void (*custom_arg_funcptr_t)(GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func195::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func196::func;
 	return execfunc(color);
 }
 
-namespace _func196
+namespace _func197
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_CreatePixelImagePrimitive", typeid(GL_Primitive *(*)(GL_Texture *, float , float , float , float , float , GL_Color , bool )), ".41550f28f84989fd415455534883ec58", nullptr, 0, 0, &func);
@@ -2539,11 +2552,11 @@ namespace _func196
 GL_Primitive *CSurface::GL_CreatePixelImagePrimitive(GL_Texture *tex, float x, float y, float size_x, float size_y, float rotate, GL_Color color, bool unk)
 {
 	typedef GL_Primitive *(*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, float size_x_arg, float size_y_arg, float rotate_arg, GL_Color color_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func196::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func197::func;
 	return execfunc(tex, x, y, size_x, size_y, rotate, color, unk);
 }
 
-namespace _func197
+namespace _func198
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::AddTexVertices", typeid(void (*)(std::vector<GL_TexVertex> *, float , float , float , float , float , float , float , float )), ".554889fd534883ec28488b07488b5f08", nullptr, 0, 0, &func);
@@ -2552,11 +2565,11 @@ namespace _func197
 void CSurface::AddTexVertices(std::vector<GL_TexVertex> *vec, float x1, float y1, float u1, float v1, float x2, float y2, float u2, float v2)
 {
 	typedef void (*custom_arg_funcptr_t)(std::vector<GL_TexVertex> *vec_arg, float x1_arg, float y1_arg, float u1_arg, float v1_arg, float x2_arg, float y2_arg, float u2_arg, float v2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func197::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func198::func;
 	return execfunc(vec, x1, y1, u1, v1, x2, y2, u2, v2);
 }
 
-namespace _func198
+namespace _func199
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_CreateImagePrimitive", typeid(GL_Primitive *(*)(GL_Texture *, float , float , float , float , float , GL_Color )), ".550f28f84889fd534883ec58", nullptr, 0, 0, &func);
@@ -2565,11 +2578,11 @@ namespace _func198
 GL_Primitive *CSurface::GL_CreateImagePrimitive(GL_Texture *tex, float x, float y, float size_x, float size_y, float rotate, GL_Color color)
 {
 	typedef GL_Primitive *(*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, float size_x_arg, float size_y_arg, float rotate_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func198::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func199::func;
 	return execfunc(tex, x, y, size_x, size_y, rotate, color);
 }
 
-namespace _func199
+namespace _func200
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_DrawCircle", typeid(bool (*)(int , int , float , GL_Color )), ".415455534883ec50660fd64c2408", nullptr, 0, 0, &func);
@@ -2578,11 +2591,11 @@ namespace _func199
 bool CSurface::GL_DrawCircle(int x, int y, float radius, GL_Color color)
 {
 	typedef bool (*custom_arg_funcptr_t)(int x_arg, int y_arg, float radius_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func199::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func200::func;
 	return execfunc(x, y, radius, color);
 }
 
-namespace _func200
+namespace _func201
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_DrawShield", typeid(bool (*)(int , int , float , float , int , int , GL_Color , float )), ".41550f28f041540f28fe4189cc55f30f5cfc89d5534883ec68", nullptr, 0, 0, &func);
@@ -2591,11 +2604,11 @@ namespace _func200
 bool CSurface::GL_DrawShield(int x, int y, float a1, float b1, int angle1, int angle2, GL_Color color, float thickness)
 {
 	typedef bool (*custom_arg_funcptr_t)(int x_arg, int y_arg, float a1_arg, float b1_arg, int angle1_arg, int angle2_arg, GL_Color color_arg, float thickness_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func200::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func201::func;
 	return execfunc(x, y, a1, b1, angle1, angle2, color, thickness);
 }
 
-namespace _func201
+namespace _func202
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_DrawLaser", typeid(bool (*)(int , int , int , int , GL_Color )), ".41554189fd41544189cc", nullptr, 0, 0, &func);
@@ -2604,11 +2617,11 @@ namespace _func201
 bool CSurface::GL_DrawLaser(int x, int y, int w, int h, GL_Color color)
 {
 	typedef bool (*custom_arg_funcptr_t)(int x_arg, int y_arg, int w_arg, int h_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func201::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func202::func;
 	return execfunc(x, y, w, h, color);
 }
 
-namespace _func202
+namespace _func203
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::FinishFrame", typeid(void (*)()), "!488b35????????488b3d????????e9", nullptr, 0, 0, &func);
@@ -2617,11 +2630,11 @@ namespace _func202
 void CSurface::FinishFrame()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func202::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func203::func;
 	return execfunc();
 }
 
-namespace _func203
+namespace _func204
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CSurface::GL_OrthoProjection", typeid(int (*)(float , float , float , float , float , float )), "440f28c94883ec48", nullptr, 0, 0, &func);
@@ -2630,11 +2643,11 @@ namespace _func203
 int CSurface::GL_OrthoProjection(float mx1, float mx2, float mx3, float mx4, float mx5, float mx6)
 {
 	typedef int (*custom_arg_funcptr_t)(float mx1_arg, float mx2_arg, float mx3_arg, float mx4_arg, float mx5_arg, float mx6_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func203::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func204::func;
 	return execfunc(mx1, mx2, mx3, mx4, mx5, mx6);
 }
 
-namespace _func204
+namespace _func205
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CachedImage::destructor", typeid(void (CachedImage::*)()), "534889fb4883ec10488b471048c707????????488d78e84881ff????????750e", nullptr, 0, 0, &func);
@@ -2643,11 +2656,11 @@ namespace _func204
 void CachedImage::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CachedImage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func204::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func205::func;
 	return execfunc(this);
 }
 
-namespace _func205
+namespace _func206
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CachedImage::SetImagePath", typeid(void (CachedImage::*)(const std::string &)), "55534889fbbf????????4883ec08e8????????483b4318", nullptr, 0, 0, &func);
@@ -2656,11 +2669,11 @@ namespace _func205
 void CachedImage::SetImagePath(const std::string &imagePath)
 {
 	typedef void (*custom_arg_funcptr_t)(CachedImage *this_arg, const std::string &imagePath_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func205::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func206::func;
 	return execfunc(this, imagePath);
 }
 
-namespace _func206
+namespace _func207
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CachedImage::SetPosition", typeid(void (CachedImage::*)(int , int )), ".41544189d45589f553397720", nullptr, 0, 0, &func);
@@ -2669,11 +2682,11 @@ namespace _func206
 void CachedImage::SetPosition(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(CachedImage *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func206::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func207::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func207
+namespace _func208
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CachedImage::constructor1", typeid(void (CachedImage::*)(const std::string &, int , int )), "41544189cc5589d5534889fb48c7470800000000", nullptr, 0, 0, &func);
@@ -2682,11 +2695,11 @@ namespace _func207
 void CachedImage::constructor1(const std::string &path, int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(CachedImage *this_arg, const std::string &path_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func207::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func208::func;
 	return execfunc(this, path, x, y);
 }
 
-namespace _func208
+namespace _func209
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CachedImage::constructor2", typeid(void (CachedImage::*)(const std::string &, CachedImage::Centered )), "53??89fb??c74708??????????c707??????????c74710??????????????????", nullptr, 0, 0, &func);
@@ -2695,11 +2708,11 @@ namespace _func208
 void CachedImage::constructor2(const std::string &path, CachedImage::Centered centered)
 {
 	typedef void (*custom_arg_funcptr_t)(CachedImage *this_arg, const std::string &path_arg, CachedImage::Centered centered_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func208::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func209::func;
 	return execfunc(this, path, centered);
 }
 
-namespace _func209
+namespace _func210
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CachedImage::constructor_copy", typeid(void (CachedImage::*)(const CachedImage &)), "554889f5488d7610534889fb488d7f104883ec0848c747f800000000", nullptr, 0, 0, &func);
@@ -2708,11 +2721,11 @@ namespace _func209
 void CachedImage::constructor_copy(const CachedImage &other)
 {
 	typedef void (*custom_arg_funcptr_t)(CachedImage *this_arg, const CachedImage &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func209::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func210::func;
 	return execfunc(this, other);
 }
 
-namespace _func210
+namespace _func211
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CachedImage::SetRotation", typeid(void (CachedImage::*)(float )), "534889fb4883ec100f2e4740", nullptr, 0, 0, &func);
@@ -2721,11 +2734,11 @@ namespace _func210
 void CachedImage::SetRotation(float _rotation)
 {
 	typedef void (*custom_arg_funcptr_t)(CachedImage *this_arg, float _rotation_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func210::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func211::func;
 	return execfunc(this, _rotation);
 }
 
-namespace _func211
+namespace _func212
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CachedImage::SetMirrored", typeid(void (CachedImage::*)(bool )), ".5589f5534889fb4883ec0840387744", nullptr, 0, 0, &func);
@@ -2734,11 +2747,11 @@ namespace _func211
 void CachedImage::SetMirrored(bool _mirrored)
 {
 	typedef void (*custom_arg_funcptr_t)(CachedImage *this_arg, bool _mirrored_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func211::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func212::func;
 	return execfunc(this, _mirrored);
 }
 
-namespace _func212
+namespace _func213
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CachedImage::SetScale", typeid(void (CachedImage::*)(float , float )), "534889fb4883ec100f2e4728", nullptr, 0, 0, &func);
@@ -2747,11 +2760,11 @@ namespace _func212
 void CachedImage::SetScale(float wScale, float hScale)
 {
 	typedef void (*custom_arg_funcptr_t)(CachedImage *this_arg, float wScale_arg, float hScale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func212::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func213::func;
 	return execfunc(this, wScale, hScale);
 }
 
-namespace _func213
+namespace _func214
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CachedImage::SetPartial", typeid(void (CachedImage::*)(float , float , float , float )), ".534889fb4883ec100f2e4730", nullptr, 0, 0, &func);
@@ -2760,11 +2773,11 @@ namespace _func213
 void CachedImage::SetPartial(float x_start, float y_start, float x_size, float y_size)
 {
 	typedef void (*custom_arg_funcptr_t)(CachedImage *this_arg, float x_start_arg, float y_start_arg, float x_size_arg, float y_size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func213::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func214::func;
 	return execfunc(this, x_start, y_start, x_size, y_size);
 }
 
-namespace _func214
+namespace _func215
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CachedImage::CreatePrimitive", typeid(void (CachedImage::*)()), "415455534889fb4883ec50488b6f184885ed", nullptr, 0, 0, &func);
@@ -2773,11 +2786,11 @@ namespace _func214
 void CachedImage::CreatePrimitive()
 {
 	typedef void (*custom_arg_funcptr_t)(CachedImage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func214::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func215::func;
 	return execfunc(this);
 }
 
-namespace _func215
+namespace _func216
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CachedPrimitive::OnRender", typeid(void (CachedPrimitive::*)(const GL_Color &)), "534889fb4883ec20488b7f084885ff", nullptr, 0, 0, &func);
@@ -2786,11 +2799,11 @@ namespace _func215
 void CachedPrimitive::OnRender(const GL_Color &color)
 {
 	typedef void (*custom_arg_funcptr_t)(CachedPrimitive *this_arg, const GL_Color &color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func215::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func216::func;
 	return execfunc(this, color);
 }
 
-namespace _func216
+namespace _func217
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CachedPrimitive::destructor", typeid(void (CachedPrimitive::*)()), "48c707????????488b7f08e9", nullptr, 0, 0, &func);
@@ -2799,11 +2812,11 @@ namespace _func216
 void CachedPrimitive::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CachedPrimitive *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func216::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func217::func;
 	return execfunc(this);
 }
 
-namespace _func217
+namespace _func218
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CachedRect::SetPosition", typeid(void (CachedRect::*)(int , int )), "41544189d45589f5533977104889fb", nullptr, 0, 0, &func);
@@ -2812,11 +2825,11 @@ namespace _func217
 void CachedRect::SetPosition(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(CachedRect *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func217::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func218::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func218
+namespace _func219
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CachedRect::SetSize", typeid(void (CachedRect::*)(int , int )), ".41544189d45589f5533977184889fb", nullptr, 0, 0, &func);
@@ -2825,11 +2838,11 @@ namespace _func218
 void CachedRect::SetSize(int w, int h)
 {
 	typedef void (*custom_arg_funcptr_t)(CachedRect *this_arg, int w_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func218::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func219::func;
 	return execfunc(this, w, h);
 }
 
-namespace _func219
+namespace _func220
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ChoiceBox::MouseMove", typeid(void (ChoiceBox::*)(int , int )), "41554189d541544989fcbf", nullptr, 0, 0, &func);
@@ -2838,11 +2851,11 @@ namespace _func219
 void ChoiceBox::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(ChoiceBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func219::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func220::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func220
+namespace _func221
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ChoiceBox::MouseClick", typeid(void (ChoiceBox::*)(int , int )), ".833d????????0274??8b4770", nullptr, 0, 0, &func);
@@ -2851,11 +2864,11 @@ namespace _func220
 void ChoiceBox::MouseClick(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(ChoiceBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func220::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func221::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func221
+namespace _func222
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ChoiceBox::OnRender", typeid(void (ChoiceBox::*)()), ".41574989ff41564155415455534881ec68020000", nullptr, 0, 0, &func);
@@ -2864,11 +2877,11 @@ namespace _func221
 void ChoiceBox::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(ChoiceBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func221::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func222::func;
 	return execfunc(this);
 }
 
-namespace _func222
+namespace _func223
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CloakingBox::constructor", typeid(void (CloakingBox::*)(Point , CloakingSystem *)), "415431c9554889d5534889fb4883ec50", nullptr, 0, 0, &func);
@@ -2877,30 +2890,17 @@ namespace _func222
 void CloakingBox::constructor(Point pos, CloakingSystem *sys)
 {
 	typedef void (*custom_arg_funcptr_t)(CloakingBox *this_arg, Point pos_arg, CloakingSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func222::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func223::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func223
+namespace _func224
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CloakingSystem::OnLoop", typeid(void (CloakingSystem::*)()), "55534889fb4883ec08e8????????488dbb68020000", nullptr, 0, 0, &func);
 }
 
 void CloakingSystem::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(CloakingSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func223::func;
-	return execfunc(this);
-}
-
-namespace _func224
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CloakingSystem::FiredWeapon", typeid(void (CloakingSystem::*)()), "534889fbbe????????4883ec30488d54241e", nullptr, 0, 0, &func);
-}
-
-void CloakingSystem::FiredWeapon()
 {
 	typedef void (*custom_arg_funcptr_t)(CloakingSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func224::func;
@@ -2910,17 +2910,30 @@ void CloakingSystem::FiredWeapon()
 namespace _func225
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CloakingSystem::FiredWeapon", typeid(void (CloakingSystem::*)()), "534889fbbe????????4883ec30488d54241e", nullptr, 0, 0, &func);
+}
+
+void CloakingSystem::FiredWeapon()
+{
+	typedef void (*custom_arg_funcptr_t)(CloakingSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func225::func;
+	return execfunc(this);
+}
+
+namespace _func226
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CloneBox::constructor", typeid(void (CloneBox::*)(Point , CloneSystem *)), "415731c94156415541544531e4554889d5534889fb4881ec08020000", nullptr, 0, 0, &func);
 }
 
 void CloneBox::constructor(Point pos, CloneSystem *sys)
 {
 	typedef void (*custom_arg_funcptr_t)(CloneBox *this_arg, Point pos_arg, CloneSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func225::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func226::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func226
+namespace _func227
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CloneSystem::OnLoop", typeid(void (CloneSystem::*)()), "415741564155415455534889fb4881ec88010000", nullptr, 0, 0, &func);
@@ -2929,11 +2942,11 @@ namespace _func226
 void CloneSystem::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(CloneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func226::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func227::func;
 	return execfunc(this);
 }
 
-namespace _func227
+namespace _func228
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatAI::UpdateMindControl", typeid(void (CombatAI::*)(bool )), "41554154554889fd534883ec48488b4760488b58604885db", nullptr, 0, 0, &func);
@@ -2942,11 +2955,11 @@ namespace _func227
 void CombatAI::UpdateMindControl(bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(CombatAI *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func227::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func228::func;
 	return execfunc(this, unk);
 }
 
-namespace _func228
+namespace _func229
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatAI::OnLoop", typeid(void (CombatAI::*)()), "4154554889fd53e8????????488b7d60", nullptr, 0, 0, &func);
@@ -2955,11 +2968,11 @@ namespace _func228
 void CombatAI::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(CombatAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func228::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func229::func;
 	return execfunc(this);
 }
 
-namespace _func229
+namespace _func230
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::RenderTarget", typeid(void (CombatControl::*)()), "415741564989fe4155415455534881ec68020000488b87f8000000", nullptr, 0, 0, &func);
@@ -2968,11 +2981,11 @@ namespace _func229
 void CombatControl::RenderTarget()
 {
 	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func229::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func230::func;
 	return execfunc(this);
 }
 
-namespace _func230
+namespace _func231
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::GetCurrentTarget", typeid(ShipManager *(CombatControl::*)()), "488b87c00700004885c0740c488b4010c3", nullptr, 0, 0, &func);
@@ -2981,19 +2994,6 @@ namespace _func230
 ShipManager *CombatControl::GetCurrentTarget()
 {
 	typedef ShipManager *(*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func230::func;
-	return execfunc(this);
-}
-
-namespace _func231
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CombatControl::CurrentTargetIsBoss", typeid(char (CombatControl::*)()), ".488bbfc00700004885ff", nullptr, 0, 0, &func);
-}
-
-char CombatControl::CurrentTargetIsBoss()
-{
-	typedef char (*custom_arg_funcptr_t)(CombatControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func231::func;
 	return execfunc(this);
 }
@@ -3001,10 +3001,10 @@ char CombatControl::CurrentTargetIsBoss()
 namespace _func232
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CombatControl::CanTargetSelf", typeid(char (CombatControl::*)()), "4154554889fd534883ec30488b87f80000004885c0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CombatControl::CurrentTargetIsBoss", typeid(char (CombatControl::*)()), ".488bbfc00700004885ff", nullptr, 0, 0, &func);
 }
 
-char CombatControl::CanTargetSelf()
+char CombatControl::CurrentTargetIsBoss()
 {
 	typedef char (*custom_arg_funcptr_t)(CombatControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func232::func;
@@ -3014,17 +3014,30 @@ char CombatControl::CanTargetSelf()
 namespace _func233
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CombatControl::CanTargetSelf", typeid(char (CombatControl::*)()), "4154554889fd534883ec30488b87f80000004885c0", nullptr, 0, 0, &func);
+}
+
+char CombatControl::CanTargetSelf()
+{
+	typedef char (*custom_arg_funcptr_t)(CombatControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func233::func;
+	return execfunc(this);
+}
+
+namespace _func234
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::OnRenderCombat", typeid(void (CombatControl::*)()), "534889fb4883ec3080bfb80e000000", nullptr, 0, 0, &func);
 }
 
 void CombatControl::OnRenderCombat()
 {
 	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func233::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func234::func;
 	return execfunc(this);
 }
 
-namespace _func234
+namespace _func235
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::AddEnemyShip", typeid(void (CombatControl::*)(CompleteShip *)), "4155415455534889fb4883ec284883bfc007000000", nullptr, 0, 0, &func);
@@ -3033,11 +3046,11 @@ namespace _func234
 void CombatControl::AddEnemyShip(CompleteShip *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg, CompleteShip *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func234::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func235::func;
 	return execfunc(this, ship);
 }
 
-namespace _func235
+namespace _func236
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::UpdateAiming", typeid(void (CombatControl::*)()), "415455534889fb4883ec1083bfdc070000ff", nullptr, 0, 0, &func);
@@ -3046,11 +3059,11 @@ namespace _func235
 void CombatControl::UpdateAiming()
 {
 	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func235::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func236::func;
 	return execfunc(this);
 }
 
-namespace _func236
+namespace _func237
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::UpdateTarget", typeid(bool (CombatControl::*)()), "41564155415455534889fb4881eca0000000f30f1087e00e0000", nullptr, 0, 0, &func);
@@ -3059,11 +3072,11 @@ namespace _func236
 bool CombatControl::UpdateTarget()
 {
 	typedef bool (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func236::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func237::func;
 	return execfunc(this);
 }
 
-namespace _func237
+namespace _func238
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::DrawHostileBox", typeid(void (CombatControl::*)(GL_Color , int )), "415731d24156415541545589f531f6534889fb4883ec38488d7c2420", nullptr, 0, 0, &func);
@@ -3072,11 +3085,11 @@ namespace _func237
 void CombatControl::DrawHostileBox(GL_Color color, int stencilBit)
 {
 	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg, GL_Color color_arg, int stencilBit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func237::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func238::func;
 	return execfunc(this, color, stencilBit);
 }
 
-namespace _func238
+namespace _func239
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::OnInit", typeid(void (CombatControl::*)(Point )), "55534889fb4883ec184883bf7011000000", nullptr, 0, 0, &func);
@@ -3085,30 +3098,17 @@ namespace _func238
 void CombatControl::OnInit(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func238::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func239::func;
 	return execfunc(this, pos);
 }
 
-namespace _func239
+namespace _func240
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::OnLoop", typeid(void (CombatControl::*)()), "415431c95531ed534889fb4883ec10488b9790070000", nullptr, 0, 0, &func);
 }
 
 void CombatControl::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func239::func;
-	return execfunc(this);
-}
-
-namespace _func240
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CombatControl::SetMouseCursor", typeid(void (CombatControl::*)()), "534883bff8000000004889fb", nullptr, 0, 0, &func);
-}
-
-void CombatControl::SetMouseCursor()
 {
 	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func240::func;
@@ -3118,17 +3118,30 @@ void CombatControl::SetMouseCursor()
 namespace _func241
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CombatControl::SetMouseCursor", typeid(void (CombatControl::*)()), "534883bff8000000004889fb", nullptr, 0, 0, &func);
+}
+
+void CombatControl::SetMouseCursor()
+{
+	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func241::func;
+	return execfunc(this);
+}
+
+namespace _func242
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::GetTeleportationCommand", typeid(std::pair<int, int> (CombatControl::*)()), "41545553488b87c0070000", nullptr, 0, 0, &func);
 }
 
 std::pair<int, int> CombatControl::GetTeleportationCommand()
 {
 	typedef std::pair<int, int> (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func241::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func242::func;
 	return execfunc(this);
 }
 
-namespace _func242
+namespace _func243
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::DisarmAll", typeid(void (CombatControl::*)()), "534883bfc0070000004889fb", nullptr, 0, 0, &func);
@@ -3137,11 +3150,11 @@ namespace _func242
 void CombatControl::DisarmAll()
 {
 	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func242::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func243::func;
 	return execfunc(this);
 }
 
-namespace _func243
+namespace _func244
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::SelectTarget", typeid(bool (CombatControl::*)()), "4157be0900000041564155415455534889fb4883ec58488b7f08", nullptr, 0, 0, &func);
@@ -3150,11 +3163,11 @@ namespace _func243
 bool CombatControl::SelectTarget()
 {
 	typedef bool (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func243::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func244::func;
 	return execfunc(this);
 }
 
-namespace _func244
+namespace _func245
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::MouseRClick", typeid(bool (CombatControl::*)(int , int )), "415541544189d45589f5534889fb4883ec08", nullptr, 0, 0, &func);
@@ -3163,11 +3176,11 @@ namespace _func244
 bool CombatControl::MouseRClick(int x, int y)
 {
 	typedef bool (*custom_arg_funcptr_t)(CombatControl *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func244::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func245::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func245
+namespace _func246
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::WeaponsArmed", typeid(bool (CombatControl::*)()), "534889fb488b7f08be09000000e8????????84c0751a", nullptr, 0, 0, &func);
@@ -3176,11 +3189,11 @@ namespace _func245
 bool CombatControl::WeaponsArmed()
 {
 	typedef bool (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func245::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func246::func;
 	return execfunc(this);
 }
 
-namespace _func246
+namespace _func247
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::KeyDown", typeid(void (CombatControl::*)(SDLKey )), "5589f5534889fb488d7f204883ec08", nullptr, 0, 0, &func);
@@ -3189,30 +3202,17 @@ namespace _func246
 void CombatControl::KeyDown(SDLKey key)
 {
 	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func246::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func247::func;
 	return execfunc(this, key);
 }
 
-namespace _func247
+namespace _func248
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::DisarmTeleporter", typeid(void (CombatControl::*)()), "55be0900000031ed534889fb4883ec08488b7f08", nullptr, 0, 0, &func);
 }
 
 void CombatControl::DisarmTeleporter()
-{
-	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func247::func;
-	return execfunc(this);
-}
-
-namespace _func248
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CombatControl::constructor", typeid(void (CombatControl::*)()), "415741564155415455534889fb488d7f104c8da3a8090000", nullptr, 0, 0, &func);
-}
-
-void CombatControl::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func248::func;
@@ -3222,10 +3222,10 @@ void CombatControl::constructor()
 namespace _func249
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CombatControl::OnRenderSelfAiming", typeid(void (CombatControl::*)()), "534889fb488d7f204883ec20e8", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CombatControl::constructor", typeid(void (CombatControl::*)()), "415741564155415455534889fb488d7f104c8da3a8090000", nullptr, 0, 0, &func);
 }
 
-void CombatControl::OnRenderSelfAiming()
+void CombatControl::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func249::func;
@@ -3235,17 +3235,30 @@ void CombatControl::OnRenderSelfAiming()
 namespace _func250
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CombatControl::OnRenderSelfAiming", typeid(void (CombatControl::*)()), "534889fb488d7f204883ec20e8", nullptr, 0, 0, &func);
+}
+
+void CombatControl::OnRenderSelfAiming()
+{
+	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func250::func;
+	return execfunc(this);
+}
+
+namespace _func251
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::RenderShipStatus", typeid(void (CombatControl::*)(Pointf , GL_Color )), "41574156415541544989fc55534881ecb8000000660fd60424", nullptr, 0, 0, &func);
 }
 
 void CombatControl::RenderShipStatus(Pointf pos, GL_Color color)
 {
 	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg, Pointf pos_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func250::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func251::func;
 	return execfunc(this, pos, color);
 }
 
-namespace _func251
+namespace _func252
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::GetCrewTooltip", typeid(std::string (CombatControl::*)(int , int )), "534889fb4883ec10488b86c00700004885c0", nullptr, 0, 0, &func);
@@ -3254,11 +3267,11 @@ namespace _func251
 std::string CombatControl::GetCrewTooltip(int x, int y)
 {
 	typedef std::string (*custom_arg_funcptr_t)(CombatControl *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func251::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func252::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func252
+namespace _func253
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::Clear", typeid(void (CombatControl::*)()), "554889fd534883ec0848c787c007000000000000", nullptr, 0, 0, &func);
@@ -3267,11 +3280,11 @@ namespace _func252
 void CombatControl::Clear()
 {
 	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func252::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func253::func;
 	return execfunc(this);
 }
 
-namespace _func253
+namespace _func254
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::MouseMove", typeid(bool (CombatControl::*)(int , int )), "f30f2ac641554189f541544189d455534889fb4883ec08", nullptr, 0, 0, &func);
@@ -3280,11 +3293,11 @@ namespace _func253
 bool CombatControl::MouseMove(int mX, int mY)
 {
 	typedef bool (*custom_arg_funcptr_t)(CombatControl *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func253::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func254::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func254
+namespace _func255
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatControl::MouseClick", typeid(void (CombatControl::*)(int , int , bool )), "415431c94189d45589f553c687e80e0000014889fb", nullptr, 0, 0, &func);
@@ -3293,11 +3306,11 @@ namespace _func254
 void CombatControl::MouseClick(int mX, int mY, bool shift)
 {
 	typedef void (*custom_arg_funcptr_t)(CombatControl *this_arg, int mX_arg, int mY_arg, bool shift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func254::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func255::func;
 	return execfunc(this, mX, mY, shift);
 }
 
-namespace _func255
+namespace _func256
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatDrone::SetWeaponTarget", typeid(void (CombatDrone::*)(Targetable *)), "554889f5534889fb4883ec084885f6743f", nullptr, 0, 0, &func);
@@ -3306,11 +3319,11 @@ namespace _func255
 void CombatDrone::SetWeaponTarget(Targetable *target)
 {
 	typedef void (*custom_arg_funcptr_t)(CombatDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func255::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func256::func;
 	return execfunc(this, target);
 }
 
-namespace _func256
+namespace _func257
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatDrone::PickTarget", typeid(void (CombatDrone::*)()), ".53488b074889fbff90000100", nullptr, 0, 0, &func);
@@ -3319,11 +3332,11 @@ namespace _func256
 void CombatDrone::PickTarget()
 {
 	typedef void (*custom_arg_funcptr_t)(CombatDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func256::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func257::func;
 	return execfunc(this);
 }
 
-namespace _func257
+namespace _func258
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CombatDrone::constructor", typeid(void (CombatDrone::*)(int , int , const DroneBlueprint *)), ".41554154554889cd4c8da5a0000000534889fb4883ec38", nullptr, 0, 0, &func);
@@ -3332,30 +3345,17 @@ namespace _func257
 void CombatDrone::constructor(int iShipId, int selfId, const DroneBlueprint *bp)
 {
 	typedef void (*custom_arg_funcptr_t)(CombatDrone *this_arg, int iShipId_arg, int selfId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func257::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func258::func;
 	return execfunc(this, iShipId, selfId, bp);
 }
 
-namespace _func258
+namespace _func259
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::Victory", typeid(void (CommandGui::*)()), "4157415641554989fd415455534883ec78488b8770190000", nullptr, 0, 0, &func);
 }
 
 void CommandGui::Victory()
-{
-	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func258::func;
-	return execfunc(this);
-}
-
-namespace _func259
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CommandGui::CheckGameover", typeid(void (CommandGui::*)()), ".415455534889fb4883ec50", nullptr, 0, 0, &func);
-}
-
-void CommandGui::CheckGameover()
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func259::func;
@@ -3365,17 +3365,30 @@ void CommandGui::CheckGameover()
 namespace _func260
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CommandGui::CheckGameover", typeid(void (CommandGui::*)()), ".415455534889fb4883ec50", nullptr, 0, 0, &func);
+}
+
+void CommandGui::CheckGameover()
+{
+	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func260::func;
+	return execfunc(this);
+}
+
+namespace _func261
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::IsGameOver", typeid(bool (CommandGui::*)()), ".803d????????00756753", nullptr, 0, 0, &func);
 }
 
 bool CommandGui::IsGameOver()
 {
 	typedef bool (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func260::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func261::func;
 	return execfunc(this);
 }
 
-namespace _func261
+namespace _func262
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::OnInit", typeid(void (CommandGui::*)()), ".415455488daf90040000534889fb4889ef4881eca0000000", nullptr, 0, 0, &func);
@@ -3384,11 +3397,11 @@ namespace _func261
 void CommandGui::OnInit()
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func261::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func262::func;
 	return execfunc(this);
 }
 
-namespace _func262
+namespace _func263
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::AddEnemyShip", typeid(void (CommandGui::*)(CompleteShip *)), ".4154554889f5534889fb488dbf880500004883ec30", nullptr, 0, 0, &func);
@@ -3397,11 +3410,11 @@ namespace _func262
 void CommandGui::AddEnemyShip(CompleteShip *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg, CompleteShip *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func262::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func263::func;
 	return execfunc(this, ship);
 }
 
-namespace _func263
+namespace _func264
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::GetWorldCoordinates", typeid(Point (CommandGui::*)(Point , bool )), ".41544189d4554889fd534889f34883ec204889e7", nullptr, 0, 0, &func);
@@ -3410,11 +3423,11 @@ namespace _func263
 Point CommandGui::GetWorldCoordinates(Point point, bool fromTarget)
 {
 	typedef Point (*custom_arg_funcptr_t)(CommandGui *this_arg, Point point_arg, bool fromTarget_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func263::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func264::func;
 	return execfunc(this, point, fromTarget);
 }
 
-namespace _func264
+namespace _func265
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::RenderPlayerShip", typeid(void (CommandGui::*)(Point &, float )), ".415431d2554889f531f6534889fb4883ec30", nullptr, 0, 0, &func);
@@ -3423,11 +3436,11 @@ namespace _func264
 void CommandGui::RenderPlayerShip(Point &shipCenter, float jumpScale)
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg, Point &shipCenter_arg, float jumpScale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func264::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func265::func;
 	return execfunc(this, shipCenter, jumpScale);
 }
 
-namespace _func265
+namespace _func266
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::LButtonUp", typeid(void (CommandGui::*)(int , int , bool )), ".4154555380bf????????004889fb", nullptr, 0, 0, &func);
@@ -3436,11 +3449,11 @@ namespace _func265
 void CommandGui::LButtonUp(int mX, int mY, bool shiftHeld)
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg, int mX_arg, int mY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func265::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func266::func;
 	return execfunc(this, mX, mY, shiftHeld);
 }
 
-namespace _func266
+namespace _func267
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::NewLocation", typeid(void (CommandGui::*)(const std::string &, std::vector<ChoiceText> *, ResourceEvent &, bool )), ".415741564155415455534889d34881ec58020000", nullptr, 0, 0, &func);
@@ -3449,11 +3462,11 @@ namespace _func266
 void CommandGui::NewLocation(const std::string &mainText, std::vector<ChoiceText> *choices, ResourceEvent &resources, bool testingEvents)
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg, const std::string &mainText_arg, std::vector<ChoiceText> *choices_arg, ResourceEvent &resources_arg, bool testingEvents_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func266::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func267::func;
 	return execfunc(this, mainText, choices, resources, testingEvents);
 }
 
-namespace _func267
+namespace _func268
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::RunCommand", typeid(void (CommandGui::*)(std::string &)), ".4157415641554989fd41544989f45531ed5331db4883ec58488b06", nullptr, 0, 0, &func);
@@ -3462,11 +3475,11 @@ namespace _func267
 void CommandGui::RunCommand(std::string &command)
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg, std::string &command_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func267::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func268::func;
 	return execfunc(this, command);
 }
 
-namespace _func268
+namespace _func269
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::CreateNewStore", typeid(Store *(CommandGui::*)(int )), ".41554189f5415455534889fbbf580600004c8da3????0000", nullptr, 0, 0, &func);
@@ -3475,11 +3488,11 @@ namespace _func268
 Store *CommandGui::CreateNewStore(int sectorNumber)
 {
 	typedef Store *(*custom_arg_funcptr_t)(CommandGui *this_arg, int sectorNumber_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func268::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func269::func;
 	return execfunc(this, sectorNumber);
 }
 
-namespace _func269
+namespace _func270
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::KeyDown", typeid(void (CommandGui::*)(SDLKey , bool )), ".415541545589f5534889fb4883ec38", nullptr, 0, 0, &func);
@@ -3488,11 +3501,11 @@ namespace _func269
 void CommandGui::KeyDown(SDLKey key, bool shiftHeld)
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg, SDLKey key_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func269::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func270::func;
 	return execfunc(this, key, shiftHeld);
 }
 
-namespace _func270
+namespace _func271
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::RenderStatic", typeid(void (CommandGui::*)()), ".41564155415455534889fb4883ec40", nullptr, 0, 0, &func);
@@ -3501,11 +3514,11 @@ namespace _func270
 void CommandGui::RenderStatic()
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func270::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func271::func;
 	return execfunc(this);
 }
 
-namespace _func271
+namespace _func272
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::LButtonDown", typeid(void (CommandGui::*)(int , int , bool )), ".415541544189d45589f5534889fb4883ec28", nullptr, 0, 0, &func);
@@ -3514,11 +3527,11 @@ namespace _func271
 void CommandGui::LButtonDown(int mX, int mY, bool shiftHeld)
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg, int mX_arg, int mY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func271::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func272::func;
 	return execfunc(this, mX, mY, shiftHeld);
 }
 
-namespace _func272
+namespace _func273
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::MouseMove", typeid(void (CommandGui::*)(int , int )), ".41544189d45589f5534889fb4883ec50", nullptr, 0, 0, &func);
@@ -3527,30 +3540,17 @@ namespace _func272
 void CommandGui::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func272::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func273::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func273
+namespace _func274
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::OnLoop", typeid(void (CommandGui::*)()), ".41564155415455534889fb4883ec20", nullptr, 0, 0, &func);
 }
 
 void CommandGui::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func273::func;
-	return execfunc(this);
-}
-
-namespace _func274
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CommandGui::constructor", typeid(void (CommandGui::*)()), ".41574156415541545548c7c5ffffffff534889fb", nullptr, 0, 0, &func);
-}
-
-void CommandGui::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func274::func;
@@ -3560,12 +3560,12 @@ void CommandGui::constructor()
 namespace _func275
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CompleteShip::PauseLoop", typeid(void (CompleteShip::*)()), "!488b7f10e9????????90660f1f440000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CommandGui::constructor", typeid(void (CommandGui::*)()), ".41574156415541545548c7c5ffffffff534889fb", nullptr, 0, 0, &func);
 }
 
-void CompleteShip::PauseLoop()
+void CommandGui::constructor()
 {
-	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
+	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func275::func;
 	return execfunc(this);
 }
@@ -3573,10 +3573,10 @@ void CompleteShip::PauseLoop()
 namespace _func276
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CompleteShip::Restart", typeid(void (CompleteShip::*)()), "!.534889fb488b7f10", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CompleteShip::PauseLoop", typeid(void (CompleteShip::*)()), "!488b7f10e9????????90660f1f440000", nullptr, 0, 0, &func);
 }
 
-void CompleteShip::Restart()
+void CompleteShip::PauseLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func276::func;
@@ -3586,17 +3586,30 @@ void CompleteShip::Restart()
 namespace _func277
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CompleteShip::Restart", typeid(void (CompleteShip::*)()), "!.534889fb488b7f10", nullptr, 0, 0, &func);
+}
+
+void CompleteShip::Restart()
+{
+	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func277::func;
+	return execfunc(this);
+}
+
+namespace _func278
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::constructor", typeid(void (CompleteShip::*)(SpaceManager *, bool , int )), ".534889fb48897718", nullptr, 0, 0, &func);
 }
 
 void CompleteShip::constructor(SpaceManager *space, bool unk, int unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, SpaceManager *space_arg, bool unk_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func277::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func278::func;
 	return execfunc(this, space, unk, unk2);
 }
 
-namespace _func278
+namespace _func279
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::SetShip", typeid(void (CompleteShip::*)(ShipManager *)), "!.8b96ac08000048897710", nullptr, 0, 0, &func);
@@ -3605,11 +3618,11 @@ namespace _func278
 void CompleteShip::SetShip(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func278::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func279::func;
 	return execfunc(this, ship);
 }
 
-namespace _func279
+namespace _func280
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::OnInit", typeid(void (CompleteShip::*)(const ShipBlueprint *, int )), "!.41554189d541544989f455534889fbbf580a0000", nullptr, 0, 0, &func);
@@ -3618,11 +3631,11 @@ namespace _func279
 void CompleteShip::OnInit(const ShipBlueprint *blueprint, int unk)
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, const ShipBlueprint *blueprint_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func279::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func280::func;
 	return execfunc(this, blueprint, unk);
 }
 
-namespace _func280
+namespace _func281
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::AddBoarders", typeid(void (CompleteShip::*)(int , const std::string &, bool )), ".415741564189ce415541544189f4be02000000554889fd534881ec88000000", nullptr, 0, 0, &func);
@@ -3631,11 +3644,11 @@ namespace _func280
 void CompleteShip::AddBoarders(int amount, const std::string &race, bool unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, int amount_arg, const std::string &race_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func280::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func281::func;
 	return execfunc(this, amount, race, unk2);
 }
 
-namespace _func281
+namespace _func282
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::AddCrewMember", typeid(CrewMember *(CompleteShip::*)(const CrewBlueprint *, bool )), ".415741564989f6415541544189d455488dae88000000534881ec38010000", nullptr, 0, 0, &func);
@@ -3644,11 +3657,11 @@ namespace _func281
 CrewMember *CompleteShip::AddCrewMember(const CrewBlueprint *blueprint, bool hostile)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(CompleteShip *this_arg, const CrewBlueprint *blueprint_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func281::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func282::func;
 	return execfunc(this, blueprint, hostile);
 }
 
-namespace _func282
+namespace _func283
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::AddCrewMember1", typeid(CrewMember *(CompleteShip::*)(const std::string &, const std::string &, bool )), ".41574889f04989ff415641554189cd415455534889d34883ec58", nullptr, 0, 0, &func);
@@ -3657,11 +3670,11 @@ namespace _func282
 CrewMember *CompleteShip::AddCrewMember1(const std::string &race, const std::string &name, bool hostile)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(CompleteShip *this_arg, const std::string &race_arg, const std::string &name_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func282::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func283::func;
 	return execfunc(this, race, name, hostile);
 }
 
-namespace _func283
+namespace _func284
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::AddDrone", typeid(Drone *(CompleteShip::*)(const DroneBlueprint *, int )), "!.488b7f10e9????????90660f1f440000", nullptr, 0, 0, &func);
@@ -3670,11 +3683,11 @@ namespace _func283
 Drone *CompleteShip::AddDrone(const DroneBlueprint *blueprint, int unk)
 {
 	typedef Drone *(*custom_arg_funcptr_t)(CompleteShip *this_arg, const DroneBlueprint *blueprint_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func283::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func284::func;
 	return execfunc(this, blueprint, unk);
 }
 
-namespace _func284
+namespace _func285
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::AddCrewMember2", typeid(CrewMember *(CompleteShip::*)(CrewMember *, int )), ".41544885f655534889f3", nullptr, 0, 0, &func);
@@ -3683,30 +3696,17 @@ namespace _func284
 CrewMember *CompleteShip::AddCrewMember2(CrewMember *member, int unk)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(CompleteShip *this_arg, CrewMember *member_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func284::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func285::func;
 	return execfunc(this, member, unk);
 }
 
-namespace _func285
+namespace _func286
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::SaveState", typeid(void (CompleteShip::*)(int )), "!.89f08bb71002000089c7", nullptr, 0, 0, &func);
 }
 
 void CompleteShip::SaveState(int unk)
-{
-	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func285::func;
-	return execfunc(this, unk);
-}
-
-namespace _func286
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CompleteShip::LoadState", typeid(void (CompleteShip::*)(int )), ".534889fb89f74883ec20", nullptr, 0, 0, &func);
-}
-
-void CompleteShip::LoadState(int unk)
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, int unk_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func286::func;
@@ -3716,17 +3716,30 @@ void CompleteShip::LoadState(int unk)
 namespace _func287
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CompleteShip::LoadState", typeid(void (CompleteShip::*)(int )), ".534889fb89f74883ec20", nullptr, 0, 0, &func);
+}
+
+void CompleteShip::LoadState(int unk)
+{
+	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, int unk_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func287::func;
+	return execfunc(this, unk);
+}
+
+namespace _func288
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::InitiateTeleport", typeid(void (CompleteShip::*)(int , int )), ".415455534889fb4883ec40488b87e0010000", nullptr, 0, 0, &func);
 }
 
 void CompleteShip::InitiateTeleport(int targetRoom, int command)
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, int targetRoom_arg, int command_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func287::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func288::func;
 	return execfunc(this, targetRoom, command);
 }
 
-namespace _func288
+namespace _func289
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::OnLoop", typeid(void (CompleteShip::*)()), "!.4157415641554989fd415455498d6d305331db4883ec18488b7f10", nullptr, 0, 0, &func);
@@ -3735,11 +3748,11 @@ namespace _func288
 void CompleteShip::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func288::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func289::func;
 	return execfunc(this);
 }
 
-namespace _func289
+namespace _func290
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::GetTeleportingParty", typeid(std::vector<CrewMember*> (CompleteShip::*)()), ".4154554889f553488b86000200004889fb", nullptr, 0, 0, &func);
@@ -3748,11 +3761,11 @@ namespace _func289
 std::vector<CrewMember*> CompleteShip::GetTeleportingParty()
 {
 	typedef std::vector<CrewMember*> (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func289::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func290::func;
 	return execfunc(this);
 }
 
-namespace _func290
+namespace _func291
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::KillRandomCrew", typeid(void (CompleteShip::*)()), "!.488b7f10e9????????90660f1f440000", nullptr, 0, 0, &func);
@@ -3761,11 +3774,11 @@ namespace _func290
 void CompleteShip::KillRandomCrew()
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func290::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func291::func;
 	return execfunc(this);
 }
 
-namespace _func291
+namespace _func292
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::CountCrew", typeid(int (CompleteShip::*)(bool )), "!.488b7f10400fb6f6", nullptr, 0, 0, &func);
@@ -3774,11 +3787,11 @@ namespace _func291
 int CompleteShip::CountCrew(bool boarders)
 {
 	typedef int (*custom_arg_funcptr_t)(CompleteShip *this_arg, bool boarders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func291::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func292::func;
 	return execfunc(this, boarders);
 }
 
-namespace _func292
+namespace _func293
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::Jump", typeid(void (CompleteShip::*)()), ".488b87e0010000488987e8010000", nullptr, 0, 0, &func);
@@ -3787,11 +3800,11 @@ namespace _func292
 void CompleteShip::Jump()
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func292::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func293::func;
 	return execfunc(this);
 }
 
-namespace _func293
+namespace _func294
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::SetEnemyShip", typeid(void (CompleteShip::*)(CompleteShip *)), "!.4885f648897720", nullptr, 0, 0, &func);
@@ -3800,11 +3813,11 @@ namespace _func293
 void CompleteShip::SetEnemyShip(CompleteShip *other)
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, CompleteShip *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func293::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func294::func;
 	return execfunc(this, other);
 }
 
-namespace _func294
+namespace _func295
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::DeadCrew", typeid(bool (CompleteShip::*)()), ".55534889fb4883ec080fb67728", nullptr, 0, 0, &func);
@@ -3813,11 +3826,11 @@ namespace _func294
 bool CompleteShip::DeadCrew()
 {
 	typedef bool (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func294::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func295::func;
 	return execfunc(this);
 }
 
-namespace _func295
+namespace _func296
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::TeleportCrew", typeid(std::vector<CrewMember*> (CompleteShip::*)(int , bool )), ".53488b76104889fb0fb6c9", nullptr, 0, 0, &func);
@@ -3826,30 +3839,17 @@ namespace _func295
 std::vector<CrewMember*> CompleteShip::TeleportCrew(int roomId, bool intruders)
 {
 	typedef std::vector<CrewMember*> (*custom_arg_funcptr_t)(CompleteShip *this_arg, int roomId_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func295::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func296::func;
 	return execfunc(this, roomId, intruders);
 }
 
-namespace _func296
+namespace _func297
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::OnRender", typeid(void (CompleteShip::*)()), "!.534889fb8b7708488b7f18ba02000000", nullptr, 0, 0, &func);
 }
 
 void CompleteShip::OnRender()
-{
-	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func296::func;
-	return execfunc(this);
-}
-
-namespace _func297
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CompleteShip::OnRenderSpace", typeid(void (CompleteShip::*)()), "!.488b7f18f30f1005????????be03000000", nullptr, 0, 0, &func);
-}
-
-void CompleteShip::OnRenderSpace()
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func297::func;
@@ -3859,17 +3859,30 @@ void CompleteShip::OnRenderSpace()
 namespace _func298
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CompleteShip::OnRenderSpace", typeid(void (CompleteShip::*)()), "!.488b7f18f30f1005????????be03000000", nullptr, 0, 0, &func);
+}
+
+void CompleteShip::OnRenderSpace()
+{
+	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func298::func;
+	return execfunc(this);
+}
+
+namespace _func299
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::OnRenderShip", typeid(void (CompleteShip::*)(bool , bool )), "!.41544189d4ba020000005589f5534889fb8b7708488b7f18", nullptr, 0, 0, &func);
 }
 
 void CompleteShip::OnRenderShip(bool unk1, bool unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, bool unk1_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func298::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func299::func;
 	return execfunc(this, unk1, unk2);
 }
 
-namespace _func299
+namespace _func300
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ConfirmWindow::Close", typeid(void (ConfirmWindow::*)()), "!534889fb488b7f70", nullptr, 0, 0, &func);
@@ -3878,11 +3891,11 @@ namespace _func299
 void ConfirmWindow::Close()
 {
 	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func299::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func300::func;
 	return execfunc(this);
 }
 
-namespace _func300
+namespace _func301
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ConfirmWindow::MouseClick", typeid(void (ConfirmWindow::*)(int , int )), ".807f0800741a", nullptr, 0, 0, &func);
@@ -3891,11 +3904,11 @@ namespace _func300
 void ConfirmWindow::MouseClick(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func300::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func301::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func301
+namespace _func302
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ConfirmWindow::constructor", typeid(void (ConfirmWindow::*)()), ".534889fb4883ec10e8????????488d7b20488d54240f", nullptr, 0, 0, &func);
@@ -3904,11 +3917,11 @@ namespace _func301
 void ConfirmWindow::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func301::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func302::func;
 	return execfunc(this);
 }
 
-namespace _func302
+namespace _func303
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ConfirmWindow::SetText", typeid(void (ConfirmWindow::*)(const TextString &, int , bool , const TextString &, const TextString &)), ".41574189cf41564189d641554989f541544d89cc554c89c5534889fb4883ec38", nullptr, 0, 0, &func);
@@ -3917,11 +3930,11 @@ namespace _func302
 void ConfirmWindow::SetText(const TextString &text_, int minWidth, bool autoCenter, const TextString &yesText_, const TextString &noText_)
 {
 	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, const TextString &text__arg, int minWidth_arg, bool autoCenter_arg, const TextString &yesText__arg, const TextString &noText__arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func302::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func303::func;
 	return execfunc(this, text_, minWidth, autoCenter, yesText_, noText_);
 }
 
-namespace _func303
+namespace _func304
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ConfirmWindow::SetPosition", typeid(void (ConfirmWindow::*)(Point )), ".41564155415455534889fb4883ec10", nullptr, 0, 0, &func);
@@ -3930,30 +3943,17 @@ namespace _func303
 void ConfirmWindow::SetPosition(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func303::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func304::func;
 	return execfunc(this, pos);
 }
 
-namespace _func304
+namespace _func305
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ConfirmWindow::Open", typeid(void (ConfirmWindow::*)()), ".415741564155415455534889fb4883ec28", nullptr, 0, 0, &func);
 }
 
 void ConfirmWindow::Open()
-{
-	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func304::func;
-	return execfunc(this);
-}
-
-namespace _func305
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ConfirmWindow::OnRender", typeid(void (ConfirmWindow::*)()), ".41574156415541544989fc55534881ec98000000488b7f70", nullptr, 0, 0, &func);
-}
-
-void ConfirmWindow::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func305::func;
@@ -3963,17 +3963,30 @@ void ConfirmWindow::OnRender()
 namespace _func306
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ConfirmWindow::OnRender", typeid(void (ConfirmWindow::*)()), ".41574156415541544989fc55534881ec98000000488b7f70", nullptr, 0, 0, &func);
+}
+
+void ConfirmWindow::OnRender()
+{
+	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func306::func;
+	return execfunc(this);
+}
+
+namespace _func307
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ConfirmWindow::MouseMove", typeid(void (ConfirmWindow::*)(int , int )), ".41545553807f08004889fb", nullptr, 0, 0, &func);
 }
 
 void ConfirmWindow::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func306::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func307::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func307
+namespace _func308
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ControlButton::OnRender", typeid(void (ControlButton::*)()), "415455534889fb4883ec608b4730", nullptr, 0, 0, &func);
@@ -3982,19 +3995,6 @@ namespace _func307
 void ControlButton::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(ControlButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func307::func;
-	return execfunc(this);
-}
-
-namespace _func308
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ControlsScreen::OnInit", typeid(void (ControlsScreen::*)()), "41574156415541544989fc55534881ece80000004883bf3006000000", nullptr, 0, 0, &func);
-}
-
-void ControlsScreen::OnInit()
-{
-	typedef void (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func308::func;
 	return execfunc(this);
 }
@@ -4002,10 +4002,10 @@ void ControlsScreen::OnInit()
 namespace _func309
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ControlsScreen::OnLoop", typeid(void (ControlsScreen::*)()), "41564155415449bcb76ddbb66ddbb66d554889fd534883ec4048638728060000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ControlsScreen::OnInit", typeid(void (ControlsScreen::*)()), "41574156415541544989fc55534881ece80000004883bf3006000000", nullptr, 0, 0, &func);
 }
 
-void ControlsScreen::OnLoop()
+void ControlsScreen::OnInit()
 {
 	typedef void (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func309::func;
@@ -4015,10 +4015,10 @@ void ControlsScreen::OnLoop()
 namespace _func310
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ControlsScreen::OnRender", typeid(void (ControlsScreen::*)()), "415741564155415455534889fb4881ec1802000080bf7001000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ControlsScreen::OnLoop", typeid(void (ControlsScreen::*)()), "41564155415449bcb76ddbb66ddbb66d554889fd534883ec4048638728060000", nullptr, 0, 0, &func);
 }
 
-void ControlsScreen::OnRender()
+void ControlsScreen::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func310::func;
@@ -4028,17 +4028,30 @@ void ControlsScreen::OnRender()
 namespace _func311
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ControlsScreen::OnRender", typeid(void (ControlsScreen::*)()), "415741564155415455534889fb4881ec1802000080bf7001000000", nullptr, 0, 0, &func);
+}
+
+void ControlsScreen::OnRender()
+{
+	typedef void (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func311::func;
+	return execfunc(this);
+}
+
+namespace _func312
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CooldownSystemBox::constructor", typeid(void (CooldownSystemBox::*)(Point , ShipSystem *, bool )), "4157415641554989fd41545589cdb901000000534889f34881ece8010000", nullptr, 0, 0, &func);
 }
 
 void CooldownSystemBox::constructor(Point pos, ShipSystem *sys, bool roundDown)
 {
 	typedef void (*custom_arg_funcptr_t)(CooldownSystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, bool roundDown_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func311::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func312::func;
 	return execfunc(this, pos, sys, roundDown);
 }
 
-namespace _func312
+namespace _func313
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CooldownSystemBox::OnRender", typeid(void (CooldownSystemBox::*)(bool )), "4154400fb6f655534889fb4883ec50", nullptr, 0, 0, &func);
@@ -4047,30 +4060,17 @@ namespace _func312
 void CooldownSystemBox::OnRender(bool ignoreStatus)
 {
 	typedef void (*custom_arg_funcptr_t)(CooldownSystemBox *this_arg, bool ignoreStatus_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func312::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func313::func;
 	return execfunc(this, ignoreStatus);
 }
 
-namespace _func313
+namespace _func314
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CreditScreen::OnRender", typeid(void (CreditScreen::*)()), "415641554154554889fd534883ec60", nullptr, 0, 0, &func);
 }
 
 void CreditScreen::OnRender()
-{
-	typedef void (*custom_arg_funcptr_t)(CreditScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func313::func;
-	return execfunc(this);
-}
-
-namespace _func314
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CreditScreen::constructor", typeid(void (CreditScreen::*)()), "48c74708????????48c74710????????c747180000000048c7472800000000", nullptr, 0, 0, &func);
-}
-
-void CreditScreen::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CreditScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func314::func;
@@ -4080,17 +4080,30 @@ void CreditScreen::constructor()
 namespace _func315
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CreditScreen::constructor", typeid(void (CreditScreen::*)()), "48c74708????????48c74710????????c747180000000048c7472800000000", nullptr, 0, 0, &func);
+}
+
+void CreditScreen::constructor()
+{
+	typedef void (*custom_arg_funcptr_t)(CreditScreen *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func315::func;
+	return execfunc(this);
+}
+
+namespace _func316
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CreditScreen::Start", typeid(void (CreditScreen::*)(const std::string &, const std::vector<std::string> &)), "4157415641554154554889d5534889fb4881ecd8010000", nullptr, 0, 0, &func);
 }
 
 void CreditScreen::Start(const std::string &shipName, const std::vector<std::string> &crewNames)
 {
 	typedef void (*custom_arg_funcptr_t)(CreditScreen *this_arg, const std::string &shipName_arg, const std::vector<std::string> &crewNames_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func315::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func316::func;
 	return execfunc(this, shipName, crewNames);
 }
 
-namespace _func316
+namespace _func317
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CreditScreen::Done", typeid(bool (CreditScreen::*)()), "488b4730482b472848baabaaaaaaaaaaaaaa", nullptr, 0, 0, &func);
@@ -4099,11 +4112,11 @@ namespace _func316
 bool CreditScreen::Done()
 {
 	typedef bool (*custom_arg_funcptr_t)(CreditScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func316::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func317::func;
 	return execfunc(this);
 }
 
-namespace _func317
+namespace _func318
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAI::PrioritizeIntruderRoom", typeid(int (CrewAI::*)(CrewMember *, int , int )), "41574156415541544989f45589d5534889fb4883ec18", nullptr, 0, 0, &func);
@@ -4112,11 +4125,11 @@ namespace _func317
 int CrewAI::PrioritizeIntruderRoom(CrewMember *crew, int roomId, int target)
 {
 	typedef int (*custom_arg_funcptr_t)(CrewAI *this_arg, CrewMember *crew_arg, int roomId_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func317::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func318::func;
 	return execfunc(this, crew, roomId, target);
 }
 
-namespace _func318
+namespace _func319
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAI::DangerRating", typeid(int (CrewAI::*)(int , int )), ".415641554989fd4154554863ea5389f34883ec50", nullptr, 0, 0, &func);
@@ -4125,11 +4138,11 @@ namespace _func318
 int CrewAI::DangerRating(int roomId, int crewId)
 {
 	typedef int (*custom_arg_funcptr_t)(CrewAI *this_arg, int roomId_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func318::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func319::func;
 	return execfunc(this, roomId, crewId);
 }
 
-namespace _func319
+namespace _func320
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAI::CheckForHealing", typeid(void (CrewAI::*)()), ".4156415541544531e45531ed534889fb4883ec20", nullptr, 0, 0, &func);
@@ -4138,11 +4151,11 @@ namespace _func319
 void CrewAI::CheckForHealing()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func319::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func320::func;
 	return execfunc(this);
 }
 
-namespace _func320
+namespace _func321
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAI::PrioritizeTask", typeid(int (CrewAI::*)(CrewTask , int )), ".415641554989fd41544189d4554863e95389f34883ec10", nullptr, 0, 0, &func);
@@ -4151,11 +4164,11 @@ namespace _func320
 int CrewAI::PrioritizeTask(CrewTask task, int crewId)
 {
 	typedef int (*custom_arg_funcptr_t)(CrewAI *this_arg, CrewTask task_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func320::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func321::func;
 	return execfunc(this, task, crewId);
 }
 
-namespace _func321
+namespace _func322
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAI::AssignCrewmembers", typeid(void (CrewAI::*)()), ".415631d241554531ed415449bcabaaaaaaaaaaaaaa5553", nullptr, 0, 0, &func);
@@ -4164,11 +4177,11 @@ namespace _func321
 void CrewAI::AssignCrewmembers()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func321::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func322::func;
 	return execfunc(this);
 }
 
-namespace _func322
+namespace _func323
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAI::UpdateCrewMember", typeid(void (CrewAI::*)(int )), ".41574863f641564155415455534889fb4883ec38", nullptr, 0, 0, &func);
@@ -4177,30 +4190,17 @@ namespace _func322
 void CrewAI::UpdateCrewMember(int crewId)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAI *this_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func322::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func323::func;
 	return execfunc(this, crewId);
 }
 
-namespace _func323
+namespace _func324
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAI::UpdateIntruders", typeid(void (CrewAI::*)()), ".415641554154554889fd534883ec10488b4730488b57284839d0", nullptr, 0, 0, &func);
 }
 
 void CrewAI::UpdateIntruders()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func323::func;
-	return execfunc(this);
-}
-
-namespace _func324
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewAI::CheckForProblems", typeid(void (CrewAI::*)()), ".41574989ff41564d89fe4155415455534881ec88000000488b07", nullptr, 0, 0, &func);
-}
-
-void CrewAI::CheckForProblems()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAI *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func324::func;
@@ -4210,10 +4210,10 @@ void CrewAI::CheckForProblems()
 namespace _func325
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewAI::UpdateDrones", typeid(void (CrewAI::*)()), ".415741564531f6415541545531ed534889fb4881eca8000000488b5710", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewAI::CheckForProblems", typeid(void (CrewAI::*)()), ".41574989ff41564d89fe4155415455534881ec88000000488b07", nullptr, 0, 0, &func);
 }
 
-void CrewAI::UpdateDrones()
+void CrewAI::CheckForProblems()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAI *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func325::func;
@@ -4223,10 +4223,10 @@ void CrewAI::UpdateDrones()
 namespace _func326
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewAI::OnLoop", typeid(void (CrewAI::*)()), ".415741564155415455534889fb4883ec48488b37", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewAI::UpdateDrones", typeid(void (CrewAI::*)()), ".415741564531f6415541545531ed534889fb4881eca8000000488b5710", nullptr, 0, 0, &func);
 }
 
-void CrewAI::OnLoop()
+void CrewAI::UpdateDrones()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAI *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func326::func;
@@ -4236,17 +4236,30 @@ void CrewAI::OnLoop()
 namespace _func327
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewAI::OnLoop", typeid(void (CrewAI::*)()), ".415741564155415455534889fb4883ec48488b37", nullptr, 0, 0, &func);
+}
+
+void CrewAI::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewAI *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func327::func;
+	return execfunc(this);
+}
+
+namespace _func328
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::destructor", typeid(void (CrewAnimation::*)()), "41574889f841564155415455534883ec68", nullptr, 0, 0, &func);
 }
 
 void CrewAnimation::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func327::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func328::func;
 	return execfunc(this);
 }
 
-namespace _func328
+namespace _func329
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::GetFiringFrame", typeid(int (CrewAnimation::*)()), ".8b475c83f8ff", nullptr, 0, 0, &func);
@@ -4255,11 +4268,11 @@ namespace _func328
 int CrewAnimation::GetFiringFrame()
 {
 	typedef int (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func328::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func329::func;
 	return execfunc(this);
 }
 
-namespace _func329
+namespace _func330
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::OnRenderProps", typeid(void (CrewAnimation::*)()), "!.41554531ed415449bc000000000000803f55", nullptr, 0, 0, &func);
@@ -4268,11 +4281,11 @@ namespace _func329
 void CrewAnimation::OnRenderProps()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func329::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func330::func;
 	return execfunc(this);
 }
 
-namespace _func330
+namespace _func331
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::OnRender", typeid(void (CrewAnimation::*)(float , int , bool )), ".41544189f45589d5534889fb4883ec50", nullptr, 0, 0, &func);
@@ -4281,11 +4294,11 @@ namespace _func330
 void CrewAnimation::OnRender(float scale, int selectedState, bool outlineOnly)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg, float scale_arg, int selectedState_arg, bool outlineOnly_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func330::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func331::func;
 	return execfunc(this, scale, selectedState, outlineOnly);
 }
 
-namespace _func331
+namespace _func332
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::FireShot", typeid(bool (CrewAnimation::*)()), "!.53488d9fd80800004889df", nullptr, 0, 0, &func);
@@ -4294,11 +4307,11 @@ namespace _func331
 bool CrewAnimation::FireShot()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func331::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func332::func;
 	return execfunc(this);
 }
 
-namespace _func332
+namespace _func333
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::RenderIcon", typeid(void (CrewAnimation::*)(bool )), ".4155415455534889fb4881ecf80000004084f6", nullptr, 0, 0, &func);
@@ -4307,11 +4320,11 @@ namespace _func332
 void CrewAnimation::RenderIcon(bool border)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg, bool border_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func332::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func333::func;
 	return execfunc(this, border);
 }
 
-namespace _func333
+namespace _func334
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::OnUpdate", typeid(void (CrewAnimation::*)(Pointf , bool , bool , bool , bool , bool )), ".415455534889fb4883ec308b4760", nullptr, 0, 0, &func);
@@ -4320,30 +4333,17 @@ namespace _func333
 void CrewAnimation::OnUpdate(Pointf position, bool moving, bool fighting, bool repairing, bool dying, bool onFire)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg, Pointf position_arg, bool moving_arg, bool fighting_arg, bool repairing_arg, bool dying_arg, bool onFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func333::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func334::func;
 	return execfunc(this, position, moving, fighting, repairing, dying, onFire);
 }
 
-namespace _func334
+namespace _func335
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::GetDeathSound", typeid(std::string (CrewAnimation::*)()), ".534889fb4883ec3080beec09000000", nullptr, 0, 0, &func);
 }
 
 std::string CrewAnimation::GetDeathSound()
-{
-	typedef std::string (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func334::func;
-	return execfunc(this);
-}
-
-namespace _func335
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewAnimation::GetShootingSound", typeid(std::string (CrewAnimation::*)()), ".534889fb4883ec30", nullptr, 0, 0, &func);
-}
-
-std::string CrewAnimation::GetShootingSound()
 {
 	typedef std::string (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func335::func;
@@ -4353,17 +4353,30 @@ std::string CrewAnimation::GetShootingSound()
 namespace _func336
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewAnimation::GetShootingSound", typeid(std::string (CrewAnimation::*)()), ".534889fb4883ec30", nullptr, 0, 0, &func);
+}
+
+std::string CrewAnimation::GetShootingSound()
+{
+	typedef std::string (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func336::func;
+	return execfunc(this);
+}
+
+namespace _func337
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::SetupStrips", typeid(void (CrewAnimation::*)()), ".4157488d87e009000041564889c64155415455534889fb4881ec08020000", nullptr, 0, 0, &func);
 }
 
 void CrewAnimation::SetupStrips()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func336::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func337::func;
 	return execfunc(this);
 }
 
-namespace _func337
+namespace _func338
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::OnInit", typeid(void (CrewAnimation::*)(const std::string &, Pointf , bool )), ".415783f20141564155415455534889fb4889f74881ec08010000", nullptr, 0, 0, &func);
@@ -4372,11 +4385,11 @@ namespace _func337
 void CrewAnimation::OnInit(const std::string &name, Pointf position, bool enemy)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg, const std::string &name_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func337::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func338::func;
 	return execfunc(this, name, position, enemy);
 }
 
-namespace _func338
+namespace _func339
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::constructor", typeid(void (CrewAnimation::*)(int , const std::string &, Pointf , bool )), ".415741564155415455534881ec98000000", nullptr, 0, 0, &func);
@@ -4385,11 +4398,11 @@ namespace _func338
 void CrewAnimation::constructor(int shipId, const std::string &race, Pointf unk, bool hostile)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg, int shipId_arg, const std::string &race_arg, Pointf unk_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func338::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func339::func;
 	return execfunc(this, shipId, race, unk, hostile);
 }
 
-namespace _func339
+namespace _func340
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::OnUpdateEffects", typeid(void (CrewAnimation::*)()), ".415741564155415455534889fb4883ec6848897c2430", nullptr, 0, 0, &func);
@@ -4398,11 +4411,11 @@ namespace _func339
 void CrewAnimation::OnUpdateEffects()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func339::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func340::func;
 	return execfunc(this);
 }
 
-namespace _func340
+namespace _func341
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBlueprint::destructor", typeid(void (CrewBlueprint::*)()), "4154554889fd534883ec1048c707????????488bbfe8000000", nullptr, 0, 0, &func);
@@ -4411,11 +4424,11 @@ namespace _func340
 void CrewBlueprint::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func340::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func341::func;
 	return execfunc(this);
 }
 
-namespace _func341
+namespace _func342
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBlueprint::RenderSkill", typeid(void (CrewBlueprint::*)(int , int , int , int , int )), "415641554189d54963d141544189f45589cd534489c34883ec40488b87b8000000", nullptr, 0, 0, &func);
@@ -4424,11 +4437,11 @@ namespace _func341
 void CrewBlueprint::RenderSkill(int x, int y, int length, int height, int skill)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int x_arg, int y_arg, int length_arg, int height_arg, int skill_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func341::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func342::func;
 	return execfunc(this, x, y, length, height, skill);
 }
 
-namespace _func342
+namespace _func343
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBlueprint::RandomSkills", typeid(void (CrewBlueprint::*)(int )), "415431c0554889fd534883ec4085f6", nullptr, 0, 0, &func);
@@ -4437,11 +4450,11 @@ namespace _func342
 void CrewBlueprint::RandomSkills(int worldLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func342::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func343::func;
 	return execfunc(this, worldLevel);
 }
 
-namespace _func343
+namespace _func344
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBlueprint::RenderIcon", typeid(void (CrewBlueprint::*)(float )), "4157415641554154554889fd53488d5f084881ece80200004889de", nullptr, 0, 0, &func);
@@ -4450,11 +4463,11 @@ namespace _func343
 void CrewBlueprint::RenderIcon(float opacity)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, float opacity_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func343::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func344::func;
 	return execfunc(this, opacity);
 }
 
-namespace _func344
+namespace _func345
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBlueprint::GetNameShort", typeid(std::string (CrewBlueprint::*)()), "415541544c8d6678554889fd534889f34883ec28", nullptr, 0, 0, &func);
@@ -4463,11 +4476,11 @@ namespace _func344
 std::string CrewBlueprint::GetNameShort()
 {
 	typedef std::string (*custom_arg_funcptr_t)(CrewBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func344::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func345::func;
 	return execfunc(this);
 }
 
-namespace _func345
+namespace _func346
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBlueprint::GetCurrentSkillColor", typeid(GL_Color (CrewBlueprint::*)(int )), "488b87b80000004863f6", nullptr, 0, 0, &func);
@@ -4476,11 +4489,11 @@ namespace _func345
 GL_Color CrewBlueprint::GetCurrentSkillColor(int skill)
 {
 	typedef GL_Color (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int skill_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func345::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func346::func;
 	return execfunc(this, skill);
 }
 
-namespace _func346
+namespace _func347
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBox::MouseClick", typeid(bool (CrewBox::*)()), "0fb6477884c0", nullptr, 0, 0, &func);
@@ -4489,19 +4502,6 @@ namespace _func346
 bool CrewBox::MouseClick()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func346::func;
-	return execfunc(this);
-}
-
-namespace _func347
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewBox::OnRenderSkillLevel", typeid(void (CrewBox::*)()), ".534889fb4883ec1080bf4c01000000", nullptr, 0, 0, &func);
-}
-
-void CrewBox::OnRenderSkillLevel()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func347::func;
 	return execfunc(this);
 }
@@ -4509,10 +4509,10 @@ void CrewBox::OnRenderSkillLevel()
 namespace _func348
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewBox::RenderIcon", typeid(void (CrewBox::*)()), "!.55534889fb4883ec18488b7f20488b07", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewBox::OnRenderSkillLevel", typeid(void (CrewBox::*)()), ".534889fb4883ec1080bf4c01000000", nullptr, 0, 0, &func);
 }
 
-void CrewBox::RenderIcon()
+void CrewBox::OnRenderSkillLevel()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func348::func;
@@ -4522,10 +4522,10 @@ void CrewBox::RenderIcon()
 namespace _func349
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewBox::RenderLabels", typeid(void (CrewBox::*)()), ".55534889fb4883ec48488b7720488d7c2420", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewBox::RenderIcon", typeid(void (CrewBox::*)()), "!.55534889fb4883ec18488b7f20488b07", nullptr, 0, 0, &func);
 }
 
-void CrewBox::RenderLabels()
+void CrewBox::RenderIcon()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func349::func;
@@ -4535,10 +4535,10 @@ void CrewBox::RenderLabels()
 namespace _func350
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewBox::RenderCloneDying", typeid(void (CrewBox::*)()), ".80bf3401000000755c488b4720", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewBox::RenderLabels", typeid(void (CrewBox::*)()), ".55534889fb4883ec48488b7720488d7c2420", nullptr, 0, 0, &func);
 }
 
-void CrewBox::RenderCloneDying()
+void CrewBox::RenderLabels()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func350::func;
@@ -4548,17 +4548,30 @@ void CrewBox::RenderCloneDying()
 namespace _func351
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewBox::RenderCloneDying", typeid(void (CrewBox::*)()), ".80bf3401000000755c488b4720", nullptr, 0, 0, &func);
+}
+
+void CrewBox::RenderCloneDying()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func351::func;
+	return execfunc(this);
+}
+
+namespace _func352
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewBox::constructor", typeid(void (CrewBox::*)(Point , CrewMember *, int )), ".41574889f048c1f8204156415541544189cc554889d5534889fb4c8d6b304881eca8000000", nullptr, 0, 0, &func);
 }
 
 void CrewBox::constructor(Point pos, CrewMember *crew, int number)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg, Point pos_arg, CrewMember *crew_arg, int number_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func351::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func352::func;
 	return execfunc(this, pos, crew, number);
 }
 
-namespace _func352
+namespace _func353
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBox::destructor", typeid(void (CrewBox::*)()), ".415641554154554889fd534883ec10488bbf58010000", nullptr, 0, 0, &func);
@@ -4567,11 +4580,11 @@ namespace _func352
 void CrewBox::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func352::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func353::func;
 	return execfunc(this);
 }
 
-namespace _func353
+namespace _func354
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBox::OnLoop", typeid(void (CrewBox::*)(bool )), "!.5589f5534889fb4883ec08488b7f20488b07", nullptr, 0, 0, &func);
@@ -4580,11 +4593,11 @@ namespace _func353
 void CrewBox::OnLoop(bool selected)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg, bool selected_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func353::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func354::func;
 	return execfunc(this, selected);
 }
 
-namespace _func354
+namespace _func355
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBox::GetSelected", typeid(CrewMember *(CrewBox::*)(int , int )), ".4157415641554c8daf6803000041544189d431d25589f5", nullptr, 0, 0, &func);
@@ -4593,11 +4606,11 @@ namespace _func354
 CrewMember *CrewBox::GetSelected(int mouseX, int mouseY)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(CrewBox *this_arg, int mouseX_arg, int mouseY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func354::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func355::func;
 	return execfunc(this, mouseX, mouseY);
 }
 
-namespace _func355
+namespace _func356
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBox::OnRender", typeid(void (CrewBox::*)()), ".415741564155415455534889fb488dbfe0010000", nullptr, 0, 0, &func);
@@ -4606,11 +4619,11 @@ namespace _func355
 void CrewBox::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func355::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func356::func;
 	return execfunc(this);
 }
 
-namespace _func356
+namespace _func357
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::ClearCrewBoxes", typeid(void (CrewControl::*)()), "41544989fc5553488b4f68488b57604889c84829d048c1f80385c0", nullptr, 0, 0, &func);
@@ -4619,11 +4632,11 @@ namespace _func356
 void CrewControl::ClearCrewBoxes()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func356::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func357::func;
 	return execfunc(this);
 }
 
-namespace _func357
+namespace _func358
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::LButton", typeid(void (CrewControl::*)(int , int , int , int , bool )), ".41574589c741564189ce41554189d541544189f455534889fb4883ec38", nullptr, 0, 0, &func);
@@ -4632,11 +4645,11 @@ namespace _func357
 void CrewControl::LButton(int mX, int mY, int wX, int wY, bool shiftHeld)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, int wX_arg, int wY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func357::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func358::func;
 	return execfunc(this, mX, mY, wX, wY, shiftHeld);
 }
 
-namespace _func358
+namespace _func359
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::RButton", typeid(void (CrewControl::*)(int , int , bool )), ".41545553807f54004889fb", nullptr, 0, 0, &func);
@@ -4645,11 +4658,11 @@ namespace _func358
 void CrewControl::RButton(int mX, int mY, bool shiftHeld)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func358::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func359::func;
 	return execfunc(this, mX, mY, shiftHeld);
 }
 
-namespace _func359
+namespace _func360
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::ClearDeadCrew", typeid(void (CrewControl::*)(std::vector<CrewMember*> *)), ".415431c0554889f553488b4e0831db", nullptr, 0, 0, &func);
@@ -4658,11 +4671,11 @@ namespace _func359
 void CrewControl::ClearDeadCrew(std::vector<CrewMember*> *crew)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg, std::vector<CrewMember*> *crew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func359::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func360::func;
 	return execfunc(this, crew);
 }
 
-namespace _func360
+namespace _func361
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::UpdateCrewBoxes", typeid(void (CrewControl::*)()), ".415731d241564155415455534889fb", nullptr, 0, 0, &func);
@@ -4671,11 +4684,11 @@ namespace _func360
 void CrewControl::UpdateCrewBoxes()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func360::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func361::func;
 	return execfunc(this);
 }
 
-namespace _func361
+namespace _func362
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::LinkShip", typeid(void (CrewControl::*)(ShipManager *)), ".534889374889fb", nullptr, 0, 0, &func);
@@ -4684,11 +4697,11 @@ namespace _func361
 void CrewControl::LinkShip(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func361::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func362::func;
 	return execfunc(this, ship);
 }
 
-namespace _func362
+namespace _func363
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::OnLoop", typeid(void (CrewControl::*)()), ".415455488dafc8000000534889fb4889ef4883ec30", nullptr, 0, 0, &func);
@@ -4697,11 +4710,11 @@ namespace _func362
 void CrewControl::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func362::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func363::func;
 	return execfunc(this);
 }
 
-namespace _func363
+namespace _func364
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::SelectCrew", typeid(void (CrewControl::*)(bool )), ".41544084f655534889fb", nullptr, 0, 0, &func);
@@ -4710,11 +4723,11 @@ namespace _func363
 void CrewControl::SelectCrew(bool keep_current)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg, bool keep_current_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func363::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func364::func;
 	return execfunc(this, keep_current);
 }
 
-namespace _func364
+namespace _func365
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::SelectPotentialCrew", typeid(void (CrewControl::*)(CrewMember *, bool )), ".55534889fb4889f74883ec184885f64889742408", nullptr, 0, 0, &func);
@@ -4723,11 +4736,11 @@ namespace _func364
 void CrewControl::SelectPotentialCrew(CrewMember *crew, bool allowTeleportLeaving)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg, CrewMember *crew_arg, bool allowTeleportLeaving_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func364::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func365::func;
 	return execfunc(this, crew, allowTeleportLeaving);
 }
 
-namespace _func365
+namespace _func366
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::KeyDown", typeid(void (CrewControl::*)(SDLKey )), ".4157415641554989fd415455534881ecc8010000", nullptr, 0, 0, &func);
@@ -4736,11 +4749,11 @@ namespace _func365
 void CrewControl::KeyDown(SDLKey key)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func365::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func366::func;
 	return execfunc(this, key);
 }
 
-namespace _func366
+namespace _func367
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::OnRender", typeid(void (CrewControl::*)()), ".415741564c8db7f000000041554989fd415455534883ec58", nullptr, 0, 0, &func);
@@ -4749,11 +4762,11 @@ namespace _func366
 void CrewControl::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func366::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func367::func;
 	return execfunc(this);
 }
 
-namespace _func367
+namespace _func368
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::MouseMove", typeid(void (CrewControl::*)(int , int , int , int )), ".41574989ff415641554589c541544189cc5589d55389f34881ec18010000", nullptr, 0, 0, &func);
@@ -4762,11 +4775,11 @@ namespace _func367
 void CrewControl::MouseMove(int mX, int mY, int wX, int wY)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, int wX_arg, int wY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func367::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func368::func;
 	return execfunc(this, mX, mY, wX, wY);
 }
 
-namespace _func368
+namespace _func369
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewCustomizeBox::CheckContents", typeid(void (CrewCustomizeBox::*)()), "534889fb4883ec2080bf6807000000", nullptr, 0, 0, &func);
@@ -4775,11 +4788,11 @@ namespace _func368
 void CrewCustomizeBox::CheckContents()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewCustomizeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func368::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func369::func;
 	return execfunc(this);
 }
 
-namespace _func369
+namespace _func370
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewDrone::OnLoop", typeid(void (CrewDrone::*)()), "41564155415455488daf48070000534889fb4889ef", nullptr, 0, 0, &func);
@@ -4788,11 +4801,11 @@ namespace _func369
 void CrewDrone::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func369::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func370::func;
 	return execfunc(this);
 }
 
-namespace _func370
+namespace _func371
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewDrone::constructor", typeid(void (CrewDrone::*)(const std::string &, const std::string &, int , const DroneBlueprint *, CrewAnimation *)), ".41574989d7415641554189cd41544d89c4554c89cd534889fb4881ec58010000", nullptr, 0, 0, &func);
@@ -4801,11 +4814,11 @@ namespace _func370
 void CrewDrone::constructor(const std::string &type, const std::string &name, int shipId, const DroneBlueprint *blueprint, CrewAnimation *anim)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewDrone *this_arg, const std::string &type_arg, const std::string &name_arg, int shipId_arg, const DroneBlueprint *blueprint_arg, CrewAnimation *anim_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func370::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func371::func;
 	return execfunc(this, type, name, shipId, blueprint, anim);
 }
 
-namespace _func371
+namespace _func372
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewDrone::ProvidesVision", typeid(bool (CrewDrone::*)()), ".8b57084889f885d2", nullptr, 0, 0, &func);
@@ -4814,11 +4827,11 @@ namespace _func371
 bool CrewDrone::ProvidesVision()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func371::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func372::func;
 	return execfunc(this);
 }
 
-namespace _func372
+namespace _func373
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewDrone::destructor", typeid(void (CrewDrone::*)()), ".415641554154554889fd534883ec10488b87e808000048c707????????48c78748070000????????488d78e84881ff????????0f8526030000", nullptr, 0, 0, &func);
@@ -4827,11 +4840,11 @@ namespace _func372
 void CrewDrone::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func372::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func373::func;
 	return execfunc(this);
 }
 
-namespace _func373
+namespace _func374
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewDrone::SetCurrentShip", typeid(void (CrewDrone::*)(int )), ".488b87c000000089b78c010000", nullptr, 0, 0, &func);
@@ -4840,11 +4853,11 @@ namespace _func373
 void CrewDrone::SetCurrentShip(int shipId)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewDrone *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func373::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func374::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func374
+namespace _func375
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::RemoveItem", typeid(void (CrewEquipBox::*)()), "534889fb488bbf800000004885ff", nullptr, 0, 0, &func);
@@ -4853,11 +4866,11 @@ namespace _func374
 void CrewEquipBox::RemoveItem()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func374::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func375::func;
 	return execfunc(this);
 }
 
-namespace _func375
+namespace _func376
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::GetConfirmDelete", typeid(bool (CrewEquipBox::*)()), ".0fb68730030000c6873003000000", nullptr, 0, 0, &func);
@@ -4866,11 +4879,11 @@ namespace _func375
 bool CrewEquipBox::GetConfirmDelete()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func375::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func376::func;
 	return execfunc(this);
 }
 
-namespace _func376
+namespace _func377
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::CloseRename", typeid(void (CrewEquipBox::*)()), ".80bfba020000007507", nullptr, 0, 0, &func);
@@ -4879,11 +4892,11 @@ namespace _func376
 void CrewEquipBox::CloseRename()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func376::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func377::func;
 	return execfunc(this);
 }
 
-namespace _func377
+namespace _func378
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::RenderLabels", typeid(void (CrewEquipBox::*)(bool , bool )), ".4154554889fd534883ec60488b47704885c0", nullptr, 0, 0, &func);
@@ -4892,11 +4905,11 @@ namespace _func377
 void CrewEquipBox::RenderLabels(bool dragging, bool isNew)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, bool dragging_arg, bool isNew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func377::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func378::func;
 	return execfunc(this, dragging, isNew);
 }
 
-namespace _func378
+namespace _func379
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::MouseClick", typeid(void (CrewEquipBox::*)()), ".55534889fb4883ec3848837f7000", nullptr, 0, 0, &func);
@@ -4905,11 +4918,11 @@ namespace _func378
 void CrewEquipBox::MouseClick()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func378::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func379::func;
 	return execfunc(this);
 }
 
-namespace _func379
+namespace _func380
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::OnTextInput", typeid(void (CrewEquipBox::*)(SDLKey )), ".5589f553488d9fc00200004883ec084889df", nullptr, 0, 0, &func);
@@ -4918,11 +4931,11 @@ namespace _func379
 void CrewEquipBox::OnTextInput(SDLKey key)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func379::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func380::func;
 	return execfunc(this, key);
 }
 
-namespace _func380
+namespace _func381
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::OnTextEvent", typeid(void (CrewEquipBox::*)(CEvent::TextEvent )), ".5589f553488d9fc00200004883ec084889df", nullptr, 0, 0, &func);
@@ -4931,11 +4944,11 @@ namespace _func380
 void CrewEquipBox::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func380::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func381::func;
 	return execfunc(this, event);
 }
 
-namespace _func381
+namespace _func382
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::constructor", typeid(void (CrewEquipBox::*)(Point , ShipManager *, int )), ".415741564189ce41554989d5ba4300000041544989f449c1fc20", nullptr, 0, 0, &func);
@@ -4944,11 +4957,11 @@ namespace _func381
 void CrewEquipBox::constructor(Point pos, ShipManager *ship, int slot)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, Point pos_arg, ShipManager *ship_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func381::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func382::func;
 	return execfunc(this, pos, ship, slot);
 }
 
-namespace _func382
+namespace _func383
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::OnRender", typeid(void (CrewEquipBox::*)(bool )), ".415541545589f5534889fb", nullptr, 0, 0, &func);
@@ -4957,11 +4970,11 @@ namespace _func382
 void CrewEquipBox::OnRender(bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func382::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func383::func;
 	return execfunc(this, unk);
 }
 
-namespace _func383
+namespace _func384
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::constructor", typeid(void (CrewManifest::*)()), "4155415455534889fb4c8d63284881ec88000000", nullptr, 0, 0, &func);
@@ -4970,30 +4983,17 @@ namespace _func383
 void CrewManifest::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func383::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func384::func;
 	return execfunc(this);
 }
 
-namespace _func384
+namespace _func385
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::OnKeyDown", typeid(void (CrewManifest::*)(SDLKey )), ".41554189f541544989fc5531ed5331db4883ec08", nullptr, 0, 0, &func);
 }
 
 void CrewManifest::OnKeyDown(SDLKey key)
-{
-	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func384::func;
-	return execfunc(this, key);
-}
-
-namespace _func385
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewManifest::OnKeyUp", typeid(void (CrewManifest::*)(SDLKey )), ".41554189f541544989fc5531ed5331db4883ec08", nullptr, 0, 0, &func);
-}
-
-void CrewManifest::OnKeyUp(SDLKey key)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func385::func;
@@ -5003,10 +5003,10 @@ void CrewManifest::OnKeyUp(SDLKey key)
 namespace _func386
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewManifest::OnTextInput", typeid(void (CrewManifest::*)(SDLKey )), ".41554189f541544989fc5531ed5331db4883ec08", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewManifest::OnKeyUp", typeid(void (CrewManifest::*)(SDLKey )), ".41554189f541544989fc5531ed5331db4883ec08", nullptr, 0, 0, &func);
 }
 
-void CrewManifest::OnTextInput(SDLKey key)
+void CrewManifest::OnKeyUp(SDLKey key)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func386::func;
@@ -5016,17 +5016,30 @@ void CrewManifest::OnTextInput(SDLKey key)
 namespace _func387
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewManifest::OnTextInput", typeid(void (CrewManifest::*)(SDLKey )), ".41554189f541544989fc5531ed5331db4883ec08", nullptr, 0, 0, &func);
+}
+
+void CrewManifest::OnTextInput(SDLKey key)
+{
+	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func387::func;
+	return execfunc(this, key);
+}
+
+namespace _func388
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::OnTextEvent", typeid(void (CrewManifest::*)(CEvent::TextEvent )), ".41554189f541544989fc5531ed5331db4883ec08", nullptr, 0, 0, &func);
 }
 
 void CrewManifest::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func387::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func388::func;
 	return execfunc(this, event);
 }
 
-namespace _func388
+namespace _func389
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::Update", typeid(void (CrewManifest::*)()), ".415431d231c9554889fd", nullptr, 0, 0, &func);
@@ -5035,11 +5048,11 @@ namespace _func388
 void CrewManifest::Update()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func388::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func389::func;
 	return execfunc(this);
 }
 
-namespace _func389
+namespace _func390
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::OnInit", typeid(void (CrewManifest::*)(ShipManager *)), ".4157415641554989f5415455534889fb4883ec38488b8fc0000000", nullptr, 0, 0, &func);
@@ -5048,11 +5061,11 @@ namespace _func389
 void CrewManifest::OnInit(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func389::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func390::func;
 	return execfunc(this, ship);
 }
 
-namespace _func390
+namespace _func391
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::Close", typeid(void (CrewManifest::*)()), "!.41544989fc5531ed53488b97b8000000", nullptr, 0, 0, &func);
@@ -5061,11 +5074,11 @@ namespace _func390
 void CrewManifest::Close()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func390::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func391::func;
 	return execfunc(this);
 }
 
-namespace _func391
+namespace _func392
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::MouseClick", typeid(void (CrewManifest::*)(int , int )), "!.55534889fb4883ec088b87a8010000", nullptr, 0, 0, &func);
@@ -5074,11 +5087,11 @@ namespace _func391
 void CrewManifest::MouseClick(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func391::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func392::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func392
+namespace _func393
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::OnRender", typeid(void (CrewManifest::*)()), ".4155415455534889fb4883ec68", nullptr, 0, 0, &func);
@@ -5087,11 +5100,11 @@ namespace _func392
 void CrewManifest::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func392::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func393::func;
 	return execfunc(this);
 }
 
-namespace _func393
+namespace _func394
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::MouseMove", typeid(void (CrewManifest::*)(int , int )), ".4157488d87d0000000415641554189d541544189f4554889fd4889c7534883ec18", nullptr, 0, 0, &func);
@@ -5100,11 +5113,11 @@ namespace _func393
 void CrewManifest::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func393::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func394::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func394
+namespace _func395
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::InsideRoom", typeid(bool (CrewMember::*)(int )), "39b79c0000000f94c0", nullptr, 0, 0, &func);
@@ -5113,11 +5126,11 @@ namespace _func394
 bool CrewMember::InsideRoom(int roomId)
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func394::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func395::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func395
+namespace _func396
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetRoomDamage", typeid(Damage (CrewMember::*)()), ".4889f8c70700000000c7470400000000", nullptr, 0, 0, &func);
@@ -5126,11 +5139,11 @@ namespace _func395
 Damage CrewMember::GetRoomDamage()
 {
 	typedef Damage (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func395::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func396::func;
 	return execfunc(this);
 }
 
-namespace _func396
+namespace _func397
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetUniqueRepairing", typeid(std::string (CrewMember::*)()), ".53be????????4889fb4883ec10", nullptr, 0, 0, &func);
@@ -5139,11 +5152,11 @@ namespace _func396
 std::string CrewMember::GetUniqueRepairing()
 {
 	typedef std::string (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func396::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func397::func;
 	return execfunc(this);
 }
 
-namespace _func397
+namespace _func398
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::CanTeleport", typeid(bool (CrewMember::*)()), ".53488b87c00000004889fb83786003", nullptr, 0, 0, &func);
@@ -5152,11 +5165,11 @@ namespace _func397
 bool CrewMember::CanTeleport()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func397::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func398::func;
 	return execfunc(this);
 }
 
-namespace _func398
+namespace _func399
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::Jump", typeid(void (CrewMember::*)()), "!.488b87e804000083400c01", nullptr, 0, 0, &func);
@@ -5165,11 +5178,11 @@ namespace _func398
 void CrewMember::Jump()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func398::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func399::func;
 	return execfunc(this);
 }
 
-namespace _func399
+namespace _func400
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetIntruder", typeid(bool (CrewMember::*)()), ".80bf31050000008b4708", nullptr, 0, 0, &func);
@@ -5178,11 +5191,11 @@ namespace _func399
 bool CrewMember::GetIntruder()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func399::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func400::func;
 	return execfunc(this);
 }
 
-namespace _func400
+namespace _func401
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetOutOfGame", typeid(void (CrewMember::*)()), ".8b05????????c6871002000001c6872002000001", nullptr, 0, 0, &func);
@@ -5191,11 +5204,11 @@ namespace _func400
 void CrewMember::SetOutOfGame()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func400::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func401::func;
 	return execfunc(this);
 }
 
-namespace _func401
+namespace _func402
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::PositionShift", typeid(float (CrewMember::*)()), ".f30f10470cf30f2a8fb4000000", nullptr, 0, 0, &func);
@@ -5204,11 +5217,11 @@ namespace _func401
 float CrewMember::PositionShift()
 {
 	typedef float (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func401::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func402::func;
 	return execfunc(this);
 }
 
-namespace _func402
+namespace _func403
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::OnRender", typeid(void (CrewMember::*)(bool )), ".55534889fb4883ec1880bf2002000000", nullptr, 0, 0, &func);
@@ -5217,11 +5230,11 @@ namespace _func402
 void CrewMember::OnRender(bool outlineOnly)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool outlineOnly_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func402::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func403::func;
 	return execfunc(this, outlineOnly);
 }
 
-namespace _func403
+namespace _func404
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::CanHeal", typeid(bool (CrewMember::*)()), ".534889fbf30f10472c0f2e4730", nullptr, 0, 0, &func);
@@ -5230,11 +5243,11 @@ namespace _func403
 bool CrewMember::CanHeal()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func403::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func404::func;
 	return execfunc(this);
 }
 
-namespace _func404
+namespace _func405
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SaveState", typeid(void (CrewMember::*)(int )), "!.41544989fc5589f55331dbf30f1087f0060000", nullptr, 0, 0, &func);
@@ -5243,30 +5256,17 @@ namespace _func404
 void CrewMember::SaveState(int fileHelper)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func404::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func405::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func405
+namespace _func406
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::destructor", typeid(void (CrewMember::*)()), ".415641554989fd415455534883ec1048c707", nullptr, 0, 0, &func);
 }
 
 void CrewMember::destructor()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func405::func;
-	return execfunc(this);
-}
-
-namespace _func406
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::Cleanup", typeid(void (CrewMember::*)()), "!.534889fb", nullptr, 0, 0, &func);
-}
-
-void CrewMember::Cleanup()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func406::func;
@@ -5276,17 +5276,30 @@ void CrewMember::Cleanup()
 namespace _func407
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMember::Cleanup", typeid(void (CrewMember::*)()), "!.534889fb", nullptr, 0, 0, &func);
+}
+
+void CrewMember::Cleanup()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func407::func;
+	return execfunc(this);
+}
+
+namespace _func408
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::LoadState", typeid(void (CrewMember::*)(int )), ".41544989fc89f75589f553", nullptr, 0, 0, &func);
 }
 
 void CrewMember::LoadState(int fileHelper)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func407::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func408::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func408
+namespace _func409
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetCurrentSystem", typeid(void (CrewMember::*)(ShipSystem *)), ".554889f5534889fb4883ec08488b07c6872802000000", nullptr, 0, 0, &func);
@@ -5295,11 +5308,11 @@ namespace _func408
 void CrewMember::SetCurrentSystem(ShipSystem *sys)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, ShipSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func408::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func409::func;
 	return execfunc(this, sys);
 }
 
-namespace _func409
+namespace _func410
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::IsManningArtillery", typeid(bool (CrewMember::*)()), ".83bfa00000000b0f94c0", nullptr, 0, 0, &func);
@@ -5308,11 +5321,11 @@ namespace _func409
 bool CrewMember::IsManningArtillery()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func409::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func410::func;
 	return execfunc(this);
 }
 
-namespace _func410
+namespace _func411
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::IncreaseSkill", typeid(void (CrewMember::*)(int )), ".4156415541545589f5534889fb4883ec20488b07", nullptr, 0, 0, &func);
@@ -5321,11 +5334,11 @@ namespace _func410
 void CrewMember::IncreaseSkill(int skillId)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func410::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func411::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func411
+namespace _func412
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::CheckSkills", typeid(void (CrewMember::*)()), ".415455534889fb488bbf30020000", nullptr, 0, 0, &func);
@@ -5334,11 +5347,11 @@ namespace _func411
 void CrewMember::CheckSkills()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func411::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func412::func;
 	return execfunc(this);
 }
 
-namespace _func412
+namespace _func413
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::MasterSkill", typeid(void (CrewMember::*)(int )), ".488b87f80200004863f6", nullptr, 0, 0, &func);
@@ -5347,11 +5360,11 @@ namespace _func412
 void CrewMember::MasterSkill(int skillId)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func412::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func413::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func413
+namespace _func414
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetSkillFromSystem", typeid(int (*)(int )), ".83ff01742b83ff06", nullptr, 0, 0, &func);
@@ -5360,11 +5373,11 @@ namespace _func413
 int CrewMember::GetSkillFromSystem(int systemId)
 {
 	typedef int (*custom_arg_funcptr_t)(int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func413::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func414::func;
 	return execfunc(systemId);
 }
 
-namespace _func414
+namespace _func415
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetResisted", typeid(void (CrewMember::*)(bool )), ".4088b7dc060000", nullptr, 0, 0, &func);
@@ -5373,11 +5386,11 @@ namespace _func414
 void CrewMember::SetResisted(bool resisted)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool resisted_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func414::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func415::func;
 	return execfunc(this, resisted);
 }
 
-namespace _func415
+namespace _func416
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetResisted", typeid(bool (CrewMember::*)()), ".0fb687dc060000", nullptr, 0, 0, &func);
@@ -5386,11 +5399,11 @@ namespace _func415
 bool CrewMember::GetResisted()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func415::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func416::func;
 	return execfunc(this);
 }
 
-namespace _func416
+namespace _func417
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetSkillProgress", typeid(void (CrewMember::*)(int , int )), ".488b87f80200004863f6", nullptr, 0, 0, &func);
@@ -5399,11 +5412,11 @@ namespace _func416
 void CrewMember::SetSkillProgress(int skillId, int skillLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg, int skillLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func416::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func417::func;
 	return execfunc(this, skillId, skillLevel);
 }
 
-namespace _func417
+namespace _func418
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetSkillLevel", typeid(int (CrewMember::*)(int )), ".83fe05b801000000", nullptr, 0, 0, &func);
@@ -5412,11 +5425,11 @@ namespace _func417
 int CrewMember::GetSkillLevel(int skillId)
 {
 	typedef int (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func417::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func418::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func418
+namespace _func419
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetSkillProgress", typeid(std::pair<int, int> (CrewMember::*)(int )), ".488b87f80200004863f6488d14f0", nullptr, 0, 0, &func);
@@ -5425,11 +5438,11 @@ namespace _func418
 std::pair<int, int> CrewMember::GetSkillProgress(int skillId)
 {
 	typedef std::pair<int, int> (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func418::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func419::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func419
+namespace _func420
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetSkillModifier", typeid(float (CrewMember::*)(int )), "!.83fe0589f2b801000000", nullptr, 0, 0, &func);
@@ -5438,11 +5451,11 @@ namespace _func419
 float CrewMember::GetSkillModifier(int skillId)
 {
 	typedef float (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func419::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func420::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func420
+namespace _func421
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::BadAtCombat", typeid(bool (CrewMember::*)()), ".488b07534889fb", nullptr, 0, 0, &func);
@@ -5451,11 +5464,11 @@ namespace _func420
 bool CrewMember::BadAtCombat()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func420::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func421::func;
 	return execfunc(this);
 }
 
-namespace _func421
+namespace _func422
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::EmptySlot", typeid(void (CrewMember::*)()), ".534889fb4883ec108b97ac00000085d2", nullptr, 0, 0, &func);
@@ -5464,11 +5477,11 @@ namespace _func421
 void CrewMember::EmptySlot()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func421::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func422::func;
 	return execfunc(this);
 }
 
-namespace _func422
+namespace _func423
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::NeedsSlot", typeid(bool (CrewMember::*)()), ".80bf20020000007509", nullptr, 0, 0, &func);
@@ -5477,11 +5490,11 @@ namespace _func422
 bool CrewMember::NeedsSlot()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func422::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func423::func;
 	return execfunc(this);
 }
 
-namespace _func423
+namespace _func424
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::DirectModifyHealth", typeid(bool (CrewMember::*)(float )), ".530f57d24889fb4883ec30f30f105f2c0f2ed3", nullptr, 0, 0, &func);
@@ -5490,11 +5503,11 @@ namespace _func423
 bool CrewMember::DirectModifyHealth(float health)
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func423::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func424::func;
 	return execfunc(this, health);
 }
 
-namespace _func424
+namespace _func425
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::ModifyHealth", typeid(void (CrewMember::*)(float )), "!.534889fbbf????????4883ec10", nullptr, 0, 0, &func);
@@ -5503,11 +5516,11 @@ namespace _func424
 void CrewMember::ModifyHealth(float health)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func424::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func425::func;
 	return execfunc(this, health);
 }
 
-namespace _func425
+namespace _func426
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::ApplyDamage", typeid(bool (CrewMember::*)(float )), ".534889fb4883ec10f30f104f2cf30f114c240c", nullptr, 0, 0, &func);
@@ -5516,30 +5529,17 @@ namespace _func425
 bool CrewMember::ApplyDamage(float damage)
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg, float damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func425::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func426::func;
 	return execfunc(this, damage);
 }
 
-namespace _func426
+namespace _func427
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::RepairingSystem", typeid(bool (CrewMember::*)()), ".534883bf88000000004889fb", nullptr, 0, 0, &func);
 }
 
 bool CrewMember::RepairingSystem()
-{
-	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func426::func;
-	return execfunc(this);
-}
-
-namespace _func427
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::Sabotaging", typeid(bool (CrewMember::*)()), ".534889fb488bbf880000004885ff", nullptr, 0, 0, &func);
-}
-
-bool CrewMember::Sabotaging()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func427::func;
@@ -5549,10 +5549,10 @@ bool CrewMember::Sabotaging()
 namespace _func428
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::RepairingFire", typeid(bool (CrewMember::*)()), ".31c04883bf8800000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::Sabotaging", typeid(bool (CrewMember::*)()), ".534889fb488bbf880000004885ff", nullptr, 0, 0, &func);
 }
 
-bool CrewMember::RepairingFire()
+bool CrewMember::Sabotaging()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func428::func;
@@ -5562,12 +5562,12 @@ bool CrewMember::RepairingFire()
 namespace _func429
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::SelectSabotageTarget", typeid(Pointf (CrewMember::*)()), ".55534889fb4883ec38488bbf88000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::RepairingFire", typeid(bool (CrewMember::*)()), ".31c04883bf8800000000", nullptr, 0, 0, &func);
 }
 
-Pointf CrewMember::SelectSabotageTarget()
+bool CrewMember::RepairingFire()
 {
-	typedef Pointf (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func429::func;
 	return execfunc(this);
 }
@@ -5575,12 +5575,12 @@ Pointf CrewMember::SelectSabotageTarget()
 namespace _func430
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::SavePosition", typeid(void (CrewMember::*)()), ".488b87ac000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::SelectSabotageTarget", typeid(Pointf (CrewMember::*)()), ".55534889fb4883ec38488bbf88000000", nullptr, 0, 0, &func);
 }
 
-void CrewMember::SavePosition()
+Pointf CrewMember::SelectSabotageTarget()
 {
-	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	typedef Pointf (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func430::func;
 	return execfunc(this);
 }
@@ -5588,10 +5588,10 @@ void CrewMember::SavePosition()
 namespace _func431
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::ClearPosition", typeid(void (CrewMember::*)()), ".c787e4060000ffffffff", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::SavePosition", typeid(void (CrewMember::*)()), ".488b87ac000000", nullptr, 0, 0, &func);
 }
 
-void CrewMember::ClearPosition()
+void CrewMember::SavePosition()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func431::func;
@@ -5601,17 +5601,30 @@ void CrewMember::ClearPosition()
 namespace _func432
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMember::ClearPosition", typeid(void (CrewMember::*)()), ".c787e4060000ffffffff", nullptr, 0, 0, &func);
+}
+
+void CrewMember::ClearPosition()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func432::func;
+	return execfunc(this);
+}
+
+namespace _func433
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetSavedPosition", typeid(Slot (CrewMember::*)()), ".488b87e0060000", nullptr, 0, 0, &func);
 }
 
 Slot CrewMember::GetSavedPosition()
 {
 	typedef Slot (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func432::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func433::func;
 	return execfunc(this);
 }
 
-namespace _func433
+namespace _func434
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetSavePosition", typeid(void (CrewMember::*)(Slot )), ".4889b7e0060000", nullptr, 0, 0, &func);
@@ -5620,11 +5633,11 @@ namespace _func433
 void CrewMember::SetSavePosition(Slot position)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, Slot position_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func433::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func434::func;
 	return execfunc(this, position);
 }
 
-namespace _func434
+namespace _func435
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::StopRepairing", typeid(void (CrewMember::*)()), ".534883bf88000000004889fb", nullptr, 0, 0, &func);
@@ -5633,11 +5646,11 @@ namespace _func434
 void CrewMember::StopRepairing()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func434::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func435::func;
 	return execfunc(this);
 }
 
-namespace _func435
+namespace _func436
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::Repairing", typeid(bool (CrewMember::*)()), ".4883bf88000000000f95c0", nullptr, 0, 0, &func);
@@ -5646,11 +5659,11 @@ namespace _func435
 bool CrewMember::Repairing()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func435::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func436::func;
 	return execfunc(this);
 }
 
-namespace _func436
+namespace _func437
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetFrozen", typeid(void (CrewMember::*)(bool )), ".4084f6741b80bfd401000000", nullptr, 0, 0, &func);
@@ -5659,11 +5672,11 @@ namespace _func436
 void CrewMember::SetFrozen(bool frozen)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool frozen_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func436::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func437::func;
 	return execfunc(this, frozen);
 }
 
-namespace _func437
+namespace _func438
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetFrozenLocation", typeid(void (CrewMember::*)(bool )), ".4088b7d5010000", nullptr, 0, 0, &func);
@@ -5672,11 +5685,11 @@ namespace _func437
 void CrewMember::SetFrozenLocation(bool frozenLocation)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool frozenLocation_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func437::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func438::func;
 	return execfunc(this, frozenLocation);
 }
 
-namespace _func438
+namespace _func439
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetTask", typeid(void (CrewMember::*)(CrewTask )), ".4889b7d80100008997e0010000", nullptr, 0, 0, &func);
@@ -5685,11 +5698,11 @@ namespace _func438
 void CrewMember::SetTask(CrewTask task)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewTask task_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func438::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func439::func;
 	return execfunc(this, task);
 }
 
-namespace _func439
+namespace _func440
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::FindSlot", typeid(Slot (CrewMember::*)(int , int , bool )), ".4155415455534889fb4883ec18488bbff0010000", nullptr, 0, 0, &func);
@@ -5698,11 +5711,11 @@ namespace _func439
 Slot CrewMember::FindSlot(int roomId, int slotId, bool closeEnough)
 {
 	typedef Slot (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg, int slotId_arg, bool closeEnough_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func439::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func440::func;
 	return execfunc(this, roomId, slotId, closeEnough);
 }
 
-namespace _func440
+namespace _func441
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::CheckRoomPath", typeid(bool (CrewMember::*)(int )), ".415531c9baffffffff41544531e4554889fd5389f34883ec38", nullptr, 0, 0, &func);
@@ -5711,11 +5724,11 @@ namespace _func440
 bool CrewMember::CheckRoomPath(int roomId)
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func440::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func441::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func441
+namespace _func442
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetPosition", typeid(void (CrewMember::*)(Point )), ".f30f2ace4889f248c1fa2055f30f2ac2534889fb4883ec18", nullptr, 0, 0, &func);
@@ -5724,30 +5737,17 @@ namespace _func441
 void CrewMember::SetPosition(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func441::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func442::func;
 	return execfunc(this, pos);
 }
 
-namespace _func442
+namespace _func443
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::ClearTask", typeid(void (CrewMember::*)()), ".8b879c000000c787e0010000ffffffff", nullptr, 0, 0, &func);
 }
 
 void CrewMember::ClearTask()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func442::func;
-	return execfunc(this);
-}
-
-namespace _func443
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::ClearPath", typeid(void (CrewMember::*)()), ".55534889fb4883ec38488b07", nullptr, 0, 0, &func);
-}
-
-void CrewMember::ClearPath()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func443::func;
@@ -5757,36 +5757,36 @@ void CrewMember::ClearPath()
 namespace _func444
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMember::ClearPath", typeid(void (CrewMember::*)()), ".55534889fb4883ec38488b07", nullptr, 0, 0, &func);
+}
+
+void CrewMember::ClearPath()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func444::func;
+	return execfunc(this);
+}
+
+namespace _func445
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetRoom", typeid(void (CrewMember::*)(int )), ".4155415455534889fb4883ec184883bff001000000", nullptr, 0, 0, &func);
 }
 
 void CrewMember::SetRoom(int roomId)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func444::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func445::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func445
+namespace _func446
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::IsBusy", typeid(bool (CrewMember::*)()), ".4883bf8800000000b801000000", nullptr, 0, 0, &func);
 }
 
 bool CrewMember::IsBusy()
-{
-	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func445::func;
-	return execfunc(this);
-}
-
-namespace _func446
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::OnInit", typeid(bool (CrewMember::*)()), ".c747241e00000048c7878000000000000000", nullptr, 0, 0, &func);
-}
-
-bool CrewMember::OnInit()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func446::func;
@@ -5796,12 +5796,12 @@ bool CrewMember::OnInit()
 namespace _func447
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::GetFinalGoal", typeid(Point (CrewMember::*)()), ".f30f1005????????0f2e4768", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::OnInit", typeid(bool (CrewMember::*)()), ".c747241e00000048c7878000000000000000", nullptr, 0, 0, &func);
 }
 
-Point CrewMember::GetFinalGoal()
+bool CrewMember::OnInit()
 {
-	typedef Point (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func447::func;
 	return execfunc(this);
 }
@@ -5809,10 +5809,10 @@ Point CrewMember::GetFinalGoal()
 namespace _func448
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::GetNextGoal", typeid(Point (CrewMember::*)()), ".534889fb4883ec20f30f104720", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::GetFinalGoal", typeid(Point (CrewMember::*)()), ".f30f1005????????0f2e4768", nullptr, 0, 0, &func);
 }
 
-Point CrewMember::GetNextGoal()
+Point CrewMember::GetFinalGoal()
 {
 	typedef Point (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func448::func;
@@ -5822,17 +5822,30 @@ Point CrewMember::GetNextGoal()
 namespace _func449
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMember::GetNextGoal", typeid(Point (CrewMember::*)()), ".534889fb4883ec20f30f104720", nullptr, 0, 0, &func);
+}
+
+Point CrewMember::GetNextGoal()
+{
+	typedef Point (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func449::func;
+	return execfunc(this);
+}
+
+namespace _func450
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::CloseDoorBehind", typeid(void (CrewMember::*)(Door *)), ".4889b780000000", nullptr, 0, 0, &func);
 }
 
 void CrewMember::CloseDoorBehind(Door *door)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, Door *door_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func449::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func450::func;
 	return execfunc(this, door);
 }
 
-namespace _func450
+namespace _func451
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetMoveSpeed", typeid(float (CrewMember::*)()), ".55be????????31ed534889fb4883ec38", nullptr, 0, 0, &func);
@@ -5841,11 +5854,11 @@ namespace _func450
 float CrewMember::GetMoveSpeed()
 {
 	typedef float (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func450::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func451::func;
 	return execfunc(this);
 }
 
-namespace _func451
+namespace _func452
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::Restart", typeid(void (CrewMember::*)()), ".4155415449bcabaaaaaaaaaaaaaa5531ed534889fb4883ec18", nullptr, 0, 0, &func);
@@ -5854,11 +5867,11 @@ namespace _func451
 void CrewMember::Restart()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func451::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func452::func;
 	return execfunc(this);
 }
 
-namespace _func452
+namespace _func453
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetDamageBoost", typeid(void (CrewMember::*)(float )), ".f30f1187d4060000", nullptr, 0, 0, &func);
@@ -5867,11 +5880,11 @@ namespace _func452
 void CrewMember::SetDamageBoost(float damageBoost)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, float damageBoost_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func452::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func453::func;
 	return execfunc(this, damageBoost);
 }
 
-namespace _func453
+namespace _func454
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetHealthBoost", typeid(void (CrewMember::*)(int )), ".538b87d00600004889fb39f0", nullptr, 0, 0, &func);
@@ -5880,11 +5893,11 @@ namespace _func453
 void CrewMember::SetHealthBoost(int healthBoost)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int healthBoost_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func453::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func454::func;
 	return execfunc(this, healthBoost);
 }
 
-namespace _func454
+namespace _func455
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::InitializeSkills", typeid(void (CrewMember::*)()), ".554889fd5331db4883ec08", nullptr, 0, 0, &func);
@@ -5893,11 +5906,11 @@ namespace _func454
 void CrewMember::InitializeSkills()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func454::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func455::func;
 	return execfunc(this);
 }
 
-namespace _func455
+namespace _func456
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetCloneReady", typeid(void (CrewMember::*)(bool )), ".534889fb4883ec2080bf2002000000", nullptr, 0, 0, &func);
@@ -5906,11 +5919,11 @@ namespace _func455
 void CrewMember::SetCloneReady(bool cloneReady)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool cloneReady_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func455::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func456::func;
 	return execfunc(this, cloneReady);
 }
 
-namespace _func456
+namespace _func457
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::Kill", typeid(void (CrewMember::*)(bool )), ".5589f5534889fb4883ec284883bf8800000000", nullptr, 0, 0, &func);
@@ -5919,11 +5932,11 @@ namespace _func456
 void CrewMember::Kill(bool noClone)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool noClone_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func456::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func457::func;
 	return execfunc(this, noClone);
 }
 
-namespace _func457
+namespace _func458
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::NeedFrozenLocation", typeid(bool (CrewMember::*)()), ".31c080bfd401000000", nullptr, 0, 0, &func);
@@ -5932,11 +5945,11 @@ namespace _func457
 bool CrewMember::NeedFrozenLocation()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func457::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func458::func;
 	return execfunc(this);
 }
 
-namespace _func458
+namespace _func459
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::CheckForTeleport", typeid(void (CrewMember::*)()), ".55534889fb4883ec08488bafc0000000", nullptr, 0, 0, &func);
@@ -5945,11 +5958,11 @@ namespace _func458
 void CrewMember::CheckForTeleport()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func458::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func459::func;
 	return execfunc(this);
 }
 
-namespace _func459
+namespace _func460
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetCurrentShip", typeid(void (CrewMember::*)(int )), ".488b87c000000089b78c010000", nullptr, 0, 0, &func);
@@ -5958,11 +5971,11 @@ namespace _func459
 void CrewMember::SetCurrentShip(int shipId)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func459::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func460::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func460
+namespace _func461
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::CheckFighting", typeid(void (CrewMember::*)()), ".4883bfb801000000", nullptr, 0, 0, &func);
@@ -5971,11 +5984,11 @@ namespace _func460
 void CrewMember::CheckFighting()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func460::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func461::func;
 	return execfunc(this);
 }
 
-namespace _func461
+namespace _func462
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetDeathNumber", typeid(void (CrewMember::*)(int )), ".3b35????????89b734050000", nullptr, 0, 0, &func);
@@ -5984,11 +5997,11 @@ namespace _func461
 void CrewMember::SetDeathNumber(int deathNum)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int deathNum_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func461::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func462::func;
 	return execfunc(this, deathNum);
 }
 
-namespace _func462
+namespace _func463
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::ForceMindControl", typeid(void (CrewMember::*)(bool )), ".4088b731050000", nullptr, 0, 0, &func);
@@ -5997,11 +6010,11 @@ namespace _func462
 void CrewMember::ForceMindControl(bool force)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func462::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func463::func;
 	return execfunc(this, force);
 }
 
-namespace _func463
+namespace _func464
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::RenderSkillUpAnimation", typeid(void (CrewMember::*)(Point )), ".41574989ff415641554531ed41544989f449c1fc20554889f5534883ec38", nullptr, 0, 0, &func);
@@ -6010,30 +6023,17 @@ namespace _func463
 void CrewMember::RenderSkillUpAnimation(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func463::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func464::func;
 	return execfunc(this, pos);
 }
 
-namespace _func464
+namespace _func465
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::Clone", typeid(void (CrewMember::*)()), ".55534889fb4883ec28c6871002000000", nullptr, 0, 0, &func);
 }
 
 void CrewMember::Clone()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func464::func;
-	return execfunc(this);
-}
-
-namespace _func465
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::UpdateHealth", typeid(void (CrewMember::*)()), ".55534889fb4883ec488b872402000085c0", nullptr, 0, 0, &func);
-}
-
-void CrewMember::UpdateHealth()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func465::func;
@@ -6043,10 +6043,10 @@ void CrewMember::UpdateHealth()
 namespace _func466
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::OnRenderPath", typeid(void (CrewMember::*)()), ".534889fb4883ec108b4f0885c9", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::UpdateHealth", typeid(void (CrewMember::*)()), ".55534889fb4883ec488b872402000085c0", nullptr, 0, 0, &func);
 }
 
-void CrewMember::OnRenderPath()
+void CrewMember::UpdateHealth()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func466::func;
@@ -6056,17 +6056,30 @@ void CrewMember::OnRenderPath()
 namespace _func467
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMember::OnRenderPath", typeid(void (CrewMember::*)()), ".534889fb4883ec108b4f0885c9", nullptr, 0, 0, &func);
+}
+
+void CrewMember::OnRenderPath()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func467::func;
+	return execfunc(this);
+}
+
+namespace _func468
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetPath", typeid(bool (CrewMember::*)(Path *)), ".4157415641554154554889f5534889fb4883ec28", nullptr, 0, 0, &func);
 }
 
 bool CrewMember::SetPath(Path *path)
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg, Path *path_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func467::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func468::func;
 	return execfunc(this, path);
 }
 
-namespace _func468
+namespace _func469
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetRoomPath", typeid(void (CrewMember::*)(int , int )), ".415455534889fb4883ec30488bbff0010000", nullptr, 0, 0, &func);
@@ -6075,11 +6088,11 @@ namespace _func468
 void CrewMember::SetRoomPath(int slotId, int roomId)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int slotId_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func468::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func469::func;
 	return execfunc(this, slotId, roomId);
 }
 
-namespace _func469
+namespace _func470
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetLocation", typeid(Point (CrewMember::*)()), ".534889fb4883ec20f30f104710", nullptr, 0, 0, &func);
@@ -6088,19 +6101,6 @@ namespace _func469
 Point CrewMember::GetLocation()
 {
 	typedef Point (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func469::func;
-	return execfunc(this);
-}
-
-namespace _func470
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::AtGoal", typeid(bool (CrewMember::*)()), ".f30f105f1c", nullptr, 0, 0, &func);
-}
-
-bool CrewMember::AtGoal()
-{
-	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func470::func;
 	return execfunc(this);
 }
@@ -6108,10 +6108,10 @@ bool CrewMember::AtGoal()
 namespace _func471
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::AtFinalGoal", typeid(bool (CrewMember::*)()), ".f30f10470cf30f2a8fb4000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::AtGoal", typeid(bool (CrewMember::*)()), ".f30f105f1c", nullptr, 0, 0, &func);
 }
 
-bool CrewMember::AtFinalGoal()
+bool CrewMember::AtGoal()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func471::func;
@@ -6121,12 +6121,12 @@ bool CrewMember::AtFinalGoal()
 namespace _func472
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::OnRenderHealth", typeid(void (CrewMember::*)()), ".4155415455534889fb4883ec7880bf2002000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::AtFinalGoal", typeid(bool (CrewMember::*)()), ".f30f10470cf30f2a8fb4000000", nullptr, 0, 0, &func);
 }
 
-void CrewMember::OnRenderHealth()
+bool CrewMember::AtFinalGoal()
 {
-	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func472::func;
 	return execfunc(this);
 }
@@ -6134,12 +6134,12 @@ void CrewMember::OnRenderHealth()
 namespace _func473
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::GetIntegerHealth", typeid(int (CrewMember::*)()), ".31c080bf2002000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::OnRenderHealth", typeid(void (CrewMember::*)()), ".4155415455534889fb4883ec7880bf2002000000", nullptr, 0, 0, &func);
 }
 
-int CrewMember::GetIntegerHealth()
+void CrewMember::OnRenderHealth()
 {
-	typedef int (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func473::func;
 	return execfunc(this);
 }
@@ -6147,10 +6147,10 @@ int CrewMember::GetIntegerHealth()
 namespace _func474
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::GetRepairingId", typeid(int (CrewMember::*)()), ".488bbf880000004885ff", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::GetIntegerHealth", typeid(int (CrewMember::*)()), ".31c080bf2002000000", nullptr, 0, 0, &func);
 }
 
-int CrewMember::GetRepairingId()
+int CrewMember::GetIntegerHealth()
 {
 	typedef int (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func474::func;
@@ -6160,17 +6160,30 @@ int CrewMember::GetRepairingId()
 namespace _func475
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMember::GetRepairingId", typeid(int (CrewMember::*)()), ".488bbf880000004885ff", nullptr, 0, 0, &func);
+}
+
+int CrewMember::GetRepairingId()
+{
+	typedef int (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func475::func;
+	return execfunc(this);
+}
+
+namespace _func476
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::WithinRect", typeid(bool (CrewMember::*)(int , int , int , int )), ".85c9784c4585c0783f", nullptr, 0, 0, &func);
 }
 
 bool CrewMember::WithinRect(int x, int y, int w, int h)
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg, int x_arg, int y_arg, int w_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func475::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func476::func;
 	return execfunc(this, x, y, w, h);
 }
 
-namespace _func476
+namespace _func477
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetLongName", typeid(std::string (CrewMember::*)()), ".5380bed0020000004889fb", nullptr, 0, 0, &func);
@@ -6179,11 +6192,11 @@ namespace _func476
 std::string CrewMember::GetLongName()
 {
 	typedef std::string (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func476::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func477::func;
 	return execfunc(this);
 }
 
-namespace _func477
+namespace _func478
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetName", typeid(void (CrewMember::*)(TextString *, bool )), ".41544189d4554889f5534889fb488dbfc80200004883ec40", nullptr, 0, 0, &func);
@@ -6192,11 +6205,11 @@ namespace _func477
 void CrewMember::SetName(TextString *name, bool force)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, TextString *name_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func477::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func478::func;
 	return execfunc(this, name, force);
 }
 
-namespace _func478
+namespace _func479
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetName", typeid(std::string (CrewMember::*)()), ".5380bec0020000004889fb", nullptr, 0, 0, &func);
@@ -6205,11 +6218,11 @@ namespace _func478
 std::string CrewMember::GetName()
 {
 	typedef std::string (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func478::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func479::func;
 	return execfunc(this);
 }
 
-namespace _func479
+namespace _func480
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetCurrentTarget", typeid(void (CrewMember::*)(CrewTarget *, bool )), ".41544189d4554889f553488b074889fb", nullptr, 0, 0, &func);
@@ -6218,11 +6231,11 @@ namespace _func479
 void CrewMember::SetCurrentTarget(CrewTarget *target, bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewTarget *target_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func479::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func480::func;
 	return execfunc(this, target, unk);
 }
 
-namespace _func480
+namespace _func481
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetNewGoal", typeid(bool (CrewMember::*)()), ".41574989ff41564155415455534883ec28", nullptr, 0, 0, &func);
@@ -6231,11 +6244,11 @@ namespace _func480
 bool CrewMember::GetNewGoal()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func480::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func481::func;
 	return execfunc(this);
 }
 
-namespace _func481
+namespace _func482
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::MoveToRoom", typeid(bool (CrewMember::*)(int , int , bool )), ".4157415641554189d541544189cc5589f5534889fb4883ec48", nullptr, 0, 0, &func);
@@ -6244,11 +6257,11 @@ namespace _func481
 bool CrewMember::MoveToRoom(int roomId, int slotId, bool forceMove)
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg, int slotId_arg, bool forceMove_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func481::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func482::func;
 	return execfunc(this, roomId, slotId, forceMove);
 }
 
-namespace _func482
+namespace _func483
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetMindControl", typeid(void (CrewMember::*)(bool )), ".5589f5534889fb4883ec084038b731050000", nullptr, 0, 0, &func);
@@ -6257,11 +6270,11 @@ namespace _func482
 void CrewMember::SetMindControl(bool controlled)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool controlled_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func482::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func483::func;
 	return execfunc(this, controlled);
 }
 
-namespace _func483
+namespace _func484
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::RestorePosition", typeid(bool (CrewMember::*)()), ".415741564155415455534889fb4883ec48488b07", nullptr, 0, 0, &func);
@@ -6270,11 +6283,11 @@ namespace _func483
 bool CrewMember::RestorePosition()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func483::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func484::func;
 	return execfunc(this);
 }
 
-namespace _func484
+namespace _func485
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::ContainsPoint", typeid(bool (CrewMember::*)(int , int )), ".f30f1005????????f30f594718", nullptr, 0, 0, &func);
@@ -6283,11 +6296,11 @@ namespace _func484
 bool CrewMember::ContainsPoint(int x, int y)
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func484::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func485::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func485
+namespace _func486
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetMedbay", typeid(void (CrewMember::*)(float )), ".534889fb4883ec10488b07f30f1144240c", nullptr, 0, 0, &func);
@@ -6296,30 +6309,17 @@ namespace _func485
 void CrewMember::SetMedbay(float health)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func485::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func486::func;
 	return execfunc(this, health);
 }
 
-namespace _func486
+namespace _func487
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::StartTeleport", typeid(void (CrewMember::*)()), "!.53488b9fc000000031f60f57c0", nullptr, 0, 0, &func);
 }
 
 void CrewMember::StartTeleport()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func486::func;
-	return execfunc(this);
-}
-
-namespace _func487
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::StartTeleportArrive", typeid(void (CrewMember::*)()), "!.53488b9fc000000031f60f57c0", nullptr, 0, 0, &func);
-}
-
-void CrewMember::StartTeleportArrive()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func487::func;
@@ -6329,36 +6329,36 @@ void CrewMember::StartTeleportArrive()
 namespace _func488
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMember::StartTeleportArrive", typeid(void (CrewMember::*)()), "!.53488b9fc000000031f60f57c0", nullptr, 0, 0, &func);
+}
+
+void CrewMember::StartTeleportArrive()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func488::func;
+	return execfunc(this);
+}
+
+namespace _func489
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::StartRepair", typeid(void (CrewMember::*)(Repairable *)), ".55534889fb4883ec28f30f10470c", nullptr, 0, 0, &func);
 }
 
 void CrewMember::StartRepair(Repairable *toRepair)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, Repairable *toRepair_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func488::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func489::func;
 	return execfunc(this, toRepair);
 }
 
-namespace _func489
+namespace _func490
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::UpdateRepair", typeid(void (CrewMember::*)()), ".55534889fb4883ec48488bbf88000000", nullptr, 0, 0, &func);
 }
 
 void CrewMember::UpdateRepair()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func489::func;
-	return execfunc(this);
-}
-
-namespace _func490
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::UpdateMovement", typeid(void (CrewMember::*)()), ".534889fb4883ec30488b87c000000083786006", nullptr, 0, 0, &func);
-}
-
-void CrewMember::UpdateMovement()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func490::func;
@@ -6368,10 +6368,10 @@ void CrewMember::UpdateMovement()
 namespace _func491
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::OnLoop", typeid(void (CrewMember::*)()), ".415741564155415455534889fb4883ec7880bf2002000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::UpdateMovement", typeid(void (CrewMember::*)()), ".534889fb4883ec30488b87c000000083786006", nullptr, 0, 0, &func);
 }
 
-void CrewMember::OnLoop()
+void CrewMember::UpdateMovement()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func491::func;
@@ -6381,17 +6381,30 @@ void CrewMember::OnLoop()
 namespace _func492
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMember::OnLoop", typeid(void (CrewMember::*)()), ".415741564155415455534889fb4883ec7880bf2002000000", nullptr, 0, 0, &func);
+}
+
+void CrewMember::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func492::func;
+	return execfunc(this);
+}
+
+namespace _func493
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetTooltip", typeid(std::string (CrewMember::*)()), ".4157415641554154554889f5", nullptr, 0, 0, &func);
 }
 
 std::string CrewMember::GetTooltip()
 {
 	typedef std::string (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func492::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func493::func;
 	return execfunc(this);
 }
 
-namespace _func493
+namespace _func494
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetSkillTooltip", typeid(std::string (*)(int , int , std::pair<int, int> , bool )), ".41574589c7415641554189d541544989fc554889cd5389f3", nullptr, 0, 0, &func);
@@ -6400,11 +6413,11 @@ namespace _func493
 std::string CrewMember::GetSkillTooltip(int skillId, int skillLevel, std::pair<int, int> progress, bool infoScreen)
 {
 	typedef std::string (*custom_arg_funcptr_t)(int skillId_arg, int skillLevel_arg, std::pair<int, int> progress_arg, bool infoScreen_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func493::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func494::func;
 	return execfunc(skillId, skillLevel, progress, infoScreen);
 }
 
-namespace _func494
+namespace _func495
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetSex", typeid(void (CrewMember::*)(bool )), ".5589f5534889fb4883ec08488bbfc0000000", nullptr, 0, 0, &func);
@@ -6413,11 +6426,11 @@ namespace _func494
 void CrewMember::SetSex(bool male)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool male_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func494::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func495::func;
 	return execfunc(this, male);
 }
 
-namespace _func495
+namespace _func496
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::CycleColorLayer", typeid(void (CrewMember::*)(int )), ".4155415449bcabaaaaaaaaaaaaaa55534889fb4883ec48", nullptr, 0, 0, &func);
@@ -6426,11 +6439,11 @@ namespace _func495
 void CrewMember::CycleColorLayer(int unk)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func495::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func496::func;
 	return execfunc(this, unk);
 }
 
-namespace _func496
+namespace _func497
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::constructor", typeid(void (CrewMember::*)(CrewBlueprint &, int , bool , CrewAnimation *)), ".415741564189d641554d89c541544189cc554889f5534889fb488d7f404881ecb8000000", nullptr, 0, 0, &func);
@@ -6439,30 +6452,17 @@ namespace _func496
 void CrewMember::constructor(CrewBlueprint &blueprint, int shipId, bool intruder, CrewAnimation *animation)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewBlueprint &blueprint_arg, int shipId_arg, bool intruder_arg, CrewAnimation *animation_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func496::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func497::func;
 	return execfunc(this, blueprint, shipId, intruder, animation);
 }
 
-namespace _func497
+namespace _func498
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::Functional", typeid(bool (CrewMember::*)()), ".4883ec08488b07", nullptr, 0, 0, &func);
 }
 
 bool CrewMember::Functional()
-{
-	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func497::func;
-	return execfunc(this);
-}
-
-namespace _func498
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::CountForVictory", typeid(bool (CrewMember::*)()), ".488b07534889fb", nullptr, 0, 0, &func);
-}
-
-bool CrewMember::CountForVictory()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func498::func;
@@ -6472,10 +6472,10 @@ bool CrewMember::CountForVictory()
 namespace _func499
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::CanSabotage", typeid(bool (CrewMember::*)()), ".0fb687bc000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::CountForVictory", typeid(bool (CrewMember::*)()), ".488b07534889fb", nullptr, 0, 0, &func);
 }
 
-bool CrewMember::CanSabotage()
+bool CrewMember::CountForVictory()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func499::func;
@@ -6485,10 +6485,10 @@ bool CrewMember::CanSabotage()
 namespace _func500
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::CanMan", typeid(bool (CrewMember::*)()), ".31c080bfbc00000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::CanSabotage", typeid(bool (CrewMember::*)()), ".0fb687bc000000", nullptr, 0, 0, &func);
 }
 
-bool CrewMember::CanMan()
+bool CrewMember::CanSabotage()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func500::func;
@@ -6498,10 +6498,10 @@ bool CrewMember::CanMan()
 namespace _func501
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::CanRepair", typeid(bool (CrewMember::*)()), ".5380bfbc00000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::CanMan", typeid(bool (CrewMember::*)()), ".31c080bfbc00000000", nullptr, 0, 0, &func);
 }
 
-bool CrewMember::CanRepair()
+bool CrewMember::CanMan()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func501::func;
@@ -6511,10 +6511,10 @@ bool CrewMember::CanRepair()
 namespace _func502
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::GetControllable", typeid(bool (CrewMember::*)()), ".538b570831c04889fb85d2", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::CanRepair", typeid(bool (CrewMember::*)()), ".5380bfbc00000000", nullptr, 0, 0, &func);
 }
 
-bool CrewMember::GetControllable()
+bool CrewMember::CanRepair()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func502::func;
@@ -6524,12 +6524,12 @@ bool CrewMember::GetControllable()
 namespace _func503
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMemberFactory::destructor", typeid(void (CrewMemberFactory::*)()), "554889fd534883ec08488b7718488b57104889f04829d048c1f8034885c0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::GetControllable", typeid(bool (CrewMember::*)()), ".538b570831c04889fb85d2", nullptr, 0, 0, &func);
 }
 
-void CrewMemberFactory::destructor()
+bool CrewMember::GetControllable()
 {
-	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
+	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func503::func;
 	return execfunc(this);
 }
@@ -6537,10 +6537,10 @@ void CrewMemberFactory::destructor()
 namespace _func504
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMemberFactory::Restart", typeid(void (CrewMemberFactory::*)()), ".53488b4f184889fb488b47104889ca4829c248c1fa034885d2", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMemberFactory::destructor", typeid(void (CrewMemberFactory::*)()), "554889fd534883ec08488b7718488b57104889f04829d048c1f8034885c0", nullptr, 0, 0, &func);
 }
 
-void CrewMemberFactory::Restart()
+void CrewMemberFactory::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func504::func;
@@ -6550,17 +6550,30 @@ void CrewMemberFactory::Restart()
 namespace _func505
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMemberFactory::Restart", typeid(void (CrewMemberFactory::*)()), ".53488b4f184889fb488b47104889ca4829c248c1fa034885d2", nullptr, 0, 0, &func);
+}
+
+void CrewMemberFactory::Restart()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func505::func;
+	return execfunc(this);
+}
+
+namespace _func506
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::CountCloneReadyCrew", typeid(int (CrewMemberFactory::*)(bool )), ".41564989fe415541545553488b4710488b57184829c2", nullptr, 0, 0, &func);
 }
 
 int CrewMemberFactory::CountCloneReadyCrew(bool player)
 {
 	typedef int (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, bool player_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func505::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func506::func;
 	return execfunc(this, player);
 }
 
-namespace _func506
+namespace _func507
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::GetCrewPortraitList", typeid(void (CrewMemberFactory::*)(std::vector<CrewMember*> *, int )), ".415731c94989ff4156415549bdffffffffffffff1f41544989f45589d55331db4883ec18", nullptr, 0, 0, &func);
@@ -6569,11 +6582,11 @@ namespace _func506
 void CrewMemberFactory::GetCrewPortraitList(std::vector<CrewMember*> *vec, int teamId)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> *vec_arg, int teamId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func506::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func507::func;
 	return execfunc(this, vec, teamId);
 }
 
-namespace _func507
+namespace _func508
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::GetCrewList", typeid(void (CrewMemberFactory::*)(std::vector<CrewMember*> *, int , bool )), ".41574531c04531ff415641554989fd41544989f45589cd5389d34883ec18", nullptr, 0, 0, &func);
@@ -6582,30 +6595,17 @@ namespace _func507
 void CrewMemberFactory::GetCrewList(std::vector<CrewMember*> *vec, int unk, bool unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> *vec_arg, int unk_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func507::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func508::func;
 	return execfunc(this, vec, unk, unk2);
 }
 
-namespace _func508
+namespace _func509
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::GetPlayerCrewCount", typeid(int (CrewMemberFactory::*)()), "!.8b07c3906666662e0f1f840000000000", nullptr, 0, 0, &func);
 }
 
 int CrewMemberFactory::GetPlayerCrewCount()
-{
-	typedef int (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func508::func;
-	return execfunc(this);
-}
-
-namespace _func509
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMemberFactory::GetEnemyCloneCount", typeid(int (CrewMemberFactory::*)()), "!.8b4708c36666662e0f1f840000000000", nullptr, 0, 0, &func);
-}
-
-int CrewMemberFactory::GetEnemyCloneCount()
 {
 	typedef int (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func509::func;
@@ -6615,17 +6615,30 @@ int CrewMemberFactory::GetEnemyCloneCount()
 namespace _func510
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMemberFactory::GetEnemyCloneCount", typeid(int (CrewMemberFactory::*)()), "!.8b4708c36666662e0f1f840000000000", nullptr, 0, 0, &func);
+}
+
+int CrewMemberFactory::GetEnemyCloneCount()
+{
+	typedef int (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func510::func;
+	return execfunc(this);
+}
+
+namespace _func511
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::GetCrewCount", typeid(int (CrewMemberFactory::*)(bool )), ".8b47044084f6", nullptr, 0, 0, &func);
 }
 
 int CrewMemberFactory::GetCrewCount(bool enemy)
 {
 	typedef int (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func510::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func511::func;
 	return execfunc(this, enemy);
 }
 
-namespace _func511
+namespace _func512
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::GetEnemyCrewCount", typeid(int (CrewMemberFactory::*)()), "!.8b4704c36666662e0f1f840000000000", nullptr, 0, 0, &func);
@@ -6634,11 +6647,11 @@ namespace _func511
 int CrewMemberFactory::GetEnemyCrewCount()
 {
 	typedef int (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func511::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func512::func;
 	return execfunc(this);
 }
 
-namespace _func512
+namespace _func513
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::IsRace", typeid(bool (*)(const std::string &)), ".53be????????", nullptr, 0, 0, &func);
@@ -6647,11 +6660,11 @@ namespace _func512
 bool CrewMemberFactory::IsRace(const std::string &species)
 {
 	typedef bool (*custom_arg_funcptr_t)(const std::string &species_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func512::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func513::func;
 	return execfunc(species);
 }
 
-namespace _func513
+namespace _func514
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::CreateBoarderDrone", typeid(BoarderDrone *(CrewMemberFactory::*)(int , const DroneBlueprint *)), ".415641554189f5", nullptr, 0, 0, &func);
@@ -6660,11 +6673,11 @@ namespace _func513
 BoarderDrone *CrewMemberFactory::CreateBoarderDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef BoarderDrone *(*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func513::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func514::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func514
+namespace _func515
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::CreateBattleDrone", typeid(BattleDrone *(CrewMemberFactory::*)(int , const DroneBlueprint *)), ".415641554989d541544189f4554889fdbf20090000534883ec40", nullptr, 0, 0, &func);
@@ -6673,11 +6686,11 @@ namespace _func514
 BattleDrone *CrewMemberFactory::CreateBattleDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef BattleDrone *(*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func514::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func515::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func515
+namespace _func516
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::GetCloneReadyList", typeid(void (CrewMemberFactory::*)(std::vector<CrewMember*> &, bool )), ".4157415641554989fd41544189d431d2554889f55331db4883ec18", nullptr, 0, 0, &func);
@@ -6686,11 +6699,11 @@ namespace _func515
 void CrewMemberFactory::GetCloneReadyList(std::vector<CrewMember*> &vec, bool player)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> &vec_arg, bool player_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func515::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func516::func;
 	return execfunc(this, vec, player);
 }
 
-namespace _func516
+namespace _func517
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::CreateRepairDrone", typeid(RepairDrone *(CrewMemberFactory::*)(int , const DroneBlueprint *)), ".41570f57c94989d741564989fe0f28c1415541545589f5534883ec68", nullptr, 0, 0, &func);
@@ -6699,11 +6712,11 @@ namespace _func516
 RepairDrone *CrewMemberFactory::CreateRepairDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef RepairDrone *(*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func516::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func517::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func517
+namespace _func518
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::GetRandomFriendlyName", typeid(std::pair<std::string, bool> (CrewMemberFactory::*)(const std::string &)), ".4157415641554989f54154554889fd534889d34883ec68", nullptr, 0, 0, &func);
@@ -6712,11 +6725,11 @@ namespace _func517
 std::pair<std::string, bool> CrewMemberFactory::GetRandomFriendlyName(const std::string &race)
 {
 	typedef std::pair<std::string, bool> (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, const std::string &race_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func517::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func518::func;
 	return execfunc(this, race);
 }
 
-namespace _func518
+namespace _func519
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::GetCrewNames", typeid(std::vector<std::string> (CrewMemberFactory::*)()), ".415631d241554989fd41544989f4555331db4883ec20", nullptr, 0, 0, &func);
@@ -6725,19 +6738,6 @@ namespace _func518
 std::vector<std::string> CrewMemberFactory::GetCrewNames()
 {
 	typedef std::vector<std::string> (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func518::func;
-	return execfunc(this);
-}
-
-namespace _func519
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMemberFactory::OnLoop", typeid(void (CrewMemberFactory::*)()), ".415741564155415455534889fb4881ecb8000000488b5710", nullptr, 0, 0, &func);
-}
-
-void CrewMemberFactory::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func519::func;
 	return execfunc(this);
 }
@@ -6745,10 +6745,10 @@ void CrewMemberFactory::OnLoop()
 namespace _func520
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMemberFactory::RemoveExcessCrew", typeid(void (CrewMemberFactory::*)()), "!.415431c0554889fd53488b4f1031db488b57184829ca", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMemberFactory::OnLoop", typeid(void (CrewMemberFactory::*)()), ".415741564155415455534889fb4881ecb8000000488b5710", nullptr, 0, 0, &func);
 }
 
-void CrewMemberFactory::RemoveExcessCrew()
+void CrewMemberFactory::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func520::func;
@@ -6758,24 +6758,37 @@ void CrewMemberFactory::RemoveExcessCrew()
 namespace _func521
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMemberFactory::RemoveExcessCrew", typeid(void (CrewMemberFactory::*)()), "!.415431c0554889fd53488b4f1031db488b57184829ca", nullptr, 0, 0, &func);
+}
+
+void CrewMemberFactory::RemoveExcessCrew()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func521::func;
+	return execfunc(this);
+}
+
+namespace _func522
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::CreateCrewMember", typeid(CrewMember *(CrewMemberFactory::*)(CrewBlueprint *, int , bool )), ".415741564189ce41554189d541544989f455488d6e08", nullptr, 0, 0, &func);
 }
 
 CrewMember *CrewMemberFactory::CreateCrewMember(CrewBlueprint *bp, int shipId, bool intruder)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, CrewBlueprint *bp_arg, int shipId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func521::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func522::func;
 	return execfunc(this, bp, shipId, intruder);
 }
 
 CrewMemberFactory *Global_CrewMemberFactory_Factory;
 
-namespace _var522
+namespace _var523
 {
     static VariableDefinition varObj("Global_CrewMemberFactory_Factory", "!f30f11834802000031c9bf(???????\?)ba020000004889e6", &Global_CrewMemberFactory_Factory);
 }
 
-namespace _func523
+namespace _func524
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewStoreBox::CanHold", typeid(bool (CrewStoreBox::*)()), "488bbf1801000031c0", nullptr, 0, 0, &func);
@@ -6784,11 +6797,11 @@ namespace _func523
 bool CrewStoreBox::CanHold()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func523::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func524::func;
 	return execfunc(this);
 }
 
-namespace _func524
+namespace _func525
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewStoreBox::constructor", typeid(void (CrewStoreBox::*)(ShipManager *, int , const std::string &)), ".41574989ff415641554154554889f5", nullptr, 0, 0, &func);
@@ -6797,11 +6810,11 @@ namespace _func524
 void CrewStoreBox::constructor(ShipManager *ship, int worldLevel, const std::string &type)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewStoreBox *this_arg, ShipManager *ship_arg, int worldLevel_arg, const std::string &type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func524::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func525::func;
 	return execfunc(this, ship, worldLevel, type);
 }
 
-namespace _func525
+namespace _func526
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewStoreBox::Purchase", typeid(void (CrewStoreBox::*)()), ".415741564531f641554989fd4154555331db4881ec18010000", nullptr, 0, 0, &func);
@@ -6810,11 +6823,11 @@ namespace _func525
 void CrewStoreBox::Purchase()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func525::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func526::func;
 	return execfunc(this);
 }
 
-namespace _func526
+namespace _func527
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewStoreBox::MouseMove", typeid(void (CrewStoreBox::*)(int , int )), ".534889fb488d7f1831c94883ec30e8????f7ff80", nullptr, 0, 0, &func);
@@ -6823,11 +6836,11 @@ namespace _func526
 void CrewStoreBox::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewStoreBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func526::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func527::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func527
+namespace _func528
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DamageMessage::constructor", typeid(void (DamageMessage::*)(float , Pointf , DamageMessage::MessageType )), "534889fb4883ec5085f648c707", nullptr, 0, 0, &func);
@@ -6836,11 +6849,11 @@ namespace _func527
 void DamageMessage::constructor(float length, Pointf pos, DamageMessage::MessageType type)
 {
 	typedef void (*custom_arg_funcptr_t)(DamageMessage *this_arg, float length_arg, Pointf pos_arg, DamageMessage::MessageType type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func527::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func528::func;
 	return execfunc(this, length, pos, type);
 }
 
-namespace _func528
+namespace _func529
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DamageMessage::constructor2", typeid(void (DamageMessage::*)(float , int , Pointf , bool )), "415741564155415455534889fb4881ec3803000084d2", nullptr, 0, 0, &func);
@@ -6849,11 +6862,11 @@ namespace _func528
 void DamageMessage::constructor2(float length, int amount, Pointf pos, bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(DamageMessage *this_arg, float length_arg, int amount_arg, Pointf pos_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func528::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func529::func;
 	return execfunc(this, length, amount, pos, unk);
 }
 
-namespace _func529
+namespace _func530
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DefenseDrone::ValidTargetObject", typeid(bool (DefenseDrone::*)(Targetable *)), "4885f60f84b7000000", nullptr, 0, 0, &func);
@@ -6862,11 +6875,11 @@ namespace _func529
 bool DefenseDrone::ValidTargetObject(Targetable *target)
 {
 	typedef bool (*custom_arg_funcptr_t)(DefenseDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func529::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func530::func;
 	return execfunc(this, target);
 }
 
-namespace _func530
+namespace _func531
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DefenseDrone::PickTarget", typeid(void (DefenseDrone::*)()), "55534889fb4883ec4880bf5d02000000", nullptr, 0, 0, &func);
@@ -6875,11 +6888,11 @@ namespace _func530
 void DefenseDrone::PickTarget()
 {
 	typedef void (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func530::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func531::func;
 	return execfunc(this);
 }
 
-namespace _func531
+namespace _func532
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DefenseDrone::SetWeaponTarget", typeid(void (DefenseDrone::*)(Targetable *)), "4154554889fd53488b074889f3", nullptr, 0, 0, &func);
@@ -6888,11 +6901,11 @@ namespace _func531
 void DefenseDrone::SetWeaponTarget(Targetable *target)
 {
 	typedef void (*custom_arg_funcptr_t)(DefenseDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func531::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func532::func;
 	return execfunc(this, target);
 }
 
-namespace _func532
+namespace _func533
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DefenseDrone::GetTooltip", typeid(std::string (DefenseDrone::*)()), "554889f5be????????534889fb4883ec38488d542420", nullptr, 0, 0, &func);
@@ -6901,11 +6914,11 @@ namespace _func532
 std::string DefenseDrone::GetTooltip()
 {
 	typedef std::string (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func532::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func533::func;
 	return execfunc(this);
 }
 
-namespace _func533
+namespace _func534
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DefenseDrone::OnLoop", typeid(void (DefenseDrone::*)()), "55534889fb4883ec28e8e2a7", nullptr, 0, 0, &func);
@@ -6914,11 +6927,11 @@ namespace _func533
 void DefenseDrone::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func533::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func534::func;
 	return execfunc(this);
 }
 
-namespace _func534
+namespace _func535
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Description::copy_assign_2", typeid(Description &(Description::*)(Description &)), "554889f5534889fb4883ec08e8????????0fb64508488d7510488d7b10884308e8????????0fb64518488d7520488d7b20884318e8????????0fb64528488d7548488d7b488843288b45308943308b45348943348b45388943388b453c89433c0fb64540884340e8????????0fb64550488d7558", nullptr, 0, 0, &func);
@@ -6927,11 +6940,11 @@ namespace _func534
 Description &Description::copy_assign_2(Description &other)
 {
 	typedef Description &(*custom_arg_funcptr_t)(Description *this_arg, Description &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func534::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func535::func;
 	return execfunc(this, other);
 }
 
-namespace _func535
+namespace _func536
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Description::copy_assign_1", typeid(Description &(Description::*)(const Description &)), ".554889f5534889fb4883ec08e8????????0fb64508488d7510488d7b10884308e8????????0fb64518488d7520488d7b20884318e8????????0fb64528488d7548488d7b488843288b45308943308b45348943348b45388943388b453c89433c0fb64540884340e8????????0fb64550488d7558", nullptr, 0, 0, &func);
@@ -6940,11 +6953,11 @@ namespace _func535
 Description &Description::copy_assign_1(const Description &other)
 {
 	typedef Description &(*custom_arg_funcptr_t)(Description *this_arg, const Description &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func535::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func536::func;
 	return execfunc(this, other);
 }
 
-namespace _func536
+namespace _func537
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Description::destructor", typeid(void (Description::*)()), "534889fb4883ec10488b4758488d78e8", nullptr, 0, 0, &func);
@@ -6953,11 +6966,11 @@ namespace _func536
 void Description::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(Description *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func536::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func537::func;
 	return execfunc(this);
 }
 
-namespace _func537
+namespace _func538
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Door::GetPosition", typeid(Point (Door::*)()), "4883ec188b97540200008bb7500200004889e7e8????????8b442404", nullptr, 0, 0, &func);
@@ -6966,11 +6979,11 @@ namespace _func537
 Point Door::GetPosition()
 {
 	typedef Point (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func537::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func538::func;
 	return execfunc(this);
 }
 
-namespace _func538
+namespace _func539
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Door::ApplyDamage", typeid(bool (Door::*)(float )), ".5380bfec01000000", nullptr, 0, 0, &func);
@@ -6979,30 +6992,17 @@ namespace _func538
 bool Door::ApplyDamage(float amount)
 {
 	typedef bool (*custom_arg_funcptr_t)(Door *this_arg, float amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func538::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func539::func;
 	return execfunc(this, amount);
 }
 
-namespace _func539
+namespace _func540
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Door::FakeOpen", typeid(void (Door::*)()), ".55534889fb4883ec0883bfb400000004c6472c01", nullptr, 0, 0, &func);
 }
 
 void Door::FakeOpen()
-{
-	typedef void (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func539::func;
-	return execfunc(this);
-}
-
-namespace _func540
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Door::FakeClose", typeid(void (Door::*)()), ".55534889fb4883ec080fb64724c6472c00", nullptr, 0, 0, &func);
-}
-
-void Door::FakeClose()
 {
 	typedef void (*custom_arg_funcptr_t)(Door *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func540::func;
@@ -7012,17 +7012,30 @@ void Door::FakeClose()
 namespace _func541
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Door::FakeClose", typeid(void (Door::*)()), ".55534889fb4883ec080fb64724c6472c00", nullptr, 0, 0, &func);
+}
+
+void Door::FakeClose()
+{
+	typedef void (*custom_arg_funcptr_t)(Door *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func541::func;
+	return execfunc(this);
+}
+
+namespace _func542
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Door::IsSealed", typeid(bool (Door::*)(int )), ".8b8f4c0200008b570885c9", nullptr, 0, 0, &func);
 }
 
 bool Door::IsSealed(int shipId)
 {
 	typedef bool (*custom_arg_funcptr_t)(Door *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func541::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func542::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func542
+namespace _func543
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Door::OnLoop", typeid(void (Door::*)()), "!.55534889fb4883ec188b874c02000085c0", nullptr, 0, 0, &func);
@@ -7031,11 +7044,11 @@ namespace _func542
 void Door::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func542::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func543::func;
 	return execfunc(this);
 }
 
-namespace _func543
+namespace _func544
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DoorBox::constructor", typeid(void (DoorBox::*)(Point , ShipSystem *, ShipManager *)), "41554989cdb901000000415455534889fb488dab700200004c8da3000300004883ec48", nullptr, 0, 0, &func);
@@ -7044,11 +7057,11 @@ namespace _func543
 void DoorBox::constructor(Point pos, ShipSystem *sys, ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(DoorBox *this_arg, Point pos_arg, ShipSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func543::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func544::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func544
+namespace _func545
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneBlueprint::RenderIcon", typeid(void (DroneBlueprint::*)(float )), "4156415541544989fc55534881ec20010000", nullptr, 0, 0, &func);
@@ -7057,17 +7070,17 @@ namespace _func544
 void DroneBlueprint::RenderIcon(float scale)
 {
 	typedef void (*custom_arg_funcptr_t)(DroneBlueprint *this_arg, float scale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func544::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func545::func;
 	return execfunc(this, scale);
 }
 
-namespace _func545
+namespace _func546
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneControl::DO_NOT_HOOK", typeid(void (DroneControl::*)()), "!5589d55389f34883ec08488b7f18", nullptr, 0, 0, &func);
 }
 
-namespace _func546
+namespace _func547
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneControl::HolderLabel", typeid(TextString (DroneControl::*)()), ".534889fb", nullptr, 0, 0, &func);
@@ -7076,11 +7089,11 @@ namespace _func546
 TextString DroneControl::HolderLabel()
 {
 	typedef TextString (*custom_arg_funcptr_t)(DroneControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func546::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func547::func;
 	return execfunc(this);
 }
 
-namespace _func547
+namespace _func548
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneControl::ArmamentHotkey", typeid(SDLKey (DroneControl::*)(unsigned int )), ".4883ec5883c60189742420488d7c2430488d742420", nullptr, 0, 0, &func);
@@ -7089,11 +7102,11 @@ namespace _func547
 SDLKey DroneControl::ArmamentHotkey(unsigned int i)
 {
 	typedef SDLKey (*custom_arg_funcptr_t)(DroneControl *this_arg, unsigned int i_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func547::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func548::func;
 	return execfunc(this, i);
 }
 
-namespace _func548
+namespace _func549
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneControl::OnLoop", typeid(void (DroneControl::*)()), ".4155be04000000415455534889fb4883ec28", nullptr, 0, 0, &func);
@@ -7102,11 +7115,11 @@ namespace _func548
 void DroneControl::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(DroneControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func548::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func549::func;
 	return execfunc(this);
 }
 
-namespace _func549
+namespace _func550
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneStoreBox::constructor", typeid(void (DroneStoreBox::*)(ShipManager *, Equipment *, const DroneBlueprint *)), "41554989d541544989f4be", nullptr, 0, 0, &func);
@@ -7115,11 +7128,11 @@ namespace _func549
 void DroneStoreBox::constructor(ShipManager *ship, Equipment *equip, const DroneBlueprint *bp)
 {
 	typedef void (*custom_arg_funcptr_t)(DroneStoreBox *this_arg, ShipManager *ship_arg, Equipment *equip_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func549::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func550::func;
 	return execfunc(this, ship, equip, bp);
 }
 
-namespace _func550
+namespace _func551
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneSystem::DePowerDrone", typeid(bool (DroneSystem::*)(Drone *, bool )), "415484d24989f4554889fd53", nullptr, 0, 0, &func);
@@ -7128,11 +7141,11 @@ namespace _func550
 bool DroneSystem::DePowerDrone(Drone *drone, bool unk)
 {
 	typedef bool (*custom_arg_funcptr_t)(DroneSystem *this_arg, Drone *drone_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func550::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func551::func;
 	return execfunc(this, drone, unk);
 }
 
-namespace _func551
+namespace _func552
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneSystem::Jump", typeid(void (DroneSystem::*)()), ".415431c94989fc", nullptr, 0, 0, &func);
@@ -7141,11 +7154,11 @@ namespace _func551
 void DroneSystem::Jump()
 {
 	typedef void (*custom_arg_funcptr_t)(DroneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func551::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func552::func;
 	return execfunc(this);
 }
 
-namespace _func552
+namespace _func553
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneSystem::StringToDrone", typeid(int (*)(std::string &)), ".53be????????4889fb", nullptr, 0, 0, &func);
@@ -7154,11 +7167,11 @@ namespace _func552
 int DroneSystem::StringToDrone(std::string &name)
 {
 	typedef int (*custom_arg_funcptr_t)(std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func552::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func553::func;
 	return execfunc(name);
 }
 
-namespace _func553
+namespace _func554
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneSystem::RemoveDrone", typeid(void (DroneSystem::*)(int )), ".31c085f60f888e00000041545553488b8f48020000", nullptr, 0, 0, &func);
@@ -7167,30 +7180,17 @@ namespace _func553
 void DroneSystem::RemoveDrone(int slot)
 {
 	typedef void (*custom_arg_funcptr_t)(DroneSystem *this_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func553::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func554::func;
 	return execfunc(this, slot);
 }
 
-namespace _func554
+namespace _func555
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneSystem::UpdateBonusPower", typeid(void (DroneSystem::*)()), ".415741564531f6415541545531ed534889fb4883ec18488b9748020000", nullptr, 0, 0, &func);
 }
 
 void DroneSystem::UpdateBonusPower()
-{
-	typedef void (*custom_arg_funcptr_t)(DroneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func554::func;
-	return execfunc(this);
-}
-
-namespace _func555
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("DroneSystem::OnLoop", typeid(void (DroneSystem::*)()), ".41574989ff41564155415455534883ec38", nullptr, 0, 0, &func);
-}
-
-void DroneSystem::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(DroneSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func555::func;
@@ -7200,17 +7200,30 @@ void DroneSystem::OnLoop()
 namespace _func556
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("DroneSystem::OnLoop", typeid(void (DroneSystem::*)()), ".41574989ff41564155415455534883ec38", nullptr, 0, 0, &func);
+}
+
+void DroneSystem::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(DroneSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func556::func;
+	return execfunc(this);
+}
+
+namespace _func557
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("DroneSystem::SetBonusPower", typeid(void (DroneSystem::*)(int , int )), ".5589f5534889fb4883ec08", nullptr, 0, 0, &func);
 }
 
 void DroneSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void (*custom_arg_funcptr_t)(DroneSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func556::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func557::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func557
+namespace _func558
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DropBox::OnRender", typeid(void (DropBox::*)()), "415741564155415455534889fb4883ec78e8", nullptr, 0, 0, &func);
@@ -7219,11 +7232,11 @@ namespace _func557
 void DropBox::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(DropBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func557::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func558::func;
 	return execfunc(this);
 }
 
-namespace _func558
+namespace _func559
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DropBox::GetHeight", typeid(int (DropBox::*)()), "488b57104889d04885c0", nullptr, 0, 0, &func);
@@ -7232,11 +7245,11 @@ namespace _func558
 int DropBox::GetHeight()
 {
 	typedef int (*custom_arg_funcptr_t)(DropBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func558::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func559::func;
 	return execfunc(this);
 }
 
-namespace _func559
+namespace _func560
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EnergyAlien::OnLoop", typeid(void (EnergyAlien::*)()), "534889fbe8????????488b83c000000083786003", nullptr, 0, 0, &func);
@@ -7245,11 +7258,11 @@ namespace _func559
 void EnergyAlien::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(EnergyAlien *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func559::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func560::func;
 	return execfunc(this);
 }
 
-namespace _func560
+namespace _func561
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EnergyAlien::GetRoomDamage", typeid(Damage (EnergyAlien::*)()), "80be41070000004889f8", nullptr, 0, 0, &func);
@@ -7258,19 +7271,6 @@ namespace _func560
 Damage EnergyAlien::GetRoomDamage()
 {
 	typedef Damage (*custom_arg_funcptr_t)(EnergyAlien *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func560::func;
-	return execfunc(this);
-}
-
-namespace _func561
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Equipment::Open", typeid(void (Equipment::*)()), "41544989fc5531ed5331dbe8", nullptr, 0, 0, &func);
-}
-
-void Equipment::Open()
-{
-	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func561::func;
 	return execfunc(this);
 }
@@ -7278,10 +7278,10 @@ void Equipment::Open()
 namespace _func562
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Equipment::Close", typeid(void (Equipment::*)()), "!.e99b61000090662e0f1f840000000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Equipment::Open", typeid(void (Equipment::*)()), "41544989fc5531ed5331dbe8", nullptr, 0, 0, &func);
 }
 
-void Equipment::Close()
+void Equipment::Open()
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func562::func;
@@ -7291,17 +7291,30 @@ void Equipment::Close()
 namespace _func563
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Equipment::Close", typeid(void (Equipment::*)()), "!.e99b61000090662e0f1f840000000000", nullptr, 0, 0, &func);
+}
+
+void Equipment::Close()
+{
+	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func563::func;
+	return execfunc(this);
+}
+
+namespace _func564
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::MouseClick", typeid(void (Equipment::*)(int , int )), ".534889fbe8????????4863831802000083f8ff", nullptr, 0, 0, &func);
 }
 
 void Equipment::MouseClick(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func563::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func564::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func564
+namespace _func565
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::OnLoop", typeid(void (Equipment::*)()), ".41554531ed41545531ed534889fb4883ec08", nullptr, 0, 0, &func);
@@ -7310,11 +7323,11 @@ namespace _func564
 void Equipment::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func564::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func565::func;
 	return execfunc(this);
 }
 
-namespace _func565
+namespace _func566
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::MouseUp", typeid(void (Equipment::*)(int , int )), ".534889fb4883ec7080bf2402000000", nullptr, 0, 0, &func);
@@ -7323,11 +7336,11 @@ namespace _func565
 void Equipment::MouseUp(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func565::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func566::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func566
+namespace _func567
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::AddDrone", typeid(void (Equipment::*)(DroneBlueprint *, bool , bool )), ".41554154554889f5534889fb4883ec4884c9", nullptr, 0, 0, &func);
@@ -7336,11 +7349,11 @@ namespace _func566
 void Equipment::AddDrone(DroneBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg, DroneBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func566::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func567::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func567
+namespace _func568
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::AddAugment", typeid(void (Equipment::*)(AugmentBlueprint *, bool , bool )), ".4154554889f5488d7608534889fb4883ec60", nullptr, 0, 0, &func);
@@ -7349,11 +7362,11 @@ namespace _func567
 void Equipment::AddAugment(AugmentBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg, AugmentBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func567::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func568::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func568
+namespace _func569
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::GetCargoHold", typeid(std::vector<std::string> (Equipment::*)()), ".41554989fd41544989f455534883ec08", nullptr, 0, 0, &func);
@@ -7362,11 +7375,11 @@ namespace _func568
 std::vector<std::string> Equipment::GetCargoHold()
 {
 	typedef std::vector<std::string> (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func568::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func569::func;
 	return execfunc(this);
 }
 
-namespace _func569
+namespace _func570
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::AddWeapon", typeid(void (Equipment::*)(WeaponBlueprint *, bool , bool )), ".415641554989f541545589cd534889fb4883ec5084c9", nullptr, 0, 0, &func);
@@ -7375,11 +7388,11 @@ namespace _func569
 void Equipment::AddWeapon(WeaponBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg, WeaponBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func569::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func570::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func570
+namespace _func571
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::AddToCargo", typeid(void (Equipment::*)(const std::string &)), ".554889fd534889f34883ec38488d7c2420", nullptr, 0, 0, &func);
@@ -7388,11 +7401,11 @@ namespace _func570
 void Equipment::AddToCargo(const std::string &name)
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func570::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func571::func;
 	return execfunc(this, name);
 }
 
-namespace _func571
+namespace _func572
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::OnInit", typeid(void (Equipment::*)(ShipManager *)), ".4157415641554154554889f5534889fb4881ec98000000", nullptr, 0, 0, &func);
@@ -7401,11 +7414,11 @@ namespace _func571
 void Equipment::OnInit(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func571::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func572::func;
 	return execfunc(this, ship);
 }
 
-namespace _func572
+namespace _func573
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::SetPosition", typeid(void (EquipmentBox::*)(Point )), "48897758897760", nullptr, 0, 0, &func);
@@ -7414,11 +7427,11 @@ namespace _func572
 void EquipmentBox::SetPosition(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func572::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func573::func;
 	return execfunc(this, pos);
 }
 
-namespace _func573
+namespace _func574
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::MouseMove", typeid(void (EquipmentBox::*)(int , int )), ".8b476031c939c6", nullptr, 0, 0, &func);
@@ -7427,11 +7440,11 @@ namespace _func573
 void EquipmentBox::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func573::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func574::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func574
+namespace _func575
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::Restart", typeid(void (EquipmentBox::*)()), ".48c747700000000048c7477800000000", nullptr, 0, 0, &func);
@@ -7440,11 +7453,11 @@ namespace _func574
 void EquipmentBox::Restart()
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func574::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func575::func;
 	return execfunc(this);
 }
 
-namespace _func575
+namespace _func576
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::AddItem", typeid(void (EquipmentBox::*)(EquipmentBoxItem )), ".488b44240848894770", nullptr, 0, 0, &func);
@@ -7453,30 +7466,17 @@ namespace _func575
 void EquipmentBox::AddItem(EquipmentBoxItem item)
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, EquipmentBoxItem item_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func575::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func576::func;
 	return execfunc(this, item);
 }
 
-namespace _func576
+namespace _func577
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::CanHoldWeapon", typeid(bool (EquipmentBox::*)()), ".488b47704885c07407", nullptr, 0, 0, &func);
 }
 
 bool EquipmentBox::CanHoldWeapon()
-{
-	typedef bool (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func576::func;
-	return execfunc(this);
-}
-
-namespace _func577
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("EquipmentBox::CanHoldDrone", typeid(bool (EquipmentBox::*)()), ".48837f7000488b4778", nullptr, 0, 0, &func);
-}
-
-bool EquipmentBox::CanHoldDrone()
 {
 	typedef bool (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func577::func;
@@ -7486,17 +7486,30 @@ bool EquipmentBox::CanHoldDrone()
 namespace _func578
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("EquipmentBox::CanHoldDrone", typeid(bool (EquipmentBox::*)()), ".48837f7000488b4778", nullptr, 0, 0, &func);
+}
+
+bool EquipmentBox::CanHoldDrone()
+{
+	typedef bool (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func578::func;
+	return execfunc(this);
+}
+
+namespace _func579
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::GetType", typeid(int (EquipmentBox::*)()), ".48837f70007411", nullptr, 0, 0, &func);
 }
 
 int EquipmentBox::GetType()
 {
 	typedef int (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func578::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func579::func;
 	return execfunc(this);
 }
 
-namespace _func579
+namespace _func580
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::OnRender", typeid(void (EquipmentBox::*)(bool )), "!.41545589f54189ec534889fb4883ec30", nullptr, 0, 0, &func);
@@ -7505,11 +7518,11 @@ namespace _func579
 void EquipmentBox::OnRender(bool isEmpty)
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool isEmpty_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func579::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func580::func;
 	return execfunc(this, isEmpty);
 }
 
-namespace _func580
+namespace _func581
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::destructor", typeid(void (EquipmentBox::*)()), ".534889fb4883ec1048c707????????488b7f28e8????????488b7b30e8????????488b7b38e8????????488b7b40e8????????488b7b08e8????????488b4320488d78e84881ff????????750e", nullptr, 0, 0, &func);
@@ -7518,30 +7531,17 @@ namespace _func580
 void EquipmentBox::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func580::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func581::func;
 	return execfunc(this);
 }
 
-namespace _func581
+namespace _func582
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::UpdateBoxImage", typeid(void (EquipmentBox::*)(bool )), ".41545589f5", nullptr, 0, 0, &func);
 }
 
 void EquipmentBox::UpdateBoxImage(bool unk)
-{
-	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func581::func;
-	return execfunc(this, unk);
-}
-
-namespace _func582
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("EquipmentBox::RenderLabels", typeid(void (EquipmentBox::*)(bool )), ".5589f5", nullptr, 0, 0, &func);
-}
-
-void EquipmentBox::RenderLabels(bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool unk_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func582::func;
@@ -7551,17 +7551,30 @@ void EquipmentBox::RenderLabels(bool unk)
 namespace _func583
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("EquipmentBox::RenderLabels", typeid(void (EquipmentBox::*)(bool )), ".5589f5", nullptr, 0, 0, &func);
+}
+
+void EquipmentBox::RenderLabels(bool unk)
+{
+	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool unk_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func583::func;
+	return execfunc(this, unk);
+}
+
+namespace _func584
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::constructor", typeid(void (EquipmentBox::*)(Point , int )), ".554889f048c1f820534889fb4883ec38", nullptr, 0, 0, &func);
 }
 
 void EquipmentBox::constructor(Point pos, int slot)
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, Point pos_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func583::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func584::func;
 	return execfunc(this, pos, slot);
 }
 
-namespace _func584
+namespace _func585
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::GetItemValue", typeid(int (EquipmentBox::*)()), ".488b47704885c0740f", nullptr, 0, 0, &func);
@@ -7570,11 +7583,11 @@ namespace _func584
 int EquipmentBox::GetItemValue()
 {
 	typedef int (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func584::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func585::func;
 	return execfunc(this);
 }
 
-namespace _func585
+namespace _func586
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::SetBlueprint", typeid(void (EquipmentBox::*)(InfoBox *, bool )), ".5531c04889f5534889fb4883ec18", nullptr, 0, 0, &func);
@@ -7583,11 +7596,11 @@ namespace _func585
 void EquipmentBox::SetBlueprint(InfoBox *infoBox, bool detailedBox)
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, InfoBox *infoBox_arg, bool detailedBox_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func585::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func586::func;
 	return execfunc(this, infoBox, detailedBox);
 }
 
-namespace _func586
+namespace _func587
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::GetBlueprint", typeid(Blueprint *(EquipmentBox::*)()), ".488b47784885c07407", nullptr, 0, 0, &func);
@@ -7596,11 +7609,11 @@ namespace _func586
 Blueprint *EquipmentBox::GetBlueprint()
 {
 	typedef Blueprint *(*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func586::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func587::func;
 	return execfunc(this);
 }
 
-namespace _func587
+namespace _func588
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventGenerator::GetImageFromList", typeid(std::string (EventGenerator::*)(const std::string &)), "415541544989d455488daec80100004889d6534889fb4889ef4883ec18", nullptr, 0, 0, &func);
@@ -7609,11 +7622,11 @@ namespace _func587
 std::string EventGenerator::GetImageFromList(const std::string &listName)
 {
 	typedef std::string (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &listName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func587::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func588::func;
 	return execfunc(this, listName);
 }
 
-namespace _func588
+namespace _func589
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventGenerator::GetShipEvent", typeid(ShipEvent (EventGenerator::*)(const std::string &)), ".4156415541544989d455488dae98010000", nullptr, 0, 0, &func);
@@ -7622,11 +7635,11 @@ namespace _func588
 ShipEvent EventGenerator::GetShipEvent(const std::string &event)
 {
 	typedef ShipEvent (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func588::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func589::func;
 	return execfunc(this, event);
 }
 
-namespace _func589
+namespace _func590
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventGenerator::GetSectorDescription", typeid(SectorDescription (EventGenerator::*)(const std::string &, int )), ".41574189cf41564989f641554989fd415455498d6e48534889d34883ec58", nullptr, 0, 0, &func);
@@ -7635,11 +7648,11 @@ namespace _func589
 SectorDescription EventGenerator::GetSectorDescription(const std::string &type, int level)
 {
 	typedef SectorDescription (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &type_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func589::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func590::func;
 	return execfunc(this, type, level);
 }
 
-namespace _func590
+namespace _func591
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventGenerator::GetSpecificSector", typeid(SectorDescription (EventGenerator::*)(const std::string &)), ".4157415641554c8d6e1841544989d4554889f5534889fb4881ecd8000000", nullptr, 0, 0, &func);
@@ -7648,11 +7661,11 @@ namespace _func590
 SectorDescription EventGenerator::GetSpecificSector(const std::string &name)
 {
 	typedef SectorDescription (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func590::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func591::func;
 	return execfunc(this, name);
 }
 
-namespace _func591
+namespace _func592
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventGenerator::CreateEvent", typeid(LocationEvent *(EventGenerator::*)(const std::string &, int , bool )), ".415741564155415455488d6f78534889f34881ec88020000", nullptr, 0, 0, &func);
@@ -7661,11 +7674,11 @@ namespace _func591
 LocationEvent *EventGenerator::CreateEvent(const std::string &name, int worldLevel, bool ignoreUnique)
 {
 	typedef LocationEvent *(*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg, int worldLevel_arg, bool ignoreUnique_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func591::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func592::func;
 	return execfunc(this, name, worldLevel, ignoreUnique);
 }
 
-namespace _func592
+namespace _func593
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventGenerator::GetBaseEvent", typeid(LocationEvent *(EventGenerator::*)(const std::string &, int , char , int )), ".5589cd534889fb4883ec184183f8ff", nullptr, 0, 0, &func);
@@ -7674,18 +7687,18 @@ namespace _func592
 LocationEvent *EventGenerator::GetBaseEvent(const std::string &name, int worldLevel, char ignoreUnique, int seed)
 {
 	typedef LocationEvent *(*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg, int worldLevel_arg, char ignoreUnique_arg, int seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func592::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func593::func;
 	return execfunc(this, name, worldLevel, ignoreUnique, seed);
 }
 
 EventGenerator *Global_EventGenerator_Generator;
 
-namespace _var593
+namespace _var594
 {
     static VariableDefinition varObj("Global_EventGenerator_Generator", "!.418b97e8090000458b87fc1400004d8da77814000031c9bf(???????\?)", &Global_EventGenerator_Generator);
 }
 
-namespace _func594
+namespace _func595
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventSystem::AddEvent", typeid(void (EventSystem::*)(int )), "85f6781a488b5718488b4720", nullptr, 0, 0, &func);
@@ -7694,11 +7707,11 @@ namespace _func594
 void EventSystem::AddEvent(int id)
 {
 	typedef void (*custom_arg_funcptr_t)(EventSystem *this_arg, int id_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func594::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func595::func;
 	return execfunc(this, id);
 }
 
-namespace _func595
+namespace _func596
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventSystem::PollEvent", typeid(bool (EventSystem::*)(int )), "85f6781c488b0f488b5708", nullptr, 0, 0, &func);
@@ -7707,18 +7720,18 @@ namespace _func595
 bool EventSystem::PollEvent(int id)
 {
 	typedef bool (*custom_arg_funcptr_t)(EventSystem *this_arg, int id_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func595::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func596::func;
 	return execfunc(this, id);
 }
 
 EventSystem *Global_EventSystem_EventManager;
 
-namespace _var596
+namespace _var597
 {
     static VariableDefinition varObj("Global_EventSystem_EventManager", "!488b7b088b348a3bb7700600007e62be06000000bf(???????\?)", &Global_EventSystem_EventManager);
 }
 
-namespace _func597
+namespace _func598
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::PullMinMax", typeid(RandomAmount (EventsParser::*)(rapidxml::xml_node<char> *, const std::string &)), "41544989d4554889f5be????????4883c540", nullptr, 0, 0, &func);
@@ -7727,11 +7740,11 @@ namespace _func597
 RandomAmount EventsParser::PullMinMax(rapidxml::xml_node<char> *node, const std::string &name)
 {
 	typedef RandomAmount (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func597::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func598::func;
 	return execfunc(this, node, name);
 }
 
-namespace _func598
+namespace _func599
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::ProcessModifyItem", typeid(ResourcesTemplate (EventsParser::*)(ResourcesTemplate &, rapidxml::xml_node<char> *, const std::string &)), ".41574d89c741564989f64c89c641554989fd4154554889d5534889cb4883ec38", nullptr, 0, 0, &func);
@@ -7740,11 +7753,11 @@ namespace _func598
 ResourcesTemplate EventsParser::ProcessModifyItem(ResourcesTemplate &resources, rapidxml::xml_node<char> *node, const std::string &unk)
 {
 	typedef ResourcesTemplate (*custom_arg_funcptr_t)(EventsParser *this_arg, ResourcesTemplate &resources_arg, rapidxml::xml_node<char> *node_arg, const std::string &unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func598::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func599::func;
 	return execfunc(this, resources, node, unk);
 }
 
-namespace _func599
+namespace _func600
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::ProcessShipEvent", typeid(ShipTemplate (EventsParser::*)(rapidxml::xml_node<char> *)), ".415741564989d641554989fd41544d8d664055534881ec98030000", nullptr, 0, 0, &func);
@@ -7753,11 +7766,11 @@ namespace _func599
 ShipTemplate EventsParser::ProcessShipEvent(rapidxml::xml_node<char> *node)
 {
 	typedef ShipTemplate (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func599::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func600::func;
 	return execfunc(this, node);
 }
 
-namespace _func600
+namespace _func601
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::ProcessEvent", typeid(std::string (EventsParser::*)(rapidxml::xml_node<char> *, const std::string &)), ".415741564989f6be????????41554989cd4154", nullptr, 0, 0, &func);
@@ -7766,11 +7779,11 @@ namespace _func600
 std::string EventsParser::ProcessEvent(rapidxml::xml_node<char> *node, const std::string &eventName)
 {
 	typedef std::string (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &eventName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func600::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func601::func;
 	return execfunc(this, node, eventName);
 }
 
-namespace _func601
+namespace _func602
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::ProcessEventList", typeid(std::vector<std::string> (EventsParser::*)(rapidxml::xml_node<char> *, const std::string &)), ".41554989cd41544989f4", nullptr, 0, 0, &func);
@@ -7779,11 +7792,11 @@ namespace _func601
 std::vector<std::string> EventsParser::ProcessEventList(rapidxml::xml_node<char> *node, const std::string &listName)
 {
 	typedef std::vector<std::string> (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &listName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func601::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func602::func;
 	return execfunc(this, node, listName);
 }
 
-namespace _func602
+namespace _func603
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::ProcessBaseNode", typeid(void (EventsParser::*)(rapidxml::xml_node<char> *, EventGenerator &)), ".415741564989fe41554989d54154554889f54c8d7d4053", nullptr, 0, 0, &func);
@@ -7792,11 +7805,11 @@ namespace _func602
 void EventsParser::ProcessBaseNode(rapidxml::xml_node<char> *node, EventGenerator &generator)
 {
 	typedef void (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, EventGenerator &generator_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func602::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func603::func;
 	return execfunc(this, node, generator);
 }
 
-namespace _func603
+namespace _func604
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::AddEvents", typeid(void (EventsParser::*)(EventGenerator &, char *, const std::string &)), ".41574989d741564155415455534881ecc8000100", nullptr, 0, 0, &func);
@@ -7805,11 +7818,11 @@ namespace _func603
 void EventsParser::AddEvents(EventGenerator &generator, char *file, const std::string &fileName)
 {
 	typedef void (*custom_arg_funcptr_t)(EventsParser *this_arg, EventGenerator &generator_arg, char *file_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func603::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func604::func;
 	return execfunc(this, generator, file, fileName);
 }
 
-namespace _func604
+namespace _func605
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::AddAllEvents", typeid(void (EventsParser::*)()), ".415531d2", nullptr, 0, 0, &func);
@@ -7818,18 +7831,18 @@ namespace _func604
 void EventsParser::AddAllEvents()
 {
 	typedef void (*custom_arg_funcptr_t)(EventsParser *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func604::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func605::func;
 	return execfunc(this);
 }
 
 EventsParser *Global_EventsParser_Parser;
 
-namespace _var605
+namespace _var606
 {
     static VariableDefinition varObj("Global_EventsParser_Parser", "!488d4c24104889c54889c2be????????bf(???????\?)", &Global_EventsParser_Parser);
 }
 
-namespace _func606
+namespace _func607
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ExplosionAnimation::LoadGibs", typeid(void (ExplosionAnimation::*)()), "41545553488b5748", nullptr, 0, 0, &func);
@@ -7838,11 +7851,11 @@ namespace _func606
 void ExplosionAnimation::LoadGibs()
 {
 	typedef void (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func606::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func607::func;
 	return execfunc(this);
 }
 
-namespace _func607
+namespace _func608
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ExplosionAnimation::OnRender", typeid(void (ExplosionAnimation::*)(Globals::Rect *, ImageDesc , GL_Primitive *)), ".415741564155415455534889fb4883ec38807f1400", nullptr, 0, 0, &func);
@@ -7851,11 +7864,11 @@ namespace _func607
 void ExplosionAnimation::OnRender(Globals::Rect *shipRect, ImageDesc shipImage, GL_Primitive *shipImagePrimitive)
 {
 	typedef void (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg, Globals::Rect *shipRect_arg, ImageDesc shipImage_arg, GL_Primitive *shipImagePrimitive_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func607::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func608::func;
 	return execfunc(this, shipRect, shipImage, shipImagePrimitive);
 }
 
-namespace _func608
+namespace _func609
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ExplosionAnimation::OnInit", typeid(void (ExplosionAnimation::*)(rapidxml::xml_node<char> *, const std::string &, Point )), ".415741564989fe4155415455534889f34881ec380200008b7f28", nullptr, 0, 0, &func);
@@ -7864,11 +7877,11 @@ namespace _func608
 void ExplosionAnimation::OnInit(rapidxml::xml_node<char> *node, const std::string &name, Point glowOffset)
 {
 	typedef void (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &name_arg, Point glowOffset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func608::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func609::func;
 	return execfunc(this, node, name, glowOffset);
 }
 
-namespace _func609
+namespace _func610
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FTLButton::OnRender", typeid(void (FTLButton::*)()), "4157be0100000041564155415455534889fb4881ecf8000000488bbf10010000", nullptr, 0, 0, &func);
@@ -7877,11 +7890,11 @@ namespace _func609
 void FTLButton::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(FTLButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func609::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func610::func;
 	return execfunc(this);
 }
 
-namespace _func610
+namespace _func611
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FTLButton::MouseMove", typeid(void (FTLButton::*)(int , int , bool )), ".4157415641554189d541544189cc5589f531f6534889fb4883ec08", nullptr, 0, 0, &func);
@@ -7890,11 +7903,11 @@ namespace _func610
 void FTLButton::MouseMove(int mX, int mY, bool silent)
 {
 	typedef void (*custom_arg_funcptr_t)(FTLButton *this_arg, int mX_arg, int mY_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func610::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func611::func;
 	return execfunc(this, mX, mY, silent);
 }
 
-namespace _func611
+namespace _func612
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::deleteFile", typeid(void (*)(const std::string &)), "534889fb488b3f31f6e8????????85c07406", nullptr, 0, 0, &func);
@@ -7903,30 +7916,17 @@ namespace _func611
 void FileHelper::deleteFile(const std::string &fileName)
 {
 	typedef void (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func611::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func612::func;
 	return execfunc(fileName);
 }
 
-namespace _func612
+namespace _func613
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::getResourceFile", typeid(std::string (*)()), ".534889fb4883ec20", nullptr, 0, 0, &func);
 }
 
 std::string FileHelper::getResourceFile()
-{
-	typedef std::string (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func612::func;
-	return execfunc();
-}
-
-namespace _func613
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::getUserFolder", typeid(std::string (*)()), ".534889fb4883ec10", nullptr, 0, 0, &func);
-}
-
-std::string FileHelper::getUserFolder()
 {
 	typedef std::string (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func613::func;
@@ -7936,10 +7936,10 @@ std::string FileHelper::getUserFolder()
 namespace _func614
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::getSaveFile", typeid(std::string (*)()), ".534889fb4883ec20", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("FileHelper::getUserFolder", typeid(std::string (*)()), ".534889fb4883ec10", nullptr, 0, 0, &func);
 }
 
-std::string FileHelper::getSaveFile()
+std::string FileHelper::getUserFolder()
 {
 	typedef std::string (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func614::func;
@@ -7949,17 +7949,30 @@ std::string FileHelper::getSaveFile()
 namespace _func615
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("FileHelper::getSaveFile", typeid(std::string (*)()), ".534889fb4883ec20", nullptr, 0, 0, &func);
+}
+
+std::string FileHelper::getSaveFile()
+{
+	typedef std::string (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func615::func;
+	return execfunc();
+}
+
+namespace _func616
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::initFileHelper", typeid(void (*)()), ".4883ec28c605????????01", nullptr, 0, 0, &func);
 }
 
 void FileHelper::initFileHelper()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func615::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func616::func;
 	return execfunc();
 }
 
-namespace _func616
+namespace _func617
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::fileExists", typeid(bool (*)(const std::string &)), ".4883ec08488b3f31f6", nullptr, 0, 0, &func);
@@ -7968,11 +7981,11 @@ namespace _func616
 bool FileHelper::fileExists(const std::string &fileName)
 {
 	typedef bool (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func616::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func617::func;
 	return execfunc(fileName);
 }
 
-namespace _func617
+namespace _func618
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::renameFile", typeid(void (*)(const std::string &, const std::string &)), "!.488b36488b3f", nullptr, 0, 0, &func);
@@ -7981,11 +7994,11 @@ namespace _func617
 void FileHelper::renameFile(const std::string &fileName, const std::string &newName)
 {
 	typedef void (*custom_arg_funcptr_t)(const std::string &fileName_arg, const std::string &newName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func617::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func618::func;
 	return execfunc(fileName, newName);
 }
 
-namespace _func618
+namespace _func619
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::createBinaryFile", typeid(int (*)(const std::string &)), ".534889fb488b3f31f6", nullptr, 0, 0, &func);
@@ -7994,11 +8007,11 @@ namespace _func618
 int FileHelper::createBinaryFile(const std::string &fileName)
 {
 	typedef int (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func618::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func619::func;
 	return execfunc(fileName);
 }
 
-namespace _func619
+namespace _func620
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::saveFileExists", typeid(bool (*)()), ".4155bf????????415455534883ec28", nullptr, 0, 0, &func);
@@ -8007,19 +8020,6 @@ namespace _func619
 bool FileHelper::saveFileExists()
 {
 	typedef bool (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func619::func;
-	return execfunc();
-}
-
-namespace _func620
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::readSaveFile", typeid(int (*)()), ".4155bf????????415455534883ec28", nullptr, 0, 0, &func);
-}
-
-int FileHelper::readSaveFile()
-{
-	typedef int (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func620::func;
 	return execfunc();
 }
@@ -8027,10 +8027,10 @@ int FileHelper::readSaveFile()
 namespace _func621
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::readStatsFile", typeid(int (*)()), ".4155bf????????415455534883ec28", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("FileHelper::readSaveFile", typeid(int (*)()), ".4155bf????????415455534883ec28", nullptr, 0, 0, &func);
 }
 
-int FileHelper::readStatsFile()
+int FileHelper::readSaveFile()
 {
 	typedef int (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func621::func;
@@ -8040,10 +8040,10 @@ int FileHelper::readStatsFile()
 namespace _func622
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::createSaveFile", typeid(int (*)()), ".488b05????????488905", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("FileHelper::readStatsFile", typeid(int (*)()), ".4155bf????????415455534883ec28", nullptr, 0, 0, &func);
 }
 
-int FileHelper::createSaveFile()
+int FileHelper::readStatsFile()
 {
 	typedef int (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func622::func;
@@ -8053,10 +8053,10 @@ int FileHelper::createSaveFile()
 namespace _func623
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::createStatsFile", typeid(int (*)()), ".488b05????????488905", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("FileHelper::createSaveFile", typeid(int (*)()), ".488b05????????488905", nullptr, 0, 0, &func);
 }
 
-int FileHelper::createStatsFile()
+int FileHelper::createSaveFile()
 {
 	typedef int (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func623::func;
@@ -8066,12 +8066,12 @@ int FileHelper::createStatsFile()
 namespace _func624
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::deleteSaveFile", typeid(void (*)()), "!.53bf????????e8", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("FileHelper::createStatsFile", typeid(int (*)()), ".488b05????????488905", nullptr, 0, 0, &func);
 }
 
-void FileHelper::deleteSaveFile()
+int FileHelper::createStatsFile()
 {
-	typedef void (*custom_arg_funcptr_t)();
+	typedef int (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func624::func;
 	return execfunc();
 }
@@ -8079,10 +8079,10 @@ void FileHelper::deleteSaveFile()
 namespace _func625
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::deleteAllSaveFiles", typeid(void (*)()), ".534883ec20e8", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("FileHelper::deleteSaveFile", typeid(void (*)()), "!.53bf????????e8", nullptr, 0, 0, &func);
 }
 
-void FileHelper::deleteAllSaveFiles()
+void FileHelper::deleteSaveFile()
 {
 	typedef void (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func625::func;
@@ -8092,17 +8092,30 @@ void FileHelper::deleteAllSaveFiles()
 namespace _func626
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("FileHelper::deleteAllSaveFiles", typeid(void (*)()), ".534883ec20e8", nullptr, 0, 0, &func);
+}
+
+void FileHelper::deleteAllSaveFiles()
+{
+	typedef void (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func626::func;
+	return execfunc();
+}
+
+namespace _func627
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::getPosition", typeid(int (*)(int )), "!.8b05????????c3", nullptr, 0, 0, &func);
 }
 
 int FileHelper::getPosition(int file)
 {
 	typedef int (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func626::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func627::func;
 	return execfunc(file);
 }
 
-namespace _func627
+namespace _func628
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::readBinaryFile", typeid(int (*)(const std::string &)), ".53488b3f31f631c0", nullptr, 0, 0, &func);
@@ -8111,11 +8124,11 @@ namespace _func627
 int FileHelper::readBinaryFile(const std::string &fileName)
 {
 	typedef int (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func627::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func628::func;
 	return execfunc(fileName);
 }
 
-namespace _func628
+namespace _func629
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::writeFloat", typeid(bool (*)(int , float )), ".415741564155415455534883ec18", nullptr, 0, 0, &func);
@@ -8124,11 +8137,11 @@ namespace _func628
 bool FileHelper::writeFloat(int file, float data)
 {
 	typedef bool (*custom_arg_funcptr_t)(int file_arg, float data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func628::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func629::func;
 	return execfunc(file, data);
 }
 
-namespace _func629
+namespace _func630
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::writeInt", typeid(bool (*)(int , int )), ".415789f141564155415455534883ec18", nullptr, 0, 0, &func);
@@ -8137,11 +8150,11 @@ namespace _func629
 bool FileHelper::writeInt(int file, int data)
 {
 	typedef bool (*custom_arg_funcptr_t)(int file_arg, int data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func629::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func630::func;
 	return execfunc(file, data);
 }
 
-namespace _func630
+namespace _func631
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::writeData", typeid(bool (*)(int , void *, int )), ".41574156415541544989f455534863da4883ec18", nullptr, 0, 0, &func);
@@ -8150,11 +8163,11 @@ namespace _func630
 bool FileHelper::writeData(int file, void *data, int len)
 {
 	typedef bool (*custom_arg_funcptr_t)(int file_arg, void *data_arg, int len_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func630::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func631::func;
 	return execfunc(file, data, len);
 }
 
-namespace _func631
+namespace _func632
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::writeString", typeid(bool (*)(int , const std::string &)), ".41574156415541545589fd534883ec28", nullptr, 0, 0, &func);
@@ -8163,11 +8176,11 @@ namespace _func631
 bool FileHelper::writeString(int file, const std::string &data)
 {
 	typedef bool (*custom_arg_funcptr_t)(int file_arg, const std::string &data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func631::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func632::func;
 	return execfunc(file, data);
 }
 
-namespace _func632
+namespace _func633
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::closeBinaryFile", typeid(void (*)(int )), ".81fffffeff7f53", nullptr, 0, 0, &func);
@@ -8176,11 +8189,11 @@ namespace _func632
 void FileHelper::closeBinaryFile(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func632::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func633::func;
 	return execfunc(file);
 }
 
-namespace _func633
+namespace _func634
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::readString", typeid(std::string (*)(int )), ".4157415641554989fd4154555389f34883ec28", nullptr, 0, 0, &func);
@@ -8189,11 +8202,11 @@ namespace _func633
 std::string FileHelper::readString(int file)
 {
 	typedef std::string (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func633::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func634::func;
 	return execfunc(file);
 }
 
-namespace _func634
+namespace _func635
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::readFloat", typeid(float (*)(int )), ".41554154555389fb4883ec18", nullptr, 0, 0, &func);
@@ -8202,11 +8215,11 @@ namespace _func634
 float FileHelper::readFloat(int file)
 {
 	typedef float (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func634::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func635::func;
 	return execfunc(file);
 }
 
-namespace _func635
+namespace _func636
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::readInteger", typeid(int (*)(int )), ".41554154555389fb4883ec18", nullptr, 0, 0, &func);
@@ -8215,11 +8228,11 @@ namespace _func635
 int FileHelper::readInteger(int file)
 {
 	typedef int (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func635::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func636::func;
 	return execfunc(file);
 }
 
-namespace _func636
+namespace _func637
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::seekPosition", typeid(bool (*)(int , int )), ".4883ec0831d2", nullptr, 0, 0, &func);
@@ -8228,11 +8241,11 @@ namespace _func636
 bool FileHelper::seekPosition(int file, int pos)
 {
 	typedef bool (*custom_arg_funcptr_t)(int file_arg, int pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func636::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func637::func;
 	return execfunc(file, pos);
 }
 
-namespace _func637
+namespace _func638
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::readBuffer", typeid(char *(*)(int , int , bool )), ".4157415641554189d541545589fd0fb6fa534863de01df4883ec08", nullptr, 0, 0, &func);
@@ -8241,11 +8254,11 @@ namespace _func637
 char *FileHelper::readBuffer(int file, int len, bool nullTerminate)
 {
 	typedef char *(*custom_arg_funcptr_t)(int file_arg, int len_arg, bool nullTerminate_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func637::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func638::func;
 	return execfunc(file, len, nullTerminate);
 }
 
-namespace _func638
+namespace _func639
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::readData", typeid(void (*)(int , void *, int )), ".41554889f141545589d55389fb4883ec08", nullptr, 0, 0, &func);
@@ -8254,11 +8267,11 @@ namespace _func638
 void FileHelper::readData(int file, void *data, int len)
 {
 	typedef void (*custom_arg_funcptr_t)(int file_arg, void *data_arg, int len_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func638::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func639::func;
 	return execfunc(file, data, len);
 }
 
-namespace _func639
+namespace _func640
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Fire::OnLoop", typeid(void (Fire::*)()), "55534889fb4883ec0880bfd801000000", nullptr, 0, 0, &func);
@@ -8267,11 +8280,11 @@ namespace _func639
 void Fire::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(Fire *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func639::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func640::func;
 	return execfunc(this);
 }
 
-namespace _func640
+namespace _func641
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Fire::UpdateDeathTimer", typeid(void (Fire::*)(int )), ".5589f5534889fb4883ec18488b07ff505084c0", nullptr, 0, 0, &func);
@@ -8280,11 +8293,11 @@ namespace _func640
 void Fire::UpdateDeathTimer(int connectedFires)
 {
 	typedef void (*custom_arg_funcptr_t)(Fire *this_arg, int connectedFires_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func640::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func641::func;
 	return execfunc(this, connectedFires);
 }
 
-namespace _func641
+namespace _func642
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Fire::UpdateStartTimer", typeid(void (Fire::*)(int )), ".5589f5534889fb4883ec18488b07ff505084c0", nullptr, 0, 0, &func);
@@ -8293,30 +8306,17 @@ namespace _func641
 void Fire::UpdateStartTimer(int doorLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(Fire *this_arg, int doorLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func641::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func642::func;
 	return execfunc(this, doorLevel);
 }
 
-namespace _func642
+namespace _func643
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FocusWindow::MouseClick", typeid(void (FocusWindow::*)(int , int )), "807f1400750af3c3", nullptr, 0, 0, &func);
 }
 
 void FocusWindow::MouseClick(int x, int y)
-{
-	typedef void (*custom_arg_funcptr_t)(FocusWindow *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func642::func;
-	return execfunc(this, x, y);
-}
-
-namespace _func643
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("FocusWindow::MouseMove", typeid(void (FocusWindow::*)(int , int )), ".8b470c83f8ff7438", nullptr, 0, 0, &func);
-}
-
-void FocusWindow::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(FocusWindow *this_arg, int x_arg, int y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func643::func;
@@ -8326,36 +8326,36 @@ void FocusWindow::MouseMove(int x, int y)
 namespace _func644
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("FocusWindow::MouseMove", typeid(void (FocusWindow::*)(int , int )), ".8b470c83f8ff7438", nullptr, 0, 0, &func);
+}
+
+void FocusWindow::MouseMove(int x, int y)
+{
+	typedef void (*custom_arg_funcptr_t)(FocusWindow *this_arg, int x_arg, int y_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func644::func;
+	return execfunc(this, x, y);
+}
+
+namespace _func645
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("GameOver::OpenText", typeid(void (GameOver::*)(const std::string &)), "415741564155415455534889fb488d7f704881ecf8000000", nullptr, 0, 0, &func);
 }
 
 void GameOver::OpenText(const std::string &text)
 {
 	typedef void (*custom_arg_funcptr_t)(GameOver *this_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func644::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func645::func;
 	return execfunc(this, text);
 }
 
-namespace _func645
+namespace _func646
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("GameOver::OnRender", typeid(void (GameOver::*)()), "415741564155415455534889fb4881ec1802000080bfd800000000", nullptr, 0, 0, &func);
 }
 
 void GameOver::OnRender()
-{
-	typedef void (*custom_arg_funcptr_t)(GameOver *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func645::func;
-	return execfunc(this);
-}
-
-namespace _func646
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("GameOver::OnLoop", typeid(void (GameOver::*)()), "4154554889fdbf????????534883ec40", nullptr, 0, 0, &func);
-}
-
-void GameOver::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(GameOver *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func646::func;
@@ -8365,17 +8365,30 @@ void GameOver::OnLoop()
 namespace _func647
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("GameOver::OnLoop", typeid(void (GameOver::*)()), "4154554889fdbf????????534883ec40", nullptr, 0, 0, &func);
+}
+
+void GameOver::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(GameOver *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func647::func;
+	return execfunc(this);
+}
+
+namespace _func648
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("GenericButton::SetLocation", typeid(void (GenericButton::*)(Point )), "8b57084889f08b4f0c48c1f82039d6", nullptr, 0, 0, &func);
 }
 
 void GenericButton::SetLocation(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(GenericButton *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func647::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func648::func;
 	return execfunc(this, pos);
 }
 
-namespace _func648
+namespace _func649
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("GenericButton::SetActive", typeid(void (GenericButton::*)(bool )), ".4084f640887748", nullptr, 0, 0, &func);
@@ -8384,11 +8397,11 @@ namespace _func648
 void GenericButton::SetActive(bool active)
 {
 	typedef void (*custom_arg_funcptr_t)(GenericButton *this_arg, bool active_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func648::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func649::func;
 	return execfunc(this, active);
 }
 
-namespace _func649
+namespace _func650
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("GenericButton::MouseMove", typeid(void (GenericButton::*)(int , int , bool )), ".8b4710440fb6474939c6", nullptr, 0, 0, &func);
@@ -8397,36 +8410,23 @@ namespace _func649
 void GenericButton::MouseMove(int x, int y, bool silent)
 {
 	typedef void (*custom_arg_funcptr_t)(GenericButton *this_arg, int x_arg, int y_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func649::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func650::func;
 	return execfunc(this, x, y, silent);
 }
 
-namespace _func650
+namespace _func651
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("GenericButton::DO_NOT_HOOK_1", typeid(void (GenericButton::*)()), "!.f3c3662e0f1f8400000000000f1f4000", nullptr, 0, 0, &func);
 }
 
-namespace _func651
+namespace _func652
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("GenericButton::OnClick", typeid(void (GenericButton::*)()), "!.f3c3662e0f1f8400000000000f1f4000", nullptr, 0, 0, &func);
 }
 
 void GenericButton::OnClick()
-{
-	typedef void (*custom_arg_funcptr_t)(GenericButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func651::func;
-	return execfunc(this);
-}
-
-namespace _func652
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("GenericButton::OnRightClick", typeid(void (GenericButton::*)()), "!.f3c3662e0f1f8400000000000f1f4000", nullptr, 0, 0, &func);
-}
-
-void GenericButton::OnRightClick()
 {
 	typedef void (*custom_arg_funcptr_t)(GenericButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func652::func;
@@ -8436,10 +8436,10 @@ void GenericButton::OnRightClick()
 namespace _func653
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("GenericButton::ResetPrimitives", typeid(void (GenericButton::*)()), "!.f3c3662e0f1f8400000000000f1f4000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("GenericButton::OnRightClick", typeid(void (GenericButton::*)()), "!.f3c3662e0f1f8400000000000f1f4000", nullptr, 0, 0, &func);
 }
 
-void GenericButton::ResetPrimitives()
+void GenericButton::OnRightClick()
 {
 	typedef void (*custom_arg_funcptr_t)(GenericButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func653::func;
@@ -8449,17 +8449,30 @@ void GenericButton::ResetPrimitives()
 namespace _func654
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("GenericButton::ResetPrimitives", typeid(void (GenericButton::*)()), "!.f3c3662e0f1f8400000000000f1f4000", nullptr, 0, 0, &func);
+}
+
+void GenericButton::ResetPrimitives()
+{
+	typedef void (*custom_arg_funcptr_t)(GenericButton *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func654::func;
+	return execfunc(this);
+}
+
+namespace _func655
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("font_text_width", typeid(float (*)(freetype::font_data &, const char *, float )), "85ff7e7e", nullptr, 0, 0, &func);
 }
 
 float __stdcall font_text_width(freetype::font_data &fontData, const char *str, float size)
 {
 	typedef float (*custom_arg_funcptr_t)(freetype::font_data &fontData_arg, const char *str_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func654::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func655::func;
 	return execfunc(fontData, str, size);
 }
 
-namespace _func655
+namespace _func656
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("random32", typeid(int (*)()), "48b82d7f954c2df45158480faf05????????4883c001488905????????48c1e821", nullptr, 0, 0, &func);
@@ -8468,11 +8481,11 @@ namespace _func655
 int __stdcall random32()
 {
 	typedef int (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func655::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func656::func;
 	return execfunc();
 }
 
-namespace _func656
+namespace _func657
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("srandom32", typeid(void (*)(unsigned int )), ".89f8488905", nullptr, 0, 0, &func);
@@ -8481,11 +8494,11 @@ namespace _func656
 void __stdcall srandom32(unsigned int seed)
 {
 	typedef void (*custom_arg_funcptr_t)(unsigned int seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func656::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func657::func;
 	return execfunc(seed);
 }
 
-namespace _func657
+namespace _func658
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("getSkillBonus", typeid(float (*)(int , int )), "83ff05772d89ff", nullptr, 0, 0, &func);
@@ -8494,11 +8507,11 @@ namespace _func657
 float __stdcall getSkillBonus(int skill, int level)
 {
 	typedef float (*custom_arg_funcptr_t)(int skill_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func657::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func658::func;
 	return execfunc(skill, level);
 }
 
-namespace _func658
+namespace _func659
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("GetValue", typeid(void (*)(ResourceEvent &, const std::string &, int , int )), "41554189cd41544c63e2554889fd534889f3", nullptr, 0, 0, &func);
@@ -8507,11 +8520,11 @@ namespace _func658
 void __stdcall GetValue(ResourceEvent &ref, const std::string &type, int level, int worldLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(ResourceEvent &ref_arg, const std::string &type_arg, int level_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func658::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func659::func;
 	return execfunc(ref, type, level, worldLevel);
 }
 
-namespace _func659
+namespace _func660
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("GenerateReward", typeid(void (*)(ResourceEvent &, RewardDesc &, int )), ".41574989f741564155415455534881ec08020000", nullptr, 0, 0, &func);
@@ -8520,11 +8533,11 @@ namespace _func659
 void __stdcall GenerateReward(ResourceEvent &ref, RewardDesc &reward, int worldLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(ResourceEvent &ref_arg, RewardDesc &reward_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func659::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func660::func;
 	return execfunc(ref, reward, worldLevel);
 }
 
-namespace _func660
+namespace _func661
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("sys_graphics_set_window_title", typeid(void (*)(char *)), "534889fb4883ec20488b3d????????e8????????", nullptr, 0, 0, &func);
@@ -8533,11 +8546,11 @@ namespace _func660
 void __stdcall sys_graphics_set_window_title(char *title)
 {
 	typedef void (*custom_arg_funcptr_t)(char *title_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func660::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func661::func;
 	return execfunc(title);
 }
 
-namespace _func661
+namespace _func662
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("graphics_clear", typeid(void (*)(float , float , float , float , float , unsigned int )), "0f57ed4883ec2889fa0f2ee5", nullptr, 0, 0, &func);
@@ -8546,11 +8559,11 @@ namespace _func661
 void __stdcall graphics_clear(float r, float g, float b, float a, float depth, unsigned int stencil)
 {
 	typedef void (*custom_arg_funcptr_t)(float r_arg, float g_arg, float b_arg, float a_arg, float depth_arg, unsigned int stencil_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func661::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func662::func;
 	return execfunc(r, g, b, a, depth, stencil);
 }
 
-namespace _func662
+namespace _func663
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Globals::GetNextPoint", typeid(Pointf (*)(Pointf , float , Pointf )), "55534883ec48660fd6542408", nullptr, 0, 0, &func);
@@ -8559,11 +8572,11 @@ namespace _func662
 Pointf Globals::GetNextPoint(Pointf current, float mag_speed, Pointf dest)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(Pointf current_arg, float mag_speed_arg, Pointf dest_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func662::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func663::func;
 	return execfunc(current, mag_speed, dest);
 }
 
-namespace _func663
+namespace _func664
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Globals::GetNextSpaceId", typeid(int (*)()), ".8b15????????b865000000", nullptr, 0, 0, &func);
@@ -8572,11 +8585,11 @@ namespace _func663
 int Globals::GetNextSpaceId()
 {
 	typedef int (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func663::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func664::func;
 	return execfunc();
 }
 
-namespace _func664
+namespace _func665
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Globals::AimAhead", typeid(float (*)(Pointf , Pointf , float )), ".4883ec18f30f59d2660fd60424488b1424", nullptr, 0, 0, &func);
@@ -8585,11 +8598,11 @@ namespace _func664
 float Globals::AimAhead(Pointf delta, Pointf vr, float muzzleV)
 {
 	typedef float (*custom_arg_funcptr_t)(Pointf delta_arg, Pointf vr_arg, float muzzleV_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func664::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func665::func;
 	return execfunc(delta, vr, muzzleV);
 }
 
-namespace _func665
+namespace _func666
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Globals::GetNextPoint", typeid(Pointf (*)(Pointf , float , float )), ".4883ec38f30f5915", nullptr, 0, 0, &func);
@@ -8598,39 +8611,39 @@ namespace _func665
 Pointf Globals::GetNextPoint(Pointf current, float mag_speed, float heading)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(Pointf current_arg, float mag_speed_arg, float heading_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func665::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func666::func;
 	return execfunc(current, mag_speed, heading);
 }
 
 TextLibrary *Global_Globals_Library;
 
-namespace _var666
+namespace _var667
 {
     static VariableDefinition varObj("Global_Globals_Library", "!4189e8488d4c2460ba010000004c89e7be(???????\?)", &Global_Globals_Library);
 }
 
 int *Globals_GetNextSpaceId_id;
 
-namespace _var667
+namespace _var668
 {
     static VariableDefinition varObj("Globals_GetNextSpaceId_id", "!8b15(???????\?)b865000000", &Globals_GetNextSpaceId_id, true, true);
 }
 
 bool *Globals_RNG;
 
-namespace _var668
+namespace _var669
 {
     static VariableDefinition varObj("Globals_RNG", "!85c00f9505(???????\?)89ef", &Globals_RNG, true, true);
 }
 
 FILE *ftl_log_logfile;
 
-namespace _var669
+namespace _var670
 {
     static VariableDefinition varObj("ftl_log_logfile", "!488d4c24184889dabe01000000e8????????488b3d(???????\?)", &ftl_log_logfile, true, true);
 }
 
-namespace _func670
+namespace _func671
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("HackBox::constructor", typeid(void (HackBox::*)(Point , HackingSystem *, ShipManager *)), "41554989cd31c94154554889d5534889fb4c8da3180300004883ec68", nullptr, 0, 0, &func);
@@ -8639,11 +8652,11 @@ namespace _func670
 void HackBox::constructor(Point pos, HackingSystem *sys, ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(HackBox *this_arg, Point pos_arg, HackingSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func670::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func671::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func671
+namespace _func672
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("HackingDrone::SetMovementTarget", typeid(void (HackingDrone::*)(Targetable *)), "554889f5534889fb4883ec184885f60f84b3000000", nullptr, 0, 0, &func);
@@ -8652,11 +8665,11 @@ namespace _func671
 void HackingDrone::SetMovementTarget(Targetable *target)
 {
 	typedef void (*custom_arg_funcptr_t)(HackingDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func671::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func672::func;
 	return execfunc(this, target);
 }
 
-namespace _func672
+namespace _func673
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("HackingDrone::CollisionMoving", typeid(CollisionResponse (HackingDrone::*)(Pointf , Pointf , Damage , bool )), ".4154554889f5534889fb4883ec60", nullptr, 0, 0, &func);
@@ -8665,11 +8678,11 @@ namespace _func672
 CollisionResponse HackingDrone::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse (*custom_arg_funcptr_t)(HackingDrone *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func672::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func673::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func673
+namespace _func674
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("HackingDrone::OnLoop", typeid(void (HackingDrone::*)()), ".55bd05000000534889fb4883ec48", nullptr, 0, 0, &func);
@@ -8678,19 +8691,6 @@ namespace _func673
 void HackingDrone::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(HackingDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func673::func;
-	return execfunc(this);
-}
-
-namespace _func674
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("HackingSystem::BlowHackingDrone", typeid(void (HackingSystem::*)()), "80bf60020000007507f3c3", nullptr, 0, 0, &func);
-}
-
-void HackingSystem::BlowHackingDrone()
-{
-	typedef void (*custom_arg_funcptr_t)(HackingSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func674::func;
 	return execfunc(this);
 }
@@ -8698,10 +8698,10 @@ void HackingSystem::BlowHackingDrone()
 namespace _func675
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("HackingSystem::OnLoop", typeid(void (HackingSystem::*)()), "55534889fb4883ec38e8????????80bb7002000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("HackingSystem::BlowHackingDrone", typeid(void (HackingSystem::*)()), "80bf60020000007507f3c3", nullptr, 0, 0, &func);
 }
 
-void HackingSystem::OnLoop()
+void HackingSystem::BlowHackingDrone()
 {
 	typedef void (*custom_arg_funcptr_t)(HackingSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func675::func;
@@ -8711,17 +8711,30 @@ void HackingSystem::OnLoop()
 namespace _func676
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("HackingSystem::OnLoop", typeid(void (HackingSystem::*)()), "55534889fb4883ec38e8????????80bb7002000000", nullptr, 0, 0, &func);
+}
+
+void HackingSystem::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(HackingSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func676::func;
+	return execfunc(this);
+}
+
+namespace _func677
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("HackingSystem::SoundLoop", typeid(bool (HackingSystem::*)()), "5380bf44020000004889fb75??31c05bc30f1f8000000000e8????????83f8ff", nullptr, 0, 0, &func);
 }
 
 bool HackingSystem::SoundLoop()
 {
 	typedef bool (*custom_arg_funcptr_t)(HackingSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func676::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func677::func;
 	return execfunc(this);
 }
 
-namespace _func677
+namespace _func678
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::constructor", typeid(void (InfoBox::*)()), "5331d24889fb31f64883ec10e8????????488d7b10", nullptr, 0, 0, &func);
@@ -8730,11 +8743,11 @@ namespace _func677
 void InfoBox::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func677::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func678::func;
 	return execfunc(this);
 }
 
-namespace _func678
+namespace _func679
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetBlueprintWeapon", typeid(void (InfoBox::*)(const WeaponBlueprint *, int , bool , int )), ".41574589c7415641554189d531d24154554889f5534889fb4c8d63304883ec58", nullptr, 0, 0, &func);
@@ -8743,11 +8756,11 @@ namespace _func678
 void InfoBox::SetBlueprintWeapon(const WeaponBlueprint *bp, int status, bool hasWeaponSystem, int yShift)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, const WeaponBlueprint *bp_arg, int status_arg, bool hasWeaponSystem_arg, int yShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func678::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func679::func;
 	return execfunc(this, bp, status, hasWeaponSystem, yShift);
 }
 
-namespace _func679
+namespace _func680
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetBlueprintDrone", typeid(void (InfoBox::*)(const DroneBlueprint *, int , bool , int )), ".41574156415541544989f4488d761055534889fb488d7f104c8d73304881ec18020000", nullptr, 0, 0, &func);
@@ -8756,11 +8769,11 @@ namespace _func679
 void InfoBox::SetBlueprintDrone(const DroneBlueprint *bp, int status, bool hasDroneSystem, int yShift)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, const DroneBlueprint *bp_arg, int status_arg, bool hasDroneSystem_arg, int yShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func679::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func680::func;
 	return execfunc(this, bp, status, hasDroneSystem, yShift);
 }
 
-namespace _func680
+namespace _func681
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetBlueprint", typeid(void (InfoBox::*)(const ItemBlueprint *)), "!.4154554889f5488d7610534889fb", nullptr, 0, 0, &func);
@@ -8769,11 +8782,11 @@ namespace _func680
 void InfoBox::SetBlueprint(const ItemBlueprint *bp)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, const ItemBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func680::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func681::func;
 	return execfunc(this, bp);
 }
 
-namespace _func681
+namespace _func682
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetBlueprintCrew", typeid(void (InfoBox::*)(const CrewBlueprint *, int , bool )), ".415741564c8d771041554989f54154554889fd53488d5e104881ecc8000000", nullptr, 0, 0, &func);
@@ -8782,11 +8795,11 @@ namespace _func681
 void InfoBox::SetBlueprintCrew(const CrewBlueprint *bp, int yShift, bool detailedCrew)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, const CrewBlueprint *bp_arg, int yShift_arg, bool detailedCrew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func681::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func682::func;
 	return execfunc(this, bp, yShift, detailedCrew);
 }
 
-namespace _func682
+namespace _func683
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetBlueprintAugment", typeid(void (InfoBox::*)(const AugmentBlueprint *)), ".4154554889f5488d7610534889fb", nullptr, 0, 0, &func);
@@ -8795,11 +8808,11 @@ namespace _func682
 void InfoBox::SetBlueprintAugment(const AugmentBlueprint *bp)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, const AugmentBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func682::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func683::func;
 	return execfunc(this, bp);
 }
 
-namespace _func683
+namespace _func684
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::IsEmpty", typeid(bool (InfoBox::*)()), ".55534889fb4883ec28837f7cff", nullptr, 0, 0, &func);
@@ -8808,11 +8821,11 @@ namespace _func683
 bool InfoBox::IsEmpty()
 {
 	typedef bool (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func683::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func684::func;
 	return execfunc(this);
 }
 
-namespace _func684
+namespace _func685
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::CalcBoxHeight", typeid(int (InfoBox::*)()), ".4156415541544989fc55534881eca0000000837f7401", nullptr, 0, 0, &func);
@@ -8821,11 +8834,11 @@ namespace _func684
 int InfoBox::CalcBoxHeight()
 {
 	typedef int (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func684::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func685::func;
 	return execfunc(this);
 }
 
-namespace _func685
+namespace _func686
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetSystemId", typeid(void (InfoBox::*)(int , int , int , int , int , int )), ".4157415641554589cd41544189f455534889fb4883ec2883feff", nullptr, 0, 0, &func);
@@ -8834,11 +8847,11 @@ namespace _func685
 void InfoBox::SetSystemId(int systemId, int maxPower, int currentLevel, int upgrade, int yShift, int forceSystemWidth)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, int systemId_arg, int maxPower_arg, int currentLevel_arg, int upgrade_arg, int yShift_arg, int forceSystemWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func685::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func686::func;
 	return execfunc(this, systemId, maxPower, currentLevel, upgrade, yShift, forceSystemWidth);
 }
 
-namespace _func686
+namespace _func687
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetDescription", typeid(void (InfoBox::*)(Description *, int , int , InfoBox::ExpandDir )), ".41564589c641554189d541544189cc554889f5534889fb", nullptr, 0, 0, &func);
@@ -8847,11 +8860,11 @@ namespace _func686
 void InfoBox::SetDescription(Description *desc, int width, int height, InfoBox::ExpandDir dir)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, Description *desc_arg, int width_arg, int height_arg, InfoBox::ExpandDir dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func686::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func687::func;
 	return execfunc(this, desc, width, height, dir);
 }
 
-namespace _func687
+namespace _func688
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetText", typeid(void (InfoBox::*)(const std::string &, const std::string &, int , int , InfoBox::ExpandDir )), ".41574989ff41564589ce41554d8d6f1041545589cd534489c34881eca8000000", nullptr, 0, 0, &func);
@@ -8860,11 +8873,11 @@ namespace _func687
 void InfoBox::SetText(const std::string &title, const std::string &text, int width, int height, InfoBox::ExpandDir dir)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, const std::string &title_arg, const std::string &text_arg, int width_arg, int height_arg, InfoBox::ExpandDir dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func687::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func688::func;
 	return execfunc(this, title, text, width, height, dir);
 }
 
-namespace _func688
+namespace _func689
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetSystem", typeid(void (InfoBox::*)(ShipSystem *, int , int , int )), ".4157415641554154554889f5534889fb4883ec384885f6", nullptr, 0, 0, &func);
@@ -8873,11 +8886,11 @@ namespace _func688
 void InfoBox::SetSystem(ShipSystem *system, int upgrade, int yShift, int forceSystemWidth)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, ShipSystem *system_arg, int upgrade_arg, int yShift_arg, int forceSystemWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func688::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func689::func;
 	return execfunc(this, system, upgrade, yShift, forceSystemWidth);
 }
 
-namespace _func689
+namespace _func690
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::Clear", typeid(void (InfoBox::*)()), ".55be????????534889fb4883ec28", nullptr, 0, 0, &func);
@@ -8886,11 +8899,11 @@ namespace _func689
 void InfoBox::Clear()
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func689::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func690::func;
 	return execfunc(this);
 }
 
-namespace _func690
+namespace _func691
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::OnRender", typeid(void (InfoBox::*)()), ".4157415641554989fd415455534881ec68020000", nullptr, 0, 0, &func);
@@ -8899,25 +8912,25 @@ namespace _func690
 void InfoBox::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func690::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func691::func;
 	return execfunc(this);
 }
 
 GL_Color *Global_InfoBox_detailsBarOff;
 
-namespace _var691
+namespace _var692
 {
     static VariableDefinition varObj("Global_InfoBox_detailsBarOff", "!f30f2a8424b0000000443b642420ba(???????\?)b8(???????\?)", &Global_InfoBox_detailsBarOff);
 }
 
 GL_Color *Global_InfoBox_detailsBarOn;
 
-namespace _var692
+namespace _var693
 {
     static VariableDefinition varObj("Global_InfoBox_detailsBarOn", "", &Global_InfoBox_detailsBarOn);
 }
 
-namespace _func693
+namespace _func694
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InputBox::OnRender", typeid(void (InputBox::*)()), "534889fb4883ec??807f08??0f84????????488d7c2410", nullptr, 0, 0, &func);
@@ -8926,11 +8939,11 @@ namespace _func693
 void InputBox::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(InputBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func693::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func694::func;
 	return execfunc(this);
 }
 
-namespace _func694
+namespace _func695
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InputBox::TextInput", typeid(void (InputBox::*)(int )), ".415683fe??415541545589f5", nullptr, 0, 0, &func);
@@ -8939,11 +8952,11 @@ namespace _func694
 void InputBox::TextInput(int ch)
 {
 	typedef void (*custom_arg_funcptr_t)(InputBox *this_arg, int ch_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func694::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func695::func;
 	return execfunc(this, ch);
 }
 
-namespace _func695
+namespace _func696
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InputBox::TextEvent", typeid(void (InputBox::*)(CEvent::TextEvent )), ".4155415455534889fb4883ec??83fe??0f84????????0f8e????????", nullptr, 0, 0, &func);
@@ -8952,11 +8965,11 @@ namespace _func695
 void InputBox::TextEvent(CEvent::TextEvent event)
 {
 	typedef void (*custom_arg_funcptr_t)(InputBox *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func695::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func696::func;
 	return execfunc(this, event);
 }
 
-namespace _func696
+namespace _func697
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InputBox::StartInput", typeid(void (InputBox::*)()), ".534889fb488d7f3831d2", nullptr, 0, 0, &func);
@@ -8965,11 +8978,11 @@ namespace _func696
 void InputBox::StartInput()
 {
 	typedef void (*custom_arg_funcptr_t)(InputBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func696::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func697::func;
 	return execfunc(this);
 }
 
-namespace _func697
+namespace _func698
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("IonDrone::GetRoomDamage", typeid(Damage (IonDrone::*)()), "554889f5534889fb4883ec08c70700000000", nullptr, 0, 0, &func);
@@ -8978,11 +8991,11 @@ namespace _func697
 Damage IonDrone::GetRoomDamage()
 {
 	typedef Damage (*custom_arg_funcptr_t)(IonDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func697::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func698::func;
 	return execfunc(this);
 }
 
-namespace _func698
+namespace _func699
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("IonDrone::constructor", typeid(void (IonDrone::*)(int , DroneBlueprint *)), ".41570f57c941560f28c1", nullptr, 0, 0, &func);
@@ -8991,11 +9004,11 @@ namespace _func698
 void IonDrone::constructor(int iShipId, DroneBlueprint *blueprint)
 {
 	typedef void (*custom_arg_funcptr_t)(IonDrone *this_arg, int iShipId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func698::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func699::func;
 	return execfunc(this, iShipId, blueprint);
 }
 
-namespace _func699
+namespace _func700
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("IonDroneAnimation::constructor", typeid(void (IonDroneAnimation::*)(int , Pointf , bool )), "41574156415541544189d45589f5be", nullptr, 0, 0, &func);
@@ -9004,11 +9017,11 @@ namespace _func699
 void IonDroneAnimation::constructor(int iShipId, Pointf position, bool enemy)
 {
 	typedef void (*custom_arg_funcptr_t)(IonDroneAnimation *this_arg, int iShipId_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func699::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func700::func;
 	return execfunc(this, iShipId, position, enemy);
 }
 
-namespace _func700
+namespace _func701
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("IonDroneAnimation::UpdateShooting", typeid(void (IonDroneAnimation::*)()), ".4155415455488dafd8080000", nullptr, 0, 0, &func);
@@ -9017,11 +9030,11 @@ namespace _func700
 void IonDroneAnimation::UpdateShooting()
 {
 	typedef void (*custom_arg_funcptr_t)(IonDroneAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func700::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func701::func;
 	return execfunc(this);
 }
 
-namespace _func701
+namespace _func702
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ItemStoreBox::constructor", typeid(void (ItemStoreBox::*)(ShipManager *, const std::string &)), "41544989f4554889d5534889fb4883ec20488b02", nullptr, 0, 0, &func);
@@ -9030,18 +9043,18 @@ namespace _func701
 void ItemStoreBox::constructor(ShipManager *ship, const std::string &resourceName)
 {
 	typedef void (*custom_arg_funcptr_t)(ItemStoreBox *this_arg, ShipManager *ship_arg, const std::string &resourceName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func701::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func702::func;
 	return execfunc(this, ship, resourceName);
 }
 
 std::vector<std::string> *Global_OptionsScreen_languageList;
 
-namespace _var702
+namespace _var703
 {
     static VariableDefinition varObj("Global_OptionsScreen_languageList", "!4889ee480335(???????\?)", &Global_OptionsScreen_languageList, true, true);
 }
 
-namespace _func703
+namespace _func704
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("LanguageChooser::OnRender", typeid(void (LanguageChooser::*)()), ".4157bef001000041564155", nullptr, 0, 0, &func);
@@ -9050,11 +9063,11 @@ namespace _func703
 void LanguageChooser::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(LanguageChooser *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func703::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func704::func;
 	return execfunc(this);
 }
 
-namespace _func704
+namespace _func705
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("LaserBlast::OnUpdate", typeid(void (LaserBlast::*)()), "534889fb4883ec1080bfc400000000745f", nullptr, 0, 0, &func);
@@ -9063,11 +9076,11 @@ namespace _func704
 void LaserBlast::OnUpdate()
 {
 	typedef void (*custom_arg_funcptr_t)(LaserBlast *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func704::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func705::func;
 	return execfunc(this);
 }
 
-namespace _func705
+namespace _func706
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("LaserBlast::OnInit", typeid(void (LaserBlast::*)()), "538b477c4889fb394778c7474001000000", nullptr, 0, 0, &func);
@@ -9076,25 +9089,25 @@ namespace _func705
 void LaserBlast::OnInit()
 {
 	typedef void (*custom_arg_funcptr_t)(LaserBlast *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func705::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func706::func;
 	return execfunc(this);
 }
 
 void **VTable_LaserBlast;
 
-namespace _var706
+namespace _var707
 {
     static VariableDefinition varObj("VTable_LaserBlast", "!b8b7600bb64589e84c89e741f7ed4489e849c70424(???????\?)c1f81f49c7442408(???????\?)", &VTable_LaserBlast);
 }
 
 void **VTable_Targetable_LaserBlast;
 
-namespace _var707
+namespace _var708
 {
     static VariableDefinition varObj("VTable_Targetable_LaserBlast", "", &VTable_Targetable_LaserBlast);
 }
 
-namespace _func708
+namespace _func709
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("LocationEvent::ClearEvent", typeid(void (LocationEvent::*)(bool )), "4157415641554154554889fd534883ec3883bfc404000001", nullptr, 0, 0, &func);
@@ -9103,11 +9116,11 @@ namespace _func708
 void LocationEvent::ClearEvent(bool force)
 {
 	typedef void (*custom_arg_funcptr_t)(LocationEvent *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func708::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func709::func;
 	return execfunc(this, force);
 }
 
-namespace _func709
+namespace _func710
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("LocationEvent::constructor", typeid(void (LocationEvent::*)()), "53be????????4889fb4883ec10488d54240fe8????????488d7b18", nullptr, 0, 0, &func);
@@ -9116,11 +9129,11 @@ namespace _func709
 void LocationEvent::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(LocationEvent *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func709::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func710::func;
 	return execfunc(this);
 }
 
-namespace _func710
+namespace _func711
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("LockdownShard::Update", typeid(void (LockdownShard::*)()), "534889fbbf????????e8????????f30f5905????????f30f5883d8000000", nullptr, 0, 0, &func);
@@ -9129,19 +9142,6 @@ namespace _func710
 void LockdownShard::Update()
 {
 	typedef void (*custom_arg_funcptr_t)(LockdownShard *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func710::func;
-	return execfunc(this);
-}
-
-namespace _func711
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("MainMenu::constructor", typeid(void (MainMenu::*)()), "41570f57c04156415541544c8d673855534889fb4c8dbbe80100004c8db378020000488dab08030000", nullptr, 0, 0, &func);
-}
-
-void MainMenu::constructor()
-{
-	typedef void (*custom_arg_funcptr_t)(MainMenu *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func711::func;
 	return execfunc(this);
 }
@@ -9149,10 +9149,10 @@ void MainMenu::constructor()
 namespace _func712
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("MainMenu::OnRender", typeid(void (MainMenu::*)()), ".415741564155415455534889fb4881ecf8040000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("MainMenu::constructor", typeid(void (MainMenu::*)()), "41570f57c04156415541544c8d673855534889fb4c8dbbe80100004c8db378020000488dab08030000", nullptr, 0, 0, &func);
 }
 
-void MainMenu::OnRender()
+void MainMenu::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(MainMenu *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func712::func;
@@ -9162,17 +9162,30 @@ void MainMenu::OnRender()
 namespace _func713
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("MainMenu::OnRender", typeid(void (MainMenu::*)()), ".415741564155415455534889fb4881ecf8040000", nullptr, 0, 0, &func);
+}
+
+void MainMenu::OnRender()
+{
+	typedef void (*custom_arg_funcptr_t)(MainMenu *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func713::func;
+	return execfunc(this);
+}
+
+namespace _func714
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("MainMenu::Open", typeid(bool (MainMenu::*)()), ".415741564155415455534889fb488dbfa02200004881ec08020000", nullptr, 0, 0, &func);
 }
 
 bool MainMenu::Open()
 {
 	typedef bool (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func713::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func714::func;
 	return execfunc(this);
 }
 
-namespace _func714
+namespace _func715
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MainMenu::MouseMove", typeid(void (MainMenu::*)(int , int )), ".4155415455534889fb4883ec3880bf????000000", nullptr, 0, 0, &func);
@@ -9181,11 +9194,11 @@ namespace _func714
 void MainMenu::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(MainMenu *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func714::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func715::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func715
+namespace _func716
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MainMenu::OnLoop", typeid(void (MainMenu::*)()), ".415741564155415455534889fb4881ec????0000", nullptr, 0, 0, &func);
@@ -9194,11 +9207,11 @@ namespace _func715
 void MainMenu::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func715::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func716::func;
 	return execfunc(this);
 }
 
-namespace _func716
+namespace _func717
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MainMenu::MouseClick", typeid(void (MainMenu::*)(int , int )), ".534889fb4883ec5080bf????000000", nullptr, 0, 0, &func);
@@ -9207,17 +9220,17 @@ namespace _func716
 void MainMenu::MouseClick(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(MainMenu *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func716::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func717::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func717
+namespace _func718
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MantisAnimation::__DO_NOT_HOOK_1", typeid(void (MantisAnimation::*)()), "!c3660f1f840000000000f3c3660f1f440000f3c3660f1f440000", nullptr, 0, 0, &func);
 }
 
-namespace _func718
+namespace _func719
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MantisAnimation::GetDeathSound", typeid(std::string (MantisAnimation::*)()), ".53be????????4889fb4883ec10", nullptr, 0, 0, &func);
@@ -9226,17 +9239,17 @@ namespace _func718
 std::string MantisAnimation::GetDeathSound()
 {
 	typedef std::string (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func718::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func719::func;
 	return execfunc(this);
 }
 
-namespace _func719
+namespace _func720
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MantisAnimation::__DO_NOT_HOOK_2", typeid(void (MantisAnimation::*)()), ".53486347584889fb488b5710", nullptr, 0, 0, &func);
 }
 
-namespace _func720
+namespace _func721
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MantisAnimation::FireShot", typeid(bool (MantisAnimation::*)()), ".53486347584889fb488b5710", nullptr, 0, 0, &func);
@@ -9245,17 +9258,17 @@ namespace _func720
 bool MantisAnimation::FireShot()
 {
 	typedef bool (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func720::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func721::func;
 	return execfunc(this);
 }
 
-namespace _func721
+namespace _func722
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MantisAnimation::__DO_NOT_HOOK_3", typeid(void (MantisAnimation::*)()), ".534889fb4883ec30803d????????007577e8????????89c1", nullptr, 0, 0, &func);
 }
 
-namespace _func722
+namespace _func723
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MantisAnimation::GetShootingSound", typeid(std::string (MantisAnimation::*)()), ".534889fb4883ec30803d????????007577e8????????89c1", nullptr, 0, 0, &func);
@@ -9264,19 +9277,6 @@ namespace _func722
 std::string MantisAnimation::GetShootingSound()
 {
 	typedef std::string (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func722::func;
-	return execfunc(this);
-}
-
-namespace _func723
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("MenuScreen::OnLanguageChange", typeid(void (MenuScreen::*)()), "415741564155415455534889fb4883ec78488b5720", nullptr, 0, 0, &func);
-}
-
-void MenuScreen::OnLanguageChange()
-{
-	typedef void (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func723::func;
 	return execfunc(this);
 }
@@ -9284,10 +9284,10 @@ void MenuScreen::OnLanguageChange()
 namespace _func724
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("MenuScreen::constructor", typeid(void (MenuScreen::*)()), ".41564155415455534889fb488d6b784881ece0000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("MenuScreen::OnLanguageChange", typeid(void (MenuScreen::*)()), "415741564155415455534889fb4883ec78488b5720", nullptr, 0, 0, &func);
 }
 
-void MenuScreen::constructor()
+void MenuScreen::OnLanguageChange()
 {
 	typedef void (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func724::func;
@@ -9297,10 +9297,10 @@ void MenuScreen::constructor()
 namespace _func725
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("MenuScreen::OnRender", typeid(void (MenuScreen::*)()), ".41564155415455534889fb4881eca000000080bf0803000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("MenuScreen::constructor", typeid(void (MenuScreen::*)()), ".41564155415455534889fb488d6b784881ece0000000", nullptr, 0, 0, &func);
 }
 
-void MenuScreen::OnRender()
+void MenuScreen::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func725::func;
@@ -9310,10 +9310,10 @@ void MenuScreen::OnRender()
 namespace _func726
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("MenuScreen::Open", typeid(void (MenuScreen::*)()), ".415641554989fd488d7f7841", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("MenuScreen::OnRender", typeid(void (MenuScreen::*)()), ".41564155415455534889fb4881eca000000080bf0803000000", nullptr, 0, 0, &func);
 }
 
-void MenuScreen::Open()
+void MenuScreen::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func726::func;
@@ -9323,17 +9323,30 @@ void MenuScreen::Open()
 namespace _func727
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("MenuScreen::Open", typeid(void (MenuScreen::*)()), ".415641554989fd488d7f7841", nullptr, 0, 0, &func);
+}
+
+void MenuScreen::Open()
+{
+	typedef void (*custom_arg_funcptr_t)(MenuScreen *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func727::func;
+	return execfunc(this);
+}
+
+namespace _func728
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("MindBox::constructor", typeid(void (MindBox::*)(Point , MindSystem *)), "415431c9554889d5534889fb4883ec60", nullptr, 0, 0, &func);
 }
 
 void MindBox::constructor(Point pos, MindSystem *sys)
 {
 	typedef void (*custom_arg_funcptr_t)(MindBox *this_arg, Point pos_arg, MindSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func727::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func728::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func728
+namespace _func729
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MindSystem::ReleaseCrew", typeid(void (MindSystem::*)()), "41554989fd415455534883ec28488b8f", nullptr, 0, 0, &func);
@@ -9342,11 +9355,11 @@ namespace _func728
 void MindSystem::ReleaseCrew()
 {
 	typedef void (*custom_arg_funcptr_t)(MindSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func728::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func729::func;
 	return execfunc(this);
 }
 
-namespace _func729
+namespace _func730
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MindSystem::SetHackingLevel", typeid(void (MindSystem::*)(int )), ".5589f553??89fb??83ec08", nullptr, 0, 0, &func);
@@ -9355,11 +9368,11 @@ namespace _func729
 void MindSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(MindSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func729::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func730::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func730
+namespace _func731
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MindSystem::SetArmed", typeid(void (MindSystem::*)(int )), ".83fe01534889fb740f", nullptr, 0, 0, &func);
@@ -9368,30 +9381,17 @@ namespace _func730
 void MindSystem::SetArmed(int armed)
 {
 	typedef void (*custom_arg_funcptr_t)(MindSystem *this_arg, int armed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func730::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func731::func;
 	return execfunc(this, armed);
 }
 
-namespace _func731
+namespace _func732
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MindSystem::InitiateMindControl", typeid(void (MindSystem::*)()), ".415741564155415455534889fb4883ec48488bb780020000", nullptr, 0, 0, &func);
 }
 
 void MindSystem::InitiateMindControl()
-{
-	typedef void (*custom_arg_funcptr_t)(MindSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func731::func;
-	return execfunc(this);
-}
-
-namespace _func732
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("MindSystem::OnLoop", typeid(void (MindSystem::*)()), ".415455534889fb4883ec20e8????????488b8380020000", nullptr, 0, 0, &func);
-}
-
-void MindSystem::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(MindSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func732::func;
@@ -9401,36 +9401,36 @@ void MindSystem::OnLoop()
 namespace _func733
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("MindSystem::OnLoop", typeid(void (MindSystem::*)()), ".415455534889fb4883ec20e8????????488b8380020000", nullptr, 0, 0, &func);
+}
+
+void MindSystem::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(MindSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func733::func;
+	return execfunc(this);
+}
+
+namespace _func734
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Missile::constructor", typeid(void (Missile::*)(Pointf , int , int , Pointf , float )), "41574989ff4156415541545589f55389d34881ecf8000000f30f11542404", nullptr, 0, 0, &func);
 }
 
 void Missile::constructor(Pointf _position, int _ownerId, int _targetId, Pointf _target, float _heading)
 {
 	typedef void (*custom_arg_funcptr_t)(Missile *this_arg, Pointf _position_arg, int _ownerId_arg, int _targetId_arg, Pointf _target_arg, float _heading_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func733::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func734::func;
 	return execfunc(this, _position, _ownerId, _targetId, _target, _heading);
 }
 
-namespace _func734
+namespace _func735
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::OnLoop", typeid(void (MouseControl::*)()), "5380bf0c010000004889fb", nullptr, 0, 0, &func);
 }
 
 void MouseControl::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func734::func;
-	return execfunc(this);
-}
-
-namespace _func735
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("MouseControl::InstantTooltip", typeid(void (MouseControl::*)()), "!.c6872001000001c3", nullptr, 0, 0, &func);
-}
-
-void MouseControl::InstantTooltip()
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func735::func;
@@ -9440,10 +9440,10 @@ void MouseControl::InstantTooltip()
 namespace _func736
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("MouseControl::ResetArmed", typeid(void (MouseControl::*)()), ".c7471000000000c7471400000000c7471800000000c7873801000000000000c7472000000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("MouseControl::InstantTooltip", typeid(void (MouseControl::*)()), "!.c6872001000001c3", nullptr, 0, 0, &func);
 }
 
-void MouseControl::ResetArmed()
+void MouseControl::InstantTooltip()
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func736::func;
@@ -9453,17 +9453,30 @@ void MouseControl::ResetArmed()
 namespace _func737
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("MouseControl::ResetArmed", typeid(void (MouseControl::*)()), ".c7471000000000c7471400000000c7471800000000c7873801000000000000c7472000000000", nullptr, 0, 0, &func);
+}
+
+void MouseControl::ResetArmed()
+{
+	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func737::func;
+	return execfunc(this);
+}
+
+namespace _func738
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::MeasureTooltip", typeid(Point (MouseControl::*)(int )), ".41550f57c941544189f40f28c155534889fb4883ec48", nullptr, 0, 0, &func);
 }
 
 Point MouseControl::MeasureTooltip(int unk)
 {
 	typedef Point (*custom_arg_funcptr_t)(MouseControl *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func737::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func738::func;
 	return execfunc(this, unk);
 }
 
-namespace _func738
+namespace _func739
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::QueueStaticTooltip", typeid(void (MouseControl::*)(Point )), "!.4889b740010000c3", nullptr, 0, 0, &func);
@@ -9472,11 +9485,11 @@ namespace _func738
 void MouseControl::QueueStaticTooltip(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func738::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func739::func;
 	return execfunc(this, pos);
 }
 
-namespace _func739
+namespace _func740
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::RenderTooltip", typeid(void (MouseControl::*)(Point , bool )), ".41574989f749c1ff2041564989f641554189f5", nullptr, 0, 0, &func);
@@ -9485,30 +9498,17 @@ namespace _func739
 void MouseControl::RenderTooltip(Point tooltipPoint, bool staticPos)
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg, Point tooltipPoint_arg, bool staticPos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func739::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func740::func;
 	return execfunc(this, tooltipPoint, staticPos);
 }
 
-namespace _func740
+namespace _func741
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::OnRender", typeid(void (MouseControl::*)()), ".41574989ff41564155415455534881ecc801000080bf0d01000000", nullptr, 0, 0, &func);
 }
 
 void MouseControl::OnRender()
-{
-	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func740::func;
-	return execfunc(this);
-}
-
-namespace _func741
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("MouseControl::Reset", typeid(void (MouseControl::*)()), ".534889fb488dbf0001000031d2", nullptr, 0, 0, &func);
-}
-
-void MouseControl::Reset()
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func741::func;
@@ -9518,36 +9518,36 @@ void MouseControl::Reset()
 namespace _func742
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("MouseControl::Reset", typeid(void (MouseControl::*)()), ".534889fb488dbf0001000031d2", nullptr, 0, 0, &func);
+}
+
+void MouseControl::Reset()
+{
+	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func742::func;
+	return execfunc(this);
+}
+
+namespace _func743
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::LoadTooltip", typeid(void (MouseControl::*)(const std::string &)), ".415541544989fc55534889f34883ec38", nullptr, 0, 0, &func);
 }
 
 void MouseControl::LoadTooltip(const std::string &tooltipName)
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltipName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func742::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func743::func;
 	return execfunc(this, tooltipName);
 }
 
-namespace _func743
+namespace _func744
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::SetTooltip", typeid(void (MouseControl::*)(const std::string &)), ".41544989f4554889fd53488b06488b58e84885db", nullptr, 0, 0, &func);
 }
 
 void MouseControl::SetTooltip(const std::string &tooltip)
-{
-	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func743::func;
-	return execfunc(this, tooltip);
-}
-
-namespace _func744
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("MouseControl::SetTooltipTitle", typeid(void (MouseControl::*)(const std::string &)), ".488b8728010000488378e800", nullptr, 0, 0, &func);
-}
-
-void MouseControl::SetTooltipTitle(const std::string &tooltip)
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltip_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func744::func;
@@ -9557,30 +9557,43 @@ void MouseControl::SetTooltipTitle(const std::string &tooltip)
 namespace _func745
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("MouseControl::SetTooltipTitle", typeid(void (MouseControl::*)(const std::string &)), ".488b8728010000488378e800", nullptr, 0, 0, &func);
+}
+
+void MouseControl::SetTooltipTitle(const std::string &tooltip)
+{
+	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltip_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func745::func;
+	return execfunc(this, tooltip);
+}
+
+namespace _func746
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::SetDoor", typeid(void (MouseControl::*)(int )), ".554889fd5389f34883ec0883fe01", nullptr, 0, 0, &func);
 }
 
 void MouseControl::SetDoor(int state)
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg, int state_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func745::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func746::func;
 	return execfunc(this, state);
 }
 
 MouseControl *Global_MouseControl_Mouse;
 
-namespace _var746
+namespace _var747
 {
     static VariableDefinition varObj("Global_MouseControl_Mouse", "!0f85570400008b85a401000083f8ff740abf(???????\?)", &Global_MouseControl_Mouse);
 }
 
-namespace _func747
+namespace _func748
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OptionsScreen::DO_NOT_HOOK_2", typeid(void (OptionsScreen::*)()), "!8b50f88d4aff8948f889d0ebc2906690", nullptr, 0, 0, &func);
 }
 
-namespace _func748
+namespace _func749
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OptionsScreen::Open", typeid(void (OptionsScreen::*)(bool )), ".4157", nullptr, 0, 0, &func);
@@ -9589,11 +9602,11 @@ namespace _func748
 void OptionsScreen::Open(bool mainMenu)
 {
 	typedef void (*custom_arg_funcptr_t)(OptionsScreen *this_arg, bool mainMenu_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func748::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func749::func;
 	return execfunc(this, mainMenu);
 }
 
-namespace _func749
+namespace _func750
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OptionsScreen::OnLoop", typeid(void (OptionsScreen::*)()), ".41574156415549bdb76ddbb66ddbb66d4154554889fd", nullptr, 0, 0, &func);
@@ -9602,17 +9615,17 @@ namespace _func749
 void OptionsScreen::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(OptionsScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func749::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func750::func;
 	return execfunc(this);
 }
 
-namespace _func750
+namespace _func751
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OptionsScreen::DO_NOT_HOOK_1", typeid(void (OptionsScreen::*)()), "!.8970f889d0e942ffffff900f1f840000000000", nullptr, 0, 0, &func);
 }
 
-namespace _func751
+namespace _func752
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OptionsScreen::OnInit", typeid(void (OptionsScreen::*)()), ".41", nullptr, 0, 0, &func);
@@ -9621,18 +9634,18 @@ namespace _func751
 void OptionsScreen::OnInit()
 {
 	typedef void (*custom_arg_funcptr_t)(OptionsScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func751::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func752::func;
 	return execfunc(this);
 }
 
 void **VTable_OuterHull;
 
-namespace _var752
+namespace _var753
 {
     static VariableDefinition varObj("VTable_OuterHull", "!498dbd880000000f28caf3410f1195840000000f28c249c74500(???????\?)", &VTable_OuterHull);
 }
 
-namespace _func753
+namespace _func754
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OxygenSystem::constructor", typeid(void (OxygenSystem::*)(int , int , int , int )), "4154554863eebe02000000534889fb", nullptr, 0, 0, &func);
@@ -9641,11 +9654,11 @@ namespace _func753
 void OxygenSystem::constructor(int numRooms, int roomId, int shipId, int startingPower)
 {
 	typedef void (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int numRooms_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func753::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func754::func;
 	return execfunc(this, numRooms, roomId, shipId, startingPower);
 }
 
-namespace _func754
+namespace _func755
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OxygenSystem::GetRefillSpeed", typeid(float (OxygenSystem::*)()), ".5380bf24020000004889fb8b8720020000", nullptr, 0, 0, &func);
@@ -9654,11 +9667,11 @@ namespace _func754
 float OxygenSystem::GetRefillSpeed()
 {
 	typedef float (*custom_arg_funcptr_t)(OxygenSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func754::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func755::func;
 	return execfunc(this);
 }
 
-namespace _func755
+namespace _func756
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OxygenSystem::ModifyRoomOxygen", typeid(void (OxygenSystem::*)(int , float )), ".488b87480200004863f6", nullptr, 0, 0, &func);
@@ -9667,11 +9680,11 @@ namespace _func755
 void OxygenSystem::ModifyRoomOxygen(int roomId, float value)
 {
 	typedef void (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, float value_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func755::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func756::func;
 	return execfunc(this, roomId, value);
 }
 
-namespace _func756
+namespace _func757
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OxygenSystem::ComputeAirLoss", typeid(void (OxygenSystem::*)(int , float , bool )), ".415541544989fc5589d55389f34883ec38", nullptr, 0, 0, &func);
@@ -9680,11 +9693,11 @@ namespace _func756
 void OxygenSystem::ComputeAirLoss(int roomId, float value, bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, float value_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func756::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func757::func;
 	return execfunc(this, roomId, value, unk);
 }
 
-namespace _func757
+namespace _func758
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OxygenSystem::UpdateBreach", typeid(void (OxygenSystem::*)(int , int , bool )), ".85d289d07e1a", nullptr, 0, 0, &func);
@@ -9693,11 +9706,11 @@ namespace _func757
 void OxygenSystem::UpdateBreach(int roomId, int hasBreach, bool unk3)
 {
 	typedef void (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, int hasBreach_arg, bool unk3_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func757::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func758::func;
 	return execfunc(this, roomId, hasBreach, unk3);
 }
 
-namespace _func758
+namespace _func759
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OxygenSystem::UpdateAirlock", typeid(void (OxygenSystem::*)(int , int )), ".4154555389d34883ec2085d2", nullptr, 0, 0, &func);
@@ -9706,11 +9719,11 @@ namespace _func758
 void OxygenSystem::UpdateAirlock(int roomId, int unk)
 {
 	typedef void (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func758::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func759::func;
 	return execfunc(this, roomId, unk);
 }
 
-namespace _func759
+namespace _func760
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OxygenSystem::EmptyOxygen", typeid(void (OxygenSystem::*)(int )), ".488b87480200004863f6", nullptr, 0, 0, &func);
@@ -9719,11 +9732,11 @@ namespace _func759
 void OxygenSystem::EmptyOxygen(int roomId)
 {
 	typedef void (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func759::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func760::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func760
+namespace _func761
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("PDSFire::OnUpdate", typeid(void (PDSFire::*)()), "55534889fb4883ec1880bfc400000000", nullptr, 0, 0, &func);
@@ -9732,11 +9745,11 @@ namespace _func760
 void PDSFire::OnUpdate()
 {
 	typedef void (*custom_arg_funcptr_t)(PDSFire *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func760::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func761::func;
 	return execfunc(this);
 }
 
-namespace _func761
+namespace _func762
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("PDSFire::CollisionCheck", typeid(void (PDSFire::*)(Collideable *)), ".554889f5534889fb4889f74883ec58488b06", nullptr, 0, 0, &func);
@@ -9745,11 +9758,11 @@ namespace _func761
 void PDSFire::CollisionCheck(Collideable *other)
 {
 	typedef void (*custom_arg_funcptr_t)(PDSFire *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func761::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func762::func;
 	return execfunc(this, other);
 }
 
-namespace _func762
+namespace _func763
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("PDSFire::constructor", typeid(void (PDSFire::*)(Point , int , Pointf )), ".415741564989fe415541544989f449c1fc205589d5534889f34881ec08010000", nullptr, 0, 0, &func);
@@ -9758,30 +9771,17 @@ namespace _func762
 void PDSFire::constructor(Point pos, int destinationSpace, Pointf destination)
 {
 	typedef void (*custom_arg_funcptr_t)(PDSFire *this_arg, Point pos_arg, int destinationSpace_arg, Pointf destination_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func762::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func763::func;
 	return execfunc(this, pos, destinationSpace, destination);
 }
 
-namespace _func763
+namespace _func764
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Point::RelativeDistance", typeid(int (Point::*)(Point )), "8b178b470429f248c1fe2029f00fafd20fafc001d0", nullptr, 0, 0, &func);
 }
 
 int Point::RelativeDistance(Point other)
-{
-	typedef int (*custom_arg_funcptr_t)(Point *this_arg, Point other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func763::func;
-	return execfunc(this, other);
-}
-
-namespace _func764
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Point::Distance", typeid(int (Point::*)(Point )), ".8b178b470429f248c1fe2029f00fafd20fafc001d0", nullptr, 0, 0, &func);
-}
-
-int Point::Distance(Point other)
 {
 	typedef int (*custom_arg_funcptr_t)(Point *this_arg, Point other_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func764::func;
@@ -9791,17 +9791,30 @@ int Point::Distance(Point other)
 namespace _func765
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Point::Distance", typeid(int (Point::*)(Point )), ".8b178b470429f248c1fe2029f00fafd20fafc001d0", nullptr, 0, 0, &func);
+}
+
+int Point::Distance(Point other)
+{
+	typedef int (*custom_arg_funcptr_t)(Point *this_arg, Point other_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func765::func;
+	return execfunc(this, other);
+}
+
+namespace _func766
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Pointf::constructor", typeid(void (Pointf::*)(float , float )), "f30f1107f30f114f04c3", nullptr, 0, 0, &func);
 }
 
 void Pointf::constructor(float x, float y)
 {
 	typedef void (*custom_arg_funcptr_t)(Pointf *this_arg, float x_arg, float y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func765::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func766::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func766
+namespace _func767
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Pointf::RelativeDistance", typeid(float (Pointf::*)(Pointf )), "660fd64424f0488b4424f0f30f1007", nullptr, 0, 0, &func);
@@ -9810,11 +9823,11 @@ namespace _func766
 float Pointf::RelativeDistance(Pointf other)
 {
 	typedef float (*custom_arg_funcptr_t)(Pointf *this_arg, Pointf other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func766::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func767::func;
 	return execfunc(this, other);
 }
 
-namespace _func767
+namespace _func768
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Pointf::Normalize", typeid(Pointf (Pointf::*)()), "4883ec28f30f100ff30f104704", nullptr, 0, 0, &func);
@@ -9823,11 +9836,11 @@ namespace _func767
 Pointf Pointf::Normalize()
 {
 	typedef Pointf (*custom_arg_funcptr_t)(Pointf *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func767::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func768::func;
 	return execfunc(this);
 }
 
-namespace _func768
+namespace _func769
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("PowerManager::SetHacked", typeid(void (PowerManager::*)(bool )), "??80fe0119c0f7d083e002894720", nullptr, 0, 0, &func);
@@ -9836,11 +9849,11 @@ namespace _func768
 void PowerManager::SetHacked(bool val)
 {
 	typedef void (*custom_arg_funcptr_t)(PowerManager *this_arg, bool val_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func768::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func769::func;
 	return execfunc(this, val);
 }
 
-namespace _func769
+namespace _func770
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("PowerManager::GetPowerManager", typeid(PowerManager *(*)(int )), ".5389fb4883ec30488b05????????488b0d????????4889c2", nullptr, 0, 0, &func);
@@ -9849,11 +9862,11 @@ namespace _func769
 PowerManager *PowerManager::GetPowerManager(int iShipId)
 {
 	typedef PowerManager *(*custom_arg_funcptr_t)(int iShipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func769::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func770::func;
 	return execfunc(iShipId);
 }
 
-namespace _func770
+namespace _func771
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::ValidTarget", typeid(bool (Projectile::*)()), "0fb6873402000083f001", nullptr, 0, 0, &func);
@@ -9862,11 +9875,11 @@ namespace _func770
 bool Projectile::ValidTarget()
 {
 	typedef bool (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func770::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func771::func;
 	return execfunc(this);
 }
 
-namespace _func771
+namespace _func772
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::ForceRenderLayer", typeid(int (Projectile::*)()), ".!b8ffffffffc3662e0f1f840000000000f3c3662e0f1f8400000000000f1f40004889b7f0020000", nullptr, 0, 32, &func);
@@ -9875,11 +9888,11 @@ namespace _func771
 int Projectile::ForceRenderLayer()
 {
 	typedef int (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func771::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func772::func;
 	return execfunc(this);
 }
 
-namespace _func772
+namespace _func773
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::CollisionMoving", typeid(CollisionResponse (Projectile::*)(Pointf , Pointf , Damage , bool )), ".554889f5534889fb488d7f044883ec18c747fc00000000", nullptr, 0, 0, &func);
@@ -9888,11 +9901,11 @@ namespace _func772
 CollisionResponse Projectile::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse (*custom_arg_funcptr_t)(Projectile *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func772::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func773::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func773
+namespace _func774
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::OnUpdate", typeid(void (Projectile::*)()), ".534889fb4883ec2080bfc400000000", nullptr, 0, 0, &func);
@@ -9901,11 +9914,11 @@ namespace _func773
 void Projectile::OnUpdate()
 {
 	typedef void (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func773::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func774::func;
 	return execfunc(this);
 }
 
-namespace _func774
+namespace _func775
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::CollisionCheck", typeid(void (Projectile::*)(Collideable *)), ".4154554889f5534889fb4883ec60448b673c488b064889f7", nullptr, 0, 0, &func);
@@ -9914,11 +9927,11 @@ namespace _func774
 void Projectile::CollisionCheck(Collideable *other)
 {
 	typedef void (*custom_arg_funcptr_t)(Projectile *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func774::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func775::func;
 	return execfunc(this, other);
 }
 
-namespace _func775
+namespace _func776
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::constructor", typeid(void (Projectile::*)(Pointf , int , int , Pointf )), ".4157415641554154554889fd534881ecf8000000", nullptr, 0, 0, &func);
@@ -9927,11 +9940,11 @@ namespace _func775
 void Projectile::constructor(Pointf position, int ownerId, int targetId, Pointf target)
 {
 	typedef void (*custom_arg_funcptr_t)(Projectile *this_arg, Pointf position_arg, int ownerId_arg, int targetId_arg, Pointf target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func775::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func776::func;
 	return execfunc(this, position, ownerId, targetId, target);
 }
 
-namespace _func776
+namespace _func777
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::Initialize", typeid(void (Projectile::*)(const WeaponBlueprint &)), ".415731d2415641554c8daed000000041544989f4554889fd5331db4881ec28010000", nullptr, 0, 0, &func);
@@ -9940,11 +9953,11 @@ namespace _func776
 void Projectile::Initialize(const WeaponBlueprint &bp)
 {
 	typedef void (*custom_arg_funcptr_t)(Projectile *this_arg, const WeaponBlueprint &bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func776::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func777::func;
 	return execfunc(this, bp);
 }
 
-namespace _func777
+namespace _func778
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::RandomSidePoint", typeid(Pointf (*)(int )), ".53baffffffff89fb89d64883ec30488d7c2420", nullptr, 0, 0, &func);
@@ -9953,11 +9966,11 @@ namespace _func777
 Pointf Projectile::RandomSidePoint(int side)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(int side_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func777::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func778::func;
 	return execfunc(side);
 }
 
-namespace _func778
+namespace _func779
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::destructor", typeid(void (Projectile::*)()), ".415641554154554889fd534883ec10488b872802000048c707????????48c74708????????48c78738020000????????488d78e84881ff????????0f8507030000", nullptr, 0, 0, &func);
@@ -9966,11 +9979,11 @@ namespace _func778
 void Projectile::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func778::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func779::func;
 	return execfunc(this);
 }
 
-namespace _func779
+namespace _func780
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::constructor", typeid(void (ProjectileFactory::*)(const WeaponBlueprint *, int )), "415741564989fe488d7f284d8dbec8000000415541544d8da680000000554889f553498d9e880000004881ec08010000", nullptr, 0, 0, &func);
@@ -9979,11 +9992,11 @@ namespace _func779
 void ProjectileFactory::constructor(const WeaponBlueprint *bp, int shipId)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, const WeaponBlueprint *bp_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func779::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func780::func;
 	return execfunc(this, bp, shipId);
 }
 
-namespace _func780
+namespace _func781
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::SelectChargeGoal", typeid(void (ProjectileFactory::*)()), ".803d????????00534889fb", nullptr, 0, 0, &func);
@@ -9992,11 +10005,11 @@ namespace _func780
 void ProjectileFactory::SelectChargeGoal()
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func780::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func781::func;
 	return execfunc(this);
 }
 
-namespace _func781
+namespace _func782
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::IsChargedGoal", typeid(bool (ProjectileFactory::*)()), ".488b47208b808401000085c0", nullptr, 0, 0, &func);
@@ -10005,11 +10018,11 @@ namespace _func781
 bool ProjectileFactory::IsChargedGoal()
 {
 	typedef bool (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func781::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func782::func;
 	return execfunc(this);
 }
 
-namespace _func782
+namespace _func783
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::SetHacked", typeid(void (ProjectileFactory::*)(int )), "!.89b7240600004881c758010000", nullptr, 0, 0, &func);
@@ -10018,11 +10031,11 @@ namespace _func782
 void ProjectileFactory::SetHacked(int hacked)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, int hacked_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func782::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func783::func;
 	return execfunc(this, hacked);
 }
 
-namespace _func783
+namespace _func784
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::SetCurrentShip", typeid(void (ProjectileFactory::*)(Targetable *)), ".4839b74801000074274885f6", nullptr, 0, 0, &func);
@@ -10031,11 +10044,11 @@ namespace _func783
 void ProjectileFactory::SetCurrentShip(Targetable *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, Targetable *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func783::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func784::func;
 	return execfunc(this, ship);
 }
 
-namespace _func784
+namespace _func785
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::SetCooldownModifier", typeid(void (ProjectileFactory::*)(float )), ".f30f104f0cf30f5e4f10", nullptr, 0, 0, &func);
@@ -10044,11 +10057,11 @@ namespace _func784
 void ProjectileFactory::SetCooldownModifier(float mod)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float mod_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func784::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func785::func;
 	return execfunc(this, mod);
 }
 
-namespace _func785
+namespace _func786
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::ForceCoolup", typeid(void (ProjectileFactory::*)()), ".5380bff2000000004889fb", nullptr, 0, 0, &func);
@@ -10057,11 +10070,11 @@ namespace _func785
 void ProjectileFactory::ForceCoolup()
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func785::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func786::func;
 	return execfunc(this);
 }
 
-namespace _func786
+namespace _func787
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::RenderChargeBar", typeid(void (ProjectileFactory::*)(float )), "!.4881c758010000", nullptr, 0, 0, &func);
@@ -10070,11 +10083,11 @@ namespace _func786
 void ProjectileFactory::RenderChargeBar(float unk)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func786::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func787::func;
 	return execfunc(this, unk);
 }
 
-namespace _func787
+namespace _func788
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::OnRender", typeid(void (ProjectileFactory::*)(float , bool )), "!.530f28c8488d9f580100004883ec10", nullptr, 0, 0, &func);
@@ -10083,30 +10096,17 @@ namespace _func787
 void ProjectileFactory::OnRender(float alpha, bool forceVisual)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float alpha_arg, bool forceVisual_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func787::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func788::func;
 	return execfunc(this, alpha, forceVisual);
 }
 
-namespace _func788
+namespace _func789
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::ClearAiming", typeid(void (ProjectileFactory::*)()), ".488b97f8000000488b87000100004829d048c1f803", nullptr, 0, 0, &func);
 }
 
 void ProjectileFactory::ClearAiming()
-{
-	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func788::func;
-	return execfunc(this);
-}
-
-namespace _func789
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ProjectileFactory::ClearProjectiles", typeid(void (ProjectileFactory::*)()), ".488b87e8050000488987f0050000", nullptr, 0, 0, &func);
-}
-
-void ProjectileFactory::ClearProjectiles()
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func789::func;
@@ -10116,17 +10116,30 @@ void ProjectileFactory::ClearProjectiles()
 namespace _func790
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ProjectileFactory::ClearProjectiles", typeid(void (ProjectileFactory::*)()), ".488b87e8050000488987f0050000", nullptr, 0, 0, &func);
+}
+
+void ProjectileFactory::ClearProjectiles()
+{
+	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func790::func;
+	return execfunc(this);
+}
+
+namespace _func791
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::FireNextShot", typeid(bool (ProjectileFactory::*)()), ".8b972006000031c085d2", nullptr, 0, 0, &func);
 }
 
 bool ProjectileFactory::FireNextShot()
 {
 	typedef bool (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func790::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func791::func;
 	return execfunc(this);
 }
 
-namespace _func791
+namespace _func792
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::StringToWeapon", typeid(int (*)(const std::string &)), ".53be????????4889fbe8????????85c0", nullptr, 0, 0, &func);
@@ -10135,11 +10148,11 @@ namespace _func791
 int ProjectileFactory::StringToWeapon(const std::string &str)
 {
 	typedef int (*custom_arg_funcptr_t)(const std::string &str_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func791::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func792::func;
 	return execfunc(str);
 }
 
-namespace _func792
+namespace _func793
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::GetProjectile", typeid(Projectile *(ProjectileFactory::*)()), ".4157415641554154554889fd488dbf58010000534883ec58", nullptr, 0, 0, &func);
@@ -10148,19 +10161,6 @@ namespace _func792
 Projectile *ProjectileFactory::GetProjectile()
 {
 	typedef Projectile *(*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func792::func;
-	return execfunc(this);
-}
-
-namespace _func793
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ProjectileFactory::SpendMissiles", typeid(int (ProjectileFactory::*)()), ".55534889fb4883ec288b8708060000", nullptr, 0, 0, &func);
-}
-
-int ProjectileFactory::SpendMissiles()
-{
-	typedef int (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func793::func;
 	return execfunc(this);
 }
@@ -10168,10 +10168,10 @@ int ProjectileFactory::SpendMissiles()
 namespace _func794
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ProjectileFactory::NumTargetsRequired", typeid(int (ProjectileFactory::*)()), ".488b472083b88401000001", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ProjectileFactory::SpendMissiles", typeid(int (ProjectileFactory::*)()), ".55534889fb4883ec288b8708060000", nullptr, 0, 0, &func);
 }
 
-int ProjectileFactory::NumTargetsRequired()
+int ProjectileFactory::SpendMissiles()
 {
 	typedef int (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func794::func;
@@ -10181,17 +10181,30 @@ int ProjectileFactory::NumTargetsRequired()
 namespace _func795
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ProjectileFactory::NumTargetsRequired", typeid(int (ProjectileFactory::*)()), ".488b472083b88401000001", nullptr, 0, 0, &func);
+}
+
+int ProjectileFactory::NumTargetsRequired()
+{
+	typedef int (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func795::func;
+	return execfunc(this);
+}
+
+namespace _func796
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::SaveProjectile", typeid(void (*)(Projectile *, int )), ".5589f5534889fb4883ec08488b07", nullptr, 0, 0, &func);
 }
 
 void ProjectileFactory::SaveProjectile(Projectile *p, int fd)
 {
 	typedef void (*custom_arg_funcptr_t)(Projectile *p_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func795::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func796::func;
 	return execfunc(p, fd);
 }
 
-namespace _func796
+namespace _func797
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::LoadProjectile", typeid(Projectile *(*)(int )), ".5589fd534883ec58", nullptr, 0, 0, &func);
@@ -10200,11 +10213,11 @@ namespace _func796
 Projectile *ProjectileFactory::LoadProjectile(int fd)
 {
 	typedef Projectile *(*custom_arg_funcptr_t)(int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func796::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func797::func;
 	return execfunc(fd);
 }
 
-namespace _func797
+namespace _func798
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::Fire", typeid(void (ProjectileFactory::*)(std::vector<Pointf> &, int )), ".41544189d4554889f553488b87000100004889fb482b87f800000048c1f80385c0", nullptr, 0, 0, &func);
@@ -10213,30 +10226,17 @@ namespace _func797
 void ProjectileFactory::Fire(std::vector<Pointf> &points, int target)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, std::vector<Pointf> &points_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func797::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func798::func;
 	return execfunc(this, points, target);
 }
 
-namespace _func798
+namespace _func799
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::Update", typeid(void (ProjectileFactory::*)()), ".4157415641554989fd415455534881ec88010000", nullptr, 0, 0, &func);
 }
 
 void ProjectileFactory::Update()
-{
-	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func798::func;
-	return execfunc(this);
-}
-
-namespace _func799
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ProjectileFactory::destructor", typeid(void (ProjectileFactory::*)()), ".415641554154554889fd534883ec1048c70770??", nullptr, 0, 0, &func);
-}
-
-void ProjectileFactory::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func799::func;
@@ -10246,12 +10246,12 @@ void ProjectileFactory::destructor()
 namespace _func800
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ReactorButton::Accept", typeid(void (ReactorButton::*)()), "55534889fb4883ec288b878c000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ProjectileFactory::destructor", typeid(void (ProjectileFactory::*)()), ".415641554154554889fd534883ec1048c70770??", nullptr, 0, 0, &func);
 }
 
-void ReactorButton::Accept()
+void ProjectileFactory::destructor()
 {
-	typedef void (*custom_arg_funcptr_t)(ReactorButton *this_arg);
+	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func800::func;
 	return execfunc(this);
 }
@@ -10259,10 +10259,10 @@ void ReactorButton::Accept()
 namespace _func801
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ReactorButton::OnClick", typeid(void (ReactorButton::*)()), "55534889fb4883ec28488bbf90000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ReactorButton::Accept", typeid(void (ReactorButton::*)()), "55534889fb4883ec288b878c000000", nullptr, 0, 0, &func);
 }
 
-void ReactorButton::OnClick()
+void ReactorButton::Accept()
 {
 	typedef void (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func801::func;
@@ -10272,10 +10272,10 @@ void ReactorButton::OnClick()
 namespace _func802
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ReactorButton::OnRightClick", typeid(void (ReactorButton::*)()), "534889fb4883ec208b878c000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ReactorButton::OnClick", typeid(void (ReactorButton::*)()), "55534889fb4883ec28488bbf90000000", nullptr, 0, 0, &func);
 }
 
-void ReactorButton::OnRightClick()
+void ReactorButton::OnClick()
 {
 	typedef void (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func802::func;
@@ -10285,24 +10285,37 @@ void ReactorButton::OnRightClick()
 namespace _func803
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ReactorButton::OnRender", typeid(void (ReactorButton::*)()), "415741564155415455534889fb4881ec3805000048897c2440", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ReactorButton::OnRightClick", typeid(void (ReactorButton::*)()), "534889fb4883ec208b878c000000", nullptr, 0, 0, &func);
 }
 
-void ReactorButton::OnRender()
+void ReactorButton::OnRightClick()
 {
 	typedef void (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func803::func;
 	return execfunc(this);
 }
 
+namespace _func804
+{
+    static void *func = 0;
+	static FunctionDefinition funcObj("ReactorButton::OnRender", typeid(void (ReactorButton::*)()), "415741564155415455534889fb4881ec3805000048897c2440", nullptr, 0, 0, &func);
+}
+
+void ReactorButton::OnRender()
+{
+	typedef void (*custom_arg_funcptr_t)(ReactorButton *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func804::func;
+	return execfunc(this);
+}
+
 void **VTable_RepairAnimation;
 
-namespace _var804
+namespace _var805
 {
     static VariableDefinition varObj("VTable_RepairAnimation", "!0f85060100004c8d6c2430bf2009000049c70424(???????\?)", &VTable_RepairAnimation);
 }
 
-namespace _func805
+namespace _func806
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("RepairStoreBox::constructor", typeid(void (RepairStoreBox::*)(ShipManager *, bool , int )), "4157415641554189cd41544989f4", nullptr, 0, 0, &func);
@@ -10311,11 +10324,11 @@ namespace _func805
 void RepairStoreBox::constructor(ShipManager *ship, bool repairAll, int price)
 {
 	typedef void (*custom_arg_funcptr_t)(RepairStoreBox *this_arg, ShipManager *ship_arg, bool repairAll_arg, int price_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func805::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func806::func;
 	return execfunc(this, ship, repairAll, price);
 }
 
-namespace _func806
+namespace _func807
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::constructor", typeid(void (ResourceControl::*)()), "4155be0a00000041545548bdffffffffffffff1f534889fb488d7f20", nullptr, 0, 0, &func);
@@ -10324,11 +10337,11 @@ namespace _func806
 void ResourceControl::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(ResourceControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func806::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func807::func;
 	return execfunc(this);
 }
 
-namespace _func807
+namespace _func808
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::RenderImage", typeid(int (ResourceControl::*)(GL_Texture *, int , int , int , GL_Color , float , bool )), ".4883ec284885f64889f7660fd60424488b0424660fd60c24", nullptr, 0, 0, &func);
@@ -10337,11 +10350,11 @@ namespace _func807
 int ResourceControl::RenderImage(GL_Texture *tex, int x, int y, int rotation, GL_Color color, float opacity, bool mirror)
 {
 	typedef int (*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float opacity_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func807::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func808::func;
 	return execfunc(this, tex, x, y, rotation, color, opacity, mirror);
 }
 
-namespace _func808
+namespace _func809
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::CreateImagePrimitive", typeid(GL_Primitive *(ResourceControl::*)(GL_Texture *, int , int , int , GL_Color , float , bool )), ".4883ec284885f64889f7660fd60424488b0424660fd60c24", nullptr, 0, 0, &func);
@@ -10350,11 +10363,11 @@ namespace _func808
 GL_Primitive *ResourceControl::CreateImagePrimitive(GL_Texture *tex, int unk1, int unk2, int unk3, GL_Color color, float alpha, bool mirror)
 {
 	typedef GL_Primitive *(*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg, int unk1_arg, int unk2_arg, int unk3_arg, GL_Color color_arg, float alpha_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func808::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func809::func;
 	return execfunc(this, tex, unk1, unk2, unk3, color, alpha, mirror);
 }
 
-namespace _func809
+namespace _func810
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::OnInit", typeid(void (ResourceControl::*)(int )), ".534889fb89b7a0000000c7870801000000000000", nullptr, 0, 0, &func);
@@ -10363,11 +10376,11 @@ namespace _func809
 void ResourceControl::OnInit(int imageSwappingMode)
 {
 	typedef void (*custom_arg_funcptr_t)(ResourceControl *this_arg, int imageSwappingMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func809::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func810::func;
 	return execfunc(this, imageSwappingMode);
 }
 
-namespace _func810
+namespace _func811
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::LoadFile", typeid(char *(ResourceControl::*)(const std::string &)), ".415541544531e4554889f5", nullptr, 0, 0, &func);
@@ -10376,11 +10389,11 @@ namespace _func810
 char *ResourceControl::LoadFile(const std::string &fileName)
 {
 	typedef char *(*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func810::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func811::func;
 	return execfunc(this, fileName);
 }
 
-namespace _func811
+namespace _func812
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::LoadFromResourceFile", typeid(char *(ResourceControl::*)(const std::string &, std::size_t &, const std::string *)), ".4156b91000000041554531ed415455", nullptr, 0, 0, &func);
@@ -10389,11 +10402,11 @@ namespace _func811
 char *ResourceControl::LoadFromResourceFile(const std::string &fileName, std::size_t &fileSize, const std::string *unused_resourceFile)
 {
 	typedef char *(*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &fileName_arg, std::size_t &fileSize_arg, const std::string *unused_resourceFile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func811::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func812::func;
 	return execfunc(this, fileName, fileSize, unused_resourceFile);
 }
 
-namespace _func812
+namespace _func813
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::GetImageData", typeid(ImageDesc (ResourceControl::*)(GL_Texture *)), ".534889d04989d14889fb488d7e604883ec10", nullptr, 0, 0, &func);
@@ -10402,11 +10415,11 @@ namespace _func812
 ImageDesc ResourceControl::GetImageData(GL_Texture *tex)
 {
 	typedef ImageDesc (*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func812::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func813::func;
 	return execfunc(this, tex);
 }
 
-namespace _func813
+namespace _func814
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::ImageExists", typeid(bool (ResourceControl::*)(const std::string &)), ".554889f5534889fb4883ec38", nullptr, 0, 0, &func);
@@ -10415,11 +10428,11 @@ namespace _func813
 bool ResourceControl::ImageExists(const std::string &name)
 {
 	typedef bool (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func813::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func814::func;
 	return execfunc(this, name);
 }
 
-namespace _func814
+namespace _func815
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::GetImageId", typeid(GL_Texture *(ResourceControl::*)(const std::string &)), ".4154554889f5be????????534889fb4883ec60", nullptr, 0, 0, &func);
@@ -10428,11 +10441,11 @@ namespace _func814
 GL_Texture *ResourceControl::GetImageId(const std::string &dir)
 {
 	typedef GL_Texture *(*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func814::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func815::func;
 	return execfunc(this, dir);
 }
 
-namespace _func815
+namespace _func816
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::RenderImageString", typeid(int (ResourceControl::*)(std::string &, int , int , int , GL_Color , float , bool )), ".41574589c7415641554589cd41544189d45589cd534883ec38", nullptr, 0, 0, &func);
@@ -10441,11 +10454,11 @@ namespace _func815
 int ResourceControl::RenderImageString(std::string &tex, int x, int y, int rotation, GL_Color color, float opacity, bool mirror)
 {
 	typedef int (*custom_arg_funcptr_t)(ResourceControl *this_arg, std::string &tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float opacity_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func815::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func816::func;
 	return execfunc(this, tex, x, y, rotation, color, opacity, mirror);
 }
 
-namespace _func816
+namespace _func817
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::CreateImagePrimitiveString", typeid(GL_Primitive *(ResourceControl::*)(const std::string &, int , int , int , GL_Color , float , bool )), ".41574589c7415641554589cd41544189d45589cd534883ec38", nullptr, 0, 0, &func);
@@ -10454,11 +10467,11 @@ namespace _func816
 GL_Primitive *ResourceControl::CreateImagePrimitiveString(const std::string &tex, int x, int y, int rotation, GL_Color color, float alpha, bool mirror)
 {
 	typedef GL_Primitive *(*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float alpha_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func816::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func817::func;
 	return execfunc(this, tex, x, y, rotation, color, alpha, mirror);
 }
 
-namespace _func817
+namespace _func818
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::RenderLoadingBar", typeid(void (ResourceControl::*)(float , float )), ".415455534889fb4883ec604883bf5001000000", nullptr, 0, 0, &func);
@@ -10467,11 +10480,11 @@ namespace _func817
 void ResourceControl::RenderLoadingBar(float initialProgress, float finalProgress)
 {
 	typedef void (*custom_arg_funcptr_t)(ResourceControl *this_arg, float initialProgress_arg, float finalProgress_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func817::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func818::func;
 	return execfunc(this, initialProgress, finalProgress);
 }
 
-namespace _func818
+namespace _func819
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::GetFontData", typeid(freetype::font_data &(ResourceControl::*)(int , bool )), ".41548d46fa55534889fb4883ec3083f802", nullptr, 0, 0, &func);
@@ -10480,11 +10493,11 @@ namespace _func818
 freetype::font_data &ResourceControl::GetFontData(int size, bool ignoreLanguage)
 {
 	typedef freetype::font_data &(*custom_arg_funcptr_t)(ResourceControl *this_arg, int size_arg, bool ignoreLanguage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func818::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func819::func;
 	return execfunc(this, size, ignoreLanguage);
 }
 
-namespace _func819
+namespace _func820
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::PreloadResources", typeid(bool (ResourceControl::*)(bool )), ".415741564155415455534889fb4881ec88000000408874241f", nullptr, 0, 0, &func);
@@ -10493,24 +10506,24 @@ namespace _func819
 bool ResourceControl::PreloadResources(bool unk)
 {
 	typedef bool (*custom_arg_funcptr_t)(ResourceControl *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func819::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func820::func;
 	return execfunc(this, unk);
 }
 
 ResourceControl *Global_ResourceControl_GlobalResources;
 
-namespace _var820
+namespace _var821
 {
     static VariableDefinition varObj("Global_ResourceControl_GlobalResources", "!be(???????\?)488983100100004889c24889e7", &Global_ResourceControl_GlobalResources);
 }
 
-namespace _func821
+namespace _func822
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK_1", typeid(void (RockAnimation::*)()), "f3c3660f1f44000053be????????4889fb4883ec10488d54240fe8????????4883c4104889d85bc353be????????4889fb4883ec10", nullptr, 0, 0, &func);
 }
 
-namespace _func822
+namespace _func823
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("RockAnimation::GetDeathSound", typeid(std::string (RockAnimation::*)()), ".53be????????4889fb4883ec10488d54240f", nullptr, 0, 0, &func);
@@ -10519,23 +10532,23 @@ namespace _func822
 std::string RockAnimation::GetDeathSound()
 {
 	typedef std::string (*custom_arg_funcptr_t)(RockAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func822::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func823::func;
 	return execfunc(this);
-}
-
-namespace _func823
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK_2", typeid(void (RockAnimation::*)()), ".534889fb4883ec30803d????????007577e8????????89c1", nullptr, 0, 0, &func);
 }
 
 namespace _func824
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK_3", typeid(void (RockAnimation::*)()), ".534889fb4883ec30803d????????007577e8????????89c1", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK_2", typeid(void (RockAnimation::*)()), ".534889fb4883ec30803d????????007577e8????????89c1", nullptr, 0, 0, &func);
 }
 
 namespace _func825
+{
+    static void *func = 0;
+	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK_3", typeid(void (RockAnimation::*)()), ".534889fb4883ec30803d????????007577e8????????89c1", nullptr, 0, 0, &func);
+}
+
+namespace _func826
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("RockAnimation::GetShootingSound", typeid(std::string (RockAnimation::*)()), ".534889fb4883ec30803d????????007577e8????????89c1", nullptr, 0, 0, &func);
@@ -10544,11 +10557,11 @@ namespace _func825
 std::string RockAnimation::GetShootingSound()
 {
 	typedef std::string (*custom_arg_funcptr_t)(RockAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func825::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func826::func;
 	return execfunc(this);
 }
 
-namespace _func826
+namespace _func827
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("RockAnimation::constructor", typeid(void (RockAnimation::*)(const std::string &, int , Pointf , bool )), ".41544189cc5589d5534889fb4883ec50", nullptr, 0, 0, &func);
@@ -10557,11 +10570,11 @@ namespace _func826
 void RockAnimation::constructor(const std::string &subRace, int iShipId, Pointf position, bool enemy)
 {
 	typedef void (*custom_arg_funcptr_t)(RockAnimation *this_arg, const std::string &subRace_arg, int iShipId_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func826::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func827::func;
 	return execfunc(this, subRace, iShipId, position, enemy);
 }
 
-namespace _func827
+namespace _func828
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::destructor", typeid(void (Room::*)()), "41574156415541544989fc55534883ec5848c707", nullptr, 0, 0, &func);
@@ -10570,11 +10583,11 @@ namespace _func827
 void Room::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(Room *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func827::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func828::func;
 	return execfunc(this);
 }
 
-namespace _func828
+namespace _func829
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::constructor", typeid(void (Room::*)(int , int , int , int , int , int )), ".41574989ff41564589ce4155415455534489c3410fafde4881ec78010000", nullptr, 0, 0, &func);
@@ -10583,11 +10596,11 @@ namespace _func828
 void Room::constructor(int iShipId, int x, int y, int w, int h, int roomId)
 {
 	typedef void (*custom_arg_funcptr_t)(Room *this_arg, int iShipId_arg, int x_arg, int y_arg, int w_arg, int h_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func828::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func829::func;
 	return execfunc(this, iShipId, x, y, w, h, roomId);
 }
 
-namespace _func829
+namespace _func830
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::GetEmptySlots", typeid(int (Room::*)(bool )), ".400fb6f6488b4750488d14b6488d14d0488b4210482b028b4a188b520848c1f80348c1e0064801c84829d0", nullptr, 0, 0, &func);
@@ -10596,11 +10609,11 @@ namespace _func829
 int Room::GetEmptySlots(bool intruder)
 {
 	typedef int (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func829::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func830::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func830
+namespace _func831
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::Full", typeid(bool (Room::*)(bool )), ".488b4750400fb6f6", nullptr, 0, 0, &func);
@@ -10609,11 +10622,11 @@ namespace _func830
 bool Room::Full(bool intruder)
 {
 	typedef bool (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func830::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func831::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func831
+namespace _func832
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::GetEmptySlot", typeid(int (Room::*)(bool )), ".4084f689f2", nullptr, 0, 0, &func);
@@ -10622,17 +10635,17 @@ namespace _func831
 int Room::GetEmptySlot(bool intruder)
 {
 	typedef int (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func831::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func832::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func832
+namespace _func833
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::DO_NOT_HOOK", typeid(void (Room::*)()), ".0fb6d2488b4f504863c64c8d049500000000", nullptr, 0, 0, &func);
 }
 
-namespace _func833
+namespace _func834
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::FillSlot", typeid(void (Room::*)(int , bool )), ".0fb6d2488b4f504863c64c8d049500000000", nullptr, 0, 0, &func);
@@ -10641,11 +10654,11 @@ namespace _func833
 void Room::FillSlot(int slot, bool intruder)
 {
 	typedef void (*custom_arg_funcptr_t)(Room *this_arg, int slot_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func833::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func834::func;
 	return execfunc(this, slot, intruder);
 }
 
-namespace _func834
+namespace _func835
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::OnRenderFloor", typeid(void (Room::*)(float , bool )), ".4883ec28f30f100d????????f30f5c8fb8000000488bbfc0000000", nullptr, 0, 0, &func);
@@ -10654,11 +10667,11 @@ namespace _func834
 void Room::OnRenderFloor(float alpha, bool experimental)
 {
 	typedef void (*custom_arg_funcptr_t)(Room *this_arg, float alpha_arg, bool experimental_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func834::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func835::func;
 	return execfunc(this, alpha, experimental);
 }
 
-namespace _func835
+namespace _func836
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::OnRenderWalls", typeid(void (Room::*)(float )), ".534889fb4883ec10807f6800", nullptr, 0, 0, &func);
@@ -10667,11 +10680,11 @@ namespace _func835
 void Room::OnRenderWalls(float alpha)
 {
 	typedef void (*custom_arg_funcptr_t)(Room *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func835::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func836::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func836
+namespace _func837
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::constructor", typeid(void (ScoreKeeper::*)()), "4157415641554c8daf8000000041544c8da78001000055488dafa000000053488d9f900000004883ec48", nullptr, 0, 0, &func);
@@ -10680,11 +10693,11 @@ namespace _func836
 void ScoreKeeper::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func836::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func837::func;
 	return execfunc(this);
 }
 
-namespace _func837
+namespace _func838
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::GetShipId", typeid(std::pair<int, int> (ScoreKeeper::*)(const std::string &)), ".4157415641554531ed41544989f45553", nullptr, 0, 0, &func);
@@ -10693,11 +10706,11 @@ namespace _func837
 std::pair<int, int> ScoreKeeper::GetShipId(const std::string &blueprintName)
 {
 	typedef std::pair<int, int> (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, const std::string &blueprintName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func837::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func838::func;
 	return execfunc(this, blueprintName);
 }
 
-namespace _func838
+namespace _func839
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::GetShipBlueprint", typeid(std::string (ScoreKeeper::*)(int )), ".4863d2534889fb", nullptr, 0, 0, &func);
@@ -10706,30 +10719,17 @@ namespace _func838
 std::string ScoreKeeper::GetShipBlueprint(int index)
 {
 	typedef std::string (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int index_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func838::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func839::func;
 	return execfunc(this, index);
 }
 
-namespace _func839
+namespace _func840
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::SaveGame", typeid(void (ScoreKeeper::*)(int )), "!.41544989fc5589f5", nullptr, 0, 0, &func);
 }
 
 void ScoreKeeper::SaveGame(int fd)
-{
-	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func839::func;
-	return execfunc(this, fd);
-}
-
-namespace _func840
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ScoreKeeper::LoadGame", typeid(void (ScoreKeeper::*)(int )), ".41544989fc89f75589f5534883ec20", nullptr, 0, 0, &func);
-}
-
-void ScoreKeeper::LoadGame(int fd)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int fd_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func840::func;
@@ -10739,17 +10739,30 @@ void ScoreKeeper::LoadGame(int fd)
 namespace _func841
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ScoreKeeper::LoadGame", typeid(void (ScoreKeeper::*)(int )), ".41544989fc89f75589f5534883ec20", nullptr, 0, 0, &func);
+}
+
+void ScoreKeeper::LoadGame(int fd)
+{
+	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int fd_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func841::func;
+	return execfunc(this, fd);
+}
+
+namespace _func842
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::GetShipUnlocked", typeid(bool (ScoreKeeper::*)(int , int )), ".83fa02760b31c0", nullptr, 0, 32, &func);
 }
 
 bool ScoreKeeper::GetShipUnlocked(int shipId, int shipVariant)
 {
 	typedef bool (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int shipId_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func841::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func842::func;
 	return execfunc(this, shipId, shipVariant);
 }
 
-namespace _func842
+namespace _func843
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::SetSector", typeid(void (ScoreKeeper::*)(int )), ".c7471800000000c7473800000000", nullptr, 0, 0, &func);
@@ -10758,11 +10771,11 @@ namespace _func842
 void ScoreKeeper::SetSector(int sector)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int sector_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func842::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func843::func;
 	return execfunc(this, sector);
 }
 
-namespace _func843
+namespace _func844
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::SetVictory", typeid(void (ScoreKeeper::*)(bool )), ".4084f64088b798010000", nullptr, 0, 0, &func);
@@ -10771,11 +10784,11 @@ namespace _func843
 void ScoreKeeper::SetVictory(bool victory)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool victory_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func843::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func844::func;
 	return execfunc(this, victory);
 }
 
-namespace _func844
+namespace _func845
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::AddScrapCollected", typeid(void (ScoreKeeper::*)(int )), ".5589f5534889fb", nullptr, 0, 0, &func);
@@ -10784,11 +10797,11 @@ namespace _func844
 void ScoreKeeper::AddScrapCollected(int scrap)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int scrap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func844::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func845::func;
 	return execfunc(this, scrap);
 }
 
-namespace _func845
+namespace _func846
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::SaveScores", typeid(void (ScoreKeeper::*)(int , std::vector<TopScore> &)), ".415741564989d6415549bdabaaaaaaaaaaaaaa415455534883ec48", nullptr, 0, 0, &func);
@@ -10797,11 +10810,11 @@ namespace _func845
 void ScoreKeeper::SaveScores(int file, std::vector<TopScore> &topScores)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int file_arg, std::vector<TopScore> &topScores_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func845::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func846::func;
 	return execfunc(this, file, topScores);
 }
 
-namespace _func846
+namespace _func847
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::AddTopScoreList", typeid(int (ScoreKeeper::*)(TopScore &, std::vector<TopScore> &)), ".415448b8abaaaaaaaaaaaaaa4989f4554889d5534883ec50", nullptr, 0, 0, &func);
@@ -10810,11 +10823,11 @@ namespace _func846
 int ScoreKeeper::AddTopScoreList(TopScore &score, std::vector<TopScore> &topScoreList)
 {
 	typedef int (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, TopScore &score_arg, std::vector<TopScore> &topScoreList_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func846::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func847::func;
 	return execfunc(this, score, topScoreList);
 }
 
-namespace _func847
+namespace _func848
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::AddTopScoreType", typeid(void (ScoreKeeper::*)(TopScore &, int )), ".4157488d46084189d7baffffffff41564989fe", nullptr, 0, 0, &func);
@@ -10823,11 +10836,11 @@ namespace _func847
 void ScoreKeeper::AddTopScoreType(TopScore &topScore, int type)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, TopScore &topScore_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func847::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func848::func;
 	return execfunc(this, topScore, type);
 }
 
-namespace _func848
+namespace _func849
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::Save", typeid(void (ScoreKeeper::*)(bool )), ".4156415541545589f5534889fb", nullptr, 0, 0, &func);
@@ -10836,11 +10849,11 @@ namespace _func848
 void ScoreKeeper::Save(bool newHighScore)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool newHighScore_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func848::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func849::func;
 	return execfunc(this, newHighScore);
 }
 
-namespace _func849
+namespace _func850
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::WipeProfile", typeid(void (ScoreKeeper::*)(bool )), ".415741564531f641554531ed41544989fc", nullptr, 0, 0, &func);
@@ -10849,11 +10862,11 @@ namespace _func849
 void ScoreKeeper::WipeProfile(bool permanent)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool permanent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func849::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func850::func;
 	return execfunc(this, permanent);
 }
 
-namespace _func850
+namespace _func851
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::UnlockShip", typeid(void (ScoreKeeper::*)(int , int , bool , bool )), ".415741564189ce41554189d541544589c4554889fd5389f34883ec28", nullptr, 0, 0, &func);
@@ -10862,11 +10875,11 @@ namespace _func850
 void ScoreKeeper::UnlockShip(int shipType, int shipVariant, bool save, bool hidePopup)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int shipType_arg, int shipVariant_arg, bool save_arg, bool hidePopup_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func850::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func851::func;
 	return execfunc(this, shipType, shipVariant, save, hidePopup);
 }
 
-namespace _func851
+namespace _func852
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::LoadVersionFour", typeid(void (ScoreKeeper::*)(int , int )), ".41574889f8415641554189d54154555389f34881ec98000000", nullptr, 0, 0, &func);
@@ -10875,11 +10888,11 @@ namespace _func851
 void ScoreKeeper::LoadVersionFour(int file, int version)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int file_arg, int version_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func851::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func852::func;
 	return execfunc(this, file, version);
 }
 
-namespace _func852
+namespace _func853
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::OnInit", typeid(void (ScoreKeeper::*)()), ".415631f64155415455534889fb488dab880500004c8da3a80b00004883ec70", nullptr, 0, 0, &func);
@@ -10888,11 +10901,11 @@ namespace _func852
 void ScoreKeeper::OnInit()
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func852::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func853::func;
 	return execfunc(this);
 }
 
-namespace _func853
+namespace _func854
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::RenderTopScores", typeid(void (ScoreKeeper::*)(const std::vector<TopScore> &, Point , int )), ".4157415641554989f5415455534881ec68020000", nullptr, 0, 0, &func);
@@ -10901,11 +10914,11 @@ namespace _func853
 void ScoreKeeper::RenderTopScores(const std::vector<TopScore> &topScoreList, Point position, int newHighScore)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, const std::vector<TopScore> &topScoreList_arg, Point position_arg, int newHighScore_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func853::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func854::func;
 	return execfunc(this, topScoreList, position, newHighScore);
 }
 
-namespace _func854
+namespace _func855
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::CheckTypes", typeid(void (ScoreKeeper::*)()), ".4155ba01000000415455534889fb4c8da3880700004883ec18", nullptr, 0, 0, &func);
@@ -10914,11 +10927,11 @@ namespace _func854
 void ScoreKeeper::CheckTypes()
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func854::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func855::func;
 	return execfunc(this);
 }
 
-namespace _func855
+namespace _func856
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::SetupTopShip", typeid(void (ScoreKeeper::*)(int )), ".41545589f5534889fb4883ec40", nullptr, 0, 0, &func);
@@ -10927,30 +10940,17 @@ namespace _func855
 void ScoreKeeper::SetupTopShip(int variant)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int variant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func855::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func856::func;
 	return execfunc(this, variant);
 }
 
-namespace _func856
+namespace _func857
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::CycleLeft", typeid(void (ScoreKeeper::*)()), "!.55bd09000000534889fb4883ec08", nullptr, 0, 0, &func);
 }
 
 void ScoreKeeper::CycleLeft()
-{
-	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func856::func;
-	return execfunc(this);
-}
-
-namespace _func857
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ScoreKeeper::CycleRight", typeid(void (ScoreKeeper::*)()), "!.5531ed534889fb4883ec08", nullptr, 0, 0, &func);
-}
-
-void ScoreKeeper::CycleRight()
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func857::func;
@@ -10960,17 +10960,30 @@ void ScoreKeeper::CycleRight()
 namespace _func858
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ScoreKeeper::CycleRight", typeid(void (ScoreKeeper::*)()), "!.5531ed534889fb4883ec08", nullptr, 0, 0, &func);
+}
+
+void ScoreKeeper::CycleRight()
+{
+	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func858::func;
+	return execfunc(this);
+}
+
+namespace _func859
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::MouseClick", typeid(void (ScoreKeeper::*)(int , int )), ".55534889fb4883ec0880bf280c000000", nullptr, 0, 0, &func);
 }
 
 void ScoreKeeper::MouseClick(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func858::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func859::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func859
+namespace _func860
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::KeyDown", typeid(bool (ScoreKeeper::*)(SDLKey )), ".5589f5534889fb4883ec18", nullptr, 0, 0, &func);
@@ -10979,11 +10992,11 @@ namespace _func859
 bool ScoreKeeper::KeyDown(SDLKey key)
 {
 	typedef bool (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func859::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func860::func;
 	return execfunc(this, key);
 }
 
-namespace _func860
+namespace _func861
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::Open", typeid(void (ScoreKeeper::*)(bool )), ".4157ba0d000000", nullptr, 0, 0, &func);
@@ -10992,11 +11005,11 @@ namespace _func860
 void ScoreKeeper::Open(bool fromGameOver)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool fromGameOver_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func860::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func861::func;
 	return execfunc(this, fromGameOver);
 }
 
-namespace _func861
+namespace _func862
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::OnRender", typeid(void (ScoreKeeper::*)(bool )), ".4157415641554189f5415455534889fb4881ec28020000", nullptr, 0, 0, &func);
@@ -11005,11 +11018,11 @@ namespace _func861
 void ScoreKeeper::OnRender(bool lastPlaythrough)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool lastPlaythrough_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func861::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func862::func;
 	return execfunc(this, lastPlaythrough);
 }
 
-namespace _func862
+namespace _func863
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::MouseMove", typeid(void (ScoreKeeper::*)(int , int )), ".4156415541544189d45589f55380bf280c000000", nullptr, 0, 0, &func);
@@ -11018,18 +11031,18 @@ namespace _func862
 void ScoreKeeper::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func862::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func863::func;
 	return execfunc(this, mX, mY);
 }
 
 ScoreKeeper *Global_ScoreKeeper_Keeper;
 
-namespace _var863
+namespace _var864
 {
     static VariableDefinition varObj("Global_ScoreKeeper_Keeper", "!488b3b488b07ff5028488b7b08488b07ff502831f6bf(???????\?)", &Global_ScoreKeeper_Keeper);
 }
 
-namespace _func864
+namespace _func865
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Settings::GetDlcEnabled", typeid(bool (*)()), "31c0803d????????007505c30f1f40004883ec08", nullptr, 0, 0, &func);
@@ -11038,11 +11051,11 @@ namespace _func864
 bool Settings::GetDlcEnabled()
 {
 	typedef bool (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func864::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func865::func;
 	return execfunc();
 }
 
-namespace _func865
+namespace _func866
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Settings::GetHotkeyName", typeid(std::string (*)(const std::string &)), ".415741564155415455534883ec58488d6c2440", nullptr, 0, 0, &func);
@@ -11051,11 +11064,11 @@ namespace _func865
 std::string Settings::GetHotkeyName(const std::string &name)
 {
 	typedef std::string (*custom_arg_funcptr_t)(const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func865::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func866::func;
 	return execfunc(name);
 }
 
-namespace _func866
+namespace _func867
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Settings::GetHotkey", typeid(SDLKey (*)(const std::string &)), ".415741564155415455534883ec2848897c2418", nullptr, 0, 0, &func);
@@ -11064,11 +11077,11 @@ namespace _func866
 SDLKey Settings::GetHotkey(const std::string &hotkeyName)
 {
 	typedef SDLKey (*custom_arg_funcptr_t)(const std::string &hotkeyName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func866::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func867::func;
 	return execfunc(hotkeyName);
 }
 
-namespace _func867
+namespace _func868
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Settings::SetHotkey", typeid(void (*)(const std::string &, SDLKey )), ".415741564155415455534883ec5848897c2420", nullptr, 0, 0, &func);
@@ -11077,11 +11090,11 @@ namespace _func867
 void Settings::SetHotkey(const std::string &hotkeyName, SDLKey key)
 {
 	typedef void (*custom_arg_funcptr_t)(const std::string &hotkeyName_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func867::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func868::func;
 	return execfunc(hotkeyName, key);
 }
 
-namespace _func868
+namespace _func869
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Settings::SaveSettings", typeid(void (*)()), ".415741564155415455534881ecc8010000", nullptr, 0, 0, &func);
@@ -11090,11 +11103,11 @@ namespace _func868
 void Settings::SaveSettings()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func868::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func869::func;
 	return execfunc();
 }
 
-namespace _func869
+namespace _func870
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Settings::GetCommandConsole", typeid(char (*)()), "!.0fb605????????c3", nullptr, 0, 32, &func);
@@ -11103,11 +11116,11 @@ namespace _func869
 char Settings::GetCommandConsole()
 {
 	typedef char (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func869::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func870::func;
 	return execfunc();
 }
 
-namespace _func870
+namespace _func871
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Settings::ResetHotkeys", typeid(void (*)()), ".415641be????????4155415441bc????????55534883ec30", nullptr, 0, 0, &func);
@@ -11116,11 +11129,11 @@ namespace _func870
 void Settings::ResetHotkeys()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func870::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func871::func;
 	return execfunc();
 }
 
-namespace _func871
+namespace _func872
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Settings::LoadSettings", typeid(void (*)()), ".415741564155415455534881ec58020000", nullptr, 0, 0, &func);
@@ -11129,18 +11142,18 @@ namespace _func871
 void Settings::LoadSettings()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func871::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func872::func;
 	return execfunc();
 }
 
 SettingValues *Global_Settings_Settings;
 
-namespace _var872
+namespace _var873
 {
     static VariableDefinition varObj("Global_Settings_Settings", "!4155415441bc(???????\?)55534883ec30", &Global_Settings_Settings);
 }
 
-namespace _func873
+namespace _func874
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Shields::SetHackingLevel", typeid(void (Shields::*)(int )), "83fe017e??83bf20020000017e??89b720020000", nullptr, 0, 0, &func);
@@ -11149,30 +11162,17 @@ namespace _func873
 void Shields::SetHackingLevel(int hackingLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(Shields *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func873::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func874::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func874
+namespace _func875
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Shields::Jump", typeid(void (Shields::*)()), ".534889fb4883ec30e8????????f30f100d", nullptr, 0, 0, &func);
 }
 
 void Shields::Jump()
-{
-	typedef void (*custom_arg_funcptr_t)(Shields *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func874::func;
-	return execfunc(this);
-}
-
-namespace _func875
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Shields::OnLoop", typeid(void (Shields::*)()), ".41564155415455534889fb4c8d6b104883ec30", nullptr, 0, 0, &func);
-}
-
-void Shields::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(Shields *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func875::func;
@@ -11182,17 +11182,30 @@ void Shields::OnLoop()
 namespace _func876
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Shields::OnLoop", typeid(void (Shields::*)()), ".41564155415455534889fb4c8d6b104883ec30", nullptr, 0, 0, &func);
+}
+
+void Shields::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(Shields *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func876::func;
+	return execfunc(this);
+}
+
+namespace _func877
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Shields::constructor", typeid(void (Shields::*)(int , int , int , const std::string &)), ".4154554c89c54189c889d189f231f6534889fb4883ec40", nullptr, 0, 0, &func);
 }
 
 void Shields::constructor(int roomId, int shipId, int startingPower, const std::string &shieldFile)
 {
 	typedef void (*custom_arg_funcptr_t)(Shields *this_arg, int roomId_arg, int shipId_arg, int startingPower_arg, const std::string &shieldFile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func876::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func877::func;
 	return execfunc(this, roomId, shipId, startingPower, shieldFile);
 }
 
-namespace _func877
+namespace _func878
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Shields::AddSuperShield", typeid(void (Shields::*)(Point )), ".55ba050000004889f5534889fb4883ec08", nullptr, 0, 0, &func);
@@ -11201,11 +11214,11 @@ namespace _func877
 void Shields::AddSuperShield(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(Shields *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func877::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func878::func;
 	return execfunc(this, pos);
 }
 
-namespace _func878
+namespace _func879
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Shields::SetBaseEllipse", typeid(void (Shields::*)(Globals::Ellipse )), ".660fd64424f8488b4424f84889b750020000", nullptr, 0, 0, &func);
@@ -11214,11 +11227,11 @@ namespace _func878
 void Shields::SetBaseEllipse(Globals::Ellipse ellipse)
 {
 	typedef void (*custom_arg_funcptr_t)(Shields *this_arg, Globals::Ellipse ellipse_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func878::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func879::func;
 	return execfunc(this, ellipse);
 }
 
-namespace _func879
+namespace _func880
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Shields::InstantCharge", typeid(void (Shields::*)()), ".55534889fb488dabd00200004883ec38", nullptr, 0, 0, &func);
@@ -11227,11 +11240,11 @@ namespace _func879
 void Shields::InstantCharge()
 {
 	typedef void (*custom_arg_funcptr_t)(Shields *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func879::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func880::func;
 	return execfunc(this);
 }
 
-namespace _func880
+namespace _func881
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Shields::RenderBase", typeid(void (Shields::*)(float , float )), ".41550f28f9415455534889fb4883ec68", nullptr, 0, 0, &func);
@@ -11240,11 +11253,11 @@ namespace _func880
 void Shields::RenderBase(float alpha, float superShieldOverwrite)
 {
 	typedef void (*custom_arg_funcptr_t)(Shields *this_arg, float alpha_arg, float superShieldOverwrite_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func880::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func881::func;
 	return execfunc(this, alpha, superShieldOverwrite);
 }
 
-namespace _func881
+namespace _func882
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Shields::CollisionTest", typeid(CollisionResponse (Shields::*)(float , float , Damage )), ".554889f5534889fb488d7f044883ec18", nullptr, 0, 0, &func);
@@ -11253,11 +11266,11 @@ namespace _func881
 CollisionResponse Shields::CollisionTest(float x, float y, Damage damage)
 {
 	typedef CollisionResponse (*custom_arg_funcptr_t)(Shields *this_arg, float x_arg, float y_arg, Damage damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func881::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func882::func;
 	return execfunc(this, x, y, damage);
 }
 
-namespace _func882
+namespace _func883
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Shields::CollisionReal", typeid(CollisionResponse (Shields::*)(float , float , Damage , bool )), ".415741564189d641554989f5415455534889fb488d7f04", nullptr, 0, 0, &func);
@@ -11266,18 +11279,18 @@ namespace _func882
 CollisionResponse Shields::CollisionReal(float x, float y, Damage damage, bool force)
 {
 	typedef CollisionResponse (*custom_arg_funcptr_t)(Shields *this_arg, float x_arg, float y_arg, Damage damage_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func882::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func883::func;
 	return execfunc(this, x, y, damage, force);
 }
 
 GL_Color *Global_COLOR_GREEN;
 
-namespace _var883
+namespace _var884
 {
     static VariableDefinition varObj("Global_COLOR_GREEN", "!f30fc2cf01488bbbf8020000f30f101d(???????\?)f30f5edd", &Global_COLOR_GREEN, true, true);
 }
 
-namespace _func884
+namespace _func885
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::GetBaseEllipse", typeid(Globals::Ellipse (Ship::*)()), "534889fb4883ec20f30f108fc4020000", nullptr, 0, 0, &func);
@@ -11286,11 +11299,11 @@ namespace _func884
 Globals::Ellipse Ship::GetBaseEllipse()
 {
 	typedef Globals::Ellipse (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func884::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func885::func;
 	return execfunc(this);
 }
 
-namespace _func885
+namespace _func886
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::RoomLocked", typeid(bool (Ship::*)(int )), ".4c8b8778040000488b8f8004000048b835c2724f232cf7344c29c148c1f903", nullptr, 0, 0, &func);
@@ -11299,11 +11312,11 @@ namespace _func885
 bool Ship::RoomLocked(int roomId)
 {
 	typedef bool (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func885::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func886::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func886
+namespace _func887
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::DestroyedDone", typeid(bool (Ship::*)()), ".0fb687b802000084c0", nullptr, 0, 0, &func);
@@ -11312,11 +11325,11 @@ namespace _func886
 bool Ship::DestroyedDone()
 {
 	typedef bool (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func886::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func887::func;
 	return execfunc(this);
 }
 
-namespace _func887
+namespace _func888
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::OnRenderJump", typeid(void (Ship::*)(float )), ".41564155415455534889fb4883ec208b7f08", nullptr, 0, 0, &func);
@@ -11325,30 +11338,17 @@ namespace _func887
 void Ship::OnRenderJump(float progress)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, float progress_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func887::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func888::func;
 	return execfunc(this, progress);
 }
 
-namespace _func888
+namespace _func889
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::OnRenderBase", typeid(void (Ship::*)(bool )), ".41554189f5415455534889fb4883ec288b7f08", nullptr, 0, 0, &func);
 }
 
 void Ship::OnRenderBase(bool unk)
-{
-	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func888::func;
-	return execfunc(this, unk);
-}
-
-namespace _func889
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Ship::OnRenderFloor", typeid(void (Ship::*)(bool )), ".5589f5534889fb4883ec1880bf7004000000", nullptr, 0, 0, &func);
-}
-
-void Ship::OnRenderFloor(bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func889::func;
@@ -11358,23 +11358,23 @@ void Ship::OnRenderFloor(bool unk)
 namespace _func890
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Ship::OnRenderSparks", typeid(void (Ship::*)()), ".5531c94889fd5331db4883ec08488b5710488b47184829d048c1f8034885c07429", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Ship::OnRenderFloor", typeid(void (Ship::*)(bool )), ".5589f5534889fb4883ec1880bf7004000000", nullptr, 0, 0, &func);
 }
 
-void Ship::OnRenderSparks()
+void Ship::OnRenderFloor(bool unk)
 {
-	typedef void (*custom_arg_funcptr_t)(Ship *this_arg);
+	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func890::func;
-	return execfunc(this);
+	return execfunc(this, unk);
 }
 
 namespace _func891
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Ship::OnRenderBreaches", typeid(void (Ship::*)()), ".41544531e45531ed53488b57404889fb", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Ship::OnRenderSparks", typeid(void (Ship::*)()), ".5531c94889fd5331db4883ec08488b5710488b47184829d048c1f8034885c07429", nullptr, 0, 0, &func);
 }
 
-void Ship::OnRenderBreaches()
+void Ship::OnRenderSparks()
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func891::func;
@@ -11384,17 +11384,30 @@ void Ship::OnRenderBreaches()
 namespace _func892
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Ship::OnRenderBreaches", typeid(void (Ship::*)()), ".41544531e45531ed53488b57404889fb", nullptr, 0, 0, &func);
+}
+
+void Ship::OnRenderBreaches()
+{
+	typedef void (*custom_arg_funcptr_t)(Ship *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func892::func;
+	return execfunc(this);
+}
+
+namespace _func893
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Ship::BreachSpecificHull", typeid(void (Ship::*)(int , int )), ".41564989fe4155415455534883ec30", nullptr, 0, 0, &func);
 }
 
 void Ship::BreachSpecificHull(int grid_x, int grid_y)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, int grid_x_arg, int grid_y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func892::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func893::func;
 	return execfunc(this, grid_x, grid_y);
 }
 
-namespace _func893
+namespace _func894
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::GetSelectedRoomId", typeid(int (Ship::*)(int , int , bool )), "!.41544189cc5589d5538b7f08", nullptr, 0, 0, &func);
@@ -11403,11 +11416,11 @@ namespace _func893
 int Ship::GetSelectedRoomId(int x, int y, bool unk)
 {
 	typedef int (*custom_arg_funcptr_t)(Ship *this_arg, int x_arg, int y_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func893::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func894::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func894
+namespace _func895
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::SetSelectedRoom", typeid(void (Ship::*)(int )), ".415431c94189f4554889fd53488b5710", nullptr, 0, 0, &func);
@@ -11416,11 +11429,11 @@ namespace _func894
 void Ship::SetSelectedRoom(int roomId)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func894::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func895::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func895
+namespace _func896
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::SetRoomBlackout", typeid(void (Ship::*)(int , bool )), "!.4863c60fb6f2", nullptr, 0, 0, &func);
@@ -11429,11 +11442,11 @@ namespace _func895
 void Ship::SetRoomBlackout(int roomId, bool blackout)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool blackout_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func895::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func896::func;
 	return execfunc(this, roomId, blackout);
 }
 
-namespace _func896
+namespace _func897
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::GetAvailableRoomSlot", typeid(int (Ship::*)(int , bool )), "!.4863c60fb6f2", nullptr, 0, 0, &func);
@@ -11442,11 +11455,11 @@ namespace _func896
 int Ship::GetAvailableRoomSlot(int roomId, bool intruder)
 {
 	typedef int (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func896::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func897::func;
 	return execfunc(this, roomId, intruder);
 }
 
-namespace _func897
+namespace _func898
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::EmptySlots", typeid(int (Ship::*)(int )), ".41544863f64c8d24f500000000554889fd", nullptr, 0, 0, &func);
@@ -11455,11 +11468,11 @@ namespace _func897
 int Ship::EmptySlots(int roomId)
 {
 	typedef int (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func897::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func898::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func898
+namespace _func899
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::FullRoom", typeid(bool (Ship::*)(int , bool )), ".488b4f10488b47184829c848c1f80339c6", nullptr, 0, 0, &func);
@@ -11468,11 +11481,11 @@ namespace _func898
 bool Ship::FullRoom(int roomId, bool intruder)
 {
 	typedef bool (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func898::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func899::func;
 	return execfunc(this, roomId, intruder);
 }
 
-namespace _func899
+namespace _func900
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::GetAvailableRoom", typeid(int (Ship::*)(int , bool )), ".41574156440fb6f2415541544189f4554889fd534883ec48", nullptr, 0, 0, &func);
@@ -11481,11 +11494,11 @@ namespace _func899
 int Ship::GetAvailableRoom(int preferred, bool intruder)
 {
 	typedef int (*custom_arg_funcptr_t)(Ship *this_arg, int preferred_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func899::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func900::func;
 	return execfunc(this, preferred, intruder);
 }
 
-namespace _func900
+namespace _func901
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::OnRenderWalls", typeid(void (Ship::*)(bool , bool )), ".41574531ff41564c8db7500400004155440fb6ee41544189d45531ed534889fb4883ec18", nullptr, 0, 0, &func);
@@ -11494,11 +11507,11 @@ namespace _func900
 void Ship::OnRenderWalls(bool forceView, bool doorControlMode)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, bool forceView_arg, bool doorControlMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func900::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func901::func;
 	return execfunc(this, forceView, doorControlMode);
 }
 
-namespace _func901
+namespace _func902
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::OnLoop", typeid(void (Ship::*)(std::vector<float> &)), ".415741564989fe41554154554889f553488d9f500400004883ec68", nullptr, 0, 0, &func);
@@ -11507,11 +11520,11 @@ namespace _func901
 void Ship::OnLoop(std::vector<float> &oxygenLevels)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, std::vector<float> &oxygenLevels_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func901::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func902::func;
 	return execfunc(this, oxygenLevels);
 }
 
-namespace _func902
+namespace _func903
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::BreachRandomHull", typeid(void (Ship::*)(int )), ".4156415541544989fc554863ee534883ec40", nullptr, 0, 0, &func);
@@ -11520,11 +11533,11 @@ namespace _func902
 void Ship::BreachRandomHull(int roomId)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func902::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func903::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func903
+namespace _func904
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::GetHullBreaches", typeid(std::vector<Repairable*> (Ship::*)(bool )), ".41554154554889f5534889fb4883ec18", nullptr, 0, 0, &func);
@@ -11533,11 +11546,11 @@ namespace _func903
 std::vector<Repairable*> Ship::GetHullBreaches(bool onlyDamaged)
 {
 	typedef std::vector<Repairable*> (*custom_arg_funcptr_t)(Ship *this_arg, bool onlyDamaged_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func903::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func904::func;
 	return execfunc(this, onlyDamaged);
 }
 
-namespace _func904
+namespace _func905
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::LockdownRoom", typeid(void (Ship::*)(int , Pointf )), ".41574989ff4156415541545589f5534881ec38010000", nullptr, 0, 0, &func);
@@ -11546,11 +11559,11 @@ namespace _func904
 void Ship::LockdownRoom(int roomId, Pointf pos)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, Pointf pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func904::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func905::func;
 	return execfunc(this, roomId, pos);
 }
 
-namespace _func905
+namespace _func906
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::OnInit", typeid(void (Ship::*)(ShipBlueprint *)), "!.41574989ff41564155415455534889f34881ec28030100", nullptr, 0, 0, &func);
@@ -11559,41 +11572,41 @@ namespace _func905
 void Ship::OnInit(ShipBlueprint *bp)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, ShipBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func905::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func906::func;
 	return execfunc(this, bp);
-}
-
-namespace _noop906
-{
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_4", "!.39c17d03(c60201)");
 }
 
 namespace _noop907
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_1", "!.39c27d03(c60101)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_4", "!.39c17d03(c60201)");
 }
 
 namespace _noop908
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_5", "!.89c67e03(c60201)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_1", "!.39c27d03(c60101)");
 }
 
 namespace _noop909
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_2", "!.89c67d03(c60101)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_5", "!.89c67e03(c60201)");
 }
 
 namespace _noop910
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_3", "!.39c17d0b(c684149000000001)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_2", "!.89c67d03(c60101)");
 }
 
 namespace _noop911
 {
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_3", "!.39c17d0b(c684149000000001)");
+}
+
+namespace _noop912
+{
     static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_0", "!.39c27d0b(c6840cb000000001)");
 }
 
-namespace _func912
+namespace _func913
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipAI::constructor", typeid(void (ShipAI::*)(bool )), "5589f5534889fb488d7f104883ec0848c747f800000000", nullptr, 0, 0, &func);
@@ -11602,11 +11615,11 @@ namespace _func912
 void ShipAI::constructor(bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipAI *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func912::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func913::func;
 	return execfunc(this, unk);
 }
 
-namespace _func913
+namespace _func914
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipAI::SetStalemate", typeid(void (ShipAI::*)(bool )), ".4084f6740980bf9801000000", nullptr, 0, 0, &func);
@@ -11615,11 +11628,11 @@ namespace _func913
 void ShipAI::SetStalemate(bool stalemate)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipAI *this_arg, bool stalemate_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func913::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func914::func;
 	return execfunc(this, stalemate);
 }
 
-namespace _func914
+namespace _func915
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipAI::OnLoop", typeid(void (ShipAI::*)(bool )), ".41545589f5534889fb4883ec304084f6488b07", nullptr, 0, 0, &func);
@@ -11628,11 +11641,11 @@ namespace _func914
 void ShipAI::OnLoop(bool hostile)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipAI *this_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func914::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func915::func;
 	return execfunc(this, hostile);
 }
 
-namespace _func915
+namespace _func916
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipAI::GetTeleportCommand", typeid(std::pair<int, int> (ShipAI::*)()), "5348837f08004889fb", nullptr, 0, 0, &func);
@@ -11641,11 +11654,11 @@ namespace _func915
 std::pair<int, int> ShipAI::GetTeleportCommand()
 {
 	typedef std::pair<int, int> (*custom_arg_funcptr_t)(ShipAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func915::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func916::func;
 	return execfunc(this);
 }
 
-namespace _func916
+namespace _func917
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBlueprint::destructor", typeid(void (ShipBlueprint::*)()), "4154554889fd534883ec10488b874002000048c707", nullptr, 0, 0, &func);
@@ -11654,11 +11667,11 @@ namespace _func916
 void ShipBlueprint::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func916::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func917::func;
 	return execfunc(this);
 }
 
-namespace _func917
+namespace _func918
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::constructor", typeid(void (ShipBuilder::*)()), "534889fb488d7f184883ec30", nullptr, 0, 0, &func);
@@ -11667,11 +11680,11 @@ namespace _func917
 void ShipBuilder::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func917::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func918::func;
 	return execfunc(this);
 }
 
-namespace _func918
+namespace _func919
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::MouseMove", typeid(void (ShipBuilder::*)(int , int )), ".4157488d87201100004989ff41564889c7415541545589d55389f34881ec08010000", nullptr, 0, 0, &func);
@@ -11680,30 +11693,17 @@ namespace _func918
 void ShipBuilder::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func918::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func919::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func919
+namespace _func920
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::ClearShipAchievements", typeid(void (ShipBuilder::*)()), ".488b87f81d0000c787101e0000ffffffff", nullptr, 0, 0, &func);
 }
 
 void ShipBuilder::ClearShipAchievements()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func919::func;
-	return execfunc(this);
-}
-
-namespace _func920
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipBuilder::SetupShipAchievements", typeid(void (ShipBuilder::*)()), ".4156be????????41554989fd415455534883ec50", nullptr, 0, 0, &func);
-}
-
-void ShipBuilder::SetupShipAchievements()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func920::func;
@@ -11713,10 +11713,10 @@ void ShipBuilder::SetupShipAchievements()
 namespace _func921
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipBuilder::CreateEquipmentBoxes", typeid(void (ShipBuilder::*)()), ".41574989ff41564155415455534883ec48488bb710110000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipBuilder::SetupShipAchievements", typeid(void (ShipBuilder::*)()), ".4156be????????41554989fd415455534883ec50", nullptr, 0, 0, &func);
 }
 
-void ShipBuilder::CreateEquipmentBoxes()
+void ShipBuilder::SetupShipAchievements()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func921::func;
@@ -11726,10 +11726,10 @@ void ShipBuilder::CreateEquipmentBoxes()
 namespace _func922
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipBuilder::CreateSystemBoxes", typeid(void (ShipBuilder::*)()), ".4157415641554154554889fd534883ec18488bb700120000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CreateEquipmentBoxes", typeid(void (ShipBuilder::*)()), ".41574989ff41564155415455534883ec48488bb710110000", nullptr, 0, 0, &func);
 }
 
-void ShipBuilder::CreateSystemBoxes()
+void ShipBuilder::CreateEquipmentBoxes()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func922::func;
@@ -11739,10 +11739,10 @@ void ShipBuilder::CreateSystemBoxes()
 namespace _func923
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipBuilder::OnRender", typeid(void (ShipBuilder::*)()), ".4155415455534889fb4883ec7880bf5814000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CreateSystemBoxes", typeid(void (ShipBuilder::*)()), ".4157415641554154554889fd534883ec18488bb700120000", nullptr, 0, 0, &func);
 }
 
-void ShipBuilder::OnRender()
+void ShipBuilder::CreateSystemBoxes()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func923::func;
@@ -11752,10 +11752,10 @@ void ShipBuilder::OnRender()
 namespace _func924
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipBuilder::OnLoop", typeid(void (ShipBuilder::*)()), ".415741564155415455534889fb", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipBuilder::OnRender", typeid(void (ShipBuilder::*)()), ".4155415455534889fb4883ec7880bf5814000000", nullptr, 0, 0, &func);
 }
 
-void ShipBuilder::OnLoop()
+void ShipBuilder::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func924::func;
@@ -11765,10 +11765,10 @@ void ShipBuilder::OnLoop()
 namespace _func925
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipBuilder::CheckTypes", typeid(void (ShipBuilder::*)()), ".4155ba01000000415455534889fb4c8da3580b00004883ec18", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipBuilder::OnLoop", typeid(void (ShipBuilder::*)()), ".415741564155415455534889fb", nullptr, 0, 0, &func);
 }
 
-void ShipBuilder::CheckTypes()
+void ShipBuilder::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func925::func;
@@ -11778,17 +11778,30 @@ void ShipBuilder::CheckTypes()
 namespace _func926
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipBuilder::CheckTypes", typeid(void (ShipBuilder::*)()), ".4155ba01000000415455534889fb4c8da3580b00004883ec18", nullptr, 0, 0, &func);
+}
+
+void ShipBuilder::CheckTypes()
+{
+	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func926::func;
+	return execfunc(this);
+}
+
+namespace _func927
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::SwitchShip", typeid(void (ShipBuilder::*)(int , int )), ".41554189f541544c63e255534889fb4883ec28", nullptr, 0, 0, &func);
 }
 
 void ShipBuilder::SwitchShip(int shipType, int shipVariant)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int shipType_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func926::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func927::func;
 	return execfunc(this, shipType, shipVariant);
 }
 
-namespace _func927
+namespace _func928
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::CycleShipNext", typeid(void (ShipBuilder::*)()), "!.41564989fe415541545553488b3f4885ff", nullptr, 0, 0, &func);
@@ -11797,11 +11810,11 @@ namespace _func927
 void ShipBuilder::CycleShipNext()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func927::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func928::func;
 	return execfunc(this);
 }
 
-namespace _func928
+namespace _func929
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::SwapType", typeid(void (ShipBuilder::*)(int )), "!.5589f5534889fb4883ec08488b3f4885ff", nullptr, 0, 0, &func);
@@ -11810,11 +11823,11 @@ namespace _func928
 void ShipBuilder::SwapType(int variant)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int variant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func928::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func929::func;
 	return execfunc(this, variant);
 }
 
-namespace _func929
+namespace _func930
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::CycleShipPrevious", typeid(void (ShipBuilder::*)()), "!.41564989fe415541545553488b3f4885ff", nullptr, 0, 0, &func);
@@ -11823,11 +11836,11 @@ namespace _func929
 void ShipBuilder::CycleShipPrevious()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func929::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func930::func;
 	return execfunc(this);
 }
 
-namespace _func930
+namespace _func931
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::OnKeyDown", typeid(void (ShipBuilder::*)(SDLKey )), ".5589f5534889fb4883ec0880bf5814000000", nullptr, 0, 0, &func);
@@ -11836,11 +11849,11 @@ namespace _func930
 void ShipBuilder::OnKeyDown(SDLKey key)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func930::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func931::func;
 	return execfunc(this, key);
 }
 
-namespace _func931
+namespace _func932
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::MouseClick", typeid(void (ShipBuilder::*)(int , int )), ".415455534889fb4883ec3080bf701b000000", nullptr, 0, 0, &func);
@@ -11849,11 +11862,11 @@ namespace _func931
 void ShipBuilder::MouseClick(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func931::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func932::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func932
+namespace _func933
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::Open", typeid(void (ShipBuilder::*)()), ".4157415641554154554889fd534881ece8030000", nullptr, 0, 0, &func);
@@ -11862,11 +11875,11 @@ namespace _func932
 void ShipBuilder::Open()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func932::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func933::func;
 	return execfunc(this);
 }
 
-namespace _func933
+namespace _func934
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipButton::constructor", typeid(void (ShipButton::*)(int , int )), "41574156415541544189d45589f5534889fb4881ec38030000", nullptr, 0, 0, &func);
@@ -11875,11 +11888,11 @@ namespace _func933
 void ShipButton::constructor(int shipType, int shipVariant)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipButton *this_arg, int shipType_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func933::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func934::func;
 	return execfunc(this, shipType, shipVariant);
 }
 
-namespace _func934
+namespace _func935
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipButton::OnInit", typeid(void (ShipButton::*)(const std::string &, Point )), ".4889d1534889fb48c1f920", nullptr, 0, 0, &func);
@@ -11888,11 +11901,11 @@ namespace _func934
 void ShipButton::OnInit(const std::string &imgName, Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipButton *this_arg, const std::string &imgName_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func934::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func935::func;
 	return execfunc(this, imgName, pos);
 }
 
-namespace _func935
+namespace _func936
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipButton::MouseMove", typeid(void (ShipButton::*)(int , int )), "!.41554189f5415455534889fb4883ec18", nullptr, 0, 0, &func);
@@ -11901,11 +11914,11 @@ namespace _func935
 void ShipButton::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipButton *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func935::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func936::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func936
+namespace _func937
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipButton::OnRender", typeid(void (ShipButton::*)()), ".55534889fb4883ec4880bf9800000000", nullptr, 0, 0, &func);
@@ -11914,11 +11927,11 @@ namespace _func936
 void ShipButton::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func936::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func937::func;
 	return execfunc(this);
 }
 
-namespace _func937
+namespace _func938
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipEvent::constructor", typeid(void (ShipEvent::*)(const ShipEvent &)), "415641554989f5488d760841544989fc488d7f08", nullptr, 0, 0, &func);
@@ -11927,11 +11940,11 @@ namespace _func937
 void ShipEvent::constructor(const ShipEvent &event)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipEvent *this_arg, const ShipEvent &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func937::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func938::func;
 	return execfunc(this, event);
 }
 
-namespace _func938
+namespace _func939
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGenerator::UpgradeSystem", typeid(bool (*)(ShipManager *, std::vector<int> &, unsigned int )), "4157415641554189d541544989fc55534883ec38", nullptr, 0, 0, &func);
@@ -11940,11 +11953,11 @@ namespace _func938
 bool ShipGenerator::UpgradeSystem(ShipManager *ship, std::vector<int> &systemMaxes, unsigned int sysId)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, unsigned int sysId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func938::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func939::func;
 	return execfunc(ship, systemMaxes, sysId);
 }
 
-namespace _func939
+namespace _func940
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGenerator::GetPossibleCrewList", typeid(std::vector<CrewBlueprint> (*)(ShipManager *, const std::string &, unsigned int )), ".41574156415541544989d4554889fd534881ec88010000", nullptr, 0, 0, &func);
@@ -11953,11 +11966,11 @@ namespace _func939
 std::vector<CrewBlueprint> ShipGenerator::GetPossibleCrewList(ShipManager *ship, const std::string &crewList, unsigned int flags)
 {
 	typedef std::vector<CrewBlueprint> (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &crewList_arg, unsigned int flags_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func939::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func940::func;
 	return execfunc(ship, crewList, flags);
 }
 
-namespace _func940
+namespace _func941
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGenerator::GetPossibleWeaponList", typeid(std::vector<WeaponBlueprint*> (*)(ShipManager *, const std::string &, int , unsigned int )), ".4157415641554589c5415455534889fb4889f74883ec68", nullptr, 0, 0, &func);
@@ -11966,11 +11979,11 @@ namespace _func940
 std::vector<WeaponBlueprint*> ShipGenerator::GetPossibleWeaponList(ShipManager *ship, const std::string &weaponList, int scrap, unsigned int flags)
 {
 	typedef std::vector<WeaponBlueprint*> (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &weaponList_arg, int scrap_arg, unsigned int flags_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func940::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func941::func;
 	return execfunc(ship, weaponList, scrap, flags);
 }
 
-namespace _func941
+namespace _func942
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGenerator::GetPossibleDroneList", typeid(std::vector<DroneBlueprint*> (*)(ShipManager *, const std::string &, int , unsigned int , bool )), ".415741564989d6415541544589c4554889fd4889f7534489cb4881ec88000000", nullptr, 0, 0, &func);
@@ -11979,11 +11992,11 @@ namespace _func941
 std::vector<DroneBlueprint*> ShipGenerator::GetPossibleDroneList(ShipManager *ship, const std::string &droneList, int scrap, unsigned int flags, bool repeat)
 {
 	typedef std::vector<DroneBlueprint*> (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &droneList_arg, int scrap_arg, unsigned int flags_arg, bool repeat_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func941::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func942::func;
 	return execfunc(ship, droneList, scrap, flags, repeat);
 }
 
-namespace _func942
+namespace _func943
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGenerator::GenerateSystemMaxes", typeid(std::vector<int> (*)(const ShipBlueprint &, int )), ".415741564989fe41554c8dae3001000041545589d55331db4883ec28", nullptr, 0, 0, &func);
@@ -11992,30 +12005,17 @@ namespace _func942
 std::vector<int> ShipGenerator::GenerateSystemMaxes(const ShipBlueprint &ship, int level)
 {
 	typedef std::vector<int> (*custom_arg_funcptr_t)(const ShipBlueprint &ship_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func942::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func943::func;
 	return execfunc(ship, level);
 }
 
-namespace _func943
+namespace _func944
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades0", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".41574989ff41564989d64155415455534889f331f64883ec58", nullptr, 0, 0, &func);
 }
 
 std::vector<int> ShipGenerator::GetPossibleSystemUpgrades0(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
-{
-	typedef std::vector<int> (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func943::func;
-	return execfunc(ship, systemMaxes, scrap, type);
-}
-
-namespace _func944
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades1", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".415741564989fe41554989d54154554889f531f6534883ec58", nullptr, 0, 0, &func);
-}
-
-std::vector<int> ShipGenerator::GetPossibleSystemUpgrades1(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func944::func;
@@ -12025,10 +12025,10 @@ std::vector<int> ShipGenerator::GetPossibleSystemUpgrades1(ShipManager *ship, st
 namespace _func945
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades2", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".415741564989fe41554989d54154554889f531f6534883ec58", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades1", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".415741564989fe41554989d54154554889f531f6534883ec58", nullptr, 0, 0, &func);
 }
 
-std::vector<int> ShipGenerator::GetPossibleSystemUpgrades2(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
+std::vector<int> ShipGenerator::GetPossibleSystemUpgrades1(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func945::func;
@@ -12038,17 +12038,30 @@ std::vector<int> ShipGenerator::GetPossibleSystemUpgrades2(ShipManager *ship, st
 namespace _func946
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades2", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".415741564989fe41554989d54154554889f531f6534883ec58", nullptr, 0, 0, &func);
+}
+
+std::vector<int> ShipGenerator::GetPossibleSystemUpgrades2(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
+{
+	typedef std::vector<int> (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func946::func;
+	return execfunc(ship, systemMaxes, scrap, type);
+}
+
+namespace _func947
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipGenerator::CreateShip", typeid(ShipManager *(*)(const std::string &, int , ShipEvent &)), ".41574156415541544189f4554889d5534881ec18050000", nullptr, 0, 0, &func);
 }
 
 ShipManager *ShipGenerator::CreateShip(const std::string &name, int sector, ShipEvent &event)
 {
 	typedef ShipManager *(*custom_arg_funcptr_t)(const std::string &name_arg, int sector_arg, ShipEvent &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func946::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func947::func;
 	return execfunc(name, sector, event);
 }
 
-namespace _func947
+namespace _func948
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".41574989ff41564989d641554154554889f531f6534489c34883ec58", nullptr, 0, 0, &func);
@@ -12057,11 +12070,11 @@ namespace _func947
 std::vector<int> ShipGenerator::GetPossibleSystemUpgrades(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func947::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func948::func;
 	return execfunc(ship, systemMaxes, scrap, type);
 }
 
-namespace _func948
+namespace _func949
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetSlotWorldPosition", typeid(Point (ShipGraph::*)(int , int )), "534863d289f34883ec20488b07", nullptr, 0, 0, &func);
@@ -12070,11 +12083,11 @@ namespace _func948
 Point ShipGraph::GetSlotWorldPosition(int slotId, int roomId)
 {
 	typedef Point (*custom_arg_funcptr_t)(ShipGraph *this_arg, int slotId_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func948::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func949::func;
 	return execfunc(this, slotId, roomId);
 }
 
-namespace _func949
+namespace _func950
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetSlotRenderPosition", typeid(Point (ShipGraph::*)(int , int , bool )), ".41554c63ea41544989fc5589cd5389f34883ec28", nullptr, 0, 0, &func);
@@ -12083,11 +12096,11 @@ namespace _func949
 Point ShipGraph::GetSlotRenderPosition(int slotId, int roomId, bool intruder)
 {
 	typedef Point (*custom_arg_funcptr_t)(ShipGraph *this_arg, int slotId_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func949::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func950::func;
 	return execfunc(this, slotId, roomId, intruder);
 }
 
-namespace _func950
+namespace _func951
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::DoorCount", typeid(int (ShipGraph::*)(int )), ".488b4f30488b573831c04829ca48c1fa02", nullptr, 0, 0, &func);
@@ -12096,11 +12109,11 @@ namespace _func950
 int ShipGraph::DoorCount(int roomId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipGraph *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func950::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func951::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func951
+namespace _func952
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ConnectingDoor", typeid(Door *(ShipGraph::*)(int , int , int , int )), ".415741564189d641554589c541544189cc5589f5534889fb4883ec68", nullptr, 0, 0, &func);
@@ -12109,11 +12122,11 @@ namespace _func951
 Door *ShipGraph::ConnectingDoor(int x1, int y1, int x2, int y2)
 {
 	typedef Door *(*custom_arg_funcptr_t)(ShipGraph *this_arg, int x1_arg, int y1_arg, int x2_arg, int y2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func951::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func952::func;
 	return execfunc(this, x1, y1, x2, y2);
 }
 
-namespace _func952
+namespace _func953
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ConnectedGridSquares", typeid(int (ShipGraph::*)(int , int , int , int )), ".41574189cf41564589c641b82300000041554531ed41544989fcbf23000000", nullptr, 0, 0, &func);
@@ -12122,11 +12135,11 @@ namespace _func952
 int ShipGraph::ConnectedGridSquares(int x1, int y1, int x2, int y2)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x1_arg, int y1_arg, int x2_arg, int y2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func952::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func953::func;
 	return execfunc(this, x1, y1, x2, y2);
 }
 
-namespace _func953
+namespace _func954
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ConnectedGridSquaresPoint", typeid(int (ShipGraph::*)(Point , Point )), "!.4889d14889f24989c8", nullptr, 0, 0, &func);
@@ -12135,11 +12148,11 @@ namespace _func953
 int ShipGraph::ConnectedGridSquaresPoint(Point p1, Point p2)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func953::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func954::func;
 	return execfunc(this, p1, p2);
 }
 
-namespace _func954
+namespace _func955
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ConnectingDoor", typeid(Door *(ShipGraph::*)(Point , Point )), "!.4889d14889f24989c8", nullptr, 0, 0, &func);
@@ -12148,11 +12161,11 @@ namespace _func954
 Door *ShipGraph::ConnectingDoor(Point p1, Point p2)
 {
 	typedef Door *(*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func954::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func955::func;
 	return execfunc(this, p1, p2);
 }
 
-namespace _func955
+namespace _func956
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetNumSlots", typeid(int (ShipGraph::*)(int )), ".488b074863f6488b04f0", nullptr, 0, 0, &func);
@@ -12161,11 +12174,11 @@ namespace _func955
 int ShipGraph::GetNumSlots(int room)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func955::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func956::func;
 	return execfunc(this, room);
 }
 
-namespace _func956
+namespace _func957
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::PopClosestDoor", typeid(int (ShipGraph::*)(std::vector<int> &, std::vector<float> &)), ".554889f5534883ec08", nullptr, 0, 0, &func);
@@ -12174,30 +12187,17 @@ namespace _func956
 int ShipGraph::PopClosestDoor(std::vector<int> &doors, std::vector<float> &distances)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipGraph *this_arg, std::vector<int> &doors_arg, std::vector<float> &distances_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func956::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func957::func;
 	return execfunc(this, doors, distances);
 }
 
-namespace _func957
+namespace _func958
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ConvertToWorldAngle", typeid(float (ShipGraph::*)(float )), ".f30f584758", nullptr, 0, 0, &func);
 }
 
 float ShipGraph::ConvertToWorldAngle(float ang)
-{
-	typedef float (*custom_arg_funcptr_t)(ShipGraph *this_arg, float ang_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func957::func;
-	return execfunc(this, ang);
-}
-
-namespace _func958
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipGraph::ConvertToLocalAngle", typeid(float (ShipGraph::*)(float )), ".f30f5c4758", nullptr, 0, 0, &func);
-}
-
-float ShipGraph::ConvertToLocalAngle(float ang)
 {
 	typedef float (*custom_arg_funcptr_t)(ShipGraph *this_arg, float ang_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func958::func;
@@ -12207,17 +12207,30 @@ float ShipGraph::ConvertToLocalAngle(float ang)
 namespace _func959
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipGraph::ConvertToLocalAngle", typeid(float (ShipGraph::*)(float )), ".f30f5c4758", nullptr, 0, 0, &func);
+}
+
+float ShipGraph::ConvertToLocalAngle(float ang)
+{
+	typedef float (*custom_arg_funcptr_t)(ShipGraph *this_arg, float ang_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func959::func;
+	return execfunc(this, ang);
+}
+
+namespace _func960
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ConvertToWorldPosition", typeid(Pointf (ShipGraph::*)(Pointf )), ".534889fb4883ec20f30f2a7f48", nullptr, 0, 0, &func);
 }
 
 Pointf ShipGraph::ConvertToWorldPosition(Pointf local)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(ShipGraph *this_arg, Pointf local_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func959::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func960::func;
 	return execfunc(this, local);
 }
 
-namespace _func960
+namespace _func961
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ConvertToLocalPosition", typeid(Pointf (ShipGraph::*)(Pointf , bool )), ".4883ec184084f6660fd60424", nullptr, 0, 0, &func);
@@ -12226,11 +12239,11 @@ namespace _func960
 Pointf ShipGraph::ConvertToLocalPosition(Pointf world, bool past)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(ShipGraph *this_arg, Pointf world_arg, bool past_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func960::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func961::func;
 	return execfunc(this, world, past);
 }
 
-namespace _func961
+namespace _func962
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ComputeCenter", typeid(void (ShipGraph::*)()), ".41574989ff41564155415455534883ec18", nullptr, 0, 0, &func);
@@ -12239,11 +12252,11 @@ namespace _func961
 void ShipGraph::ComputeCenter()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipGraph *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func961::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func962::func;
 	return execfunc(this);
 }
 
-namespace _func962
+namespace _func963
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ContainsPoint", typeid(bool (ShipGraph::*)(int , int )), ".8b4f6831c039f1", nullptr, 0, 0, &func);
@@ -12252,11 +12265,11 @@ namespace _func962
 bool ShipGraph::ContainsPoint(int x, int y)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func962::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func963::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func963
+namespace _func964
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetSelectedRoom", typeid(int (ShipGraph::*)(int , int , bool )), ".41574531c04989ff41564531f6415541544189f45589d5530fb6d94883ec08", nullptr, 0, 0, &func);
@@ -12265,11 +12278,11 @@ namespace _func963
 int ShipGraph::GetSelectedRoom(int x, int y, bool unk)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x_arg, int y_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func963::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func964::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func964
+namespace _func965
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::RoomCount", typeid(int (ShipGraph::*)()), ".488b4708482b0748c1f803", nullptr, 0, 0, &func);
@@ -12278,11 +12291,11 @@ namespace _func964
 int ShipGraph::RoomCount()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipGraph *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func964::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func965::func;
 	return execfunc(this);
 }
 
-namespace _func965
+namespace _func966
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetRoomOxygen", typeid(float (ShipGraph::*)(int )), ".85f60f57c0", nullptr, 0, 0, &func);
@@ -12291,11 +12304,11 @@ namespace _func965
 float ShipGraph::GetRoomOxygen(int room)
 {
 	typedef float (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func965::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func966::func;
 	return execfunc(this, room);
 }
 
-namespace _func966
+namespace _func967
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetRoomBlackedOut", typeid(bool (ShipGraph::*)(int )), ".85f6b801000000", nullptr, 0, 0, &func);
@@ -12304,11 +12317,11 @@ namespace _func966
 bool ShipGraph::GetRoomBlackedOut(int room)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func966::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func967::func;
 	return execfunc(this, room);
 }
 
-namespace _func967
+namespace _func968
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetDoors", typeid(std::vector<Door*> (ShipGraph::*)(int )), ".41564531c04989f6415541544189d4554889fd53", nullptr, 0, 0, &func);
@@ -12317,11 +12330,11 @@ namespace _func967
 std::vector<Door*> ShipGraph::GetDoors(int roomId)
 {
 	typedef std::vector<Door*> (*custom_arg_funcptr_t)(ShipGraph *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func967::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func968::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func968
+namespace _func969
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::IsRoomConnected", typeid(bool (ShipGraph::*)(int , int )), ".41564155415441bc010000005589d55389f34883ec20", nullptr, 0, 0, &func);
@@ -12330,11 +12343,11 @@ namespace _func968
 bool ShipGraph::IsRoomConnected(int room1, int room2)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room1_arg, int room2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func968::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func969::func;
 	return execfunc(this, room1, room2);
 }
 
-namespace _func969
+namespace _func970
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetShipInfo", typeid(ShipGraph *(*)(int )), ".5389fb4881ec90000000", nullptr, 0, 0, &func);
@@ -12343,11 +12356,11 @@ namespace _func969
 ShipGraph *ShipGraph::GetShipInfo(int shipId)
 {
 	typedef ShipGraph *(*custom_arg_funcptr_t)(int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func969::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func970::func;
 	return execfunc(shipId);
 }
 
-namespace _func970
+namespace _func971
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::Dijkstra", typeid(Path (ShipGraph::*)(Point , Point , int )), ".41574989f741564155415455534889d348c1eb204881ecc8000000", nullptr, 0, 0, &func);
@@ -12356,11 +12369,11 @@ namespace _func970
 Path ShipGraph::Dijkstra(Point start, Point goal, int shipId)
 {
 	typedef Path (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point start_arg, Point goal_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func970::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func971::func;
 	return execfunc(this, start, goal, shipId);
 }
 
-namespace _func971
+namespace _func972
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::FindPath", typeid(Path (ShipGraph::*)(Point , Point , int )), ".415741564989f641554154554889d548c1ed20534889fb4883ec58", nullptr, 0, 0, &func);
@@ -12369,11 +12382,11 @@ namespace _func971
 Path ShipGraph::FindPath(Point p1, Point p2, int shipId)
 {
 	typedef Path (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func971::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func972::func;
 	return execfunc(this, p1, p2, shipId);
 }
 
-namespace _func972
+namespace _func973
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetClosestSlot", typeid(Slot (ShipGraph::*)(Point , int , bool )), ".41574889f04531ff48c1e820415641554189f54154440fb6e1554889fd534889c34881eca8000000", nullptr, 0, 0, &func);
@@ -12382,11 +12395,11 @@ namespace _func972
 Slot ShipGraph::GetClosestSlot(Point pos, int shipId, bool intruder)
 {
 	typedef Slot (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point pos_arg, int shipId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func972::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func973::func;
 	return execfunc(this, pos, shipId, intruder);
 }
 
-namespace _func973
+namespace _func974
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipInfo::AddAugmentation", typeid(char (ShipInfo::*)(const std::string &)), "415731c041564155415455534889fb4883ec48837f6002", nullptr, 0, 0, &func);
@@ -12395,11 +12408,11 @@ namespace _func973
 char ShipInfo::AddAugmentation(const std::string &augment)
 {
 	typedef char (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func973::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func974::func;
 	return execfunc(this, augment);
 }
 
-namespace _func974
+namespace _func975
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipInfo::HasAugmentation", typeid(bool (ShipInfo::*)(const std::string &)), "4157488d47084989f7415641554989fd4154554889c5534883ec28", nullptr, 0, 0, &func);
@@ -12408,11 +12421,11 @@ namespace _func974
 bool ShipInfo::HasAugmentation(const std::string &augment)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func974::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func975::func;
 	return execfunc(this, augment);
 }
 
-namespace _func975
+namespace _func976
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipInfo::GetAugmentationValue", typeid(float (ShipInfo::*)(const std::string &)), ".4157415641554989fd415455534883ec48488d7c2430", nullptr, 0, 0, &func);
@@ -12421,11 +12434,11 @@ namespace _func975
 float ShipInfo::GetAugmentationValue(const std::string &augment)
 {
 	typedef float (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func975::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func976::func;
 	return execfunc(this, augment);
 }
 
-namespace _func976
+namespace _func977
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::IsCloaked", typeid(bool (ShipManager::*)()), "488b8758060000837828ff7413488b4750", nullptr, 0, 0, &func);
@@ -12434,11 +12447,11 @@ namespace _func976
 bool ShipManager::IsCloaked()
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func976::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func977::func;
 	return execfunc(this);
 }
 
-namespace _func977
+namespace _func978
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetShieldPower", typeid(ShieldPower (ShipManager::*)()), ".488b87800000004885c0741c", nullptr, 0, 0, &func);
@@ -12447,30 +12460,17 @@ namespace _func977
 ShieldPower ShipManager::GetShieldPower()
 {
 	typedef ShieldPower (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func977::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func978::func;
 	return execfunc(this);
 }
 
-namespace _func978
+namespace _func979
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CanFitSystem", typeid(bool (ShipManager::*)(int )), ".415483fe054989fc5553", nullptr, 0, 0, &func);
 }
 
 bool ShipManager::CanFitSystem(int systemId)
-{
-	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func978::func;
-	return execfunc(this, systemId);
-}
-
-namespace _func979
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::CanFitSubsystem", typeid(bool (ShipManager::*)(int )), ".41544989fc5553488b5728488b47304829d0", nullptr, 0, 0, &func);
-}
-
-bool ShipManager::CanFitSubsystem(int systemId)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func979::func;
@@ -12480,17 +12480,30 @@ bool ShipManager::CanFitSubsystem(int systemId)
 namespace _func980
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::CanFitSubsystem", typeid(bool (ShipManager::*)(int )), ".41544989fc5553488b5728488b47304829d0", nullptr, 0, 0, &func);
+}
+
+bool ShipManager::CanFitSubsystem(int systemId)
+{
+	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func980::func;
+	return execfunc(this, systemId);
+}
+
+namespace _func981
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::DamageHull", typeid(int (ShipManager::*)(int , bool )), ".41544189d45589f553488b074889fb", nullptr, 0, 0, &func);
 }
 
 int ShipManager::DamageHull(int dmg, bool force)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int dmg_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func980::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func981::func;
 	return execfunc(this, dmg, force);
 }
 
-namespace _func981
+namespace _func982
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ModifyScrapCount", typeid(void (ShipManager::*)(int , bool )), ".41545589f5534889fb4883ec3085f6", nullptr, 0, 0, &func);
@@ -12499,11 +12512,11 @@ namespace _func981
 void ShipManager::ModifyScrapCount(int scrap, bool income)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int scrap_arg, bool income_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func981::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func982::func;
 	return execfunc(this, scrap, income);
 }
 
-namespace _func982
+namespace _func983
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetCrewmember", typeid(CrewMember *(ShipManager::*)(int , bool )), ".4156415541544989fc5589f553488bb7c8000000", nullptr, 0, 0, &func);
@@ -12512,11 +12525,11 @@ namespace _func982
 CrewMember *ShipManager::GetCrewmember(int slot, bool present)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(ShipManager *this_arg, int slot_arg, bool present_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func982::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func983::func;
 	return execfunc(this, slot, present);
 }
 
-namespace _func983
+namespace _func984
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::FindCrew", typeid(CrewMember *(ShipManager::*)(const CrewBlueprint *)), ".415731c931d2", nullptr, 0, 0, &func);
@@ -12525,11 +12538,11 @@ namespace _func983
 CrewMember *ShipManager::FindCrew(const CrewBlueprint *bp)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(ShipManager *this_arg, const CrewBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func983::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func984::func;
 	return execfunc(this, bp);
 }
 
-namespace _func984
+namespace _func985
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ResetScrapLevel", typeid(void (ShipManager::*)()), ".8b05????????c787700600001e00000083f801", nullptr, 0, 0, &func);
@@ -12538,11 +12551,11 @@ namespace _func984
 void ShipManager::ResetScrapLevel()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func984::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func985::func;
 	return execfunc(this);
 }
 
-namespace _func985
+namespace _func986
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CountPlayerCrew", typeid(int (ShipManager::*)()), ".41564989fe415541545553488b87c800", nullptr, 0, 0, &func);
@@ -12551,11 +12564,11 @@ namespace _func985
 int ShipManager::CountPlayerCrew()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func985::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func986::func;
 	return execfunc(this);
 }
 
-namespace _func986
+namespace _func987
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CountCrew", typeid(int (ShipManager::*)(bool )), ".41574989ff41564155415455534883ec08488b8fc0000000", nullptr, 0, 0, &func);
@@ -12564,11 +12577,11 @@ namespace _func986
 int ShipManager::CountCrew(bool boarders)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, bool boarders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func986::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func987::func;
 	return execfunc(this, boarders);
 }
 
-namespace _func987
+namespace _func988
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CountCrewShipId", typeid(int (ShipManager::*)(int , int )), ".415741564989fe4155415455534883ec18488b87c8000000", nullptr, 0, 0, &func);
@@ -12577,30 +12590,17 @@ namespace _func987
 int ShipManager::CountCrewShipId(int roomId, int shipId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func987::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func988::func;
 	return execfunc(this, roomId, shipId);
 }
 
-namespace _func988
+namespace _func989
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::IsCrewOverFull", typeid(bool (ShipManager::*)()), ".538b470831f64889fb", nullptr, 0, 0, &func);
 }
 
 bool ShipManager::IsCrewOverFull()
-{
-	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func988::func;
-	return execfunc(this);
-}
-
-namespace _func989
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::IsCrewFull", typeid(bool (ShipManager::*)()), ".538b470831f64889fb", nullptr, 0, 0, &func);
-}
-
-bool ShipManager::IsCrewFull()
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func989::func;
@@ -12610,36 +12610,36 @@ bool ShipManager::IsCrewFull()
 namespace _func990
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::IsCrewFull", typeid(bool (ShipManager::*)()), ".538b470831f64889fb", nullptr, 0, 0, &func);
+}
+
+bool ShipManager::IsCrewFull()
+{
+	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func990::func;
+	return execfunc(this);
+}
+
+namespace _func991
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::DoSensorsProvide", typeid(bool (ShipManager::*)(int )), ".4883ec08488b87580600004863401c83f8ff", nullptr, 0, 0, &func);
 }
 
 bool ShipManager::DoSensorsProvide(int vision)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int vision_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func990::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func991::func;
 	return execfunc(this, vision);
 }
 
-namespace _func991
+namespace _func992
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::SetDestroyed", typeid(void (ShipManager::*)()), "!.5531c94889fd5331db4883ec08488b5728", nullptr, 0, 0, &func);
 }
 
 void ShipManager::SetDestroyed()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func991::func;
-	return execfunc(this);
-}
-
-namespace _func992
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::JumpLeave", typeid(void (ShipManager::*)()), ".415431c055534889fb4883ec2083af1006000001", nullptr, 0, 0, &func);
-}
-
-void ShipManager::JumpLeave()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func992::func;
@@ -12649,36 +12649,36 @@ void ShipManager::JumpLeave()
 namespace _func993
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::JumpLeave", typeid(void (ShipManager::*)()), ".415431c055534889fb4883ec2083af1006000001", nullptr, 0, 0, &func);
+}
+
+void ShipManager::JumpLeave()
+{
+	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func993::func;
+	return execfunc(this);
+}
+
+namespace _func994
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::DamageCrew", typeid(bool (ShipManager::*)(CrewMember *, Damage )), ".4156415541545553807c245e004889f3", nullptr, 0, 0, &func);
 }
 
 bool ShipManager::DamageCrew(CrewMember *crew, Damage dmg)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, Damage dmg_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func993::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func994::func;
 	return execfunc(this, crew, dmg);
 }
 
-namespace _func994
+namespace _func995
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::Wait", typeid(void (ShipManager::*)()), ".55534889fb4883ec08488b875806000083780cff", nullptr, 0, 0, &func);
 }
 
 void ShipManager::Wait()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func994::func;
-	return execfunc(this);
-}
-
-namespace _func995
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::JumpArrive", typeid(void (ShipManager::*)()), ".55534889fb488dbf200600004883ec28", nullptr, 0, 0, &func);
-}
-
-void ShipManager::JumpArrive()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func995::func;
@@ -12688,10 +12688,10 @@ void ShipManager::JumpArrive()
 namespace _func996
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::InstantPowerShields", typeid(void (ShipManager::*)()), ".53488b87580600004889fb48630083f8ff", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipManager::JumpArrive", typeid(void (ShipManager::*)()), ".55534889fb488dbf200600004883ec28", nullptr, 0, 0, &func);
 }
 
-void ShipManager::InstantPowerShields()
+void ShipManager::JumpArrive()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func996::func;
@@ -12701,10 +12701,10 @@ void ShipManager::InstantPowerShields()
 namespace _func997
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::CheckSpreadDamage", typeid(void (ShipManager::*)()), ".41574989ff41564155415455534883ec28488b4f28", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipManager::InstantPowerShields", typeid(void (ShipManager::*)()), ".53488b87580600004889fb48630083f8ff", nullptr, 0, 0, &func);
 }
 
-void ShipManager::CheckSpreadDamage()
+void ShipManager::InstantPowerShields()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func997::func;
@@ -12714,36 +12714,36 @@ void ShipManager::CheckSpreadDamage()
 namespace _func998
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::CheckSpreadDamage", typeid(void (ShipManager::*)()), ".41574989ff41564155415455534883ec28488b4f28", nullptr, 0, 0, &func);
+}
+
+void ShipManager::CheckSpreadDamage()
+{
+	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func998::func;
+	return execfunc(this);
+}
+
+namespace _func999
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetSystemPower", typeid(int (ShipManager::*)(int )), ".488b87580600004863f6486304b083f8ff740d", nullptr, 0, 0, &func);
 }
 
 int ShipManager::GetSystemPower(int systemId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func998::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func999::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func999
+namespace _func1000
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CheckVision", typeid(void (ShipManager::*)()), ".415741564155415455534889fb4883ec28488b8758060000", nullptr, 0, 0, &func);
 }
 
 void ShipManager::CheckVision()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func999::func;
-	return execfunc(this);
-}
-
-namespace _func1000
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::ClearStatusAll", typeid(void (ShipManager::*)()), "!.5531c94889fd5331db4883ec08488b5728", nullptr, 0, 0, &func);
-}
-
-void ShipManager::ClearStatusAll()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1000::func;
@@ -12753,23 +12753,36 @@ void ShipManager::ClearStatusAll()
 namespace _func1001
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::ClearStatusAll", typeid(void (ShipManager::*)()), "!.5531c94889fd5331db4883ec08488b5728", nullptr, 0, 0, &func);
+}
+
+void ShipManager::ClearStatusAll()
+{
+	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1001::func;
+	return execfunc(this);
+}
+
+namespace _func1002
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ClearStatusSystem", typeid(void (ShipManager::*)(int )), ".83fe11743383feff7426", nullptr, 0, 0, &func);
 }
 
 void ShipManager::ClearStatusSystem(int system)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int system_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1001::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1002::func;
 	return execfunc(this, system);
 }
 
-namespace _func1002
+namespace _func1003
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::DO_NOT_HOOK", typeid(void (ShipManager::*)()), ".83fe11743b83feff742e", nullptr, 0, 0, &func);
 }
 
-namespace _func1003
+namespace _func1004
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::SetSystemPowerLoss", typeid(void (ShipManager::*)(int , int )), ".83fe11743b83feff742e", nullptr, 0, 0, &func);
@@ -12778,11 +12791,11 @@ namespace _func1003
 void ShipManager::SetSystemPowerLoss(int systemId, int powerLoss)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int powerLoss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1003::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1004::func;
 	return execfunc(this, systemId, powerLoss);
 }
 
-namespace _func1004
+namespace _func1005
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ForceDecreaseSystemPower", typeid(bool (ShipManager::*)(int )), ".83feff743b488b87580600004863f6486304b083f8ff7428488b5728488b3cc24885ff741b488b07be01000000488b8008010000", nullptr, 0, 0, &func);
@@ -12791,11 +12804,11 @@ namespace _func1004
 bool ShipManager::ForceDecreaseSystemPower(int sys)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1004::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1005::func;
 	return execfunc(this, sys);
 }
 
-namespace _func1005
+namespace _func1006
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetSystemInRoom", typeid(ShipSystem *(ShipManager::*)(int )), ".415531d24989fd41545589f55331db4883ec08488b4f28", nullptr, 0, 0, &func);
@@ -12804,11 +12817,11 @@ namespace _func1005
 ShipSystem *ShipManager::GetSystemInRoom(int roomId)
 {
 	typedef ShipSystem *(*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1005::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1006::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1006
+namespace _func1007
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetSystemRoom", typeid(int (ShipManager::*)(int )), ".83feff7433488b87580600004863f6", nullptr, 0, 0, &func);
@@ -12817,11 +12830,11 @@ namespace _func1006
 int ShipManager::GetSystemRoom(int sysId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int sysId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1006::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1007::func;
 	return execfunc(this, sysId);
 }
 
-namespace _func1007
+namespace _func1008
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetSystem", typeid(ShipSystem *(ShipManager::*)(int )), ".83feff7423488b87580600004863f6", nullptr, 0, 0, &func);
@@ -12830,11 +12843,11 @@ namespace _func1007
 ShipSystem *ShipManager::GetSystem(int systemId)
 {
 	typedef ShipSystem *(*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1007::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1008::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1008
+namespace _func1009
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::DoorsFunction", typeid(bool (ShipManager::*)()), ".53488b87580600004889fb4863402083f8ff", nullptr, 0, 0, &func);
@@ -12843,11 +12856,11 @@ namespace _func1008
 bool ShipManager::DoorsFunction()
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1008::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1009::func;
 	return execfunc(this);
 }
 
-namespace _func1009
+namespace _func1010
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::SystemFunctions", typeid(bool (ShipManager::*)(int )), ".488b87580600004863f6486304b083f8ff7415", nullptr, 0, 0, &func);
@@ -12856,11 +12869,11 @@ namespace _func1009
 bool ShipManager::SystemFunctions(int systemId)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1009::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1010::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1010
+namespace _func1011
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetDodgeFactor", typeid(int (ShipManager::*)()), ".534889fb4883ec10488b9758060000", nullptr, 0, 0, &func);
@@ -12869,11 +12882,11 @@ namespace _func1010
 int ShipManager::GetDodgeFactor()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1010::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1011::func;
 	return execfunc(this);
 }
 
-namespace _func1011
+namespace _func1012
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetDodged", typeid(bool (ShipManager::*)()), ".415455534889fb4883ec20807f1c00", nullptr, 0, 0, &func);
@@ -12882,11 +12895,11 @@ namespace _func1011
 bool ShipManager::GetDodged()
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1011::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1012::func;
 	return execfunc(this);
 }
 
-namespace _func1012
+namespace _func1013
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::HasSystem", typeid(bool (ShipManager::*)(int )), ".83fe11741b488b8758060000", nullptr, 0, 0, &func);
@@ -12895,11 +12908,11 @@ namespace _func1012
 bool ShipManager::HasSystem(int systemId)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1012::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1013::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1013
+namespace _func1014
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetSystemPowerMax", typeid(int (ShipManager::*)(int )), ".488b87580600004863f6486304b083f8ff740d", nullptr, 0, 0, &func);
@@ -12908,11 +12921,11 @@ namespace _func1013
 int ShipManager::GetSystemPowerMax(int systemId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1013::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1014::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1014
+namespace _func1015
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::UpgradeSystem", typeid(void (ShipManager::*)(int , int )), ".55534889fb4883ec1883fe11", nullptr, 0, 0, &func);
@@ -12921,11 +12934,11 @@ namespace _func1014
 void ShipManager::UpgradeSystem(int id, int amount)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int id_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1014::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1015::func;
 	return execfunc(this, id, amount);
 }
 
-namespace _func1015
+namespace _func1016
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CanUpgrade", typeid(int (ShipManager::*)(int , int )), ".83fe117453", nullptr, 0, 0, &func);
@@ -12934,11 +12947,11 @@ namespace _func1015
 int ShipManager::CanUpgrade(int systemId, int amount)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1015::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1016::func;
 	return execfunc(this, systemId, amount);
 }
 
-namespace _func1016
+namespace _func1017
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CommandCrewMoveRoom", typeid(bool (ShipManager::*)(CrewMember *, int )), "!.4889f731c989d6baffffffff", nullptr, 0, 0, &func);
@@ -12947,11 +12960,11 @@ namespace _func1016
 bool ShipManager::CommandCrewMoveRoom(CrewMember *crew, int roomId)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1016::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1017::func;
 	return execfunc(this, crew, roomId);
 }
 
-namespace _func1017
+namespace _func1018
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetSelectedCrewPoint", typeid(CrewMember *(ShipManager::*)(int , int , bool )), ".415741564989fe41554189d5415455534883ec38", nullptr, 0, 0, &func);
@@ -12960,11 +12973,11 @@ namespace _func1017
 CrewMember *ShipManager::GetSelectedCrewPoint(int x, int y, bool intruder)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(ShipManager *this_arg, int x_arg, int y_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1017::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1018::func;
 	return execfunc(this, x, y, intruder);
 }
 
-namespace _func1018
+namespace _func1019
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetTooltip", typeid(std::string (ShipManager::*)(int , int )), ".415741564989fe41554189cd41544989f4", nullptr, 0, 0, &func);
@@ -12973,11 +12986,11 @@ namespace _func1018
 std::string ShipManager::GetTooltip(int x, int y)
 {
 	typedef std::string (*custom_arg_funcptr_t)(ShipManager *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1018::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1019::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1019
+namespace _func1020
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetWeaponList", typeid(std::vector<ProjectileFactory*> (ShipManager::*)()), ".41545553488b86580600004889fb83780cff", nullptr, 0, 0, &func);
@@ -12986,11 +12999,11 @@ namespace _func1019
 std::vector<ProjectileFactory*> ShipManager::GetWeaponList()
 {
 	typedef std::vector<ProjectileFactory*> (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1019::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1020::func;
 	return execfunc(this);
 }
 
-namespace _func1020
+namespace _func1021
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetDroneCount", typeid(int (ShipManager::*)()), ".488b8758060000837810ff7413", nullptr, 0, 0, &func);
@@ -12999,11 +13012,11 @@ namespace _func1020
 int ShipManager::GetDroneCount()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1020::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1021::func;
 	return execfunc(this);
 }
 
-namespace _func1021
+namespace _func1022
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ModifyDroneCount", typeid(void (ShipManager::*)(int )), ".488b8758060000837810ff7523", nullptr, 0, 0, &func);
@@ -13012,11 +13025,11 @@ namespace _func1021
 void ShipManager::ModifyDroneCount(int drones)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int drones_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1021::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1022::func;
 	return execfunc(this, drones);
 }
 
-namespace _func1022
+namespace _func1023
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetOxygenPercentage", typeid(int (ShipManager::*)()), ".488b8758060000837808ff742b", nullptr, 0, 0, &func);
@@ -13025,11 +13038,11 @@ namespace _func1022
 int ShipManager::GetOxygenPercentage()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1022::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1023::func;
 	return execfunc(this);
 }
 
-namespace _func1023
+namespace _func1024
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::RemoveItem", typeid(void (ShipManager::*)(const std::string &)), ".41574156415541544989f455534889fb4883ec48", nullptr, 0, 0, &func);
@@ -13038,11 +13051,11 @@ namespace _func1023
 void ShipManager::RemoveItem(const std::string &name)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1023::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1024::func;
 	return execfunc(this, name);
 }
 
-namespace _func1024
+namespace _func1025
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::AddWeapon", typeid(int (ShipManager::*)(const WeaponBlueprint *, int )), ".488b875806000083780cff7413", nullptr, 0, 0, &func);
@@ -13051,11 +13064,11 @@ namespace _func1024
 int ShipManager::AddWeapon(const WeaponBlueprint *bp, int slot)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, const WeaponBlueprint *bp_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1024::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1025::func;
 	return execfunc(this, bp, slot);
 }
 
-namespace _func1025
+namespace _func1026
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ModifyMissileCount", typeid(void (ShipManager::*)(int )), ".488b875806000083780cff7523", nullptr, 0, 0, &func);
@@ -13064,11 +13077,11 @@ namespace _func1025
 void ShipManager::ModifyMissileCount(int missiles)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int missiles_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1025::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1026::func;
 	return execfunc(this, missiles);
 }
 
-namespace _func1026
+namespace _func1027
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetMissileCount", typeid(int (ShipManager::*)()), ".488b875806000083780cff7413", nullptr, 0, 0, &func);
@@ -13077,11 +13090,11 @@ namespace _func1026
 int ShipManager::GetMissileCount()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1026::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1027::func;
 	return execfunc(this);
 }
 
-namespace _func1027
+namespace _func1028
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetDroneList", typeid(std::vector<Drone*> (ShipManager::*)()), ".41545553488b86580600004889fb837810ff", nullptr, 0, 0, &func);
@@ -13090,11 +13103,11 @@ namespace _func1027
 std::vector<Drone*> ShipManager::GetDroneList()
 {
 	typedef std::vector<Drone*> (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1027::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1028::func;
 	return execfunc(this);
 }
 
-namespace _func1028
+namespace _func1029
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::IsSystemHacked", typeid(int (ShipManager::*)(int )), ".83fe11741b488b87580600004863d6", nullptr, 0, 0, &func);
@@ -13103,11 +13116,11 @@ namespace _func1028
 int ShipManager::IsSystemHacked(int systemId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1028::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1029::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1029
+namespace _func1030
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ExportBattleState", typeid(void (ShipManager::*)(int )), ".4157415641554154554889fd5389f34883ec28", nullptr, 0, 0, &func);
@@ -13116,11 +13129,11 @@ namespace _func1029
 void ShipManager::ExportBattleState(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1029::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1030::func;
 	return execfunc(this, file);
 }
 
-namespace _func1030
+namespace _func1031
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::StartFire", typeid(void (ShipManager::*)(int )), "!.4881c7d8000000", nullptr, 0, 0, &func);
@@ -13129,11 +13142,11 @@ namespace _func1030
 void ShipManager::StartFire(int roomId)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1030::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1031::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1031
+namespace _func1032
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetFireCount", typeid(int (ShipManager::*)(int )), "!.4881c7d8000000", nullptr, 0, 0, &func);
@@ -13142,11 +13155,11 @@ namespace _func1031
 int ShipManager::GetFireCount(int roomId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1031::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1032::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1032
+namespace _func1033
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::AddCrewMember", typeid(void (ShipManager::*)(CrewMember *, int )), ".5589d5534889fb4889f74883ec184889742408", nullptr, 0, 0, &func);
@@ -13155,11 +13168,11 @@ namespace _func1032
 void ShipManager::AddCrewMember(CrewMember *crew, int roomId)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1032::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1033::func;
 	return execfunc(this, crew, roomId);
 }
 
-namespace _func1033
+namespace _func1034
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::TeleportCrew", typeid(std::vector<CrewMember*> (ShipManager::*)(int , bool )), ".4157415641554989fd41544989f455534883ec18", nullptr, 0, 0, &func);
@@ -13168,11 +13181,11 @@ namespace _func1033
 std::vector<CrewMember*> ShipManager::TeleportCrew(int roomId, bool intruders)
 {
 	typedef std::vector<CrewMember*> (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1033::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1034::func;
 	return execfunc(this, roomId, intruders);
 }
 
-namespace _func1034
+namespace _func1035
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetLeavingCrew", typeid(std::vector<CrewMember*> (ShipManager::*)(bool )), ".415631c941554989f541544989fc5589d553", nullptr, 0, 0, &func);
@@ -13181,11 +13194,11 @@ namespace _func1034
 std::vector<CrewMember*> ShipManager::GetLeavingCrew(bool intruders)
 {
 	typedef std::vector<CrewMember*> (*custom_arg_funcptr_t)(ShipManager *this_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1034::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1035::func;
 	return execfunc(this, intruders);
 }
 
-namespace _func1035
+namespace _func1036
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::AddCrewMemberFromBlueprint", typeid(CrewMember *(ShipManager::*)(CrewBlueprint *, int , bool , int , bool )), ".41574989ff415641554589cd4154554889f5", nullptr, 0, 0, &func);
@@ -13194,11 +13207,11 @@ namespace _func1035
 CrewMember *ShipManager::AddCrewMemberFromBlueprint(CrewBlueprint *bp, int slot, bool init, int roomId, bool intruder)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(ShipManager *this_arg, CrewBlueprint *bp_arg, int slot_arg, bool init_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1035::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1036::func;
 	return execfunc(this, bp, slot, init, roomId, intruder);
 }
 
-namespace _func1036
+namespace _func1037
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::DamageSystem", typeid(void (ShipManager::*)(int , Damage )), ".41574989ff4156415541545589f5534883ec48", nullptr, 0, 0, &func);
@@ -13207,11 +13220,11 @@ namespace _func1036
 void ShipManager::DamageSystem(int systemId, Damage damage)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, Damage damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1036::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1037::func;
 	return execfunc(this, systemId, damage);
 }
 
-namespace _func1037
+namespace _func1038
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CheckCrystalAugment", typeid(void (ShipManager::*)(Pointf )), ".4157be????????4156415541544989fc55534883ec68", nullptr, 0, 0, &func);
@@ -13220,11 +13233,11 @@ namespace _func1037
 void ShipManager::CheckCrystalAugment(Pointf pos)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1037::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1038::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1038
+namespace _func1039
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::PrepareSuperBarrage", typeid(void (ShipManager::*)()), ".415741564155415455534889fb4881ec980000004883bf0006000000", nullptr, 0, 0, &func);
@@ -13233,11 +13246,11 @@ namespace _func1038
 void ShipManager::PrepareSuperBarrage()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1038::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1039::func;
 	return execfunc(this);
 }
 
-namespace _func1039
+namespace _func1040
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::RestoreCrewPositions", typeid(bool (ShipManager::*)()), ".415531d2bf????????415455534883ec684889e6", nullptr, 0, 0, &func);
@@ -13246,11 +13259,11 @@ namespace _func1039
 bool ShipManager::RestoreCrewPositions()
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1039::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1040::func;
 	return execfunc(this);
 }
 
-namespace _func1040
+namespace _func1041
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::UpdateEnvironment", typeid(void (ShipManager::*)()), ".4157488d87d800000041564989fe4889c74155415455534883ec78", nullptr, 0, 0, &func);
@@ -13259,11 +13272,11 @@ namespace _func1040
 void ShipManager::UpdateEnvironment()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1040::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1041::func;
 	return execfunc(this);
 }
 
-namespace _func1041
+namespace _func1042
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::SelectRandomCrew", typeid(CrewBlueprint (ShipManager::*)(int , const std::string &)), ".41574156415541544989fc554889cd534883ec68", nullptr, 0, 0, &func);
@@ -13272,30 +13285,17 @@ namespace _func1041
 CrewBlueprint ShipManager::SelectRandomCrew(int seed, const std::string &racePref)
 {
 	typedef CrewBlueprint (*custom_arg_funcptr_t)(ShipManager *this_arg, int seed_arg, const std::string &racePref_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1041::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1042::func;
 	return execfunc(this, seed, racePref);
 }
 
-namespace _func1042
+namespace _func1043
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CollisionShield", typeid(CollisionResponse (ShipManager::*)(Pointf , Pointf , Damage , bool )), ".415741564189d641554154554889f5534889fb4881ece8000000", nullptr, 0, 0, &func);
 }
 
 CollisionResponse ShipManager::CollisionShield(Pointf start, Pointf finish, Damage damage, bool raytrace)
-{
-	typedef CollisionResponse (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1042::func;
-	return execfunc(this, start, finish, damage, raytrace);
-}
-
-namespace _func1043
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::CollisionMoving", typeid(CollisionResponse (ShipManager::*)(Pointf , Pointf , Damage , bool )), ".41574989ff488d7f044156415541544189d4554889f5534881ec08010000", nullptr, 0, 0, &func);
-}
-
-CollisionResponse ShipManager::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1043::func;
@@ -13305,36 +13305,36 @@ CollisionResponse ShipManager::CollisionMoving(Pointf start, Pointf finish, Dama
 namespace _func1044
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::CollisionMoving", typeid(CollisionResponse (ShipManager::*)(Pointf , Pointf , Damage , bool )), ".41574989ff488d7f044156415541544189d4554889f5534881ec08010000", nullptr, 0, 0, &func);
+}
+
+CollisionResponse ShipManager::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
+{
+	typedef CollisionResponse (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1044::func;
+	return execfunc(this, start, finish, damage, raytrace);
+}
+
+namespace _func1045
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::DamageArea", typeid(bool (ShipManager::*)(Pointf , Damage , bool )), ".4157b901000000415641554189f5415455534889fb4881ecc8000000", nullptr, 0, 0, &func);
 }
 
 bool ShipManager::DamageArea(Pointf location, Damage dmg, bool forceHit)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf location_arg, Damage dmg_arg, bool forceHit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1044::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1045::func;
 	return execfunc(this, location, dmg, forceHit);
 }
 
-namespace _func1045
+namespace _func1046
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::PrepareSuperDrones", typeid(void (ShipManager::*)()), ".415741564155415455534889fb4883ec58488b87b8090000", nullptr, 0, 0, &func);
 }
 
 void ShipManager::PrepareSuperDrones()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1045::func;
-	return execfunc(this);
-}
-
-namespace _func1046
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::RenderChargeBars", typeid(void (ShipManager::*)()), ".4155415455534889fb4883ec388b5708", nullptr, 0, 0, &func);
-}
-
-void ShipManager::RenderChargeBars()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1046::func;
@@ -13344,10 +13344,10 @@ void ShipManager::RenderChargeBars()
 namespace _func1047
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::RenderWeapons", typeid(void (ShipManager::*)()), ".41574156415541544c8da718010000554889fd4c89e7534883ec68", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipManager::RenderChargeBars", typeid(void (ShipManager::*)()), ".4155415455534889fb4883ec388b5708", nullptr, 0, 0, &func);
 }
 
-void ShipManager::RenderWeapons()
+void ShipManager::RenderChargeBars()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1047::func;
@@ -13357,17 +13357,30 @@ void ShipManager::RenderWeapons()
 namespace _func1048
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::RenderWeapons", typeid(void (ShipManager::*)()), ".41574156415541544c8da718010000554889fd4c89e7534883ec68", nullptr, 0, 0, &func);
+}
+
+void ShipManager::RenderWeapons()
+{
+	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1048::func;
+	return execfunc(this);
+}
+
+namespace _func1049
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::OnRender", typeid(void (ShipManager::*)(bool , bool )), ".4157415641554989fd4154555389f34881ec98000000", nullptr, 0, 0, &func);
 }
 
 void ShipManager::OnRender(bool showInterior, bool doorControlMode)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, bool showInterior_arg, bool doorControlMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1048::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1049::func;
 	return execfunc(this, showInterior, doorControlMode);
 }
 
-namespace _func1049
+namespace _func1050
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CreateCrewDrone", typeid(CrewDrone *(ShipManager::*)(const DroneBlueprint *)), ".55534889fb4883ec188b4670", nullptr, 0, 0, &func);
@@ -13376,11 +13389,11 @@ namespace _func1049
 CrewDrone *ShipManager::CreateCrewDrone(const DroneBlueprint *bp)
 {
 	typedef CrewDrone *(*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1049::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1050::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1050
+namespace _func1051
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CreateSpaceDrone", typeid(SpaceDrone *(ShipManager::*)(const DroneBlueprint *)), ".41554154554889f5534883ec38837e7007", nullptr, 0, 0, &func);
@@ -13389,11 +13402,11 @@ namespace _func1050
 SpaceDrone *ShipManager::CreateSpaceDrone(const DroneBlueprint *bp)
 {
 	typedef SpaceDrone *(*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1050::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1051::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1051
+namespace _func1052
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::AddDrone", typeid(Drone *(ShipManager::*)(const DroneBlueprint *, int )), ".4155415455534889fb4883ec18488b8758060000", nullptr, 0, 0, &func);
@@ -13402,11 +13415,11 @@ namespace _func1051
 Drone *ShipManager::AddDrone(const DroneBlueprint *bp, int slot)
 {
 	typedef Drone *(*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1051::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1052::func;
 	return execfunc(this, bp, slot);
 }
 
-namespace _func1052
+namespace _func1053
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::AddEquipmentFromList", typeid(void (ShipManager::*)(std::vector<std::string> *)), ".415641554154554889f5534883ec30", nullptr, 0, 0, &func);
@@ -13415,11 +13428,11 @@ namespace _func1052
 void ShipManager::AddEquipmentFromList(std::vector<std::string> *equipmentList)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, std::vector<std::string> *equipmentList_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1052::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1053::func;
 	return execfunc(this, equipmentList);
 }
 
-namespace _func1053
+namespace _func1054
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::AddSystem", typeid(int (ShipManager::*)(int )), ".415741564155415455534889fb4881ece8000000", nullptr, 0, 0, &func);
@@ -13428,11 +13441,11 @@ namespace _func1053
 int ShipManager::AddSystem(int systemId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1053::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1054::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1054
+namespace _func1055
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CreateSystems", typeid(int (ShipManager::*)()), ".4154488d8fb007000055534889fb4883ec20", nullptr, 0, 0, &func);
@@ -13441,11 +13454,11 @@ namespace _func1054
 int ShipManager::CreateSystems()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1054::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1055::func;
 	return execfunc(this);
 }
 
-namespace _func1055
+namespace _func1056
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::DamageBeam", typeid(bool (ShipManager::*)(Pointf , Pointf , Damage )), ".4157415641554154554889fd534881ece8000000", nullptr, 0, 0, &func);
@@ -13454,11 +13467,11 @@ namespace _func1055
 bool ShipManager::DamageBeam(Pointf location1, Pointf location2, Damage dmg)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf location1_arg, Pointf location2_arg, Damage dmg_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1055::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1056::func;
 	return execfunc(this, location1, location2, dmg);
 }
 
-namespace _func1056
+namespace _func1057
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::UpdateCrewMembers", typeid(void (ShipManager::*)()), ".415731c94156415541544989fc555331db4881ec38010000", nullptr, 0, 0, &func);
@@ -13467,11 +13480,11 @@ namespace _func1056
 void ShipManager::UpdateCrewMembers()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1056::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1057::func;
 	return execfunc(this);
 }
 
-namespace _func1057
+namespace _func1058
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::PowerDrone", typeid(bool (ShipManager::*)(Drone *, int , bool , bool )), ".41554154554889fd534883ec08488b87", nullptr, 0, 0, &func);
@@ -13480,11 +13493,11 @@ namespace _func1057
 bool ShipManager::PowerDrone(Drone *drone, int roomId, bool userDriven, bool force)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, Drone *drone_arg, int roomId_arg, bool userDriven_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1057::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1058::func;
 	return execfunc(this, drone, roomId, userDriven, force);
 }
 
-namespace _func1058
+namespace _func1059
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ImportBattleState", typeid(void (ShipManager::*)(int )), "!.4157415641554154554889fd5389f34883ec18", nullptr, 0, 0, &func);
@@ -13493,11 +13506,11 @@ namespace _func1058
 void ShipManager::ImportBattleState(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1058::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1059::func;
 	return execfunc(this, file);
 }
 
-namespace _func1059
+namespace _func1060
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::OnLoop", typeid(void (ShipManager::*)()), ".41574989ffbe????????41564155415455534881ec48010000", nullptr, 0, 0, &func);
@@ -13506,11 +13519,11 @@ namespace _func1059
 void ShipManager::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1059::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1060::func;
 	return execfunc(this);
 }
 
-namespace _func1060
+namespace _func1061
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ExportShip", typeid(void (ShipManager::*)(int )), ".41574989ff415641554154555389f3488db75807000089df4881ec78010000", nullptr, 0, 0, &func);
@@ -13519,11 +13532,11 @@ namespace _func1060
 void ShipManager::ExportShip(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1060::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1061::func;
 	return execfunc(this, file);
 }
 
-namespace _func1061
+namespace _func1062
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::AddCrewMemberFromString", typeid(CrewMember *(ShipManager::*)(const std::string &, const std::string &, bool , int , bool , bool )), ".415741564589c641554154554889fd534881ec58020000", nullptr, 0, 0, &func);
@@ -13532,11 +13545,11 @@ namespace _func1061
 CrewMember *ShipManager::AddCrewMemberFromString(const std::string &name, const std::string &race, bool intruder, int roomId, bool init, bool male)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(ShipManager *this_arg, const std::string &name_arg, const std::string &race_arg, bool intruder_arg, int roomId_arg, bool init_arg, bool male_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1061::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1062::func;
 	return execfunc(this, name, race, intruder, roomId, init, male);
 }
 
-namespace _func1062
+namespace _func1063
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::AddInitialCrew", typeid(void (ShipManager::*)(std::vector<CrewBlueprint> &)), ".41574156415541544989f4be????????554889fd534881ec88010000", nullptr, 0, 0, &func);
@@ -13545,11 +13558,11 @@ namespace _func1062
 void ShipManager::AddInitialCrew(std::vector<CrewBlueprint> &blueprints)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, std::vector<CrewBlueprint> &blueprints_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1062::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1063::func;
 	return execfunc(this, blueprints);
 }
 
-namespace _func1063
+namespace _func1064
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::Restart", typeid(void (ShipManager::*)()), ".415641554154554889fd534883ec208b4708", nullptr, 0, 0, &func);
@@ -13558,11 +13571,11 @@ namespace _func1063
 void ShipManager::Restart()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1063::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1064::func;
 	return execfunc(this);
 }
 
-namespace _func1064
+namespace _func1065
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::SaveToBlueprint", typeid(ShipBlueprint (ShipManager::*)(bool )), ".4157415641554189d54154554889f5534889fb4883ec48", nullptr, 0, 0, &func);
@@ -13571,11 +13584,11 @@ namespace _func1064
 ShipBlueprint ShipManager::SaveToBlueprint(bool unk)
 {
 	typedef ShipBlueprint (*custom_arg_funcptr_t)(ShipManager *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1064::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1065::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1065
+namespace _func1066
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::OnInit", typeid(int (ShipManager::*)(ShipBlueprint *, int )), ".4156415541544c8da7800600005589d5534889fb4c89e74883ec50", nullptr, 0, 0, &func);
@@ -13584,11 +13597,11 @@ namespace _func1065
 int ShipManager::OnInit(ShipBlueprint *bp, int shipLevel)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, ShipBlueprint *bp_arg, int shipLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1065::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1066::func;
 	return execfunc(this, bp, shipLevel);
 }
 
-namespace _func1066
+namespace _func1067
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ImportShip", typeid(void (ShipManager::*)(int )), ".415741564189f64155415455534889fb4c8dab800600004c8dbb880700004881ec18040000", nullptr, 0, 0, &func);
@@ -13597,11 +13610,11 @@ namespace _func1066
 void ShipManager::ImportShip(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1066::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1067::func;
 	return execfunc(this, file);
 }
 
-namespace _func1067
+namespace _func1068
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::constructor", typeid(int (ShipManager::*)(int )), ".415741564989fe488dbfd800000041554154555389f34881ec98000000", nullptr, 0, 0, &func);
@@ -13610,30 +13623,17 @@ namespace _func1067
 int ShipManager::constructor(int shipId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1067::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1068::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func1068
+namespace _func1069
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::destructor", typeid(void (ShipManager::*)()), ".415641554989fd4154555348c707", nullptr, 0, 0, &func);
 }
 
 void ShipManager::destructor()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1068::func;
-	return execfunc(this);
-}
-
-namespace _func1069
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::destructor2", typeid(void (ShipManager::*)()), "!.534889fb", nullptr, 0, 0, &func);
-}
-
-void ShipManager::destructor2()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1069::func;
@@ -13643,17 +13643,30 @@ void ShipManager::destructor2()
 namespace _func1070
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::destructor2", typeid(void (ShipManager::*)()), "!.534889fb", nullptr, 0, 0, &func);
+}
+
+void ShipManager::destructor2()
+{
+	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1070::func;
+	return execfunc(this);
+}
+
+namespace _func1071
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::GetAugmentationCount", typeid(int (ShipObject::*)()), "8b570831c0488b0d????????85d2", nullptr, 0, 0, &func);
 }
 
 int ShipObject::GetAugmentationCount()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1070::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1071::func;
 	return execfunc(this);
 }
 
-namespace _func1071
+namespace _func1072
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::ClearShipInfo", typeid(void (ShipObject::*)()), ".538b570831c085d20f94c0488d14004801c2488d1490", nullptr, 0, 0, &func);
@@ -13662,11 +13675,11 @@ namespace _func1071
 void ShipObject::ClearShipInfo()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1071::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1072::func;
 	return execfunc(this);
 }
 
-namespace _func1072
+namespace _func1073
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::GetAugmentationList", typeid(std::vector<std::string> (ShipObject::*)()), ".415631c04155415455538b56084889fb85d20f94c0488d14004801c2488d1490", nullptr, 0, 0, &func);
@@ -13675,11 +13688,11 @@ namespace _func1072
 std::vector<std::string> ShipObject::GetAugmentationList()
 {
 	typedef std::vector<std::string> (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1072::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1073::func;
 	return execfunc(this);
 }
 
-namespace _func1073
+namespace _func1074
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::HasAugmentation", typeid(int (ShipObject::*)(const std::string &)), ".415741564155415455534889fb4883ec38488d7c2420", nullptr, 0, 0, &func);
@@ -13688,11 +13701,11 @@ namespace _func1073
 int ShipObject::HasAugmentation(const std::string &augment)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1073::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1074::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1074
+namespace _func1075
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::HasEquipment", typeid(int (ShipObject::*)(const std::string &)), ".415741564155415455534889f34883ec68", nullptr, 0, 0, &func);
@@ -13701,11 +13714,11 @@ namespace _func1074
 int ShipObject::HasEquipment(const std::string &equip)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1074::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1075::func;
 	return execfunc(this, equip);
 }
 
-namespace _func1075
+namespace _func1076
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::GetAugmentationValue", typeid(float (ShipObject::*)(const std::string &)), ".415741564155415455534889fb4883ec58488d7c2430", nullptr, 0, 0, &func);
@@ -13714,11 +13727,11 @@ namespace _func1075
 float ShipObject::GetAugmentationValue(const std::string &augment)
 {
 	typedef float (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1075::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1076::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1076
+namespace _func1077
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::AddAugmentation", typeid(bool (ShipObject::*)(const std::string &)), ".415741564155415455534889fb4883ec58488d7c2430", nullptr, 0, 0, &func);
@@ -13727,11 +13740,11 @@ namespace _func1076
 bool ShipObject::AddAugmentation(const std::string &augment)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1076::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1077::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1077
+namespace _func1078
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::RemoveAugmentation", typeid(void (ShipObject::*)(const std::string &)), ".415741564155415455534889fb4883ec48488d7c2420", nullptr, 0, 0, &func);
@@ -13740,37 +13753,24 @@ namespace _func1077
 void ShipObject::RemoveAugmentation(const std::string &augment)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1077::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1078::func;
 	return execfunc(this, augment);
 }
 
 ShipInfo **Global_ShipObject_ShipInfoList;
 
-namespace _var1078
+namespace _var1079
 {
     static VariableDefinition varObj("Global_ShipObject_ShipInfoList", "!8b570831c0488b0d(???????\?)85d20f94c0488d14004801c2", &Global_ShipObject_ShipInfoList, true, true);
 }
 
-namespace _func1079
+namespace _func1080
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSelect::constructor", typeid(void (ShipSelect::*)()), "53ba6e0000004889fbbe700000004883ec10", nullptr, 0, 0, &func);
 }
 
 void ShipSelect::constructor()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1079::func;
-	return execfunc(this);
-}
-
-namespace _func1080
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipSelect::ClearShipButtons", typeid(void (ShipSelect::*)()), ".554889fd534883ec08488b4f30488b57284889c84829d048c1f80385c0", nullptr, 0, 0, &func);
-}
-
-void ShipSelect::ClearShipButtons()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1080::func;
@@ -13780,10 +13780,10 @@ void ShipSelect::ClearShipButtons()
 namespace _func1081
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipSelect::OnLoop", typeid(void (ShipSelect::*)()), ".415741564155415455534889fb4881ec0801000080bf5005000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipSelect::ClearShipButtons", typeid(void (ShipSelect::*)()), ".554889fd534883ec08488b4f30488b57284889c84829d048c1f80385c0", nullptr, 0, 0, &func);
 }
 
-void ShipSelect::OnLoop()
+void ShipSelect::ClearShipButtons()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1081::func;
@@ -13793,36 +13793,36 @@ void ShipSelect::OnLoop()
 namespace _func1082
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipSelect::OnLoop", typeid(void (ShipSelect::*)()), ".415741564155415455534889fb4881ec0801000080bf5005000000", nullptr, 0, 0, &func);
+}
+
+void ShipSelect::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1082::func;
+	return execfunc(this);
+}
+
+namespace _func1083
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipSelect::KeyDown", typeid(int (ShipSelect::*)(SDLKey )), "!.4881c748050000", nullptr, 0, 0, &func);
 }
 
 int ShipSelect::KeyDown(SDLKey key)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipSelect *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1082::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1083::func;
 	return execfunc(this, key);
 }
 
-namespace _func1083
+namespace _func1084
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSelect::MouseClick", typeid(void (ShipSelect::*)()), "!.5380bf50050000004889fb", nullptr, 0, 0, &func);
 }
 
 void ShipSelect::MouseClick()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1083::func;
-	return execfunc(this);
-}
-
-namespace _func1084
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipSelect::Close", typeid(void (ShipSelect::*)()), "!.c64758004881c748050000", nullptr, 0, 0, &func);
-}
-
-void ShipSelect::Close()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1084::func;
@@ -13832,12 +13832,12 @@ void ShipSelect::Close()
 namespace _func1085
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipSelect::GetSelectedShip", typeid(int (ShipSelect::*)()), "!.8b475cc3", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipSelect::Close", typeid(void (ShipSelect::*)()), "!.c64758004881c748050000", nullptr, 0, 0, &func);
 }
 
-int ShipSelect::GetSelectedShip()
+void ShipSelect::Close()
 {
-	typedef int (*custom_arg_funcptr_t)(ShipSelect *this_arg);
+	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1085::func;
 	return execfunc(this);
 }
@@ -13845,23 +13845,23 @@ int ShipSelect::GetSelectedShip()
 namespace _func1086
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipSelect::SelectShip", typeid(void (ShipSelect::*)(int )), ".415789f241564989fe4155415455534881eca8020000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipSelect::GetSelectedShip", typeid(int (ShipSelect::*)()), "!.8b475cc3", nullptr, 0, 0, &func);
 }
 
-void ShipSelect::SelectShip(int shipType)
+int ShipSelect::GetSelectedShip()
 {
-	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg, int shipType_arg);
+	typedef int (*custom_arg_funcptr_t)(ShipSelect *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1086::func;
-	return execfunc(this, shipType);
+	return execfunc(this);
 }
 
 namespace _func1087
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipSelect::PreSelectShip", typeid(void (ShipSelect::*)(int )), "!.85f6534889fb", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipSelect::SelectShip", typeid(void (ShipSelect::*)(int )), ".415789f241564989fe4155415455534881eca8020000", nullptr, 0, 0, &func);
 }
 
-void ShipSelect::PreSelectShip(int shipType)
+void ShipSelect::SelectShip(int shipType)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg, int shipType_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1087::func;
@@ -13871,17 +13871,30 @@ void ShipSelect::PreSelectShip(int shipType)
 namespace _func1088
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipSelect::PreSelectShip", typeid(void (ShipSelect::*)(int )), "!.85f6534889fb", nullptr, 0, 0, &func);
+}
+
+void ShipSelect::PreSelectShip(int shipType)
+{
+	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg, int shipType_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1088::func;
+	return execfunc(this, shipType);
+}
+
+namespace _func1089
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipSelect::MouseMove", typeid(void (ShipSelect::*)(int , int )), ".41574189f74156415541544189d4554889fd534881ec18010000", nullptr, 0, 0, &func);
 }
 
 void ShipSelect::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1088::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1089::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1089
+namespace _func1090
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSelect::Open", typeid(void (ShipSelect::*)(int , int )), ".41574989ff41564155415455534881ecc8010000", nullptr, 0, 0, &func);
@@ -13890,11 +13903,11 @@ namespace _func1089
 void ShipSelect::Open(int currentId, int currentType)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg, int currentId_arg, int currentType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1089::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1090::func;
 	return execfunc(this, currentId, currentType);
 }
 
-namespace _func1090
+namespace _func1091
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSelect::OnRender", typeid(void (ShipSelect::*)()), ".41564155415455534889fb4883ec5080bf5005000000", nullptr, 0, 0, &func);
@@ -13903,11 +13916,11 @@ namespace _func1090
 void ShipSelect::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1090::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1091::func;
 	return execfunc(this);
 }
 
-namespace _func1091
+namespace _func1092
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipStatus::RenderHealth", typeid(void (ShipStatus::*)(bool )), "4155415455534881ec880000004084f6", nullptr, 0, 0, &func);
@@ -13916,11 +13929,11 @@ namespace _func1091
 void ShipStatus::RenderHealth(bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1091::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1092::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1092
+namespace _func1093
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipStatus::OnInit", typeid(void (ShipStatus::*)(Point , float )), "415741564155415455534889fb4881ece8010000f30f114708", nullptr, 0, 0, &func);
@@ -13929,11 +13942,11 @@ namespace _func1092
 void ShipStatus::OnInit(Point unk, float unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipStatus *this_arg, Point unk_arg, float unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1092::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1093::func;
 	return execfunc(this, unk, unk2);
 }
 
-namespace _func1093
+namespace _func1094
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipStatus::RenderEvadeOxygen", typeid(void (ShipStatus::*)(bool )), "415741564155415455534889fb4881ec580300004084f6", nullptr, 0, 0, &func);
@@ -13942,11 +13955,11 @@ namespace _func1093
 void ShipStatus::RenderEvadeOxygen(bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1093::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1094::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1094
+namespace _func1095
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipStatus::OnRender", typeid(void (ShipStatus::*)()), "4155415455534889fb4881ec88000000e8????????f30f2a03", nullptr, 0, 0, &func);
@@ -13955,11 +13968,11 @@ namespace _func1094
 void ShipStatus::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1094::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1095::func;
 	return execfunc(this);
 }
 
-namespace _func1095
+namespace _func1096
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipStatus::RenderShields", typeid(void (ShipStatus::*)(bool )), "41574156415541544989fc55534883ec18488b7f10", nullptr, 0, 0, &func);
@@ -13968,11 +13981,11 @@ namespace _func1095
 void ShipStatus::RenderShields(bool renderText)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool renderText_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1095::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1096::func;
 	return execfunc(this, renderText);
 }
 
-namespace _func1096
+namespace _func1097
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipStatus::OnLoop", typeid(void (ShipStatus::*)()), "415541544531e4554889fd5331db4883ec48", nullptr, 0, 0, &func);
@@ -13981,11 +13994,11 @@ namespace _func1096
 void ShipStatus::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1096::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1097::func;
 	return execfunc(this);
 }
 
-namespace _func1097
+namespace _func1098
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::SetHackingLevel", typeid(void (ShipSystem::*)(int )), "89b720020000", nullptr, 0, 0, &func);
@@ -13994,11 +14007,11 @@ namespace _func1097
 void ShipSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1097::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1098::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func1098
+namespace _func1099
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::ForceDecreasePower", typeid(bool (ShipSystem::*)(int )), ".415641554154554889fd5380bf8c01000000", nullptr, 0, 0, &func);
@@ -14007,11 +14020,11 @@ namespace _func1098
 bool ShipSystem::ForceDecreasePower(int powerLoss)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, int powerLoss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1098::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1099::func;
 	return execfunc(this, powerLoss);
 }
 
-namespace _func1099
+namespace _func1100
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::AddDamage", typeid(void (ShipSystem::*)(int )), ".8b87740100008b977801000029f08b775439d00f4fc231c985c00f48c1", nullptr, 0, 0, &func);
@@ -14020,11 +14033,11 @@ namespace _func1099
 void ShipSystem::AddDamage(int amount)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1099::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1100::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1100
+namespace _func1101
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::Ioned", typeid(bool (ShipSystem::*)(int )), ".8b879c01000083f8ff0f94c285c00f9fc008d0", nullptr, 0, 0, &func);
@@ -14033,11 +14046,11 @@ namespace _func1100
 bool ShipSystem::Ioned(int num)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, int num_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1100::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1101::func;
 	return execfunc(this, num);
 }
 
-namespace _func1101
+namespace _func1102
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::destructor", typeid(void (ShipSystem::*)()), ".415441bc05000000554889fd534889eb4883ec10", nullptr, 0, 0, &func);
@@ -14046,30 +14059,17 @@ namespace _func1101
 void ShipSystem::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1101::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1102::func;
 	return execfunc(this);
 }
 
-namespace _func1102
+namespace _func1103
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::SaveState", typeid(void (ShipSystem::*)(int )), "!.554889fd5389f34883ec088bb790010000", nullptr, 0, 0, &func);
 }
 
 void ShipSystem::SaveState(int file)
-{
-	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1102::func;
-	return execfunc(this, file);
-}
-
-namespace _func1103
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipSystem::LoadState", typeid(void (ShipSystem::*)(int )), ".5589f5534889fb89f74883ec08", nullptr, 0, 0, &func);
-}
-
-void ShipSystem::LoadState(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1103::func;
@@ -14079,17 +14079,30 @@ void ShipSystem::LoadState(int file)
 namespace _func1104
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipSystem::LoadState", typeid(void (ShipSystem::*)(int )), ".5589f5534889fb89f74883ec08", nullptr, 0, 0, &func);
+}
+
+void ShipSystem::LoadState(int file)
+{
+	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1104::func;
+	return execfunc(this, file);
+}
+
+namespace _func1105
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::GetEffectivePower", typeid(int (ShipSystem::*)()), ".8b474831d285c0", nullptr, 0, 0, &func);
 }
 
 int ShipSystem::GetEffectivePower()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1104::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1105::func;
 	return execfunc(this);
 }
 
-namespace _func1105
+namespace _func1106
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::SetBonusPower", typeid(void (ShipSystem::*)(int , int )), ".4154555380bf8c010000004889fb", nullptr, 0, 0, &func);
@@ -14098,11 +14111,11 @@ namespace _func1105
 void ShipSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1105::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1106::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func1106
+namespace _func1107
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::GetPowerCap", typeid(int (ShipSystem::*)()), ".8b979001000031c083fa07", nullptr, 0, 0, &func);
@@ -14111,11 +14124,11 @@ namespace _func1106
 int ShipSystem::GetPowerCap()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1106::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1107::func;
 	return execfunc(this);
 }
 
-namespace _func1107
+namespace _func1108
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::BlockedBoosted", typeid(bool (ShipSystem::*)(bool )), ".4084f6534889fb", nullptr, 0, 0, &func);
@@ -14124,11 +14137,11 @@ namespace _func1107
 bool ShipSystem::BlockedBoosted(bool countLimit)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool countLimit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1107::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1108::func;
 	return execfunc(this, countLimit);
 }
 
-namespace _func1108
+namespace _func1109
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::IsMannedBoost", typeid(int (ShipSystem::*)()), ".8b474885c07e21", nullptr, 0, 0, &func);
@@ -14137,11 +14150,11 @@ namespace _func1108
 int ShipSystem::IsMannedBoost()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1108::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1109::func;
 	return execfunc(this);
 }
 
-namespace _func1109
+namespace _func1110
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::GetLocked", typeid(bool (ShipSystem::*)()), ".8b879c01000083f8ff", nullptr, 0, 0, &func);
@@ -14150,11 +14163,11 @@ namespace _func1109
 bool ShipSystem::GetLocked()
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1109::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1110::func;
 	return execfunc(this);
 }
 
-namespace _func1110
+namespace _func1111
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::GetLockTimer", typeid(TimerHelper (ShipSystem::*)()), ".488b96a0", nullptr, 0, 0, &func);
@@ -14163,11 +14176,11 @@ namespace _func1110
 TimerHelper ShipSystem::GetLockTimer()
 {
 	typedef TimerHelper (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1110::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1111::func;
 	return execfunc(this);
 }
 
-namespace _func1111
+namespace _func1112
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::StopHacking", typeid(void (ShipSystem::*)()), "!.488b07c6872402000000", nullptr, 0, 0, &func);
@@ -14176,11 +14189,11 @@ namespace _func1111
 void ShipSystem::StopHacking()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1111::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1112::func;
 	return execfunc(this);
 }
 
-namespace _func1112
+namespace _func1113
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::UpgradeSystem", typeid(bool (ShipSystem::*)(int )), ".5589f5534889fb4883ec08488b07", nullptr, 0, 0, &func);
@@ -14189,11 +14202,11 @@ namespace _func1112
 bool ShipSystem::UpgradeSystem(int amount)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1112::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1113::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1113
+namespace _func1114
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::GetMaxPower", typeid(int (ShipSystem::*)()), ".8b4f548b877401000031d2", nullptr, 0, 0, &func);
@@ -14202,11 +14215,11 @@ namespace _func1113
 int ShipSystem::GetMaxPower()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1113::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1114::func;
 	return execfunc(this);
 }
 
-namespace _func1114
+namespace _func1115
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::CheckMaxPower", typeid(void (ShipSystem::*)()), ".4155415455534889fb4883ec0880bf8c01000000", nullptr, 0, 0, &func);
@@ -14215,11 +14228,11 @@ namespace _func1114
 void ShipSystem::CheckMaxPower()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1114::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1115::func;
 	return execfunc(this);
 }
 
-namespace _func1115
+namespace _func1116
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::RenderSystemSymbol", typeid(void (ShipSystem::*)(bool , int )), ".41545589d5534889fb4883ec", nullptr, 0, 0, &func);
@@ -14228,11 +14241,11 @@ namespace _func1115
 void ShipSystem::RenderSystemSymbol(bool forPowerUI, int forceColor)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool forPowerUI_arg, int forceColor_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1115::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1116::func;
 	return execfunc(this, forPowerUI, forceColor);
 }
 
-namespace _func1116
+namespace _func1117
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::RenderPowerBoxesPlain", typeid(int (*)(int , int , int , int , int , int , int , int )), ".4157b840", nullptr, 0, 0, &func);
@@ -14241,11 +14254,11 @@ namespace _func1116
 int ShipSystem::RenderPowerBoxesPlain(int x, int y, int width, int height, int gap, int current, int temp, int max)
 {
 	typedef int (*custom_arg_funcptr_t)(int x_arg, int y_arg, int width_arg, int height_arg, int gap_arg, int current_arg, int temp_arg, int max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1116::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1117::func;
 	return execfunc(x, y, width, height, gap, current, temp, max);
 }
 
-namespace _func1117
+namespace _func1118
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::IsSubsystem", typeid(bool (*)(int )), ".83ff0c741383ff06", nullptr, 0, 0, &func);
@@ -14254,11 +14267,11 @@ namespace _func1117
 bool ShipSystem::IsSubsystem(int systemType)
 {
 	typedef bool (*custom_arg_funcptr_t)(int systemType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1117::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1118::func;
 	return execfunc(systemType);
 }
 
-namespace _func1118
+namespace _func1119
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::RenderPowerBoxes", typeid(int (ShipSystem::*)(int , int , int , int , int , int , bool )), "!.41574989ff41564189ce41554189f541544589c4554489cd5389d34881ec88000000", nullptr, 0, 0, &func);
@@ -14267,116 +14280,116 @@ namespace _func1118
 int ShipSystem::RenderPowerBoxes(int x, int y, int width, int height, int gap, int heightMod, bool flash)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipSystem *this_arg, int x_arg, int y_arg, int width_arg, int height_arg, int gap_arg, int heightMod_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1118::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1119::func;
 	return execfunc(this, x, y, width, height, gap, heightMod, flash);
 }
 
 GL_Primitive **ShipSystem__glowWhite;
 
-namespace _var1119
+namespace _var1120
 {
     static VariableDefinition varObj("ShipSystem__glowWhite", "!.488b3d(???????\?)", &ShipSystem__glowWhite, true, true);
 }
 
 GL_Primitive **ShipSystem__lockBlue;
 
-namespace _var1120
+namespace _var1121
 {
     static VariableDefinition varObj("ShipSystem__lockBlue", "!.4c8b05(???????\?)", &ShipSystem__lockBlue, true, true);
 }
 
 GL_Primitive **ShipSystem__fireImage;
 
-namespace _var1121
+namespace _var1122
 {
     static VariableDefinition varObj("ShipSystem__fireImage", "!.488b3d(???????\?)", &ShipSystem__fireImage, true, true);
 }
 
 GL_Primitive **ShipSystem__lockHack;
 
-namespace _var1122
+namespace _var1123
 {
     static VariableDefinition varObj("ShipSystem__lockHack", "!.488b3d(???????\?)", &ShipSystem__lockHack, true, true);
 }
 
 GL_Primitive **ShipSystem__manningBarIon;
 
-namespace _var1123
+namespace _var1124
 {
     static VariableDefinition varObj("ShipSystem__manningBarIon", "!.488b3d(???????\?)", &ShipSystem__manningBarIon, true, true);
 }
 
 GL_Primitive **ShipSystem__manningBarOff;
 
-namespace _var1124
+namespace _var1125
 {
     static VariableDefinition varObj("ShipSystem__manningBarOff", "!.480f443d(???????\?)", &ShipSystem__manningBarOff, true, true);
 }
 
 GL_Primitive **ShipSystem__lockWhite;
 
-namespace _var1125
+namespace _var1126
 {
     static VariableDefinition varObj("ShipSystem__lockWhite", "!.4c8b05(???????\?)", &ShipSystem__lockWhite, true, true);
 }
 
 GL_Primitive **ShipSystem__sabotageImage;
 
-namespace _var1126
+namespace _var1127
 {
     static VariableDefinition varObj("ShipSystem__sabotageImage", "!.488b3d(???????\?)", &ShipSystem__sabotageImage, true, true);
 }
 
 GL_Primitive **ShipSystem__manningOutline;
 
-namespace _var1127
+namespace _var1128
 {
     static VariableDefinition varObj("ShipSystem__manningOutline", "!.488b3d(???????\?)", &ShipSystem__manningOutline, true, true);
 }
 
 GL_Primitive **ShipSystem__manningBarOn;
 
-namespace _var1128
+namespace _var1129
 {
     static VariableDefinition varObj("ShipSystem__manningBarOn", "!.488b3d(???????\?)", &ShipSystem__manningBarOn, true, true);
 }
 
 GL_Primitive **ShipSystem__manningWhite;
 
-namespace _var1129
+namespace _var1130
 {
     static VariableDefinition varObj("ShipSystem__manningWhite", "!.488b3d(???????\?)", &ShipSystem__manningWhite, true, true);
 }
 
 GL_Primitive **ShipSystem__manningGreen;
 
-namespace _var1130
+namespace _var1131
 {
     static VariableDefinition varObj("ShipSystem__manningGreen", "!.488b3d(???????\?)", &ShipSystem__manningGreen, true, true);
 }
 
 GL_Primitive **ShipSystem__manningYellow;
 
-namespace _var1131
+namespace _var1132
 {
     static VariableDefinition varObj("ShipSystem__manningYellow", "!.488b3d(???????\?)", &ShipSystem__manningYellow, true, true);
 }
 
 GL_Primitive **ShipSystem__glowBlue;
 
-namespace _var1132
+namespace _var1133
 {
     static VariableDefinition varObj("ShipSystem__glowBlue", "!.488b3d(???????\?)", &ShipSystem__glowBlue, true, true);
 }
 
 GL_Primitive **ShipSystem__glowRed;
 
-namespace _var1133
+namespace _var1134
 {
     static VariableDefinition varObj("ShipSystem__glowRed", "!.488b3d(???????\?)", &ShipSystem__glowRed, true, true);
 }
 
-namespace _func1134
+namespace _func1135
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::IncreasePower", typeid(bool (ShipSystem::*)(int , bool )), ".534889fb4883ec108b879c010000", nullptr, 0, 0, &func);
@@ -14385,11 +14398,11 @@ namespace _func1134
 bool ShipSystem::IncreasePower(int amount, bool force)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1134::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1135::func;
 	return execfunc(this, amount, force);
 }
 
-namespace _func1135
+namespace _func1136
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::DecreasePower", typeid(bool (ShipSystem::*)(bool )), ".55534889fb4883ec080fb6878c010000", nullptr, 0, 0, &func);
@@ -14398,11 +14411,11 @@ namespace _func1135
 bool ShipSystem::DecreasePower(bool force)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1135::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1136::func;
 	return execfunc(this, force);
 }
 
-namespace _func1136
+namespace _func1137
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::DamageOverTime", typeid(bool (ShipSystem::*)(float )), ".55534889fb", nullptr, 0, 0, &func);
@@ -14411,11 +14424,11 @@ namespace _func1136
 bool ShipSystem::DamageOverTime(float unk)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, float unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1136::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1137::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1137
+namespace _func1138
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::CheckForRepower", typeid(void (ShipSystem::*)()), ".415541544531e455534889fb4883ec08", nullptr, 0, 0, &func);
@@ -14424,11 +14437,11 @@ namespace _func1137
 void ShipSystem::CheckForRepower()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1137::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1138::func;
 	return execfunc(this);
 }
 
-namespace _func1138
+namespace _func1139
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::LockSystem", typeid(void (ShipSystem::*)(int )), ".83fe00751b8b879c010000", nullptr, 0, 0, &func);
@@ -14437,11 +14450,11 @@ namespace _func1138
 void ShipSystem::LockSystem(int lock)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1138::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1139::func;
 	return execfunc(this, lock);
 }
 
-namespace _func1139
+namespace _func1140
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::ClearStatus", typeid(void (ShipSystem::*)()), ".83bf9001000007", nullptr, 0, 0, &func);
@@ -14450,11 +14463,11 @@ namespace _func1139
 void ShipSystem::ClearStatus()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1139::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1140::func;
 	return execfunc(this);
 }
 
-namespace _func1140
+namespace _func1141
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::SetPowerCap", typeid(void (ShipSystem::*)(int )), "!.53488b074889fb89b790010000", nullptr, 0, 0, &func);
@@ -14463,11 +14476,11 @@ namespace _func1140
 void ShipSystem::SetPowerCap(int cap)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int cap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1140::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1141::func;
 	return execfunc(this, cap);
 }
 
-namespace _func1141
+namespace _func1142
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::SetPowerLoss", typeid(int (ShipSystem::*)(int )), "!.53488b074889fb89b794010000", nullptr, 0, 0, &func);
@@ -14476,11 +14489,11 @@ namespace _func1141
 int ShipSystem::SetPowerLoss(int power)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipSystem *this_arg, int power_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1141::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1142::func;
 	return execfunc(this, power);
 }
 
-namespace _func1142
+namespace _func1143
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::PartialRepair", typeid(bool (ShipSystem::*)(float , bool )), ".5531c0534889fb4883ec18", nullptr, 0, 0, &func);
@@ -14489,11 +14502,11 @@ namespace _func1142
 bool ShipSystem::PartialRepair(float speed, bool autoRepair)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, float speed_arg, bool autoRepair_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1142::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1143::func;
 	return execfunc(this, speed, autoRepair);
 }
 
-namespace _func1143
+namespace _func1144
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::AddLock", typeid(void (ShipSystem::*)(int )), ".8b879c01000083f8ff", nullptr, 0, 0, &func);
@@ -14502,11 +14515,11 @@ namespace _func1143
 void ShipSystem::AddLock(int lock)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1143::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1144::func;
 	return execfunc(this, lock);
 }
 
-namespace _func1144
+namespace _func1145
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::OnLoop", typeid(void (ShipSystem::*)()), ".415455538b879c0100004889fb85c0", nullptr, 0, 0, &func);
@@ -14515,11 +14528,11 @@ namespace _func1144
 void ShipSystem::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1144::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1145::func;
 	return execfunc(this);
 }
 
-namespace _func1145
+namespace _func1146
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::NameToSystemId", typeid(int (*)(const std::string &)), ".53be????????4889fb", nullptr, 0, 0, &func);
@@ -14528,11 +14541,11 @@ namespace _func1145
 int ShipSystem::NameToSystemId(const std::string &name)
 {
 	typedef int (*custom_arg_funcptr_t)(const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1145::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1146::func;
 	return execfunc(name);
 }
 
-namespace _func1146
+namespace _func1147
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::SystemIdToName", typeid(std::string (*)(int )), ".534889fb4883ec1083fe11488d54240f", nullptr, 0, 0, &func);
@@ -14541,11 +14554,11 @@ namespace _func1146
 std::string ShipSystem::SystemIdToName(int systemId)
 {
 	typedef std::string (*custom_arg_funcptr_t)(int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1146::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1147::func;
 	return execfunc(systemId);
 }
 
-namespace _func1147
+namespace _func1148
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::GetLevelDescription", typeid(std::string (*)(int , int , bool )), ".4156415541544189d455534889fb4881ec10020000", nullptr, 0, 0, &func);
@@ -14554,11 +14567,11 @@ namespace _func1147
 std::string ShipSystem::GetLevelDescription(int systemId, int level, bool tooltip)
 {
 	typedef std::string (*custom_arg_funcptr_t)(int systemId_arg, int level_arg, bool tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1147::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1148::func;
 	return execfunc(systemId, level, tooltip);
 }
 
-namespace _func1148
+namespace _func1149
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::constructor", typeid(void (ShipSystem::*)(int , int , int , int )), ".41574989ff41564189f641554589c54154555389d389ca4881ecd8010000", nullptr, 0, 0, &func);
@@ -14567,11 +14580,11 @@ namespace _func1148
 void ShipSystem::constructor(int systemId, int roomId, int shipId, int startingPower)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int systemId_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1148::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1149::func;
 	return execfunc(this, systemId, roomId, shipId, startingPower);
 }
 
-namespace _func1149
+namespace _func1150
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::PartialDamage", typeid(bool (ShipSystem::*)(float )), "55534889fbbf????????4883ec18f30f1144240c", nullptr, 0, 0, &func);
@@ -14580,11 +14593,11 @@ namespace _func1149
 bool ShipSystem::PartialDamage(float amount)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, float amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1149::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1150::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1150
+namespace _func1151
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SoundControl::StopPlaylist", typeid(void (SoundControl::*)(int )), "415541544989fc55534883ec38803f000f84c8000000", nullptr, 0, 0, &func);
@@ -14593,11 +14606,11 @@ namespace _func1150
 void SoundControl::StopPlaylist(int fadeOut)
 {
 	typedef void (*custom_arg_funcptr_t)(SoundControl *this_arg, int fadeOut_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1150::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1151::func;
 	return execfunc(this, fadeOut);
 }
 
-namespace _func1151
+namespace _func1152
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SoundControl::StartPlaylist", typeid(void (SoundControl::*)(std::vector<std::string> &)), ".41574156415541544989fc55534883ec58803f004889742420", nullptr, 0, 0, &func);
@@ -14606,11 +14619,11 @@ namespace _func1151
 void SoundControl::StartPlaylist(std::vector<std::string> &playlist)
 {
 	typedef void (*custom_arg_funcptr_t)(SoundControl *this_arg, std::vector<std::string> &playlist_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1151::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1152::func;
 	return execfunc(this, playlist);
 }
 
-namespace _func1152
+namespace _func1153
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SoundControl::PlaySoundMix", typeid(int (SoundControl::*)(const std::string &, float , bool )), ".415731c04156415541544989fc55534883ec48803f00", nullptr, 0, 0, &func);
@@ -14619,11 +14632,11 @@ namespace _func1152
 int SoundControl::PlaySoundMix(const std::string &soundName, float volume, bool loop)
 {
 	typedef int (*custom_arg_funcptr_t)(SoundControl *this_arg, const std::string &soundName_arg, float volume_arg, bool loop_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1152::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1153::func;
 	return execfunc(this, soundName, volume, loop);
 }
 
-namespace _func1153
+namespace _func1154
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SoundControl::UpdateSoundLoop", typeid(void (SoundControl::*)(const std::string &, float )), ".4157415641554154554889fd534883ec38", nullptr, 0, 0, &func);
@@ -14632,18 +14645,18 @@ namespace _func1153
 void SoundControl::UpdateSoundLoop(const std::string &loopId, float count)
 {
 	typedef void (*custom_arg_funcptr_t)(SoundControl *this_arg, const std::string &loopId_arg, float count_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1153::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1154::func;
 	return execfunc(this, loopId, count);
 }
 
 SoundControl *Global_SoundControl_Sounds;
 
-namespace _var1154
+namespace _var1155
 {
     static VariableDefinition varObj("Global_SoundControl_Sounds", "!488b8360020000488378e80074cf4881c36002000031d2bf(???????\?)", &Global_SoundControl_Sounds);
 }
 
-namespace _func1155
+namespace _func1156
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceDrone::SetMovementTarget", typeid(void (SpaceDrone::*)(Targetable *)), "554889f5534889fb4883ec084885f6744f488b06", nullptr, 0, 0, &func);
@@ -14652,11 +14665,11 @@ namespace _func1155
 void SpaceDrone::SetMovementTarget(Targetable *target)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1155::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1156::func;
 	return execfunc(this, target);
 }
 
-namespace _func1156
+namespace _func1157
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceDrone::SetDeployed", typeid(void (SpaceDrone::*)(bool )), ".5589f5534889fb4883ec08488b07ff506084c0743b", nullptr, 0, 0, &func);
@@ -14665,11 +14678,11 @@ namespace _func1156
 void SpaceDrone::SetDeployed(bool deployed)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceDrone *this_arg, bool deployed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1156::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1157::func;
 	return execfunc(this, deployed);
 }
 
-namespace _func1157
+namespace _func1158
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceDrone::CollisionMoving", typeid(CollisionResponse (SpaceDrone::*)(Pointf , Pointf , Damage , bool )), ".41554154554889f5534889fb488d7f044883ec18", nullptr, 0, 0, &func);
@@ -14678,11 +14691,11 @@ namespace _func1157
 CollisionResponse SpaceDrone::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1157::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1158::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func1158
+namespace _func1159
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceDrone::UpdateAimingAngle", typeid(float (SpaceDrone::*)(Pointf , float , float )), ".530f28e14889fb4883ec30660fd60424", nullptr, 0, 0, &func);
@@ -14691,11 +14704,11 @@ namespace _func1158
 float SpaceDrone::UpdateAimingAngle(Pointf location, float percentage, float forceDesired)
 {
 	typedef float (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Pointf location_arg, float percentage_arg, float forceDesired_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1158::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1159::func;
 	return execfunc(this, location, percentage, forceDesired);
 }
 
-namespace _func1159
+namespace _func1160
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceDrone::GetNextProjectile", typeid(Projectile *(SpaceDrone::*)()), ".415741564155415455534889fb4883ec68488b07", nullptr, 0, 0, &func);
@@ -14704,11 +14717,11 @@ namespace _func1159
 Projectile *SpaceDrone::GetNextProjectile()
 {
 	typedef Projectile *(*custom_arg_funcptr_t)(SpaceDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1159::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1160::func;
 	return execfunc(this);
 }
 
-namespace _func1160
+namespace _func1161
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceDrone::constructor", typeid(void (SpaceDrone::*)(int , int , DroneBlueprint *)), "41570f57d24989ff", nullptr, 0, 0, &func);
@@ -14717,11 +14730,11 @@ namespace _func1160
 void SpaceDrone::constructor(int iShipId, int selfId, DroneBlueprint *blueprint)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceDrone *this_arg, int iShipId_arg, int selfId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1160::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1161::func;
 	return execfunc(this, iShipId, selfId, blueprint);
 }
 
-namespace _func1161
+namespace _func1162
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceDrone::destructor", typeid(void (SpaceDrone::*)(int )), "4157415641554154554889fd488dbf80", nullptr, 0, 0, &func);
@@ -14730,11 +14743,11 @@ namespace _func1161
 void SpaceDrone::destructor(int __in_chrg)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceDrone *this_arg, int __in_chrg_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1161::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1162::func;
 	return execfunc(this, __in_chrg);
 }
 
-namespace _func1162
+namespace _func1163
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::constructor", typeid(void (SpaceManager::*)()), "!415455534889fb488d7f18488dabe00100004c8da3700200004883ec10", nullptr, 0, 0, &func);
@@ -14743,11 +14756,11 @@ namespace _func1162
 void SpaceManager::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1162::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1163::func;
 	return execfunc(this);
 }
 
-namespace _func1163
+namespace _func1164
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::GetScreenShake", typeid(int (SpaceManager::*)()), ".0fb687b0040000", nullptr, 0, 0, &func);
@@ -14756,11 +14769,11 @@ namespace _func1163
 int SpaceManager::GetScreenShake()
 {
 	typedef int (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1163::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1164::func;
 	return execfunc(this);
 }
 
-namespace _func1164
+namespace _func1165
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SaveSpace", typeid(void (SpaceManager::*)(int )), ".41544189f455530fb6b7500300004889fb4489e7", nullptr, 0, 0, &func);
@@ -14769,11 +14782,11 @@ namespace _func1164
 void SpaceManager::SaveSpace(int fileHelper)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1164::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1165::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1165
+namespace _func1166
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SwitchBeacon", typeid(ImageDesc (SpaceManager::*)()), ".488b96d80300004889f8", nullptr, 0, 0, &func);
@@ -14782,11 +14795,11 @@ namespace _func1165
 ImageDesc SpaceManager::SwitchBeacon()
 {
 	typedef ImageDesc (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1165::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1166::func;
 	return execfunc(this);
 }
 
-namespace _func1166
+namespace _func1167
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SwitchPlanet", typeid(ImageDesc (SpaceManager::*)(const std::string &)), ".4157415641554989d541544989fc4889d755534889f3", nullptr, 0, 0, &func);
@@ -14795,11 +14808,11 @@ namespace _func1166
 ImageDesc SpaceManager::SwitchPlanet(const std::string &name)
 {
 	typedef ImageDesc (*custom_arg_funcptr_t)(SpaceManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1166::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1167::func;
 	return execfunc(this, name);
 }
 
-namespace _func1167
+namespace _func1168
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::UpdatePlanetImage", typeid(void (SpaceManager::*)()), ".55534889fb4883ec68488bb710010000", nullptr, 0, 0, &func);
@@ -14808,11 +14821,11 @@ namespace _func1167
 void SpaceManager::UpdatePlanetImage()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1167::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1168::func;
 	return execfunc(this);
 }
 
-namespace _func1168
+namespace _func1169
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SwitchImages", typeid(void (SpaceManager::*)(ImageDesc , ImageDesc , ImageDesc )), ".55534889fb4883ec68488b8424a0000000", nullptr, 0, 0, &func);
@@ -14821,11 +14834,11 @@ namespace _func1168
 void SpaceManager::SwitchImages(ImageDesc planet, ImageDesc unk1, ImageDesc unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, ImageDesc planet_arg, ImageDesc unk1_arg, ImageDesc unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1168::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1169::func;
 	return execfunc(this, planet, unk1, unk2);
 }
 
-namespace _func1169
+namespace _func1170
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SwitchBackground", typeid(ImageDesc (SpaceManager::*)(const std::string &)), ".415641be????????41554989d541544989f4554889fd534883ec30", nullptr, 0, 0, &func);
@@ -14834,11 +14847,11 @@ namespace _func1169
 ImageDesc SpaceManager::SwitchBackground(const std::string &name)
 {
 	typedef ImageDesc (*custom_arg_funcptr_t)(SpaceManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1169::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1170::func;
 	return execfunc(this, name);
 }
 
-namespace _func1170
+namespace _func1171
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::StartAsteroids", typeid(void (SpaceManager::*)(int , bool )), ".4883ec28488b87d8000000482b87d00000000fb6ca", nullptr, 0, 0, &func);
@@ -14847,11 +14860,11 @@ namespace _func1170
 void SpaceManager::StartAsteroids(int shieldCount, bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, int shieldCount_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1170::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1171::func;
 	return execfunc(this, shieldCount, unk);
 }
 
-namespace _func1171
+namespace _func1172
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SetFireLevel", typeid(void (SpaceManager::*)(bool )), ".55488dafa0030000bad0840000534889fb4883ec28", nullptr, 0, 0, &func);
@@ -14860,11 +14873,11 @@ namespace _func1171
 void SpaceManager::SetFireLevel(bool state)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1171::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1172::func;
 	return execfunc(this, state);
 }
 
-namespace _func1172
+namespace _func1173
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SetPlanetaryDefense", typeid(void (SpaceManager::*)(char , int )), ".41544189f4be204e000055488dafa0030000534889fb4881ec90000000", nullptr, 0, 0, &func);
@@ -14873,11 +14886,11 @@ namespace _func1172
 void SpaceManager::SetPlanetaryDefense(char state, int target)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, char state_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1172::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1173::func;
 	return execfunc(this, state, target);
 }
 
-namespace _func1173
+namespace _func1174
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SetPulsarLevel", typeid(void (SpaceManager::*)(bool )), ".55488dafa0030000ba50460000534889fb4883ec28", nullptr, 0, 0, &func);
@@ -14886,11 +14899,11 @@ namespace _func1173
 void SpaceManager::SetPulsarLevel(bool pulsarLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool pulsarLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1173::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1174::func;
 	return execfunc(this, pulsarLevel);
 }
 
-namespace _func1174
+namespace _func1175
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::DangerousEnvironment", typeid(bool (SpaceManager::*)()), ".0fb6977003000084d2", nullptr, 0, 0, &func);
@@ -14899,11 +14912,11 @@ namespace _func1174
 bool SpaceManager::DangerousEnvironment()
 {
 	typedef bool (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1174::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1175::func;
 	return execfunc(this);
 }
 
-namespace _func1175
+namespace _func1176
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::MouseMove", typeid(void (SpaceManager::*)(int , int , int )), ".41574989ff41564531f641554189f541544189d45589cd5331db4883ec08", nullptr, 0, 0, &func);
@@ -14912,11 +14925,11 @@ namespace _func1175
 void SpaceManager::MouseMove(int x, int y, int unk)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, int x_arg, int y_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1175::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1176::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func1176
+namespace _func1177
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::GetSelectedDrone", typeid(SpaceDrone *(SpaceManager::*)(int , int , int )), ".41574156415541544989fc55534883ec184c8b87e8000000", nullptr, 0, 0, &func);
@@ -14925,11 +14938,11 @@ namespace _func1176
 SpaceDrone *SpaceManager::GetSelectedDrone(int x, int y, int unk)
 {
 	typedef SpaceDrone *(*custom_arg_funcptr_t)(SpaceManager *this_arg, int x_arg, int y_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1176::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1177::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func1177
+namespace _func1178
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::GetFlashOpacity", typeid(float (SpaceManager::*)()), ".530f57c04883ec10", nullptr, 0, 0, &func);
@@ -14938,11 +14951,11 @@ namespace _func1177
 float SpaceManager::GetFlashOpacity()
 {
 	typedef float (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1177::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1178::func;
 	return execfunc(this);
 }
 
-namespace _func1178
+namespace _func1179
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::GetColorTint", typeid(GL_Color (SpaceManager::*)()), ".80bf7c04000000", nullptr, 0, 0, &func);
@@ -14951,19 +14964,6 @@ namespace _func1178
 GL_Color SpaceManager::GetColorTint()
 {
 	typedef GL_Color (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1178::func;
-	return execfunc(this);
-}
-
-namespace _func1179
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::OnRenderFleet", typeid(void (SpaceManager::*)()), ".41564989fe4155415455534883ec2080bf7c04000000", nullptr, 0, 0, &func);
-}
-
-void SpaceManager::OnRenderFleet()
-{
-	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1179::func;
 	return execfunc(this);
 }
@@ -14971,10 +14971,10 @@ void SpaceManager::OnRenderFleet()
 namespace _func1180
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::OnRenderForeground", typeid(void (SpaceManager::*)()), ".55534889fb4883ec4880bf7c04000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnRenderFleet", typeid(void (SpaceManager::*)()), ".41564989fe4155415455534883ec2080bf7c04000000", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::OnRenderForeground()
+void SpaceManager::OnRenderFleet()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1180::func;
@@ -14984,17 +14984,30 @@ void SpaceManager::OnRenderForeground()
 namespace _func1181
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("SpaceManager::OnRenderForeground", typeid(void (SpaceManager::*)()), ".55534889fb4883ec4880bf7c04000000", nullptr, 0, 0, &func);
+}
+
+void SpaceManager::OnRenderForeground()
+{
+	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1181::func;
+	return execfunc(this);
+}
+
+namespace _func1182
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SetDangerZone", typeid(void (SpaceManager::*)(int )), ".4157415641554989fd41544189f455534883ec28", nullptr, 0, 0, &func);
 }
 
 void SpaceManager::SetDangerZone(int fleetType)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fleetType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1181::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1182::func;
 	return execfunc(this, fleetType);
 }
 
-namespace _func1182
+namespace _func1183
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::OnRenderAsteroids", typeid(void (SpaceManager::*)(int , float )), ".554889fd534883ec1880bfc800000000", nullptr, 0, 0, &func);
@@ -15003,11 +15016,11 @@ namespace _func1182
 void SpaceManager::OnRenderAsteroids(int fieldLayers, float unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fieldLayers_arg, float unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1182::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1183::func;
 	return execfunc(this, fieldLayers, unk2);
 }
 
-namespace _func1183
+namespace _func1184
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::OnRenderProjectiles", typeid(void (SpaceManager::*)(int , int )), ".415741564189d6415541544189f455534889fb4883ec28", nullptr, 0, 0, &func);
@@ -15016,30 +15029,17 @@ namespace _func1183
 void SpaceManager::OnRenderProjectiles(int iShipId, int layerCommand)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, int iShipId_arg, int layerCommand_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1183::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1184::func;
 	return execfunc(this, iShipId, layerCommand);
 }
 
-namespace _func1184
+namespace _func1185
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::OnInit", typeid(void (SpaceManager::*)()), ".55be????????534889fb4883ec58", nullptr, 0, 0, &func);
 }
 
 void SpaceManager::OnInit()
-{
-	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1184::func;
-	return execfunc(this);
-}
-
-namespace _func1185
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::Restart", typeid(void (SpaceManager::*)()), "!.41545553488b0f4889fb", nullptr, 0, 0, &func);
-}
-
-void SpaceManager::Restart()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1185::func;
@@ -15049,10 +15049,10 @@ void SpaceManager::Restart()
 namespace _func1186
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::ClearEnvironment", typeid(void (SpaceManager::*)()), ".c6875003000000c6875103000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::Restart", typeid(void (SpaceManager::*)()), "!.41545553488b0f4889fb", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::ClearEnvironment()
+void SpaceManager::Restart()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1186::func;
@@ -15062,10 +15062,10 @@ void SpaceManager::ClearEnvironment()
 namespace _func1187
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::Clear", typeid(void (SpaceManager::*)()), "!.41545553488b87d0000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::ClearEnvironment", typeid(void (SpaceManager::*)()), ".c6875003000000c6875103000000", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::Clear()
+void SpaceManager::ClearEnvironment()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1187::func;
@@ -15075,10 +15075,10 @@ void SpaceManager::Clear()
 namespace _func1188
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::ClearProjectiles", typeid(void (SpaceManager::*)()), ".41545553488b0f4889fb", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::Clear", typeid(void (SpaceManager::*)()), "!.41545553488b87d0000000", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::ClearProjectiles()
+void SpaceManager::Clear()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1188::func;
@@ -15088,23 +15088,23 @@ void SpaceManager::ClearProjectiles()
 namespace _func1189
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::UpdateProjectile", typeid(void (SpaceManager::*)(Projectile *)), ".415741564531f641554531ed41544531e4554889fd4889f7534889f34883ec08", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::ClearProjectiles", typeid(void (SpaceManager::*)()), ".41545553488b0f4889fb", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::UpdateProjectile(Projectile *proj)
+void SpaceManager::ClearProjectiles()
 {
-	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
+	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1189::func;
-	return execfunc(this, proj);
+	return execfunc(this);
 }
 
 namespace _func1190
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::TransferProjectile", typeid(void (SpaceManager::*)(Projectile *)), "!.554889f7534889f34883ec08", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::UpdateProjectile", typeid(void (SpaceManager::*)(Projectile *)), ".415741564531f641554531ed41544531e4554889fd4889f7534889f34883ec08", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::TransferProjectile(Projectile *proj)
+void SpaceManager::UpdateProjectile(Projectile *proj)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1190::func;
@@ -15114,17 +15114,30 @@ void SpaceManager::TransferProjectile(Projectile *proj)
 namespace _func1191
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("SpaceManager::TransferProjectile", typeid(void (SpaceManager::*)(Projectile *)), "!.554889f7534889f34883ec08", nullptr, 0, 0, &func);
+}
+
+void SpaceManager::TransferProjectile(Projectile *proj)
+{
+	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1191::func;
+	return execfunc(this, proj);
+}
+
+namespace _func1192
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::OnRenderBackground", typeid(void (SpaceManager::*)()), ".41564989fe4155415455534883ec1080bf7c04000000", nullptr, 0, 0, &func);
 }
 
 void SpaceManager::OnRenderBackground()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1191::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1192::func;
 	return execfunc(this);
 }
 
-namespace _func1192
+namespace _func1193
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::AddProjectile", typeid(void (SpaceManager::*)(Projectile *)), ".4883ec18488b4708483b47104889742408", nullptr, 0, 0, &func);
@@ -15133,11 +15146,11 @@ namespace _func1192
 void SpaceManager::AddProjectile(Projectile *proj)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1192::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1193::func;
 	return execfunc(this, proj);
 }
 
-namespace _func1193
+namespace _func1194
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::LoadSpace", typeid(void (SpaceManager::*)(int )), ".415741564189f64155415455534889fb89f74883ec48", nullptr, 0, 0, &func);
@@ -15146,11 +15159,11 @@ namespace _func1193
 void SpaceManager::LoadSpace(int fileHelper)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1193::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1194::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1194
+namespace _func1195
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::AddShip", typeid(void (SpaceManager::*)(ShipManager *)), ".415455534889fb4883ec30488b87d8000000", nullptr, 0, 0, &func);
@@ -15159,30 +15172,17 @@ namespace _func1194
 void SpaceManager::AddShip(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1194::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1195::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1195
+namespace _func1196
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::UpdatePDS", typeid(void (SpaceManager::*)()), ".415731d241564531f64155415449bcabaaaaaaaaaaaaaa554889fd4c8dad98040000534881ec28010000", nullptr, 0, 0, &func);
 }
 
 void SpaceManager::UpdatePDS()
-{
-	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1195::func;
-	return execfunc(this);
-}
-
-namespace _func1196
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::OnLoopNebulas", typeid(void (SpaceManager::*)()), ".415748ba398ee3388ee3388e415641554989fd415455534881ecc8010000", nullptr, 0, 0, &func);
-}
-
-void SpaceManager::OnLoopNebulas()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1196::func;
@@ -15192,10 +15192,10 @@ void SpaceManager::OnLoopNebulas()
 namespace _func1197
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::OnLoop", typeid(void (SpaceManager::*)()), ".41574156415541544989fc488dbf1804000055534883ec48", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnLoopNebulas", typeid(void (SpaceManager::*)()), ".415748ba398ee3388ee3388e415641554989fd415455534881ecc8010000", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::OnLoop()
+void SpaceManager::OnLoopNebulas()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1197::func;
@@ -15205,23 +15205,23 @@ void SpaceManager::OnLoop()
 namespace _func1198
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::SetNebula", typeid(void (SpaceManager::*)(bool )), ".4157415641554154554889fd534881ec98000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnLoop", typeid(void (SpaceManager::*)()), ".41574156415541544989fc488dbf1804000055534883ec48", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::SetNebula(bool state)
+void SpaceManager::OnLoop()
 {
-	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
+	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1198::func;
-	return execfunc(this, state);
+	return execfunc(this);
 }
 
 namespace _func1199
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::SetStorm", typeid(void (SpaceManager::*)(bool )), ".4883ec28be01000000c6873a04000001", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::SetNebula", typeid(void (SpaceManager::*)(bool )), ".4157415641554154554889fd534881ec98000000", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::SetStorm(bool state)
+void SpaceManager::SetNebula(bool state)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1199::func;
@@ -15231,17 +15231,30 @@ void SpaceManager::SetStorm(bool state)
 namespace _func1200
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("SpaceManager::SetStorm", typeid(void (SpaceManager::*)(bool )), ".4883ec28be01000000c6873a04000001", nullptr, 0, 0, &func);
+}
+
+void SpaceManager::SetStorm(bool state)
+{
+	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1200::func;
+	return execfunc(this, state);
+}
+
+namespace _func1201
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("SpaceStatus::OnInit", typeid(void (SpaceStatus::*)(SpaceManager *, Point )), "41564889d08d4add48c1e820", nullptr, 0, 0, &func);
 }
 
 void SpaceStatus::OnInit(SpaceManager *space, Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceStatus *this_arg, SpaceManager *space_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1200::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1201::func;
 	return execfunc(this, space, pos);
 }
 
-namespace _func1201
+namespace _func1202
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceStatus::RenderWarningText", typeid(void (SpaceStatus::*)(int , int )), ".415741564155415449bc0000", nullptr, 0, 0, &func);
@@ -15250,11 +15263,11 @@ namespace _func1201
 void SpaceStatus::RenderWarningText(int effect, int textOffset)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceStatus *this_arg, int effect_arg, int textOffset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1201::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1202::func;
 	return execfunc(this, effect, textOffset);
 }
 
-namespace _func1202
+namespace _func1203
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceStatus::MouseMove", typeid(void (SpaceStatus::*)(int , int )), ".41544189d45589f5534889fb4883ec20", nullptr, 0, 0, &func);
@@ -15263,11 +15276,11 @@ namespace _func1202
 void SpaceStatus::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceStatus *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1202::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1203::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1203
+namespace _func1204
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceStatus::OnRender", typeid(void (SpaceStatus::*)()), ".415455534889fb4883ec10488b7f58e8", nullptr, 0, 0, &func);
@@ -15276,11 +15289,11 @@ namespace _func1203
 void SpaceStatus::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1203::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1204::func;
 	return execfunc(this);
 }
 
-namespace _func1204
+namespace _func1205
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::SetPosition", typeid(void (StarMap::*)(Point )), "4889b7a0000000", nullptr, 0, 0, &func);
@@ -15289,11 +15302,11 @@ namespace _func1204
 void StarMap::SetPosition(Point unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1204::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1205::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1205
+namespace _func1206
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::SetOpen", typeid(void (StarMap::*)(bool )), "!.4084f6488b07", nullptr, 0, 0, &func);
@@ -15302,11 +15315,11 @@ namespace _func1205
 void StarMap::SetOpen(bool unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, bool unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1205::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1206::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1206
+namespace _func1207
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GetNextDangerMove", typeid(int (StarMap::*)()), ".8b8f0805000085c9", nullptr, 0, 0, &func);
@@ -15315,11 +15328,11 @@ namespace _func1206
 int StarMap::GetNextDangerMove()
 {
 	typedef int (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1206::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1207::func;
 	return execfunc(this);
 }
 
-namespace _func1207
+namespace _func1208
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::KeyDown", typeid(void (StarMap::*)(int )), ".80bfb808000000", nullptr, 0, 0, &func);
@@ -15328,30 +15341,17 @@ namespace _func1207
 void StarMap::KeyDown(int unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1207::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1208::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1208
+namespace _func1209
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::Close", typeid(void (StarMap::*)()), ".534889fb4883ec2080bf3c08000000", nullptr, 0, 0, &func);
 }
 
 void StarMap::Close()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1208::func;
-	return execfunc(this);
-}
-
-namespace _func1209
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::Open", typeid(void (StarMap::*)()), ".53807f08004889fb", nullptr, 0, 0, &func);
-}
-
-void StarMap::Open()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1209::func;
@@ -15361,10 +15361,10 @@ void StarMap::Open()
 namespace _func1210
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::InitMapTitle", typeid(void (StarMap::*)()), ".41554154554889fd534883ec68488bbf38050000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::Open", typeid(void (StarMap::*)()), ".53807f08004889fb", nullptr, 0, 0, &func);
 }
 
-void StarMap::InitMapTitle()
+void StarMap::Open()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1210::func;
@@ -15374,10 +15374,10 @@ void StarMap::InitMapTitle()
 namespace _func1211
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::InitNoFuelText", typeid(void (StarMap::*)()), ".41554989fd415455534883ec38488bbf80050000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::InitMapTitle", typeid(void (StarMap::*)()), ".41554154554889fd534883ec68488bbf38050000", nullptr, 0, 0, &func);
 }
 
-void StarMap::InitNoFuelText()
+void StarMap::InitMapTitle()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1211::func;
@@ -15387,10 +15387,10 @@ void StarMap::InitNoFuelText()
 namespace _func1212
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::InitBossMessageBox", typeid(void (StarMap::*)()), ".55534889fb4883ec38488baf78070000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::InitNoFuelText", typeid(void (StarMap::*)()), ".41554989fd415455534883ec38488bbf80050000", nullptr, 0, 0, &func);
 }
 
-void StarMap::InitBossMessageBox()
+void StarMap::InitNoFuelText()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1212::func;
@@ -15400,10 +15400,10 @@ void StarMap::InitBossMessageBox()
 namespace _func1213
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::OnLanguageChange", typeid(void (StarMap::*)()), "!.534889fbe8????????4889dfe8", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::InitBossMessageBox", typeid(void (StarMap::*)()), ".55534889fb4883ec38488baf78070000", nullptr, 0, 0, &func);
 }
 
-void StarMap::OnLanguageChange()
+void StarMap::InitBossMessageBox()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1213::func;
@@ -15413,17 +15413,30 @@ void StarMap::OnLanguageChange()
 namespace _func1214
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::OnLanguageChange", typeid(void (StarMap::*)()), "!.534889fbe8????????4889dfe8", nullptr, 0, 0, &func);
+}
+
+void StarMap::OnLanguageChange()
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1214::func;
+	return execfunc(this);
+}
+
+namespace _func1215
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GetRandomSectorChoice", typeid(int (StarMap::*)()), ".4883ec08803d????????00753b", nullptr, 0, 0, &func);
 }
 
 int StarMap::GetRandomSectorChoice()
 {
 	typedef int (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1214::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1215::func;
 	return execfunc(this);
 }
 
-namespace _func1215
+namespace _func1216
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::NeighboringSector", typeid(void (StarMap::*)(int )), ".31c085f67867", nullptr, 0, 0, &func);
@@ -15432,11 +15445,11 @@ namespace _func1215
 void StarMap::NeighboringSector(int unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1215::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1216::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1216
+namespace _func1217
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GetSelectedSector", typeid(void (StarMap::*)(int , int , int )), ".41554989fd415441bcffffffff5589cd534883ec18", nullptr, 0, 0, &func);
@@ -15445,11 +15458,11 @@ namespace _func1216
 void StarMap::GetSelectedSector(int unk0, int unk1, int unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg, int unk1_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1216::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1217::func;
 	return execfunc(this, unk0, unk1, unk2);
 }
 
-namespace _func1217
+namespace _func1218
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::StartSecretSector", typeid(void (StarMap::*)()), ".4883ec28488b87b0080000c687b908000001", nullptr, 0, 0, &func);
@@ -15458,30 +15471,17 @@ namespace _func1217
 void StarMap::StartSecretSector()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1217::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1218::func;
 	return execfunc(this);
 }
 
-namespace _func1218
+namespace _func1219
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::ReachSector", typeid(void (StarMap::*)(Sector *)), ".41574989ff41564155415455534883ec58488b7e10", nullptr, 0, 0, &func);
 }
 
 void StarMap::ReachSector(Sector *unk0)
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1218::func;
-	return execfunc(this, unk0);
-}
-
-namespace _func1219
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::UpdateSectorMap", typeid(void (StarMap::*)(Sector *)), "!.4885f6743b", nullptr, 0, 0, &func);
-}
-
-void StarMap::UpdateSectorMap(Sector *unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1219::func;
@@ -15491,36 +15491,36 @@ void StarMap::UpdateSectorMap(Sector *unk0)
 namespace _func1220
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::UpdateSectorMap", typeid(void (StarMap::*)(Sector *)), "!.4885f6743b", nullptr, 0, 0, &func);
+}
+
+void StarMap::UpdateSectorMap(Sector *unk0)
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1220::func;
+	return execfunc(this, unk0);
+}
+
+namespace _func1221
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::SaveGame", typeid(void (StarMap::*)(int )), ".415731d24156415541545589f5534889fb4883ec48", nullptr, 0, 0, &func);
 }
 
 void StarMap::SaveGame(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1220::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1221::func;
 	return execfunc(this, file);
 }
 
-namespace _func1221
+namespace _func1222
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::InitStatistics", typeid(void (StarMap::*)()), "!.f3c366666666662e0f1f840000000000", nullptr, 0, 0, &func);
 }
 
 void StarMap::InitStatistics()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1221::func;
-	return execfunc(this);
-}
-
-namespace _func1222
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::PrintStatistics", typeid(void (StarMap::*)()), "!.f3c366666666662e0f1f840000000000", nullptr, 0, 0, &func);
-}
-
-void StarMap::PrintStatistics()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1222::func;
@@ -15530,10 +15530,10 @@ void StarMap::PrintStatistics()
 namespace _func1223
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::AnalyzeMap", typeid(void (StarMap::*)()), "!.f3c366666666662e0f1f840000000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::PrintStatistics", typeid(void (StarMap::*)()), "!.f3c366666666662e0f1f840000000000", nullptr, 0, 0, &func);
 }
 
-void StarMap::AnalyzeMap()
+void StarMap::PrintStatistics()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1223::func;
@@ -15543,36 +15543,36 @@ void StarMap::AnalyzeMap()
 namespace _func1224
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::AnalyzeMap", typeid(void (StarMap::*)()), "!.f3c366666666662e0f1f840000000000", nullptr, 0, 0, &func);
+}
+
+void StarMap::AnalyzeMap()
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1224::func;
+	return execfunc(this);
+}
+
+namespace _func1225
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::ModifyPursuit", typeid(void (StarMap::*)(int )), ".01b708050000", nullptr, 0, 0, &func);
 }
 
 void StarMap::ModifyPursuit(int unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1224::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1225::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1225
+namespace _func1226
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::AtBeacon", typeid(void (StarMap::*)()), ".488b87880000000fb64020", nullptr, 0, 0, &func);
 }
 
 void StarMap::AtBeacon()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1225::func;
-	return execfunc(this);
-}
-
-namespace _func1226
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::GetWaitLocation", typeid(void (StarMap::*)()), ".80bfc0000000007427", nullptr, 0, 0, &func);
-}
-
-void StarMap::GetWaitLocation()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1226::func;
@@ -15582,10 +15582,10 @@ void StarMap::GetWaitLocation()
 namespace _func1227
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::StartBeacon", typeid(void (StarMap::*)()), ".8b970005000031c085d2", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::GetWaitLocation", typeid(void (StarMap::*)()), ".80bfc0000000007427", nullptr, 0, 0, &func);
 }
 
-void StarMap::StartBeacon()
+void StarMap::GetWaitLocation()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1227::func;
@@ -15595,17 +15595,30 @@ void StarMap::StartBeacon()
 namespace _func1228
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::StartBeacon", typeid(void (StarMap::*)()), ".8b970005000031c085d2", nullptr, 0, 0, &func);
+}
+
+void StarMap::StartBeacon()
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1228::func;
+	return execfunc(this);
+}
+
+namespace _func1229
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::LocationsConnected", typeid(bool (StarMap::*)(Location *, Location *)), ".488b7e08488b76104829fe48c1fe034885f6", nullptr, 0, 0, &func);
 }
 
 bool StarMap::LocationsConnected(Location *unk0, Location *unk1)
 {
 	typedef bool (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg, Location *unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1228::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1229::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1229
+namespace _func1230
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::PointToGrid", typeid(Point (StarMap::*)(float , float )), ".4883ec280f28d90f28e0488d7c2410", nullptr, 0, 0, &func);
@@ -15614,11 +15627,11 @@ namespace _func1229
 Point StarMap::PointToGrid(float x, float y)
 {
 	typedef Point (*custom_arg_funcptr_t)(StarMap *this_arg, float x_arg, float y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1229::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1230::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1230
+namespace _func1231
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::TravelToLocation", typeid(void (StarMap::*)(Location *)), ".80bea0000000004889b788000000", nullptr, 0, 0, &func);
@@ -15627,30 +15640,17 @@ namespace _func1230
 void StarMap::TravelToLocation(Location *unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1230::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1231::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1231
+namespace _func1232
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::ForceExitBeacon", typeid(void (StarMap::*)()), ".488b8788000000c6402001", nullptr, 0, 0, &func);
 }
 
 void StarMap::ForceExitBeacon()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1231::func;
-	return execfunc(this);
-}
-
-namespace _func1232
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::OnRenderFogEffect", typeid(void (StarMap::*)()), "!.f3c366666666662e0f1f840000000000", nullptr, 0, 0, &func);
-}
-
-void StarMap::OnRenderFogEffect()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1232::func;
@@ -15660,23 +15660,23 @@ void StarMap::OnRenderFogEffect()
 namespace _func1233
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::LocationHasBoss", typeid(void (StarMap::*)(Location *)), ".48638fa00a0000488b97b00a0000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::OnRenderFogEffect", typeid(void (StarMap::*)()), "!.f3c366666666662e0f1f840000000000", nullptr, 0, 0, &func);
 }
 
-void StarMap::LocationHasBoss(Location *unk0)
+void StarMap::OnRenderFogEffect()
 {
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1233::func;
-	return execfunc(this, unk0);
+	return execfunc(this);
 }
 
 namespace _func1234
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::LocationHasStore", typeid(void (StarMap::*)(Location *)), ".488b46304885c0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::LocationHasBoss", typeid(void (StarMap::*)(Location *)), ".48638fa00a0000488b97b00a0000", nullptr, 0, 0, &func);
 }
 
-void StarMap::LocationHasStore(Location *unk0)
+void StarMap::LocationHasBoss(Location *unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1234::func;
@@ -15686,10 +15686,10 @@ void StarMap::LocationHasStore(Location *unk0)
 namespace _func1235
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::LocationHasShip", typeid(void (StarMap::*)(Location *)), ".488b46304885c0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::LocationHasStore", typeid(void (StarMap::*)(Location *)), ".488b46304885c0", nullptr, 0, 0, &func);
 }
 
-void StarMap::LocationHasShip(Location *unk0)
+void StarMap::LocationHasStore(Location *unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1235::func;
@@ -15699,17 +15699,30 @@ void StarMap::LocationHasShip(Location *unk0)
 namespace _func1236
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::LocationHasShip", typeid(void (StarMap::*)(Location *)), ".488b46304885c0", nullptr, 0, 0, &func);
+}
+
+void StarMap::LocationHasShip(Location *unk0)
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1236::func;
+	return execfunc(this, unk0);
+}
+
+namespace _func1237
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::AdvanceWorldLevel", typeid(void (StarMap::*)()), ".55534889fb4883ec488b8700050000", nullptr, 0, 0, &func);
 }
 
 void StarMap::AdvanceWorldLevel()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1236::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1237::func;
 	return execfunc(this);
 }
 
-namespace _func1237
+namespace _func1238
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GetLocationText", typeid(std::string (StarMap::*)(const Location *)), ".41554154554889fd534889f3", nullptr, 0, 0, &func);
@@ -15718,30 +15731,17 @@ namespace _func1237
 std::string StarMap::GetLocationText(const Location *loc)
 {
 	typedef std::string (*custom_arg_funcptr_t)(StarMap *this_arg, const Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1237::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1238::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1238
+namespace _func1239
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::ReverseBossPath", typeid(void (StarMap::*)()), ".488b8fb80a0000488b87b00a0000", nullptr, 0, 0, &func);
 }
 
 void StarMap::ReverseBossPath()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1238::func;
-	return execfunc(this);
-}
-
-namespace _func1239
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::ForceBossJump", typeid(void (StarMap::*)()), ".80bfa80a000000c687a90a000001", nullptr, 0, 0, &func);
-}
-
-void StarMap::ForceBossJump()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1239::func;
@@ -15751,10 +15751,10 @@ void StarMap::ForceBossJump()
 namespace _func1240
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::ClearBoss", typeid(void (StarMap::*)()), ".41544989fc5531ed53488b572831db488b4730c687c80a000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::ForceBossJump", typeid(void (StarMap::*)()), ".80bfa80a000000c687a90a000001", nullptr, 0, 0, &func);
 }
 
-void StarMap::ClearBoss()
+void StarMap::ForceBossJump()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1240::func;
@@ -15764,36 +15764,36 @@ void StarMap::ClearBoss()
 namespace _func1241
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::ClearBoss", typeid(void (StarMap::*)()), ".41544989fc5531ed53488b572831db488b4730c687c80a000000", nullptr, 0, 0, &func);
+}
+
+void StarMap::ClearBoss()
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1241::func;
+	return execfunc(this);
+}
+
+namespace _func1242
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::SetBossStage", typeid(void (StarMap::*)(int )), ".89b7500c0000", nullptr, 0, 0, &func);
 }
 
 void StarMap::SetBossStage(int stage)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int stage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1241::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1242::func;
 	return execfunc(this, stage);
 }
 
-namespace _func1242
+namespace _func1243
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::CheckGameOver", typeid(void (StarMap::*)()), ".31c083bfa40a000004", nullptr, 0, 0, &func);
 }
 
 void StarMap::CheckGameOver()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1242::func;
-	return execfunc(this);
-}
-
-namespace _func1243
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::RenderLabels", typeid(void (StarMap::*)()), ".415741564155415455534889fb4881ec98000000", nullptr, 0, 0, &func);
-}
-
-void StarMap::RenderLabels()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1243::func;
@@ -15803,10 +15803,10 @@ void StarMap::RenderLabels()
 namespace _func1244
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::DeleteMap", typeid(void (StarMap::*)()), ".41554154554889fd534883ec184c8baf380c0000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::RenderLabels", typeid(void (StarMap::*)()), ".415741564155415455534889fb4881ec98000000", nullptr, 0, 0, &func);
 }
 
-void StarMap::DeleteMap()
+void StarMap::RenderLabels()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1244::func;
@@ -15816,36 +15816,36 @@ void StarMap::DeleteMap()
 namespace _func1245
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::DeleteMap", typeid(void (StarMap::*)()), ".41554154554889fd534883ec184c8baf380c0000", nullptr, 0, 0, &func);
+}
+
+void StarMap::DeleteMap()
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1245::func;
+	return execfunc(this);
+}
+
+namespace _func1246
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::MouseClick", typeid(void (StarMap::*)(int , int )), ".55534889fb4883ec2880bfc006000000", nullptr, 0, 0, &func);
 }
 
 void StarMap::MouseClick(int unk0, int unk1)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg, int unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1245::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1246::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1246
+namespace _func1247
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::AddSectorColumn", typeid(void (StarMap::*)()), ".415741564155415455bd56555555534889fb4881ec48010000", nullptr, 0, 0, &func);
 }
 
 void StarMap::AddSectorColumn()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1246::func;
-	return execfunc(this);
-}
-
-namespace _func1247
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::PushSectorColumn", typeid(void (StarMap::*)()), "!.41544989fc31d25531ed53", nullptr, 0, 0, &func);
-}
-
-void StarMap::PushSectorColumn()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1247::func;
@@ -15855,17 +15855,30 @@ void StarMap::PushSectorColumn()
 namespace _func1248
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::PushSectorColumn", typeid(void (StarMap::*)()), "!.41544989fc31d25531ed53", nullptr, 0, 0, &func);
+}
+
+void StarMap::PushSectorColumn()
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1248::func;
+	return execfunc(this);
+}
+
+namespace _func1249
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::SelectNewSector", typeid(void (StarMap::*)(int )), "!.534c8b87900800004889fb488b8f980800004c29c148c1f903", nullptr, 0, 0, &func);
 }
 
 void StarMap::SelectNewSector(int unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1248::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1249::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1249
+namespace _func1250
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GenerateSectorMap", typeid(void (StarMap::*)()), ".415741564155415455534889fb4881ec18010000488bb798080000", nullptr, 0, 0, &func);
@@ -15874,11 +15887,11 @@ namespace _func1249
 void StarMap::GenerateSectorMap()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1249::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1250::func;
 	return execfunc(this);
 }
 
-namespace _func1250
+namespace _func1251
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::DrawConnection", typeid(void (StarMap::*)(const Pointf &, const Pointf &, const GL_Color *)), ".4157415641554989d541544989f4554889fd4889d7534889cb4881ec98000000", nullptr, 0, 0, &func);
@@ -15887,11 +15900,11 @@ namespace _func1250
 void StarMap::DrawConnection(const Pointf &pos1, const Pointf &pos2, const GL_Color *color)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, const Pointf &pos1_arg, const Pointf &pos2_arg, const GL_Color *color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1250::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1251::func;
 	return execfunc(this, pos1, pos2, color);
 }
 
-namespace _func1251
+namespace _func1252
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::SetupNoFuel", typeid(void (StarMap::*)(int , const std::string &)), ".415741564989fe41554154554889d5534881ecb8000000", nullptr, 0, 0, &func);
@@ -15900,11 +15913,11 @@ namespace _func1251
 void StarMap::SetupNoFuel(int seed, const std::string &forceEscape)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int seed_arg, const std::string &forceEscape_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1251::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1252::func;
 	return execfunc(this, seed, forceEscape);
 }
 
-namespace _func1252
+namespace _func1253
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::TurnIntoFleetLocation", typeid(void (StarMap::*)(Location *)), ".41554154554889fd534889f34883ec38488b7e30", nullptr, 0, 0, &func);
@@ -15913,30 +15926,17 @@ namespace _func1252
 void StarMap::TurnIntoFleetLocation(Location *loc)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1252::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1253::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1253
+namespace _func1254
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::UpdateBoss", typeid(void (StarMap::*)()), ".554889fd534883ec288b87a00a0000", nullptr, 0, 0, &func);
 }
 
 void StarMap::UpdateBoss()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1253::func;
-	return execfunc(this);
-}
-
-namespace _func1254
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::UpdateDangerZone", typeid(void (StarMap::*)()), ".415455534889fb4883ec4080bf3c08000000", nullptr, 0, 0, &func);
-}
-
-void StarMap::UpdateDangerZone()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1254::func;
@@ -15946,17 +15946,30 @@ void StarMap::UpdateDangerZone()
 namespace _func1255
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::UpdateDangerZone", typeid(void (StarMap::*)()), ".415455534889fb4883ec4080bf3c08000000", nullptr, 0, 0, &func);
+}
+
+void StarMap::UpdateDangerZone()
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1255::func;
+	return execfunc(this);
+}
+
+namespace _func1256
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GetNewLocation", typeid(Location *(StarMap::*)()), ".5331c080bfc0000000004889fb", nullptr, 0, 0, &func);
 }
 
 Location *StarMap::GetNewLocation()
 {
 	typedef Location *(*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1255::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1256::func;
 	return execfunc(this);
 }
 
-namespace _func1256
+namespace _func1257
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::OnLoop", typeid(void (StarMap::*)()), ".41564155415455534889fb4883ec20807f0800", nullptr, 0, 0, &func);
@@ -15965,11 +15978,11 @@ namespace _func1256
 void StarMap::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1256::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1257::func;
 	return execfunc(this);
 }
 
-namespace _func1257
+namespace _func1258
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GenerateNebulas", typeid(void (StarMap::*)(const std::vector<std::string> &)), ".41574156415541544989f455534881ecb8000000", nullptr, 0, 0, &func);
@@ -15978,11 +15991,11 @@ namespace _func1257
 void StarMap::GenerateNebulas(const std::vector<std::string> &names)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, const std::vector<std::string> &names_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1257::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1258::func;
 	return execfunc(this, names);
 }
 
-namespace _func1258
+namespace _func1259
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GenerateEvents", typeid(void (StarMap::*)(bool )), ".4157415641554989fd41545589f55348bbabaaaaaaaaaaaaaa4881ec58010000", nullptr, 0, 0, &func);
@@ -15991,11 +16004,11 @@ namespace _func1258
 void StarMap::GenerateEvents(bool tutorial)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, bool tutorial_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1258::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1259::func;
 	return execfunc(this, tutorial);
 }
 
-namespace _func1259
+namespace _func1260
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::AddConnections", typeid(void (StarMap::*)(Location *)), ".415641554989fd41544c8da7800c0000554889f5534c89e34883ec10", nullptr, 0, 0, &func);
@@ -16004,11 +16017,11 @@ namespace _func1259
 void StarMap::AddConnections(Location *unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1259::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1260::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1260
+namespace _func1261
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::MapConnected", typeid(void (StarMap::*)()), ".53488bb7880c00004889fb488dbf780c0000", nullptr, 0, 0, &func);
@@ -16017,11 +16030,11 @@ namespace _func1260
 void StarMap::MapConnected()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1260::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1261::func;
 	return execfunc(this);
 }
 
-namespace _func1261
+namespace _func1262
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::ConnectLocations", typeid(void (StarMap::*)(Point , Point )), ".415741564155415455488d6f4853488d5f404883ec38", nullptr, 0, 0, &func);
@@ -16030,11 +16043,11 @@ namespace _func1261
 void StarMap::ConnectLocations(Point unk0, Point unk1)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg, Point unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1261::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1262::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1262
+namespace _func1263
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::PopulateGrid", typeid(void (StarMap::*)(Point )), ".415541544989fc5553488d5f404883ec38", nullptr, 0, 0, &func);
@@ -16043,11 +16056,11 @@ namespace _func1262
 void StarMap::PopulateGrid(Point unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1262::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1263::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1263
+namespace _func1264
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::PopClosestLoc", typeid(Location *(StarMap::*)(std::vector<Location*> &, std::map<Location*, int> &)), ".4157415641554989f541544989d455534883ec28488b4e08", nullptr, 0, 0, &func);
@@ -16056,11 +16069,11 @@ namespace _func1263
 Location *StarMap::PopClosestLoc(std::vector<Location*> &vec, std::map<Location*, int> &map)
 {
 	typedef Location *(*custom_arg_funcptr_t)(StarMap *this_arg, std::vector<Location*> &vec_arg, std::map<Location*, int> &map_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1263::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1264::func;
 	return execfunc(this, vec, map);
 }
 
-namespace _func1264
+namespace _func1265
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::AddQuest", typeid(bool (StarMap::*)(const std::string &, bool )), ".415731c941b8ffffffff415641554989fd4154554889f5534883ec78", nullptr, 0, 0, &func);
@@ -16069,11 +16082,11 @@ namespace _func1264
 bool StarMap::AddQuest(const std::string &questEvent, bool force)
 {
 	typedef bool (*custom_arg_funcptr_t)(StarMap *this_arg, const std::string &questEvent_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1264::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1265::func;
 	return execfunc(this, questEvent, force);
 }
 
-namespace _func1265
+namespace _func1266
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GenerateMap", typeid(Location *(StarMap::*)(bool , bool )), ".41574156415541544189f455534889fb4881ec38010000", nullptr, 0, 0, &func);
@@ -16082,11 +16095,11 @@ namespace _func1265
 Location *StarMap::GenerateMap(bool tutorial, bool seed)
 {
 	typedef Location *(*custom_arg_funcptr_t)(StarMap *this_arg, bool tutorial_arg, bool seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1265::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1266::func;
 	return execfunc(this, tutorial, seed);
 }
 
-namespace _func1266
+namespace _func1267
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::NewGame", typeid(Location *(StarMap::*)(bool )), ".415741564989fe41554189f5415455534883ec78", nullptr, 0, 0, &func);
@@ -16095,11 +16108,11 @@ namespace _func1266
 Location *StarMap::NewGame(bool unk0)
 {
 	typedef Location *(*custom_arg_funcptr_t)(StarMap *this_arg, bool unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1266::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1267::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1267
+namespace _func1268
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::Dijkstra", typeid(std::vector<Location*> (StarMap::*)(Location *, Location *, bool )), ".415741564155415455534881ecf8000000", nullptr, 0, 0, &func);
@@ -16108,11 +16121,11 @@ namespace _func1267
 std::vector<Location*> StarMap::Dijkstra(Location *start, Location *finish, bool include_unknown)
 {
 	typedef std::vector<Location*> (*custom_arg_funcptr_t)(StarMap *this_arg, Location *start_arg, Location *finish_arg, bool include_unknown_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1267::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1268::func;
 	return execfunc(this, start, finish, include_unknown);
 }
 
-namespace _func1268
+namespace _func1269
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::OnTouch", typeid(void (StarMap::*)(TouchAction , int , int , int , int , int )), ".41574989ff41564189ce41554589cd41544589c45589d55389f34881ec98000000", nullptr, 0, 0, &func);
@@ -16121,11 +16134,11 @@ namespace _func1268
 void StarMap::OnTouch(TouchAction unk0, int unk1, int unk2, int unk3, int unk4, int unk5)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, TouchAction unk0_arg, int unk1_arg, int unk2_arg, int unk3_arg, int unk4_arg, int unk5_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1268::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1269::func;
 	return execfunc(this, unk0, unk1, unk2, unk3, unk4, unk5);
 }
 
-namespace _func1269
+namespace _func1270
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::MouseMove", typeid(void (StarMap::*)(int , int )), ".415741564989fe41554189d541544189f455534881ec88000000", nullptr, 0, 0, &func);
@@ -16134,11 +16147,11 @@ namespace _func1269
 void StarMap::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1269::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1270::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1270
+namespace _func1271
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::RenderSectorName", typeid(void (StarMap::*)(Sector *, GL_Color )), ".4157415641554989f541544989fc55534881ecf8010000", nullptr, 0, 0, &func);
@@ -16147,11 +16160,11 @@ namespace _func1270
 void StarMap::RenderSectorName(Sector *unk0, GL_Color unk1)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg, GL_Color unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1270::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1271::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1271
+namespace _func1272
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::constructor", typeid(void (StarMap::*)()), ".41574989ff41564d8db7d80100004155", nullptr, 0, 0, &func);
@@ -16160,11 +16173,11 @@ namespace _func1271
 void StarMap::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1271::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1272::func;
 	return execfunc(this);
 }
 
-namespace _func1272
+namespace _func1273
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::LoadGame", typeid(Location *(StarMap::*)(int )), ".415741564189f64155415455534889fb89f74881ecf8030000", nullptr, 0, 0, &func);
@@ -16173,11 +16186,11 @@ namespace _func1272
 Location *StarMap::LoadGame(int fileHelper)
 {
 	typedef Location *(*custom_arg_funcptr_t)(StarMap *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1272::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1273::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1273
+namespace _func1274
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::RenderLeftInsetButton", typeid(void (StarMap::*)(float , float , bool )), ".41544189f455534889fb4883ec50", nullptr, 0, 0, &func);
@@ -16186,30 +16199,17 @@ namespace _func1273
 void StarMap::RenderLeftInsetButton(float unk0, float unk1, bool unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, float unk0_arg, float unk1_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1273::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1274::func;
 	return execfunc(this, unk0, unk1, unk2);
 }
 
-namespace _func1274
+namespace _func1275
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::RenderDistressButtons", typeid(void (StarMap::*)()), ".4156be????????41554154554889fd", nullptr, 0, 0, &func);
 }
 
 void StarMap::RenderDistressButtons()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1274::func;
-	return execfunc(this);
-}
-
-namespace _func1275
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::OnRender", typeid(void (StarMap::*)()), ".415741564155415455534889fb4881ec78010000", nullptr, 0, 0, &func);
-}
-
-void StarMap::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1275::func;
@@ -16219,17 +16219,30 @@ void StarMap::OnRender()
 namespace _func1276
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::OnRender", typeid(void (StarMap::*)()), ".415741564155415455534889fb4881ec78010000", nullptr, 0, 0, &func);
+}
+
+void StarMap::OnRender()
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1276::func;
+	return execfunc(this);
+}
+
+namespace _func1277
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StatusEffect::GetNebulaEffect", typeid(StatusEffect (*)()), "4883ec08803d????????007433660f6f05????????48b8020000000700000048ba0000000002000000", nullptr, 0, 0, &func);
 }
 
 StatusEffect StatusEffect::GetNebulaEffect()
 {
 	typedef StatusEffect (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1276::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1277::func;
 	return execfunc();
 }
 
-namespace _func1277
+namespace _func1278
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::KeyDown", typeid(bool (Store::*)(SDLKey )), "5383bf2c060000024889fb", nullptr, 0, 0, &func);
@@ -16238,30 +16251,17 @@ namespace _func1277
 bool Store::KeyDown(SDLKey key)
 {
 	typedef bool (*custom_arg_funcptr_t)(Store *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1277::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1278::func;
 	return execfunc(this, key);
 }
 
-namespace _func1278
+namespace _func1279
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::OnLoop", typeid(void (Store::*)()), ".5531c94889fd5331db4883ec08488b9778040000", nullptr, 0, 0, &func);
 }
 
 void Store::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1278::func;
-	return execfunc(this);
-}
-
-namespace _func1279
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Store::Close", typeid(void (Store::*)()), "!.534889fbc6470800488bbf48060000", nullptr, 0, 0, &func);
-}
-
-void Store::Close()
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1279::func;
@@ -16271,10 +16271,10 @@ void Store::Close()
 namespace _func1280
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Store::constructor", typeid(void (Store::*)()), ".415455534889fb488d6b284c8d63684883ec10", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Store::Close", typeid(void (Store::*)()), "!.534889fbc6470800488bbf48060000", nullptr, 0, 0, &func);
 }
 
-void Store::constructor()
+void Store::Close()
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1280::func;
@@ -16284,17 +16284,30 @@ void Store::constructor()
 namespace _func1281
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Store::constructor", typeid(void (Store::*)()), ".415455534889fb488d6b284c8d63684883ec10", nullptr, 0, 0, &func);
+}
+
+void Store::constructor()
+{
+	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1281::func;
+	return execfunc(this);
+}
+
+namespace _func1282
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Store::SaveStore", typeid(void (Store::*)(int )), ".41574156415541545589f5534889fb4883ec18", nullptr, 0, 0, &func);
 }
 
 void Store::SaveStore(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1281::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1282::func;
 	return execfunc(this, file);
 }
 
-namespace _func1282
+namespace _func1283
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::RelinkShip", typeid(void (Store::*)(ShipManager *, Equipment *)), ".41554989fd4531c041544989d4554889f55331db4883ec08", nullptr, 0, 0, &func);
@@ -16303,11 +16316,11 @@ namespace _func1282
 void Store::RelinkShip(ShipManager *ship, Equipment *equip)
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg, ShipManager *ship_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1282::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1283::func;
 	return execfunc(this, ship, equip);
 }
 
-namespace _func1283
+namespace _func1284
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::HasType", typeid(bool (Store::*)(int )), ".39b730060000", nullptr, 0, 0, &func);
@@ -16316,11 +16329,11 @@ namespace _func1283
 bool Store::HasType(int type)
 {
 	typedef bool (*custom_arg_funcptr_t)(Store *this_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1283::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1284::func;
 	return execfunc(this, type);
 }
 
-namespace _func1284
+namespace _func1285
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::Clear", typeid(void (Store::*)()), ".554889fd534883ec08488bb780040000", nullptr, 0, 0, &func);
@@ -16329,11 +16342,11 @@ namespace _func1284
 void Store::Clear()
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1284::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1285::func;
 	return execfunc(this);
 }
 
-namespace _func1285
+namespace _func1286
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::InitHeading", typeid(void (Store::*)(int , Point )), ".554863ee", nullptr, 0, 0, &func);
@@ -16342,11 +16355,11 @@ namespace _func1285
 void Store::InitHeading(int index, Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg, int index_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1285::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1286::func;
 	return execfunc(this, index, pos);
 }
 
-namespace _func1286
+namespace _func1287
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::DrawBuySellTabText", typeid(void (*)()), ".55be????????534883ec58488d54241f488d7c2440", nullptr, 0, 0, &func);
@@ -16355,11 +16368,11 @@ namespace _func1286
 void Store::DrawBuySellTabText()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1286::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1287::func;
 	return execfunc();
 }
 
-namespace _func1287
+namespace _func1288
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::SetPositions", typeid(void (Store::*)()), ".4157ba2a000000bec60000004156415541545531ed534889fb4883ec78", nullptr, 0, 0, &func);
@@ -16368,11 +16381,11 @@ namespace _func1287
 void Store::SetPositions()
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1287::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1288::func;
 	return execfunc(this);
 }
 
-namespace _func1288
+namespace _func1289
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::LoadStore", typeid(void (Store::*)(int , int )), ".4157415641554189f5415455534889fb4883ec68", nullptr, 0, 0, &func);
@@ -16381,11 +16394,11 @@ namespace _func1288
 void Store::LoadStore(int file, int worldLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg, int file_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1288::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1289::func;
 	return execfunc(this, file, worldLevel);
 }
 
-namespace _func1289
+namespace _func1290
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::SetPosition", typeid(void (Store::*)(Point )), "!.534889fb", nullptr, 0, 0, &func);
@@ -16394,11 +16407,11 @@ namespace _func1289
 void Store::SetPosition(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1289::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1290::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1290
+namespace _func1291
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::CreateStoreBoxes", typeid(void (Store::*)(int , Equipment *)), ".4157415641554189f541544989fc55534881ec88000000", nullptr, 0, 0, &func);
@@ -16407,11 +16420,11 @@ namespace _func1290
 void Store::CreateStoreBoxes(int type, Equipment *equip)
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg, int type_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1290::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1291::func;
 	return execfunc(this, type, equip);
 }
 
-namespace _func1291
+namespace _func1292
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::OnInit", typeid(void (Store::*)(ShipManager *, Equipment *, int )), "!.415641554989d541544189cc554889f553", nullptr, 0, 0, &func);
@@ -16420,30 +16433,17 @@ namespace _func1291
 void Store::OnInit(ShipManager *shopper, Equipment *equip, int worldLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg, ShipManager *shopper_arg, Equipment *equip_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1291::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1292::func;
 	return execfunc(this, shopper, equip, worldLevel);
 }
 
-namespace _func1292
+namespace _func1293
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::MouseMove", typeid(void (Store::*)(int , int )), ".415741564189d641554189f5415455534889fb4883ec78", nullptr, 0, 0, &func);
 }
 
 void Store::MouseMove(int x, int y)
-{
-	typedef void (*custom_arg_funcptr_t)(Store *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1292::func;
-	return execfunc(this, x, y);
-}
-
-namespace _func1293
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Store::MouseClick", typeid(void (Store::*)(int , int )), ".41564189d641554189f5415455534889fb4883ec40", nullptr, 0, 0, &func);
-}
-
-void Store::MouseClick(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg, int x_arg, int y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1293::func;
@@ -16453,23 +16453,23 @@ void Store::MouseClick(int x, int y)
 namespace _func1294
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Store::OnRender", typeid(void (Store::*)()), ".415741564989fe4155415455534881ecd8010000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Store::MouseClick", typeid(void (Store::*)(int , int )), ".41564189d641554189f5415455534889fb4883ec40", nullptr, 0, 0, &func);
 }
 
-void Store::OnRender()
+void Store::MouseClick(int x, int y)
 {
-	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
+	typedef void (*custom_arg_funcptr_t)(Store *this_arg, int x_arg, int y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1294::func;
-	return execfunc(this);
+	return execfunc(this, x, y);
 }
 
 namespace _func1295
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Store::destructor", typeid(void (Store::*)()), ".415531c94154554889fd5331db4883ec18", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Store::OnRender", typeid(void (Store::*)()), ".415741564989fe4155415455534881ecd8010000", nullptr, 0, 0, &func);
 }
 
-void Store::destructor()
+void Store::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1295::func;
@@ -16479,17 +16479,30 @@ void Store::destructor()
 namespace _func1296
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Store::destructor", typeid(void (Store::*)()), ".415531c94154554889fd5331db4883ec18", nullptr, 0, 0, &func);
+}
+
+void Store::destructor()
+{
+	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1296::func;
+	return execfunc(this);
+}
+
+namespace _func1297
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StoreBox::MouseClick", typeid(void (StoreBox::*)(int , int )), "807f60007412807f6100740c", nullptr, 0, 0, &func);
 }
 
 void StoreBox::MouseClick(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1296::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1297::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1297
+namespace _func1298
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StoreBox::Activate", typeid(void (StoreBox::*)()), ".4883ec28488b8718010000", nullptr, 0, 0, &func);
@@ -16498,11 +16511,11 @@ namespace _func1297
 void StoreBox::Activate()
 {
 	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1297::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1298::func;
 	return execfunc(this);
 }
 
-namespace _func1298
+namespace _func1299
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StoreBox::SetPosition", typeid(void (StoreBox::*)(Point )), ".554889f248c1fa2053488d5f184883ec18", nullptr, 0, 0, &func);
@@ -16511,11 +16524,11 @@ namespace _func1298
 void StoreBox::SetPosition(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1298::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1299::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1299
+namespace _func1300
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StoreBox::InitBlueprint", typeid(void (StoreBox::*)(Blueprint *)), ".554889f5488d7610534889fb488dbfb0000000", nullptr, 0, 0, &func);
@@ -16524,11 +16537,11 @@ namespace _func1299
 void StoreBox::InitBlueprint(Blueprint *bp)
 {
 	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg, Blueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1299::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1300::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1300
+namespace _func1301
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StoreBox::constructor", typeid(void (StoreBox::*)(const std::string &, ShipManager *, Equipment *)), ".41574989d7415641554989f5415455534889fb", nullptr, 0, 0, &func);
@@ -16537,30 +16550,17 @@ namespace _func1300
 void StoreBox::constructor(const std::string &buttonImage, ShipManager *shopper, Equipment *equip)
 {
 	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg, const std::string &buttonImage_arg, ShipManager *shopper_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1300::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1301::func;
 	return execfunc(this, buttonImage, shopper, equip);
 }
 
-namespace _func1301
+namespace _func1302
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StoreBox::OnLoop", typeid(void (StoreBox::*)()), "!.538b871001000031f64889fb85c0", nullptr, 0, 0, &func);
 }
 
 void StoreBox::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1301::func;
-	return execfunc(this);
-}
-
-namespace _func1302
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StoreBox::Purchase", typeid(void (StoreBox::*)()), ".534889fbbe", nullptr, 0, 0, &func);
-}
-
-void StoreBox::Purchase()
 {
 	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1302::func;
@@ -16570,10 +16570,10 @@ void StoreBox::Purchase()
 namespace _func1303
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StoreBox::OnRender", typeid(void (StoreBox::*)()), ".415741564155415455534889fb488d7f184881ecc8040000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StoreBox::Purchase", typeid(void (StoreBox::*)()), ".534889fbbe", nullptr, 0, 0, &func);
 }
 
-void StoreBox::OnRender()
+void StoreBox::Purchase()
 {
 	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1303::func;
@@ -16583,17 +16583,30 @@ void StoreBox::OnRender()
 namespace _func1304
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StoreBox::OnRender", typeid(void (StoreBox::*)()), ".415741564155415455534889fb488d7f184881ecc8040000", nullptr, 0, 0, &func);
+}
+
+void StoreBox::OnRender()
+{
+	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1304::func;
+	return execfunc(this);
+}
+
+namespace _func1305
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("SuperShieldDrone::constructor", typeid(void (SuperShieldDrone::*)(int , int , DroneBlueprint *)), "53??89fb??83ec??e8??????????8d????0e??8d????10????????????c703??????????c74340??????????c74350????????e8??????????8dbbc8040000", nullptr, 0, 0, &func);
 }
 
 void SuperShieldDrone::constructor(int iShipId, int selfId, DroneBlueprint *blueprint)
 {
 	typedef void (*custom_arg_funcptr_t)(SuperShieldDrone *this_arg, int iShipId_arg, int selfId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1304::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1305::func;
 	return execfunc(this, iShipId, selfId, blueprint);
 }
 
-namespace _func1305
+namespace _func1306
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SuperShieldDrone::OnLoop", typeid(void (SuperShieldDrone::*)()), "534889fb4883ec30e813fdff", nullptr, 0, 0, &func);
@@ -16602,11 +16615,11 @@ namespace _func1305
 void SuperShieldDrone::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(SuperShieldDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1305::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1306::func;
 	return execfunc(this);
 }
 
-namespace _func1306
+namespace _func1307
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemBox::OnRender", typeid(void (SystemBox::*)(bool )), "4157b8010000004156415541545589f5534889fb4883ec58", nullptr, 0, 0, &func);
@@ -16615,11 +16628,11 @@ namespace _func1306
 void SystemBox::OnRender(bool ignoreStatus)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemBox *this_arg, bool ignoreStatus_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1306::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1307::func;
 	return execfunc(this, ignoreStatus);
 }
 
-namespace _func1307
+namespace _func1308
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemBox::MouseClick", typeid(bool (SystemBox::*)(bool )), ".41544189f4554889fd5331db4883ec20", nullptr, 0, 0, &func);
@@ -16628,11 +16641,11 @@ namespace _func1307
 bool SystemBox::MouseClick(bool shift)
 {
 	typedef bool (*custom_arg_funcptr_t)(SystemBox *this_arg, bool shift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1307::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1308::func;
 	return execfunc(this, shift);
 }
 
-namespace _func1308
+namespace _func1309
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemBox::constructor", typeid(void (SystemBox::*)(Point , ShipSystem *, bool )), ".4157415641be01000000415541544189cc55534889fb", nullptr, 0, 0, &func);
@@ -16641,11 +16654,11 @@ namespace _func1308
 void SystemBox::constructor(Point pos, ShipSystem *sys, bool playerUI)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, bool playerUI_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1308::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1309::func;
 	return execfunc(this, pos, sys, playerUI);
 }
 
-namespace _func1309
+namespace _func1310
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemBox::KeyDown", typeid(void (SystemBox::*)(SDLKey , bool )), ".415541544189d45589f5534889fb4883ec38", nullptr, 0, 0, &func);
@@ -16654,11 +16667,11 @@ namespace _func1309
 void SystemBox::KeyDown(SDLKey key, bool shift)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemBox *this_arg, SDLKey key_arg, bool shift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1309::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1310::func;
 	return execfunc(this, key, shift);
 }
 
-namespace _func1310
+namespace _func1311
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemBox::MouseMove", typeid(void (SystemBox::*)(int , int )), ".5589f5534889fb4883ec388b87ac010000", nullptr, 0, 0, &func);
@@ -16667,11 +16680,11 @@ namespace _func1310
 void SystemBox::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1310::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1311::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1311
+namespace _func1312
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemControl::GetSystemBox", typeid(SystemBox *(SystemControl::*)(int )), "415531d24989fd41545589f55331db4883ec08488b4f10488b47184829c848c1f8034885c07522eb57", nullptr, 0, 0, &func);
@@ -16680,11 +16693,11 @@ namespace _func1311
 SystemBox *SystemControl::GetSystemBox(int systemId)
 {
 	typedef SystemBox *(*custom_arg_funcptr_t)(SystemControl *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1311::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1312::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1312
+namespace _func1313
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemControl::GetPowerBars", typeid(SystemControl::PowerBars *(*)(int , int , int , bool )), ".41574189f24189d34189cf415641554c63ee41545589fd534863df4989d84889d84881ec88000000", nullptr, 0, 0, &func);
@@ -16693,11 +16706,11 @@ namespace _func1312
 SystemControl::PowerBars *SystemControl::GetPowerBars(int width, int height, int gap, bool useShieldGap)
 {
 	typedef SystemControl::PowerBars *(*custom_arg_funcptr_t)(int width_arg, int height_arg, int gap_arg, bool useShieldGap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1312::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1313::func;
 	return execfunc(width, height, gap, useShieldGap);
 }
 
-namespace _func1313
+namespace _func1314
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemControl::RenderPowerBar", typeid(void (SystemControl::*)()), ".415741564989fe4155415455534883ec28488b3f", nullptr, 0, 0, &func);
@@ -16706,11 +16719,11 @@ namespace _func1313
 void SystemControl::RenderPowerBar()
 {
 	typedef void (*custom_arg_funcptr_t)(SystemControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1313::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1314::func;
 	return execfunc(this);
 }
 
-namespace _func1314
+namespace _func1315
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemControl::CreateSystemBoxes", typeid(void (SystemControl::*)()), ".415731d231f641564155415455534889fb4883ec58488d7c2430", nullptr, 0, 0, &func);
@@ -16719,25 +16732,25 @@ namespace _func1314
 void SystemControl::CreateSystemBoxes()
 {
 	typedef void (*custom_arg_funcptr_t)(SystemControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1314::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1315::func;
 	return execfunc(this);
 }
 
 Point *Global_SystemControl_weapon_position;
 
-namespace _var1315
+namespace _var1316
 {
     static VariableDefinition varObj("Global_SystemControl_weapon_position", "!488b442430488d7c243031d231f6488905(???????\?)e8????????488b442430488b7318488b5310488905(???????\?)", &Global_SystemControl_weapon_position, true, true);
 }
 
 Point *Global_SystemControl_drone_position;
 
-namespace _var1316
+namespace _var1317
 {
     static VariableDefinition varObj("Global_SystemControl_drone_position", "", &Global_SystemControl_drone_position, true, true);
 }
 
-namespace _func1317
+namespace _func1318
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemCustomBox::constructor", typeid(void (SystemCustomBox::*)(Point , ShipSystem *, ShipManager *)), "41544989cc31c9554889f5534889fb4883ec40", nullptr, 0, 0, &func);
@@ -16746,11 +16759,11 @@ namespace _func1317
 void SystemCustomBox::constructor(Point pos, ShipSystem *sys, ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemCustomBox *this_arg, Point pos_arg, ShipSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1317::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1318::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func1318
+namespace _func1319
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemStoreBox::CanHold", typeid(bool (SystemStoreBox::*)()), "534883bf18010000004889fb", nullptr, 0, 0, &func);
@@ -16759,11 +16772,11 @@ namespace _func1318
 bool SystemStoreBox::CanHold()
 {
 	typedef bool (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1318::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1319::func;
 	return execfunc(this);
 }
 
-namespace _func1319
+namespace _func1320
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemStoreBox::SetExtraData", typeid(void (SystemStoreBox::*)(int )), ".55534889fb4883ec38837f0804", nullptr, 0, 0, &func);
@@ -16772,11 +16785,11 @@ namespace _func1319
 void SystemStoreBox::SetExtraData(int droneChoice)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, int droneChoice_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1319::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1320::func;
 	return execfunc(this, droneChoice);
 }
 
-namespace _func1320
+namespace _func1321
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemStoreBox::Activate", typeid(void (SystemStoreBox::*)()), ".534889fb4883ec20488bbf180100008b83e0000000", nullptr, 0, 0, &func);
@@ -16785,11 +16798,11 @@ namespace _func1320
 void SystemStoreBox::Activate()
 {
 	typedef void (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1320::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1321::func;
 	return execfunc(this);
 }
 
-namespace _func1321
+namespace _func1322
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemStoreBox::constructor", typeid(void (SystemStoreBox::*)(ShipManager *, Equipment *, int )), ".41568d41fa41554989d541544989f45589cd534889fb4883ec5083f802", nullptr, 0, 0, &func);
@@ -16798,11 +16811,11 @@ namespace _func1321
 void SystemStoreBox::constructor(ShipManager *shopper, Equipment *equip, int sys)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, ShipManager *shopper_arg, Equipment *equip_arg, int sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1321::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1322::func;
 	return execfunc(this, shopper, equip, sys);
 }
 
-namespace _func1322
+namespace _func1323
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemStoreBox::Purchase", typeid(void (SystemStoreBox::*)()), ".534889fb4883ec30e8????????8b7308", nullptr, 0, 0, &func);
@@ -16811,11 +16824,11 @@ namespace _func1322
 void SystemStoreBox::Purchase()
 {
 	typedef void (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1322::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1323::func;
 	return execfunc(this);
 }
 
-namespace _func1323
+namespace _func1324
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemStoreBox::MouseMove", typeid(void (SystemStoreBox::*)(int , int )), ".41544189d45589f5534889fb4883ec308b8710010000", nullptr, 0, 0, &func);
@@ -16824,11 +16837,11 @@ namespace _func1323
 void SystemStoreBox::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1323::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1324::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1324
+namespace _func1325
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TabbedWindow::Close", typeid(void (TabbedWindow::*)()), "538b57684889fb488b4738", nullptr, 0, 0, &func);
@@ -16837,11 +16850,11 @@ namespace _func1324
 void TabbedWindow::Close()
 {
 	typedef void (*custom_arg_funcptr_t)(TabbedWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1324::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1325::func;
 	return execfunc(this);
 }
 
-namespace _func1325
+namespace _func1326
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportBox::constructor", typeid(void (TeleportBox::*)(Point , TeleportSystem *)), "4155b9010000004989d5415455534889fb4c8da370020000488dab000300004883ec58", nullptr, 0, 0, &func);
@@ -16850,11 +16863,11 @@ namespace _func1325
 void TeleportBox::constructor(Point pos, TeleportSystem *sys)
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportBox *this_arg, Point pos_arg, TeleportSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1325::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1326::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func1326
+namespace _func1327
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::Jump", typeid(void (TeleportSystem::*)()), "534889fbe8????????c78344020000000000005b", nullptr, 0, 0, &func);
@@ -16863,11 +16876,11 @@ namespace _func1326
 void TeleportSystem::Jump()
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1326::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1327::func;
 	return execfunc(this);
 }
 
-namespace _func1327
+namespace _func1328
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::SetHackingLevel", typeid(void (TeleportSystem::*)(int )), ".5589f5534889fb4883ec0883fe017e09", nullptr, 0, 0, &func);
@@ -16876,11 +16889,11 @@ namespace _func1327
 void TeleportSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1327::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1328::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func1328
+namespace _func1329
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::OnRenderFloor", typeid(void (TeleportSystem::*)()), ".415741564155415455534889fb4883ec38", nullptr, 0, 0, &func);
@@ -16889,11 +16902,11 @@ namespace _func1328
 void TeleportSystem::OnRenderFloor()
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1328::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1329::func;
 	return execfunc(this);
 }
 
-namespace _func1329
+namespace _func1330
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::constructor", typeid(void (TeleportSystem::*)(int , int , int , int )), ".5589d5534889fb4883ec08", nullptr, 0, 0, &func);
@@ -16902,11 +16915,11 @@ namespace _func1329
 void TeleportSystem::constructor(int systemId, int roomId, int shipId, int startingPower)
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int systemId_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1329::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1330::func;
 	return execfunc(this, systemId, roomId, shipId, startingPower);
 }
 
-namespace _func1330
+namespace _func1331
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::GetChargedPercent", typeid(float (TeleportSystem::*)()), ".f30f108744020000", nullptr, 0, 0, &func);
@@ -16915,11 +16928,11 @@ namespace _func1330
 float TeleportSystem::GetChargedPercent()
 {
 	typedef float (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1330::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1331::func;
 	return execfunc(this);
 }
 
-namespace _func1331
+namespace _func1332
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::Charged", typeid(bool (TeleportSystem::*)()), ".534889fb", nullptr, 0, 0, &func);
@@ -16928,11 +16941,11 @@ namespace _func1331
 bool TeleportSystem::Charged()
 {
 	typedef bool (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1331::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1332::func;
 	return execfunc(this);
 }
 
-namespace _func1332
+namespace _func1333
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::ClearCrewLocations", typeid(void (TeleportSystem::*)()), ".41564155415455534c63a77c0200004889fb", nullptr, 0, 0, &func);
@@ -16941,11 +16954,11 @@ namespace _func1332
 void TeleportSystem::ClearCrewLocations()
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1332::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1333::func;
 	return execfunc(this);
 }
 
-namespace _func1333
+namespace _func1334
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::UpdateCrewLocation", typeid(void (TeleportSystem::*)(int )), ".488b97500200004863c689f148c1e806488d14c2b801000000", nullptr, 0, 0, &func);
@@ -16954,11 +16967,11 @@ namespace _func1333
 void TeleportSystem::UpdateCrewLocation(int unk)
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1333::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1334::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1334
+namespace _func1335
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::SetArmed", typeid(void (TeleportSystem::*)(int )), ".534889fb4883ec3083fe01", nullptr, 0, 0, &func);
@@ -16967,11 +16980,11 @@ namespace _func1334
 void TeleportSystem::SetArmed(int armed)
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int armed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1334::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1335::func;
 	return execfunc(this, armed);
 }
 
-namespace _func1335
+namespace _func1336
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::ForceReady", typeid(void (TeleportSystem::*)()), "!.c787440200000000c84231f6", nullptr, 0, 0, &func);
@@ -16980,19 +16993,6 @@ namespace _func1335
 void TeleportSystem::ForceReady()
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1335::func;
-	return execfunc(this);
-}
-
-namespace _func1336
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("TeleportSystem::CanSend", typeid(bool (TeleportSystem::*)()), ".534889fb4883ec308b4f1885c9", nullptr, 0, 0, &func);
-}
-
-bool TeleportSystem::CanSend()
-{
-	typedef bool (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1336::func;
 	return execfunc(this);
 }
@@ -17000,10 +17000,10 @@ bool TeleportSystem::CanSend()
 namespace _func1337
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TeleportSystem::CanReceive", typeid(bool (TeleportSystem::*)()), ".5589f5534889fb4883ec0880bf4902000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TeleportSystem::CanSend", typeid(bool (TeleportSystem::*)()), ".534889fb4883ec308b4f1885c9", nullptr, 0, 0, &func);
 }
 
-bool TeleportSystem::CanReceive()
+bool TeleportSystem::CanSend()
 {
 	typedef bool (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1337::func;
@@ -17013,12 +17013,12 @@ bool TeleportSystem::CanReceive()
 namespace _func1338
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TeleportSystem::OnLoop", typeid(void (TeleportSystem::*)()), ".534889fb4883ec30", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TeleportSystem::CanReceive", typeid(bool (TeleportSystem::*)()), ".5589f5534889fb4883ec0880bf4902000000", nullptr, 0, 0, &func);
 }
 
-void TeleportSystem::OnLoop()
+bool TeleportSystem::CanReceive()
 {
-	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
+	typedef bool (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1338::func;
 	return execfunc(this);
 }
@@ -17026,10 +17026,10 @@ void TeleportSystem::OnLoop()
 namespace _func1339
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TeleportSystem::InitiateTeleport", typeid(void (TeleportSystem::*)()), ".534889fb4883ec20", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TeleportSystem::OnLoop", typeid(void (TeleportSystem::*)()), ".534889fb4883ec30", nullptr, 0, 0, &func);
 }
 
-void TeleportSystem::InitiateTeleport()
+void TeleportSystem::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1339::func;
@@ -17039,17 +17039,30 @@ void TeleportSystem::InitiateTeleport()
 namespace _func1340
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("TeleportSystem::InitiateTeleport", typeid(void (TeleportSystem::*)()), ".534889fb4883ec20", nullptr, 0, 0, &func);
+}
+
+void TeleportSystem::InitiateTeleport()
+{
+	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1340::func;
+	return execfunc(this);
+}
+
+namespace _func1341
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::ResetPrimitives", typeid(void (TextButton::*)()), "554889fd5331db4883ec08488b7c1d50", nullptr, 0, 0, &func);
 }
 
 void TextButton::ResetPrimitives()
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1340::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1341::func;
 	return execfunc(this);
 }
 
-namespace _func1341
+namespace _func1342
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::GetIdealButtonWidth", typeid(int (TextButton::*)()), "55534889fb4883ec3880bfe800000000", nullptr, 0, 0, &func);
@@ -17058,11 +17071,11 @@ namespace _func1341
 int TextButton::GetIdealButtonWidth()
 {
 	typedef int (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1341::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1342::func;
 	return execfunc(this);
 }
 
-namespace _func1342
+namespace _func1343
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::OnInit", typeid(void (TextButton::*)(Point , Point , int , TextString *, int )), "415741564d89c641554989d541544989f44c89c6554489cd534889fb488dbfe0000000", nullptr, 0, 0, &func);
@@ -17071,30 +17084,17 @@ namespace _func1342
 void TextButton::OnInit(Point pos, Point size, int cornerInset, TextString *buttonLabel, int font)
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, Point pos_arg, Point size_arg, int cornerInset_arg, TextString *buttonLabel_arg, int font_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1342::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1343::func;
 	return execfunc(this, pos, size, cornerInset, buttonLabel, font);
 }
 
-namespace _func1343
+namespace _func1344
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::OnRender", typeid(void (TextButton::*)()), "4157415641554989fd415455534883ec5880bfd000000000", nullptr, 0, 0, &func);
 }
 
 void TextButton::OnRender()
-{
-	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1343::func;
-	return execfunc(this);
-}
-
-namespace _func1344
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("TextButton::destructor", typeid(void (TextButton::*)()), "534889fb4883ec1048c707????????488b7f50", nullptr, 0, 0, &func);
-}
-
-void TextButton::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1344::func;
@@ -17104,17 +17104,30 @@ void TextButton::destructor()
 namespace _func1345
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("TextButton::destructor", typeid(void (TextButton::*)()), "534889fb4883ec1048c707????????488b7f50", nullptr, 0, 0, &func);
+}
+
+void TextButton::destructor()
+{
+	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1345::func;
+	return execfunc(this);
+}
+
+namespace _func1346
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::GetSize", typeid(Point (TextButton::*)()), "4155415455534889fb4883ec1880bfd000000000751a", nullptr, 0, 0, &func);
 }
 
 Point TextButton::GetSize()
 {
 	typedef Point (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1345::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1346::func;
 	return execfunc(this);
 }
 
-namespace _func1346
+namespace _func1347
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::OnInitRect", typeid(void (TextButton::*)(Globals::Rect &, int , TextString &, int )), "41574156415541544989cc554889f5534889fb4883ec488954240c", nullptr, 0, 0, &func);
@@ -17123,11 +17136,11 @@ namespace _func1346
 void TextButton::OnInitRect(Globals::Rect &rect, int cornerInset, TextString &buttonLabel, int font)
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, Globals::Rect &rect_arg, int cornerInset_arg, TextString &buttonLabel_arg, int font_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1346::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1347::func;
 	return execfunc(this, rect, cornerInset, buttonLabel, font);
 }
 
-namespace _func1347
+namespace _func1348
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::SetBaseImage", typeid(void (TextButton::*)(const std::string &, Point , int )), "4154488b065553488378e800", nullptr, 0, 0, &func);
@@ -17136,11 +17149,11 @@ namespace _func1347
 void TextButton::SetBaseImage(const std::string &name, Point pos, int autoWidthMin)
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, const std::string &name_arg, Point pos_arg, int autoWidthMin_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1347::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1348::func;
 	return execfunc(this, name, pos, autoWidthMin);
 }
 
-namespace _func1348
+namespace _func1349
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::SetAutoWidth", typeid(void (TextButton::*)(bool , bool , int , int )), "4585c04088b7d0000000", nullptr, 0, 0, &func);
@@ -17149,30 +17162,17 @@ namespace _func1348
 void TextButton::SetAutoWidth(bool autoWidth, bool autoRightAlign, int margin, int min)
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, bool autoWidth_arg, bool autoRightAlign_arg, int margin_arg, int min_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1348::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1349::func;
 	return execfunc(this, autoWidth, autoRightAlign, margin, min);
 }
 
-namespace _func1349
+namespace _func1350
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::UpdateAutoWidth", typeid(void (TextButton::*)()), ".4155415455534889fb4883ec1880bfd000000000", nullptr, 0, 0, &func);
 }
 
 void TextButton::UpdateAutoWidth()
-{
-	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1349::func;
-	return execfunc(this);
-}
-
-namespace _func1350
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("TextButton::constructor", typeid(void (TextButton::*)()), "55534889fb488d7f08488d6b284883ec28", nullptr, 0, 0, &func);
-}
-
-void TextButton::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1350::func;
@@ -17182,23 +17182,23 @@ void TextButton::constructor()
 namespace _func1351
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TextButton::SetInactiveColor", typeid(void (TextButton::*)(GL_Color )), ".!80bf8000000000660fd64c24f0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TextButton::constructor", typeid(void (TextButton::*)()), "55534889fb488d7f08488d6b284883ec28", nullptr, 0, 0, &func);
 }
 
-void TextButton::SetInactiveColor(GL_Color color)
+void TextButton::constructor()
 {
-	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
+	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1351::func;
-	return execfunc(this, color);
+	return execfunc(this);
 }
 
 namespace _func1352
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TextButton::SetActiveColor", typeid(void (TextButton::*)(GL_Color )), ".!80bf8000000000660fd64c24f0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TextButton::SetInactiveColor", typeid(void (TextButton::*)(GL_Color )), ".!80bf8000000000660fd64c24f0", nullptr, 0, 0, &func);
 }
 
-void TextButton::SetActiveColor(GL_Color color)
+void TextButton::SetInactiveColor(GL_Color color)
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1352::func;
@@ -17208,10 +17208,10 @@ void TextButton::SetActiveColor(GL_Color color)
 namespace _func1353
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TextButton::SetSelectedColor", typeid(void (TextButton::*)(GL_Color )), ".!80bf8000000000660fd64c24f0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TextButton::SetActiveColor", typeid(void (TextButton::*)(GL_Color )), ".!80bf8000000000660fd64c24f0", nullptr, 0, 0, &func);
 }
 
-void TextButton::SetSelectedColor(GL_Color color)
+void TextButton::SetActiveColor(GL_Color color)
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1353::func;
@@ -17221,10 +17221,10 @@ void TextButton::SetSelectedColor(GL_Color color)
 namespace _func1354
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TextButton::SetTextColor", typeid(void (TextButton::*)(GL_Color )), ".80bf8000000000660fd64c24f8", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TextButton::SetSelectedColor", typeid(void (TextButton::*)(GL_Color )), ".!80bf8000000000660fd64c24f0", nullptr, 0, 0, &func);
 }
 
-void TextButton::SetTextColor(GL_Color color)
+void TextButton::SetSelectedColor(GL_Color color)
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1354::func;
@@ -17234,17 +17234,30 @@ void TextButton::SetTextColor(GL_Color color)
 namespace _func1355
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("TextButton::SetTextColor", typeid(void (TextButton::*)(GL_Color )), ".80bf8000000000660fd64c24f8", nullptr, 0, 0, &func);
+}
+
+void TextButton::SetTextColor(GL_Color color)
+{
+	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1355::func;
+	return execfunc(this, color);
+}
+
+namespace _func1356
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::InitPrimitives", typeid(void (TextButton::*)()), "415741564989fe4155415455534881ecb800000080bf8000000000", nullptr, 0, 0, &func);
 }
 
 void TextButton::InitPrimitives()
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1355::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1356::func;
 	return execfunc(this);
 }
 
-namespace _func1356
+namespace _func1357
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextInput::constructor", typeid(void (TextInput::*)(int , TextInput::AllowedCharType , const std::string &)), "!41544189d45589f54889ce534889fb", nullptr, 0, 0, &func);
@@ -17253,11 +17266,11 @@ namespace _func1356
 void TextInput::constructor(int maxChars, TextInput::AllowedCharType allowedCharType, const std::string &prompt)
 {
 	typedef void (*custom_arg_funcptr_t)(TextInput *this_arg, int maxChars_arg, TextInput::AllowedCharType allowedCharType_arg, const std::string &prompt_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1356::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1357::func;
 	return execfunc(this, maxChars, allowedCharType, prompt);
 }
 
-namespace _func1357
+namespace _func1358
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextInput::OnRender", typeid(void (TextInput::*)(int , Point )), ".4156b9ffffffff41554189f54889fe41544989d431d255534889fb4883ec70", nullptr, 0, 0, &func);
@@ -17266,11 +17279,11 @@ namespace _func1357
 void TextInput::OnRender(int font, Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(TextInput *this_arg, int font_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1357::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1358::func;
 	return execfunc(this, font, pos);
 }
 
-namespace _func1358
+namespace _func1359
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextInput::OnLoop", typeid(void (TextInput::*)()), ".!538b473839473c", nullptr, 0, 0, &func);
@@ -17279,11 +17292,11 @@ namespace _func1358
 void TextInput::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1358::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1359::func;
 	return execfunc(this);
 }
 
-namespace _func1359
+namespace _func1360
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextInput::OnTextEvent", typeid(void (TextInput::*)(CEvent::TextEvent )), ".53807f40004889fb", nullptr, 0, 0, &func);
@@ -17292,11 +17305,11 @@ namespace _func1359
 void TextInput::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void (*custom_arg_funcptr_t)(TextInput *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1359::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1360::func;
 	return execfunc(this, event);
 }
 
-namespace _func1360
+namespace _func1361
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextInput::GetActive", typeid(bool (TextInput::*)()), ".!0fb64740c3", nullptr, 0, 0, &func);
@@ -17305,11 +17318,11 @@ namespace _func1360
 bool TextInput::GetActive()
 {
 	typedef bool (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1360::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1361::func;
 	return execfunc(this);
 }
 
-namespace _func1361
+namespace _func1362
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextInput::GetText", typeid(std::string (TextInput::*)()), ".53b9ffffffff4889fb31d2", nullptr, 0, 0, &func);
@@ -17318,19 +17331,6 @@ namespace _func1361
 std::string TextInput::GetText()
 {
 	typedef std::string (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1361::func;
-	return execfunc(this);
-}
-
-namespace _func1362
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("TextInput::Start", typeid(void (TextInput::*)()), ".534883ec30488b4710482b4708", nullptr, 0, 0, &func);
-}
-
-void TextInput::Start()
-{
-	typedef void (*custom_arg_funcptr_t)(TextInput *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1362::func;
 	return execfunc(this);
 }
@@ -17338,10 +17338,10 @@ void TextInput::Start()
 namespace _func1363
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TextInput::Stop", typeid(void (TextInput::*)()), ".!c6474000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TextInput::Start", typeid(void (TextInput::*)()), ".534883ec30488b4710482b4708", nullptr, 0, 0, &func);
 }
 
-void TextInput::Stop()
+void TextInput::Start()
 {
 	typedef void (*custom_arg_funcptr_t)(TextInput *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1363::func;
@@ -17351,17 +17351,30 @@ void TextInput::Stop()
 namespace _func1364
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("TextInput::Stop", typeid(void (TextInput::*)()), ".!c6474000", nullptr, 0, 0, &func);
+}
+
+void TextInput::Stop()
+{
+	typedef void (*custom_arg_funcptr_t)(TextInput *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1364::func;
+	return execfunc(this);
+}
+
+namespace _func1365
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("TextInput::SetText", typeid(int (TextInput::*)(const std::string &)), ".55488d6f08534889fb4883ec28", nullptr, 0, 0, &func);
 }
 
 int TextInput::SetText(const std::string &text)
 {
 	typedef int (*custom_arg_funcptr_t)(TextInput *this_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1364::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1365::func;
 	return execfunc(this, text);
 }
 
-namespace _func1365
+namespace _func1366
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextInput::OnTextInput", typeid(void (TextInput::*)(int )), ".41564155415455534889fb4883ec30807f4000", nullptr, 0, 0, &func);
@@ -17370,11 +17383,11 @@ namespace _func1365
 void TextInput::OnTextInput(int asciiChar)
 {
 	typedef void (*custom_arg_funcptr_t)(TextInput *this_arg, int asciiChar_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1365::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1366::func;
 	return execfunc(this, asciiChar);
 }
 
-namespace _func1366
+namespace _func1367
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextLibrary::GetText", typeid(std::string (TextLibrary::*)(const std::string &, const std::string &)), "41574156415541544989fc5553488d5e384883ec48", nullptr, 0, 0, &func);
@@ -17383,11 +17396,11 @@ namespace _func1366
 std::string TextLibrary::GetText(const std::string &name, const std::string &lang)
 {
 	typedef std::string (*custom_arg_funcptr_t)(TextLibrary *this_arg, const std::string &name_arg, const std::string &lang_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1366::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1367::func;
 	return execfunc(this, name, lang);
 }
 
-namespace _func1367
+namespace _func1368
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextString::GetText", typeid(std::string (TextString::*)()), "53807e08004889fb", nullptr, 0, 0, &func);
@@ -17396,11 +17409,11 @@ namespace _func1367
 std::string TextString::GetText()
 {
 	typedef std::string (*custom_arg_funcptr_t)(TextString *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1367::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1368::func;
 	return execfunc(this);
 }
 
-namespace _func1368
+namespace _func1369
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TimerHelper::Start", typeid(void (TimerHelper::*)(int )), "83feffc6471101c7470800000000", nullptr, 0, 0, &func);
@@ -17409,11 +17422,11 @@ namespace _func1368
 void TimerHelper::Start(int goal)
 {
 	typedef void (*custom_arg_funcptr_t)(TimerHelper *this_arg, int goal_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1368::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1369::func;
 	return execfunc(this, goal);
 }
 
-namespace _func1369
+namespace _func1370
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TimerHelper::Running", typeid(bool (TimerHelper::*)()), "!.0fb64711c3", nullptr, 0, 0, &func);
@@ -17422,11 +17435,11 @@ namespace _func1369
 bool TimerHelper::Running()
 {
 	typedef bool (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1369::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1370::func;
 	return execfunc(this);
 }
 
-namespace _func1370
+namespace _func1371
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TimerHelper::ResetMinMax", typeid(void (TimerHelper::*)(int , int )), ".8917897704", nullptr, 0, 0, &func);
@@ -17435,11 +17448,11 @@ namespace _func1370
 void TimerHelper::ResetMinMax(int min, int max)
 {
 	typedef void (*custom_arg_funcptr_t)(TimerHelper *this_arg, int min_arg, int max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1370::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1371::func;
 	return execfunc(this, min, max);
 }
 
-namespace _func1371
+namespace _func1372
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TimerHelper::SetMaxTime", typeid(void (TimerHelper::*)(float )), ".f30f104f08f30f5e4f0c", nullptr, 0, 0, &func);
@@ -17448,30 +17461,17 @@ namespace _func1371
 void TimerHelper::SetMaxTime(float max)
 {
 	typedef void (*custom_arg_funcptr_t)(TimerHelper *this_arg, float max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1371::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1372::func;
 	return execfunc(this, max);
 }
 
-namespace _func1372
+namespace _func1373
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TimerHelper::Stop", typeid(void (TimerHelper::*)()), "!.c6471100c3", nullptr, 0, 0, &func);
 }
 
 void TimerHelper::Stop()
-{
-	typedef void (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1372::func;
-	return execfunc(this);
-}
-
-namespace _func1373
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("TimerHelper::Update", typeid(void (TimerHelper::*)()), ".53807f11004889fb", nullptr, 0, 0, &func);
-}
-
-void TimerHelper::Update()
 {
 	typedef void (*custom_arg_funcptr_t)(TimerHelper *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1373::func;
@@ -17481,17 +17481,30 @@ void TimerHelper::Update()
 namespace _func1374
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("TimerHelper::Update", typeid(void (TimerHelper::*)()), ".53807f11004889fb", nullptr, 0, 0, &func);
+}
+
+void TimerHelper::Update()
+{
+	typedef void (*custom_arg_funcptr_t)(TimerHelper *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1374::func;
+	return execfunc(this);
+}
+
+namespace _func1375
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("TimerHelper::Done", typeid(bool (TimerHelper::*)()), ".0fb6471184c0", nullptr, 0, 0, &func);
 }
 
 bool TimerHelper::Done()
 {
 	typedef bool (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1374::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1375::func;
 	return execfunc(this);
 }
 
-namespace _func1375
+namespace _func1376
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TutorialManager::constructor", typeid(void (TutorialManager::*)()), "!534889fb488d7f084883ec10c647f800", nullptr, 0, 0, &func);
@@ -17500,11 +17513,11 @@ namespace _func1375
 void TutorialManager::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1375::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1376::func;
 	return execfunc(this);
 }
 
-namespace _func1376
+namespace _func1377
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TutorialManager::Running", typeid(bool (TutorialManager::*)()), "!.0fb607c3", nullptr, 0, 0, &func);
@@ -17513,11 +17526,11 @@ namespace _func1376
 bool TutorialManager::Running()
 {
 	typedef bool (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1376::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1377::func;
 	return execfunc(this);
 }
 
-namespace _func1377
+namespace _func1378
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TutorialManager::OnInit", typeid(void (TutorialManager::*)(ShipManager *, CommandGui *, CrewControl *, Upgrades *, CombatControl *, SystemControl *, TabbedWindow *)), ".415455534889fb4883ec404889b790010000", nullptr, 0, 0, &func);
@@ -17526,18 +17539,18 @@ namespace _func1377
 void TutorialManager::OnInit(ShipManager *ship, CommandGui *gui, CrewControl *crewControl, Upgrades *upgradesScreen, CombatControl *combatControl, SystemControl *sysControl, TabbedWindow *unk)
 {
 	typedef void (*custom_arg_funcptr_t)(TutorialManager *this_arg, ShipManager *ship_arg, CommandGui *gui_arg, CrewControl *crewControl_arg, Upgrades *upgradesScreen_arg, CombatControl *combatControl_arg, SystemControl *sysControl_arg, TabbedWindow *unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1377::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1378::func;
 	return execfunc(this, ship, gui, crewControl, upgradesScreen, combatControl, sysControl, unk);
 }
 
 TutorialManager *Global_TutorialManager_Tutorial;
 
-namespace _var1378
+namespace _var1379
 {
     static VariableDefinition varObj("Global_TutorialManager_Tutorial", "!498b07488b7810488b07ff908000000084c00f84????????bf(???????\?)", &Global_TutorialManager_Tutorial);
 }
 
-namespace _func1379
+namespace _func1380
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("UnlockArrow::constructor", typeid(void (UnlockArrow::*)(Point , int , int )), "554889f5534889fb4883ec28803d????????00", nullptr, 0, 0, &func);
@@ -17546,11 +17559,11 @@ namespace _func1379
 void UnlockArrow::constructor(Point pos, int unk1, int unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(UnlockArrow *this_arg, Point pos_arg, int unk1_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1379::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1380::func;
 	return execfunc(this, pos, unk1, unk2);
 }
 
-namespace _func1380
+namespace _func1381
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("UnlockArrow::MouseMove", typeid(bool (UnlockArrow::*)(int , int )), ".837f0403", nullptr, 0, 0, &func);
@@ -17559,11 +17572,11 @@ namespace _func1380
 bool UnlockArrow::MouseMove(int x, int y)
 {
 	typedef bool (*custom_arg_funcptr_t)(UnlockArrow *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1380::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1381::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1381
+namespace _func1382
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("UnlockArrow::OnRender", typeid(void (UnlockArrow::*)()), ".534889fb4883ec308b0785c0", nullptr, 0, 0, &func);
@@ -17572,11 +17585,11 @@ namespace _func1381
 void UnlockArrow::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(UnlockArrow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1381::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1382::func;
 	return execfunc(this);
 }
 
-namespace _func1382
+namespace _func1383
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("UpgradeBox::OnRender", typeid(void (UpgradeBox::*)()), "415741564989fe4155415455534881ecd801000080bf5901000000", nullptr, 0, 0, &func);
@@ -17585,30 +17598,17 @@ namespace _func1382
 void UpgradeBox::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1382::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1383::func;
 	return execfunc(this);
 }
 
-namespace _func1383
+namespace _func1384
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("UpgradeBox::MouseMove", typeid(void (UpgradeBox::*)(int , int )), ".48833f007412", nullptr, 0, 0, &func);
 }
 
 void UpgradeBox::MouseMove(int mX, int mY)
-{
-	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1383::func;
-	return execfunc(this, mX, mY);
-}
-
-namespace _func1384
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("UpgradeBox::MouseClick", typeid(void (UpgradeBox::*)(int , int )), ".534889fb4883ec20488b074885c0", nullptr, 0, 0, &func);
-}
-
-void UpgradeBox::MouseClick(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1384::func;
@@ -17618,10 +17618,10 @@ void UpgradeBox::MouseClick(int mX, int mY)
 namespace _func1385
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("UpgradeBox::MouseRightClick", typeid(void (UpgradeBox::*)(int , int )), ".534889fb4883ec20488b074885c0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("UpgradeBox::MouseClick", typeid(void (UpgradeBox::*)(int , int )), ".534889fb4883ec20488b074885c0", nullptr, 0, 0, &func);
 }
 
-void UpgradeBox::MouseRightClick(int mX, int mY)
+void UpgradeBox::MouseClick(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1385::func;
@@ -17631,23 +17631,23 @@ void UpgradeBox::MouseRightClick(int mX, int mY)
 namespace _func1386
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("UpgradeBox::Undo", typeid(void (UpgradeBox::*)()), ".538b47204889fb85c0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("UpgradeBox::MouseRightClick", typeid(void (UpgradeBox::*)(int , int )), ".534889fb4883ec20488b074885c0", nullptr, 0, 0, &func);
 }
 
-void UpgradeBox::Undo()
+void UpgradeBox::MouseRightClick(int mX, int mY)
 {
-	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
+	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1386::func;
-	return execfunc(this);
+	return execfunc(this, mX, mY);
 }
 
 namespace _func1387
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("UpgradeBox::Accept", typeid(void (UpgradeBox::*)()), ".534889fb4883ec20488b3f4885ff", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("UpgradeBox::Undo", typeid(void (UpgradeBox::*)()), ".538b47204889fb85c0", nullptr, 0, 0, &func);
 }
 
-void UpgradeBox::Accept()
+void UpgradeBox::Undo()
 {
 	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1387::func;
@@ -17657,17 +17657,30 @@ void UpgradeBox::Accept()
 namespace _func1388
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("UpgradeBox::Accept", typeid(void (UpgradeBox::*)()), ".534889fb4883ec20488b3f4885ff", nullptr, 0, 0, &func);
+}
+
+void UpgradeBox::Accept()
+{
+	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1388::func;
+	return execfunc(this);
+}
+
+namespace _func1389
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("UpgradeBox::constructorEmpty", typeid(void (UpgradeBox::*)(Point , bool )), ".41554189d541544989f449c1fc20554889f5534889fb488d7f384883ec38", nullptr, 0, 0, &func);
 }
 
 void UpgradeBox::constructorEmpty(Point pos, bool subsystem)
 {
 	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg, Point pos_arg, bool subsystem_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1388::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1389::func;
 	return execfunc(this, pos, subsystem);
 }
 
-namespace _func1389
+namespace _func1390
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("UpgradeBox::constructorSystem", typeid(void (UpgradeBox::*)(ShipManager *, ShipSystem *, Point , bool )), ".41574589c741564c8d773841554989cd41544989d455488dafc8000000534889fb4883ec38", nullptr, 0, 0, &func);
@@ -17676,11 +17689,11 @@ namespace _func1389
 void UpgradeBox::constructorSystem(ShipManager *ship, ShipSystem *sys, Point pos, bool subsystem)
 {
 	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg, ShipManager *ship_arg, ShipSystem *sys_arg, Point pos_arg, bool subsystem_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1389::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1390::func;
 	return execfunc(this, ship, sys, pos, subsystem);
 }
 
-namespace _func1390
+namespace _func1391
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("UpgradeBox::destructor", typeid(void (UpgradeBox::*)()), ".534889fb4883ec10488bbf60010000", nullptr, 0, 0, &func);
@@ -17689,30 +17702,17 @@ namespace _func1390
 void UpgradeBox::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1390::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1391::func;
 	return execfunc(this);
 }
 
-namespace _func1391
+namespace _func1392
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Upgrades::MouseMove", typeid(void (Upgrades::*)(int , int )), "!41554989fd41544189d45589f55331db4883ec08", nullptr, 0, 0, &func);
 }
 
 void Upgrades::MouseMove(int mX, int mY)
-{
-	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1391::func;
-	return execfunc(this, mX, mY);
-}
-
-namespace _func1392
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Upgrades::MouseRightClick", typeid(void (Upgrades::*)(int , int )), ".415431c94989fc5531ed534883ec20", nullptr, 0, 0, &func);
-}
-
-void Upgrades::MouseRightClick(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1392::func;
@@ -17722,23 +17722,23 @@ void Upgrades::MouseRightClick(int mX, int mY)
 namespace _func1393
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Upgrades::Close", typeid(void (Upgrades::*)()), ".41554154554889fd534883ec28807f0800", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Upgrades::MouseRightClick", typeid(void (Upgrades::*)(int , int )), ".415431c94989fc5531ed534883ec20", nullptr, 0, 0, &func);
 }
 
-void Upgrades::Close()
+void Upgrades::MouseRightClick(int mX, int mY)
 {
-	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg);
+	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1393::func;
-	return execfunc(this);
+	return execfunc(this, mX, mY);
 }
 
 namespace _func1394
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Upgrades::OnLoop", typeid(void (Upgrades::*)()), ".4155415455534889fb4883ec68807f0800", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Upgrades::Close", typeid(void (Upgrades::*)()), ".41554154554889fd534883ec28807f0800", nullptr, 0, 0, &func);
 }
 
-void Upgrades::OnLoop()
+void Upgrades::Close()
 {
 	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1394::func;
@@ -17748,10 +17748,10 @@ void Upgrades::OnLoop()
 namespace _func1395
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Upgrades::ConfirmUpgrades", typeid(void (Upgrades::*)()), ".415531c941bd????????41544989fc5531ed534883ec28", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Upgrades::OnLoop", typeid(void (Upgrades::*)()), ".4155415455534889fb4883ec68807f0800", nullptr, 0, 0, &func);
 }
 
-void Upgrades::ConfirmUpgrades()
+void Upgrades::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1395::func;
@@ -17761,17 +17761,30 @@ void Upgrades::ConfirmUpgrades()
 namespace _func1396
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Upgrades::ConfirmUpgrades", typeid(void (Upgrades::*)()), ".415531c941bd????????41544989fc5531ed534883ec28", nullptr, 0, 0, &func);
+}
+
+void Upgrades::ConfirmUpgrades()
+{
+	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1396::func;
+	return execfunc(this);
+}
+
+namespace _func1397
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Upgrades::MouseClick", typeid(void (Upgrades::*)(int , int )), ".41554189d541544189f4554889fd5331db4883ec28", nullptr, 0, 0, &func);
 }
 
 void Upgrades::MouseClick(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1396::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1397::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1397
+namespace _func1398
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Upgrades::ClearUpgradeBoxes", typeid(void (Upgrades::*)()), ".41544989fc55534883ec10488b4f30488b57284889c84829d048c1f80385c0", nullptr, 0, 0, &func);
@@ -17780,11 +17793,11 @@ namespace _func1397
 void Upgrades::ClearUpgradeBoxes()
 {
 	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1397::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1398::func;
 	return execfunc(this);
 }
 
-namespace _func1398
+namespace _func1399
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Upgrades::OnInit", typeid(void (Upgrades::*)(ShipManager *)), ".41574989ff41564155415455534881ecb8000000", nullptr, 0, 0, &func);
@@ -17793,11 +17806,11 @@ namespace _func1398
 void Upgrades::OnInit(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1398::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1399::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1399
+namespace _func1400
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Upgrades::OnRender", typeid(void (Upgrades::*)()), ".415455534889fb4883ec50488b7f20", nullptr, 0, 0, &func);
@@ -17806,11 +17819,11 @@ namespace _func1399
 void Upgrades::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1399::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1400::func;
 	return execfunc(this);
 }
 
-namespace _func1400
+namespace _func1401
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::RenderWithAlpha", typeid(void (WarningMessage::*)(float )), "41570f28f041564155415455534889fb4883ec48", nullptr, 0, 0, &func);
@@ -17819,11 +17832,11 @@ namespace _func1400
 void WarningMessage::RenderWithAlpha(float alpha)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1400::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1401::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func1401
+namespace _func1402
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::constructor", typeid(void (WarningMessage::*)()), ".0f57c0534889fb488d7f2831d24883ec20", nullptr, 0, 0, &func);
@@ -17832,11 +17845,11 @@ namespace _func1401
 void WarningMessage::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1401::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1402::func;
 	return execfunc(this);
 }
 
-namespace _func1402
+namespace _func1403
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::InitImage", typeid(void (WarningMessage::*)(const std::string &, Point , float , bool )), ".41564189ce415541544989f4554889d5534889fb488dbfa80000004c8d6b604883ec10", nullptr, 0, 0, &func);
@@ -17845,11 +17858,11 @@ namespace _func1402
 void WarningMessage::InitImage(const std::string &imageName, Point position, float time, bool flash)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &imageName_arg, Point position_arg, float time_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1402::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1403::func;
 	return execfunc(this, imageName, position, time, flash);
 }
 
-namespace _func1403
+namespace _func1404
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::InitText", typeid(void (WarningMessage::*)(const TextString &, Point , float , GL_Color , bool , bool )), ".41574589c741564189ce41554154554889f5534889fb488d7f384883ec28", nullptr, 0, 0, &func);
@@ -17858,30 +17871,17 @@ namespace _func1403
 void WarningMessage::InitText(const TextString &text, Point position, float time, GL_Color textColor, bool centerText, bool flash)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg, Point position_arg, float time_arg, GL_Color textColor_arg, bool centerText_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1403::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1404::func;
 	return execfunc(this, text, position, time, textColor, centerText, flash);
 }
 
-namespace _func1404
+namespace _func1405
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::OnLoop", typeid(void (WarningMessage::*)()), ".55488d6f08534889fb4889ef4883ec08", nullptr, 0, 0, &func);
 }
 
 void WarningMessage::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1404::func;
-	return execfunc(this);
-}
-
-namespace _func1405
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("WarningMessage::OnRender", typeid(void (WarningMessage::*)()), ".53807f1e004889fb", nullptr, 0, 0, &func);
-}
-
-void WarningMessage::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1405::func;
@@ -17891,17 +17891,30 @@ void WarningMessage::OnRender()
 namespace _func1406
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("WarningMessage::OnRender", typeid(void (WarningMessage::*)()), ".53807f1e004889fb", nullptr, 0, 0, &func);
+}
+
+void WarningMessage::OnRender()
+{
+	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1406::func;
+	return execfunc(this);
+}
+
+namespace _func1407
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::SetImage", typeid(void (WarningMessage::*)(const std::string &)), ".4155415455534889fb4883ec08807f3000", nullptr, 0, 0, &func);
 }
 
 void WarningMessage::SetImage(const std::string &imageName)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &imageName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1406::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1407::func;
 	return execfunc(this, imageName);
 }
 
-namespace _func1407
+namespace _func1408
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::SetText", typeid(void (WarningMessage::*)(const TextString &)), ".4155415455534889fb4883ec08807f3000", nullptr, 0, 0, &func);
@@ -17910,11 +17923,11 @@ namespace _func1407
 void WarningMessage::SetText(const TextString &text)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1407::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1408::func;
 	return execfunc(this, text);
 }
 
-namespace _func1408
+namespace _func1409
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::SetText", typeid(void (WarningMessage::*)(const TextString &, GL_Color )), ".415741564155415455534889fb4883ec18807f3000", nullptr, 0, 0, &func);
@@ -17923,11 +17936,11 @@ namespace _func1408
 void WarningMessage::SetText(const TextString &text, GL_Color textColor)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg, GL_Color textColor_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1408::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1409::func;
 	return execfunc(this, text, textColor);
 }
 
-namespace _func1409
+namespace _func1410
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::SetPosition", typeid(void (WarningMessage::*)(Point )), ".807f300048897728", nullptr, 0, 0, &func);
@@ -17936,11 +17949,11 @@ namespace _func1409
 void WarningMessage::SetPosition(Point position)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, Point position_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1409::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1410::func;
 	return execfunc(this, position);
 }
 
-namespace _func1410
+namespace _func1411
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::SetLoop", typeid(void (WarningMessage::*)(bool )), "!.0f57c0400fb6f64883c708", nullptr, 0, 0, &func);
@@ -17949,11 +17962,11 @@ namespace _func1410
 void WarningMessage::SetLoop(bool loop)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, bool loop_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1410::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1411::func;
 	return execfunc(this, loop);
 }
 
-namespace _func1411
+namespace _func1412
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::SetSound", typeid(void (WarningMessage::*)(const std::string &)), "!.4881c7b8000000", nullptr, 0, 0, &func);
@@ -17962,11 +17975,11 @@ namespace _func1411
 void WarningMessage::SetSound(const std::string &sound)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &sound_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1411::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1412::func;
 	return execfunc(this, sound);
 }
 
-namespace _func1412
+namespace _func1413
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::Start", typeid(void (WarningMessage::*)()), ".53807f1c004889fb", nullptr, 0, 0, &func);
@@ -17975,11 +17988,11 @@ namespace _func1412
 void WarningMessage::Start()
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1412::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1413::func;
 	return execfunc(this);
 }
 
-namespace _func1413
+namespace _func1414
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponAnimation::StartFire", typeid(bool (WeaponAnimation::*)()), "530fb687c10000004889fb84c0", nullptr, 0, 0, &func);
@@ -17988,11 +18001,11 @@ namespace _func1413
 bool WeaponAnimation::StartFire()
 {
 	typedef bool (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1413::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1414::func;
 	return execfunc(this);
 }
 
-namespace _func1414
+namespace _func1415
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponAnimation::SetFireTime", typeid(void (WeaponAnimation::*)(float )), "8b470889c22b97c8000000", nullptr, 0, 0, &func);
@@ -18001,11 +18014,11 @@ namespace _func1414
 void WeaponAnimation::SetFireTime(float time)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float time_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1414::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1415::func;
 	return execfunc(this, time);
 }
 
-namespace _func1415
+namespace _func1416
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponAnimation::GetSlide", typeid(Pointf (WeaponAnimation::*)()), "534889fb488dbff8", nullptr, 0, 0, &func);
@@ -18014,11 +18027,11 @@ namespace _func1415
 Pointf WeaponAnimation::GetSlide()
 {
 	typedef Pointf (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1415::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1416::func;
 	return execfunc(this);
 }
 
-namespace _func1416
+namespace _func1417
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponAnimation::Update", typeid(void (WeaponAnimation::*)()), "415455534889fb4883ec1080bfc100000000", nullptr, 0, 0, &func);
@@ -18027,11 +18040,11 @@ namespace _func1416
 void WeaponAnimation::Update()
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1416::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1417::func;
 	return execfunc(this);
 }
 
-namespace _func1417
+namespace _func1418
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponAnimation::OnRender", typeid(void (WeaponAnimation::*)(float )), ".??57??56??55??545553??89fb??83ec38", nullptr, 0, 0, &func);
@@ -18040,11 +18053,11 @@ namespace _func1417
 void WeaponAnimation::OnRender(float alpha)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1417::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1418::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func1418
+namespace _func1419
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponBlueprint::RenderIcon", typeid(void (WeaponBlueprint::*)(float )), "!488db738010000", nullptr, 0, 0, &func);
@@ -18053,11 +18066,11 @@ namespace _func1418
 void WeaponBlueprint::RenderIcon(float scale)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg, float scale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1418::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1419::func;
 	return execfunc(this, scale);
 }
 
-namespace _func1419
+namespace _func1420
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponBlueprint::GetDimensions", typeid(Point (WeaponBlueprint::*)()), ".53??8d9738010000", nullptr, 0, 0, &func);
@@ -18066,11 +18079,11 @@ namespace _func1419
 Point WeaponBlueprint::GetDimensions()
 {
 	typedef Point (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1419::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1420::func;
 	return execfunc(this);
 }
 
-namespace _func1420
+namespace _func1421
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponBlueprint::GetDescription", typeid(std::string (WeaponBlueprint::*)(bool )), ".4157415641554989fd4154554889f5534881ec08010000", nullptr, 0, 0, &func);
@@ -18079,30 +18092,17 @@ namespace _func1420
 std::string WeaponBlueprint::GetDescription(bool tooltip)
 {
 	typedef std::string (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg, bool tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1420::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1421::func;
 	return execfunc(this, tooltip);
 }
 
-namespace _func1421
+namespace _func1422
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponBlueprint::constructor", typeid(void (WeaponBlueprint::*)()), ".534889fb488d7f08be????????4883ec20", nullptr, 0, 0, &func);
 }
 
 void WeaponBlueprint::constructor()
-{
-	typedef void (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1421::func;
-	return execfunc(this);
-}
-
-namespace _func1422
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("WeaponBlueprint::destructor", typeid(void (WeaponBlueprint::*)()), ".4154554889fd534883ec10488b8788010000", nullptr, 0, 0, &func);
-}
-
-void WeaponBlueprint::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1422::func;
@@ -18112,17 +18112,30 @@ void WeaponBlueprint::destructor()
 namespace _func1423
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("WeaponBlueprint::destructor", typeid(void (WeaponBlueprint::*)()), ".4154554889fd534883ec10488b8788010000", nullptr, 0, 0, &func);
+}
+
+void WeaponBlueprint::destructor()
+{
+	typedef void (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1423::func;
+	return execfunc(this);
+}
+
+namespace _func1424
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("WeaponBox::RenderBox", typeid(void (WeaponBox::*)(bool , bool )), "41570fb6d2400fb6f641564155415455534889fb4881ec68030000", nullptr, 0, 0, &func);
 }
 
 void WeaponBox::RenderBox(bool dragging, bool flashPowerBox)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponBox *this_arg, bool dragging_arg, bool flashPowerBox_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1423::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1424::func;
 	return execfunc(this, dragging, flashPowerBox);
 }
 
-namespace _func1424
+namespace _func1425
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponBox::GenerateTooltip", typeid(std::string (WeaponBox::*)()), "554889f5534889fb4889f74883ec38488b06", nullptr, 0, 0, &func);
@@ -18131,17 +18144,17 @@ namespace _func1424
 std::string WeaponBox::GenerateTooltip()
 {
 	typedef std::string (*custom_arg_funcptr_t)(WeaponBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1424::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1425::func;
 	return execfunc(this);
 }
 
-namespace _func1425
+namespace _func1426
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::DO_NOT_HOOK", typeid(void (WeaponControl::*)()), "!488b14e9eb??0f1f4000", nullptr, 0, 0, &func);
 }
 
-namespace _func1426
+namespace _func1427
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::HolderLabel", typeid(TextString (WeaponControl::*)()), ".534889fbbe", nullptr, 0, 0, &func);
@@ -18150,11 +18163,11 @@ namespace _func1426
 TextString WeaponControl::HolderLabel()
 {
 	typedef TextString (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1426::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1427::func;
 	return execfunc(this);
 }
 
-namespace _func1427
+namespace _func1428
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::constructor", typeid(void (WeaponControl::*)()), ".4157be03000000415641554989fd415455498dad3802000053498d9d180300004881ec58030000", nullptr, 0, 0, &func);
@@ -18163,11 +18176,11 @@ namespace _func1427
 void WeaponControl::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1427::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1428::func;
 	return execfunc(this);
 }
 
-namespace _func1428
+namespace _func1429
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::RenderBeamAiming", typeid(void (*)(Pointf , Pointf , bool )), ".41545589fd534883ec40", nullptr, 0, 0, &func);
@@ -18176,30 +18189,17 @@ namespace _func1428
 void WeaponControl::RenderBeamAiming(Pointf one, Pointf two, bool bAutoFire)
 {
 	typedef void (*custom_arg_funcptr_t)(Pointf one_arg, Pointf two_arg, bool bAutoFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1428::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1429::func;
 	return execfunc(one, two, bAutoFire);
 }
 
-namespace _func1429
+namespace _func1430
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::RenderAiming", typeid(void (WeaponControl::*)()), ".41574989ff415641554531ed4154555331db4883ec38", nullptr, 0, 0, &func);
 }
 
 void WeaponControl::RenderAiming()
-{
-	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1429::func;
-	return execfunc(this);
-}
-
-namespace _func1430
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("WeaponControl::RenderSelfAiming", typeid(void (WeaponControl::*)()), ".4157415641554531ed41544989fc555331db4883ec18", nullptr, 0, 0, &func);
-}
-
-void WeaponControl::RenderSelfAiming()
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1430::func;
@@ -18209,17 +18209,30 @@ void WeaponControl::RenderSelfAiming()
 namespace _func1431
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("WeaponControl::RenderSelfAiming", typeid(void (WeaponControl::*)()), ".4157415641554531ed41544989fc555331db4883ec18", nullptr, 0, 0, &func);
+}
+
+void WeaponControl::RenderSelfAiming()
+{
+	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1431::func;
+	return execfunc(this);
+}
+
+namespace _func1432
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::SetAutofiring", typeid(void (WeaponControl::*)(bool , bool )), ".41554189d54154554889fd534883ec484084f64088b7e0000000", nullptr, 0, 0, &func);
 }
 
 void WeaponControl::SetAutofiring(bool on, bool simple)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg, bool on_arg, bool simple_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1431::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1432::func;
 	return execfunc(this, on, simple);
 }
 
-namespace _func1432
+namespace _func1433
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::Fire", typeid(void (WeaponControl::*)(std::vector<Pointf> &, int , bool )), ".4155415455534889fb4883ec28488bbfd80000004885ff", nullptr, 0, 0, &func);
@@ -18228,11 +18241,11 @@ namespace _func1432
 void WeaponControl::Fire(std::vector<Pointf> &points, int target, bool autoFire)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg, std::vector<Pointf> &points_arg, int target_arg, bool autoFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1432::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1433::func;
 	return execfunc(this, points, target, autoFire);
 }
 
-namespace _func1433
+namespace _func1434
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::ArmamentHotkey", typeid(SDLKey (WeaponControl::*)(unsigned int )), ".4883ec5883c60189742420488d7c2430", nullptr, 0, 0, &func);
@@ -18241,11 +18254,11 @@ namespace _func1433
 SDLKey WeaponControl::ArmamentHotkey(unsigned int i)
 {
 	typedef SDLKey (*custom_arg_funcptr_t)(WeaponControl *this_arg, unsigned int i_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1433::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1434::func;
 	return execfunc(this, i);
 }
 
-namespace _func1434
+namespace _func1435
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::OnLanguageChange", typeid(void (WeaponControl::*)()), ".41564155415455534889fb4883ec70", nullptr, 0, 0, &func);
@@ -18254,11 +18267,11 @@ namespace _func1434
 void WeaponControl::OnLanguageChange()
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1434::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1435::func;
 	return execfunc(this);
 }
 
-namespace _func1435
+namespace _func1436
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::OnRender", typeid(void (WeaponControl::*)(bool )), ".41545589f5be03000000534889fb4883ec10488b7f18", nullptr, 0, 0, &func);
@@ -18267,11 +18280,11 @@ namespace _func1435
 void WeaponControl::OnRender(bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1435::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1436::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1436
+namespace _func1437
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::LButton", typeid(bool (WeaponControl::*)(int , int , bool )), ".80bf30010000007427530fb69f3101000084db", nullptr, 0, 0, &func);
@@ -18280,11 +18293,11 @@ namespace _func1436
 bool WeaponControl::LButton(int x, int y, bool holdingShift)
 {
 	typedef bool (*custom_arg_funcptr_t)(WeaponControl *this_arg, int x_arg, int y_arg, bool holdingShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1436::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1437::func;
 	return execfunc(this, x, y, holdingShift);
 }
 
-namespace _func1437
+namespace _func1438
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::MouseMove", typeid(void (WeaponControl::*)(int , int )), ".41544189d45589f5534889fb", nullptr, 0, 0, &func);
@@ -18293,11 +18306,11 @@ namespace _func1437
 void WeaponControl::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1437::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1438::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1438
+namespace _func1439
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::KeyDown", typeid(bool (WeaponControl::*)(SDLKey )), ".4155415441bc010000005589f5534889fb4883ec28", nullptr, 0, 0, &func);
@@ -18306,11 +18319,11 @@ namespace _func1438
 bool WeaponControl::KeyDown(SDLKey key)
 {
 	typedef bool (*custom_arg_funcptr_t)(WeaponControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1438::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1439::func;
 	return execfunc(this, key);
 }
 
-namespace _func1439
+namespace _func1440
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::LinkShip", typeid(void (WeaponControl::*)(ShipManager *)), ".55534889fb4883ec28", nullptr, 0, 0, &func);
@@ -18319,17 +18332,17 @@ namespace _func1439
 void WeaponControl::LinkShip(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1439::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1440::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1440
+namespace _func1441
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponStoreBox::__DO_NOT_HOOK", typeid(void (WeaponStoreBox::*)()), "41554989d541544989f4be", nullptr, 0, 0, &func);
 }
 
-namespace _func1441
+namespace _func1442
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponStoreBox::constructor", typeid(void (WeaponStoreBox::*)(ShipManager *, Equipment *, const WeaponBlueprint *)), ".41554989d541544989f4be", nullptr, 0, 0, &func);
@@ -18338,11 +18351,11 @@ namespace _func1441
 void WeaponStoreBox::constructor(ShipManager *ship, Equipment *equip, const WeaponBlueprint *weaponBp)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponStoreBox *this_arg, ShipManager *ship_arg, Equipment *equip_arg, const WeaponBlueprint *weaponBp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1441::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1442::func;
 	return execfunc(this, ship, equip, weaponBp);
 }
 
-namespace _func1442
+namespace _func1443
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponSystem::RemoveWeapon", typeid(void (WeaponSystem::*)(int )), "31c085f60f88d800000041564155415455534889fb4883ec20", nullptr, 0, 0, &func);
@@ -18351,11 +18364,11 @@ namespace _func1442
 void WeaponSystem::RemoveWeapon(int slot)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponSystem *this_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1442::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1443::func;
 	return execfunc(this, slot);
 }
 
-namespace _func1443
+namespace _func1444
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponSystem::SetBonusPower", typeid(void (WeaponSystem::*)(int , int )), "!.5589f5534889fb4883ec08e8????????39e8", nullptr, 0, 0, &func);
@@ -18364,11 +18377,11 @@ namespace _func1443
 void WeaponSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1443::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1444::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func1444
+namespace _func1445
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponSystem::OnLoop", typeid(void (WeaponSystem::*)()), ".415741564155415455534889fb4883ec38e8????????488b9350020000", nullptr, 0, 0, &func);
@@ -18377,11 +18390,11 @@ namespace _func1444
 void WeaponSystem::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1444::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1445::func;
 	return execfunc(this);
 }
 
-namespace _func1445
+namespace _func1446
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponSystemBox::constructor", typeid(void (WeaponSystemBox::*)(Point , ShipSystem *, WeaponControl *)), "554889cdb901000000534889fb4883ec08e8????????488dbb70020000", nullptr, 0, 0, &func);
@@ -18390,11 +18403,11 @@ namespace _func1445
 void WeaponSystemBox::constructor(Point pos, ShipSystem *sys, WeaponControl *weapCtrl)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponSystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, WeaponControl *weapCtrl_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1445::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1446::func;
 	return execfunc(this, pos, sys, weapCtrl);
 }
 
-namespace _func1446
+namespace _func1447
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WindowFrame::constructor", typeid(void (WindowFrame::*)(int , int , int , int )), "41574156415541545589d55389f34881ecc8000000", nullptr, 0, 0, &func);
@@ -18403,11 +18416,11 @@ namespace _func1446
 void WindowFrame::constructor(int x, int y, int w, int h)
 {
 	typedef void (*custom_arg_funcptr_t)(WindowFrame *this_arg, int x_arg, int y_arg, int w_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1446::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1447::func;
 	return execfunc(this, x, y, w, h);
 }
 
-namespace _func1447
+namespace _func1448
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WindowFrame::destructor", typeid(void (WindowFrame::*)()), "!.534889fb488b7f10", nullptr, 0, 0, &func);
@@ -18416,11 +18429,11 @@ namespace _func1447
 void WindowFrame::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(WindowFrame *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1447::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1448::func;
 	return execfunc(this);
 }
 
-namespace _func1448
+namespace _func1449
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WindowFrame::Draw", typeid(void (WindowFrame::*)(int , int )), "!.41544189d45589f5534889fb", nullptr, 0, 0, &func);
@@ -18429,11 +18442,11 @@ namespace _func1448
 void WindowFrame::Draw(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(WindowFrame *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1448::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1449::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1449
+namespace _func1450
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WindowFrame::DrawMask", typeid(void (WindowFrame::*)(int )), "!.5389f24889fbbf01000000", nullptr, 0, 0, &func);
@@ -18442,11 +18455,11 @@ namespace _func1449
 void WindowFrame::DrawMask(int unk)
 {
 	typedef void (*custom_arg_funcptr_t)(WindowFrame *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1449::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1450::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1450
+namespace _func1451
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::constructor", typeid(void (WorldManager::*)()), "534889fb488d7f104883ec10", nullptr, 0, 0, &func);
@@ -18455,11 +18468,11 @@ namespace _func1450
 void WorldManager::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1450::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1451::func;
 	return execfunc(this);
 }
 
-namespace _func1451
+namespace _func1452
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::OnInit", typeid(int (WorldManager::*)()), ".415455488d6f10534889fb4889ef", nullptr, 0, 0, &func);
@@ -18468,11 +18481,11 @@ namespace _func1451
 int WorldManager::OnInit()
 {
 	typedef int (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1451::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1452::func;
 	return execfunc(this);
 }
 
-namespace _func1452
+namespace _func1453
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::CreateStore", typeid(void (WorldManager::*)(LocationEvent *)), ".554889f5534889fb4883ec08488bb6d0040000", nullptr, 0, 0, &func);
@@ -18481,11 +18494,11 @@ namespace _func1452
 void WorldManager::CreateStore(LocationEvent *event)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1452::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1453::func;
 	return execfunc(this, event);
 }
 
-namespace _func1453
+namespace _func1454
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::CheckRequirements", typeid(bool (WorldManager::*)(LocationEvent *, bool )), ".415455534889f34883ec204885f6", nullptr, 0, 0, &func);
@@ -18494,11 +18507,11 @@ namespace _func1453
 bool WorldManager::CheckRequirements(LocationEvent *event, bool hidden)
 {
 	typedef bool (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg, bool hidden_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1453::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1454::func;
 	return execfunc(this, event, hidden);
 }
 
-namespace _func1454
+namespace _func1455
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::AddBoarders", typeid(bool (WorldManager::*)(BoardingEvent &)), ".4154554889fd534883ec20488b07488b5010", nullptr, 0, 0, &func);
@@ -18507,11 +18520,11 @@ namespace _func1454
 bool WorldManager::AddBoarders(BoardingEvent &boardingEvent)
 {
 	typedef bool (*custom_arg_funcptr_t)(WorldManager *this_arg, BoardingEvent &boardingEvent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1454::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1455::func;
 	return execfunc(this, boardingEvent);
 }
 
-namespace _func1455
+namespace _func1456
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::HostileEnvironment", typeid(bool (WorldManager::*)()), ".534889fb488d7f10", nullptr, 0, 0, &func);
@@ -18520,11 +18533,11 @@ namespace _func1455
 bool WorldManager::HostileEnvironment()
 {
 	typedef bool (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1455::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1456::func;
 	return execfunc(this);
 }
 
-namespace _func1456
+namespace _func1457
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::ModifyEnvironment", typeid(void (WorldManager::*)(int , int )), ".83fe01534889fb", nullptr, 0, 0, &func);
@@ -18533,11 +18546,11 @@ namespace _func1456
 void WorldManager::ModifyEnvironment(int envFlag, int envTarget)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, int envFlag_arg, int envTarget_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1456::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1457::func;
 	return execfunc(this, envFlag, envTarget);
 }
 
-namespace _func1457
+namespace _func1458
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::ModifyStatusEffect", typeid(void (WorldManager::*)(StatusEffect , ShipManager *, int )), ".41554889d04989fd48c1f82041544989cc4889f148c1f920", nullptr, 0, 0, &func);
@@ -18546,11 +18559,11 @@ namespace _func1457
 void WorldManager::ModifyStatusEffect(StatusEffect effect, ShipManager *target, int targetType)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, StatusEffect effect_arg, ShipManager *target_arg, int targetType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1457::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1458::func;
 	return execfunc(this, effect, target, targetType);
 }
 
-namespace _func1458
+namespace _func1459
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::ModifyResources", typeid(LocationEvent *(WorldManager::*)(LocationEvent *)), ".41574989f7488db65803000041564d8db78803000041554154554889fd534881ecd8020000", nullptr, 0, 0, &func);
@@ -18559,11 +18572,11 @@ namespace _func1458
 LocationEvent *WorldManager::ModifyResources(LocationEvent *event)
 {
 	typedef LocationEvent *(*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1458::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1459::func;
 	return execfunc(this, event);
 }
 
-namespace _func1459
+namespace _func1460
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::CheckStatusEffects", typeid(void (WorldManager::*)(std::vector<StatusEffect> &)), "!.415741564989fe41554531ed41544c8da7001500005531ed534889f34883ec08", nullptr, 0, 0, &func);
@@ -18572,30 +18585,17 @@ namespace _func1459
 void WorldManager::CheckStatusEffects(std::vector<StatusEffect> &vec)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, std::vector<StatusEffect> &vec_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1459::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1460::func;
 	return execfunc(this, vec);
 }
 
-namespace _func1460
+namespace _func1461
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::CreateChoiceBox", typeid(void (WorldManager::*)(LocationEvent *)), ".4157488d87501500004989ff41564889c741554154554889f5534889c34881ec08030000", nullptr, 0, 0, &func);
 }
 
 void WorldManager::CreateChoiceBox(LocationEvent *event)
-{
-	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1460::func;
-	return execfunc(this, event);
-}
-
-namespace _func1461
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("WorldManager::CreateChoiceBox0", typeid(void (WorldManager::*)(LocationEvent *)), ".554889f5534889fb4883ec08488b07488b7810488b17", nullptr, 0, 0, &func);
-}
-
-void WorldManager::CreateChoiceBox0(LocationEvent *event)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1461::func;
@@ -18605,17 +18605,30 @@ void WorldManager::CreateChoiceBox0(LocationEvent *event)
 namespace _func1462
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("WorldManager::CreateChoiceBox0", typeid(void (WorldManager::*)(LocationEvent *)), ".554889f5534889fb4883ec08488b07488b7810488b17", nullptr, 0, 0, &func);
+}
+
+void WorldManager::CreateChoiceBox0(LocationEvent *event)
+{
+	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1462::func;
+	return execfunc(this, event);
+}
+
+namespace _func1463
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::CreateShip", typeid(CompleteShip *(WorldManager::*)(ShipEvent *, bool )), ".4156415541544989fc55534881ec60030000", nullptr, 0, 0, &func);
 }
 
 CompleteShip *WorldManager::CreateShip(ShipEvent *shipEvent, bool boss)
 {
 	typedef CompleteShip *(*custom_arg_funcptr_t)(WorldManager *this_arg, ShipEvent *shipEvent_arg, bool boss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1462::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1463::func;
 	return execfunc(this, shipEvent, boss);
 }
 
-namespace _func1463
+namespace _func1464
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::CreateLocation", typeid(void (WorldManager::*)(Location *)), ".41574156415541544989f455534889fb4881ecf8030000", nullptr, 0, 0, &func);
@@ -18624,30 +18637,17 @@ namespace _func1463
 void WorldManager::CreateLocation(Location *loc)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1463::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1464::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1464
+namespace _func1465
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::UpdateLocation", typeid(void (WorldManager::*)(LocationEvent *)), ".4157415641554154554889fd534889f34881ec88030000", nullptr, 0, 0, &func);
 }
 
 void WorldManager::UpdateLocation(LocationEvent *event)
-{
-	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1464::func;
-	return execfunc(this, event);
-}
-
-namespace _func1465
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("WorldManager::UpdateLocation0", typeid(void (WorldManager::*)(LocationEvent *)), ".554889f5534889fb4883ec08488b07488b7810488b17", nullptr, 0, 0, &func);
-}
-
-void WorldManager::UpdateLocation0(LocationEvent *event)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1465::func;
@@ -18657,17 +18657,30 @@ void WorldManager::UpdateLocation0(LocationEvent *event)
 namespace _func1466
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("WorldManager::UpdateLocation0", typeid(void (WorldManager::*)(LocationEvent *)), ".554889f5534889fb4883ec08488b07488b7810488b17", nullptr, 0, 0, &func);
+}
+
+void WorldManager::UpdateLocation0(LocationEvent *event)
+{
+	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1466::func;
+	return execfunc(this, event);
+}
+
+namespace _func1467
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::ClearLocation", typeid(void (WorldManager::*)()), ".415741564155415455534889fb488d7f104881ec68020000", nullptr, 0, 0, &func);
 }
 
 void WorldManager::ClearLocation()
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1466::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1467::func;
 	return execfunc(this);
 }
 
-namespace _func1467
+namespace _func1468
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::LoadGame", typeid(void (WorldManager::*)(const std::string &)), ".415741564155415455534889fb4881ece8010000", nullptr, 0, 0, &func);
@@ -18676,30 +18689,17 @@ namespace _func1467
 void WorldManager::LoadGame(const std::string &fileName)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1467::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1468::func;
 	return execfunc(this, fileName);
 }
 
-namespace _func1468
+namespace _func1469
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::SaveGame", typeid(void (WorldManager::*)()), ".415455534889fb4883ec20488bbfb8110000", nullptr, 0, 0, &func);
 }
 
 void WorldManager::SaveGame()
-{
-	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1468::func;
-	return execfunc(this);
-}
-
-namespace _func1469
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("WorldManager::CreateNewGame", typeid(void (WorldManager::*)()), ".554889fd5331db4883ec28488b07488b78104881c718010000", nullptr, 0, 0, &func);
-}
-
-void WorldManager::CreateNewGame()
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1469::func;
@@ -18709,36 +18709,36 @@ void WorldManager::CreateNewGame()
 namespace _func1470
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("WorldManager::CreateNewGame", typeid(void (WorldManager::*)()), ".554889fd5331db4883ec28488b07488b78104881c718010000", nullptr, 0, 0, &func);
+}
+
+void WorldManager::CreateNewGame()
+{
+	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1470::func;
+	return execfunc(this);
+}
+
+namespace _func1471
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::StartGame", typeid(void (WorldManager::*)(ShipManager *)), ".4154554889f5534889fb4883ec20", nullptr, 0, 0, &func);
 }
 
 void WorldManager::StartGame(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1470::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1471::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1471
+namespace _func1472
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::Restart", typeid(void (WorldManager::*)()), "!.534889fbe8????????e8????????e8", nullptr, 0, 0, &func);
 }
 
 void WorldManager::Restart()
-{
-	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1471::func;
-	return execfunc(this);
-}
-
-namespace _func1472
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("WorldManager::OnLoop", typeid(void (WorldManager::*)()), ".415731f64989ff41564155415455534881ecf8000000", nullptr, 0, 0, &func);
-}
-
-void WorldManager::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1472::func;
@@ -18748,10 +18748,10 @@ void WorldManager::OnLoop()
 namespace _func1473
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("WorldManager::PauseLoop", typeid(void (WorldManager::*)()), ".41554154554889fd534883ec28488b3f", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("WorldManager::OnLoop", typeid(void (WorldManager::*)()), ".415731f64989ff41564155415455534881ecf8000000", nullptr, 0, 0, &func);
 }
 
-void WorldManager::PauseLoop()
+void WorldManager::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1473::func;
@@ -18761,17 +18761,30 @@ void WorldManager::PauseLoop()
 namespace _func1474
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("WorldManager::PauseLoop", typeid(void (WorldManager::*)()), ".41554154554889fd534883ec28488b3f", nullptr, 0, 0, &func);
+}
+
+void WorldManager::PauseLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1474::func;
+	return execfunc(this);
+}
+
+namespace _func1475
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("freetype::font_data::init", typeid(void (freetype::font_data::*)(const void *, int , unsigned int , bool )), "89c9534889fbf3480f2ac14889f731c989d631d2", nullptr, 0, 0, &func);
 }
 
 void freetype::font_data::init(const void *buffer, int bufferSize, unsigned int h, bool glow)
 {
 	typedef void (*custom_arg_funcptr_t)(freetype::font_data *this_arg, const void *buffer_arg, int bufferSize_arg, unsigned int h_arg, bool glow_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1474::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1475::func;
 	return execfunc(this, buffer, bufferSize, h, glow);
 }
 
-namespace _func1475
+namespace _func1476
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("freetype::font_data::init_bitmap", typeid(void (freetype::font_data::*)(const void *, int , int , int )), ".41544189cc31c955", nullptr, 0, 0, &func);
@@ -18780,11 +18793,11 @@ namespace _func1475
 void freetype::font_data::init_bitmap(const void *buffer, int bufferSize, int size, int h)
 {
 	typedef void (*custom_arg_funcptr_t)(freetype::font_data *this_arg, const void *buffer_arg, int bufferSize_arg, int size_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1475::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1476::func;
 	return execfunc(this, buffer, bufferSize, size, h);
 }
 
-namespace _func1476
+namespace _func1477
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("freetype::font_data::clean", typeid(void (freetype::font_data::*)()), "!.8b7f04e9", nullptr, 0, 0, &func);
@@ -18793,11 +18806,11 @@ namespace _func1476
 void freetype::font_data::clean()
 {
 	typedef void (*custom_arg_funcptr_t)(freetype::font_data *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1476::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1477::func;
 	return execfunc(this);
 }
 
-namespace _func1477
+namespace _func1478
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("freetype::easy_measurePrintLines", typeid(Pointf (*)(int , float , float , int , const std::string &)), ".554889d089fd5389f34883ec38", nullptr, 0, 0, &func);
@@ -18806,11 +18819,11 @@ namespace _func1477
 Pointf freetype::easy_measurePrintLines(int fontSize, float x, float y, int line_length, const std::string &text)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1477::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1478::func;
 	return execfunc(fontSize, x, y, line_length, text);
 }
 
-namespace _func1478
+namespace _func1479
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("freetype::easy_measureWidth", typeid(int (*)(int , const std::string &)), ".5389fb4883ec30488b36488d54241e", nullptr, 0, 0, &func);
@@ -18819,30 +18832,17 @@ namespace _func1478
 int freetype::easy_measureWidth(int fontSize, const std::string &text)
 {
 	typedef int (*custom_arg_funcptr_t)(int fontSize_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1478::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1479::func;
 	return execfunc(fontSize, text);
 }
 
-namespace _func1479
+namespace _func1480
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("freetype::easy_print", typeid(Pointf (*)(int , float , float , const std::string &)), ".5389fb4883ec30488b36488d54241e", nullptr, 0, 0, &func);
 }
 
 Pointf freetype::easy_print(int fontSize, float x, float y, const std::string &text)
-{
-	typedef Pointf (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1479::func;
-	return execfunc(fontSize, x, y, text);
-}
-
-namespace _func1480
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("freetype::easy_printRightAlign", typeid(Pointf (*)(int , float , float , const std::string &)), ".5389fb4883ec30488b36488d54241e", nullptr, 0, 0, &func);
-}
-
-Pointf freetype::easy_printRightAlign(int fontSize, float x, float y, const std::string &text)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1480::func;
@@ -18852,23 +18852,23 @@ Pointf freetype::easy_printRightAlign(int fontSize, float x, float y, const std:
 namespace _func1481
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("freetype::easy_printNewlinesCentered", typeid(Pointf (*)(int , float , float , int , const std::string &)), ".554889d089fd5389f34883ec38", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("freetype::easy_printRightAlign", typeid(Pointf (*)(int , float , float , const std::string &)), ".5389fb4883ec30488b36488d54241e", nullptr, 0, 0, &func);
 }
 
-Pointf freetype::easy_printNewlinesCentered(int fontSize, float x, float y, int line_length, const std::string &text)
+Pointf freetype::easy_printRightAlign(int fontSize, float x, float y, const std::string &text)
 {
-	typedef Pointf (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
+	typedef Pointf (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1481::func;
-	return execfunc(fontSize, x, y, line_length, text);
+	return execfunc(fontSize, x, y, text);
 }
 
 namespace _func1482
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("freetype::easy_printAutoNewlines", typeid(Pointf (*)(int , float , float , int , const std::string &)), ".554889d089fd5389f34883ec38", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("freetype::easy_printNewlinesCentered", typeid(Pointf (*)(int , float , float , int , const std::string &)), ".554889d089fd5389f34883ec38", nullptr, 0, 0, &func);
 }
 
-Pointf freetype::easy_printAutoNewlines(int fontSize, float x, float y, int line_length, const std::string &text)
+Pointf freetype::easy_printNewlinesCentered(int fontSize, float x, float y, int line_length, const std::string &text)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1482::func;
@@ -18878,17 +18878,30 @@ Pointf freetype::easy_printAutoNewlines(int fontSize, float x, float y, int line
 namespace _func1483
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("freetype::easy_printAutoNewlines", typeid(Pointf (*)(int , float , float , int , const std::string &)), ".554889d089fd5389f34883ec38", nullptr, 0, 0, &func);
+}
+
+Pointf freetype::easy_printAutoNewlines(int fontSize, float x, float y, int line_length, const std::string &text)
+{
+	typedef Pointf (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1483::func;
+	return execfunc(fontSize, x, y, line_length, text);
+}
+
+namespace _func1484
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("freetype::easy_printCenter", typeid(Pointf (*)(int , float , float , const std::string &)), ".5389fb4883ec30488b36488d54241e", nullptr, 0, 0, &func);
 }
 
 Pointf freetype::easy_printCenter(int fontSize, float x, float y, const std::string &text)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1483::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1484::func;
 	return execfunc(fontSize, x, y, text);
 }
 
-namespace _func1484
+namespace _func1485
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("freetype::easy_printAutoShrink", typeid(void (*)(int , float , float , int , bool , const std::string &)), ".41578d47cc415641554989cd4154555389fb4883ec5883f801", nullptr, 0, 0, &func);
@@ -18897,11 +18910,11 @@ namespace _func1484
 void freetype::easy_printAutoShrink(int fontId, float x, float y, int maxWidth, bool centered, const std::string &text)
 {
 	typedef void (*custom_arg_funcptr_t)(int fontId_arg, float x_arg, float y_arg, int maxWidth_arg, bool centered_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1484::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1485::func;
 	return execfunc(fontId, x, y, maxWidth, centered, text);
 }
 
-namespace _func1485
+namespace _func1486
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("font_height", typeid(float (*)(int , float )), ".85ff530f8e", nullptr, 0, 0, &func);
@@ -18910,11 +18923,11 @@ namespace _func1485
 float __stdcall font_height(int font_id, float size)
 {
 	typedef float (*custom_arg_funcptr_t)(int font_id_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1485::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1486::func;
 	return execfunc(font_id, size);
 }
 
-namespace _func1486
+namespace _func1487
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("font_baseline", typeid(float (*)(int , float )), ".85ff530f8e", nullptr, 0, 0, &func);
@@ -18923,13 +18936,13 @@ namespace _func1486
 float __stdcall font_baseline(int font_id, float size)
 {
 	typedef float (*custom_arg_funcptr_t)(int font_id_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1486::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1487::func;
 	return execfunc(font_id, size);
 }
 
 float *Global_freetype_sil_freetype_outline;
 
-namespace _var1487
+namespace _var1488
 {
     static VariableDefinition varObj("Global_freetype_sil_freetype_outline", "!.f30f5905(???????\?)4531c031c9f30f2df0", &Global_freetype_sil_freetype_outline, true, true);
 }

--- a/FTLGameELF64.h
+++ b/FTLGameELF64.h
@@ -563,6 +563,7 @@ struct AchievementTracker
 	LIBZHL_API void LoadAchievementDescriptions();
 	LIBZHL_API void LoadProfile(int file, int version);
 	LIBZHL_API void OnLanguageChange();
+	LIBZHL_API void OnLoop();
 	LIBZHL_API void ResetFlags();
 	LIBZHL_API void SaveProfile(int file);
 	LIBZHL_API void SetAchievement(const std::string &achievement, bool noPopup, bool sendToServer);

--- a/FTLGameWin32.cpp
+++ b/FTLGameWin32.cpp
@@ -223,14 +223,28 @@ void AchievementTracker::ResetFlags()
 	return execfunc(this);
 }
 
+namespace _func15
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("AchievementTracker::OnLoop", typeid(void (AchievementTracker::*)()), "578d7c????83e4f0ff????5589e557565389cb83ec4c8b013b", argdata, 1, 5, &func);
+}
+
+void AchievementTracker::OnLoop()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AchievementTracker *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func15::func;
+	return execfunc(this);
+}
+
 AchievementTracker *Global_AchievementTracker_Tracker;
 
-namespace _var15
+namespace _var16
 {
     static VariableDefinition varObj("Global_AchievementTracker_Tracker", "!b9(???????\?)e8????????c744240c00000000", &Global_AchievementTracker_Tracker);
 }
 
-namespace _func16
+namespace _func17
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -240,11 +254,11 @@ namespace _func16
 void Animation::constructor(const std::string &_image, int _length, float _time, Pointf _position, int _imageWidth, int _imageHeight, int _stripStartX, int _numFrames)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Animation *this_arg, const std::string &_image_arg, int _length_arg, float _time_arg, Pointf _position_arg, int _imageWidth_arg, int _imageHeight_arg, int _stripStartX_arg, int _numFrames_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func16::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func17::func;
 	return execfunc(this, _image, _length, _time, _position, _imageWidth, _imageHeight, _stripStartX, _numFrames);
 }
 
-namespace _func17
+namespace _func18
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x4ff, 0x1ff};
@@ -254,11 +268,11 @@ namespace _func17
 void Animation::OnRender(float opacity, GL_Color color, bool mirror)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Animation *this_arg, float opacity_arg, GL_Color color_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func17::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func18::func;
 	return execfunc(this, opacity, color, mirror);
 }
 
-namespace _func18
+namespace _func19
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -268,11 +282,11 @@ namespace _func18
 void Animation::Update()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Animation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func18::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func19::func;
 	return execfunc(this);
 }
 
-namespace _func19
+namespace _func20
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -282,11 +296,11 @@ namespace _func19
 void Animation::SetCurrentFrame(int frame)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Animation *this_arg, int frame_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func19::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func20::func;
 	return execfunc(this, frame);
 }
 
-namespace _func20
+namespace _func21
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -296,11 +310,11 @@ namespace _func20
 void Animation::Start(bool reset)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Animation *this_arg, bool reset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func20::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func21::func;
 	return execfunc(this, reset);
 }
 
-namespace _func21
+namespace _func22
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -310,11 +324,11 @@ namespace _func21
 void Animation::AddSoundQueue(int frame, const std::string &sound)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Animation *this_arg, int frame_arg, const std::string &sound_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func21::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func22::func;
 	return execfunc(this, frame, sound);
 }
 
-namespace _func22
+namespace _func23
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -324,11 +338,11 @@ namespace _func22
 void Animation::SetAnimationId(GL_Texture *tex)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Animation *this_arg, GL_Texture *tex_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func22::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func23::func;
 	return execfunc(this, tex);
 }
 
-namespace _func23
+namespace _func24
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -338,11 +352,11 @@ namespace _func23
 void Animation::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Animation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func23::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func24::func;
 	return execfunc(this);
 }
 
-namespace _func24
+namespace _func25
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -352,11 +366,11 @@ namespace _func24
 void Animation::StartReverse(bool reset)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Animation *this_arg, bool reset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func24::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func25::func;
 	return execfunc(this, reset);
 }
 
-namespace _func25
+namespace _func26
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -366,11 +380,11 @@ namespace _func25
 void Animation::SetProgress(float progress)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Animation *this_arg, float progress_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func25::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func26::func;
 	return execfunc(this, progress);
 }
 
-namespace _func26
+namespace _func27
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -380,11 +394,11 @@ namespace _func26
 int Animation::RandomStart()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Animation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func26::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func27::func;
 	return execfunc(this);
 }
 
-namespace _func27
+namespace _func28
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -394,11 +408,11 @@ namespace _func27
 void Animation::SaveState(int fd)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Animation *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func27::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func28::func;
 	return execfunc(this, fd);
 }
 
-namespace _func28
+namespace _func29
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -408,11 +422,11 @@ namespace _func28
 void Animation::LoadState(int fd)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Animation *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func28::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func29::func;
 	return execfunc(this, fd);
 }
 
-namespace _func29
+namespace _func30
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -422,11 +436,11 @@ namespace _func29
 bool Animation::Done()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Animation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func29::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func30::func;
 	return execfunc(this);
 }
 
-namespace _func30
+namespace _func31
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -436,18 +450,18 @@ namespace _func30
 Animation AnimationControl::GetAnimation(const std::string &animName)
 {
 	typedef Animation __attribute__((thiscall)) (*custom_arg_funcptr_t)(AnimationControl *this_arg, const std::string &animName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func30::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func31::func;
 	return execfunc(this, animName);
 }
 
 AnimationControl *Global_AnimationControl_Animations;
 
-namespace _var31
+namespace _var32
 {
     static VariableDefinition varObj("Global_AnimationControl_Animations", "!c70424(???????\?)89c18985ecfeffff", &Global_AnimationControl_Animations);
 }
 
-namespace _func32
+namespace _func33
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -457,11 +471,11 @@ namespace _func32
 void AnimationTracker::Update()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func32::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func33::func;
 	return execfunc(this);
 }
 
-namespace _func33
+namespace _func34
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -471,11 +485,11 @@ namespace _func33
 void AnimationTracker::SetLoop(bool loop, float loopDelay)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg, bool loop_arg, float loopDelay_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func33::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func34::func;
 	return execfunc(this, loop, loopDelay);
 }
 
-namespace _func34
+namespace _func35
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -485,11 +499,11 @@ namespace _func34
 void AnimationTracker::Stop(bool resetTime)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg, bool resetTime_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func34::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func35::func;
 	return execfunc(this, resetTime);
 }
 
-namespace _func35
+namespace _func36
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -497,20 +511,6 @@ namespace _func35
 }
 
 void AnimationTracker::Start(float time)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg, float time_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func35::func;
-	return execfunc(this, time);
-}
-
-namespace _func36
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("AnimationTracker::StartReverse", typeid(void (AnimationTracker::*)(float )), ".660fefc9c6411200f30f10442404c64110010f2ec876??f30f104104", argdata, 2, 5, &func);
-}
-
-void AnimationTracker::StartReverse(float time)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg, float time_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func36::func;
@@ -521,17 +521,31 @@ namespace _func37
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("AnimationTracker::StartReverse", typeid(void (AnimationTracker::*)(float )), ".660fefc9c6411200f30f10442404c64110010f2ec876??f30f104104", argdata, 2, 5, &func);
+}
+
+void AnimationTracker::StartReverse(float time)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg, float time_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func37::func;
+	return execfunc(this, time);
+}
+
+namespace _func38
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("AnimationTracker::Progress", typeid(float (AnimationTracker::*)(float )), ".83ec0480791000f30f104c2408660fefc074??0f2ec10f28d077??f30f10410cf30f5ec1", argdata, 2, 1, &func);
 }
 
 float AnimationTracker::Progress(float speed)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg, float speed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func37::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func38::func;
 	return execfunc(this, speed);
 }
 
-namespace _func38
+namespace _func39
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -541,11 +555,11 @@ namespace _func38
 void AnimationTracker::SetProgress(float time)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg, float time_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func38::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func39::func;
 	return execfunc(this, time);
 }
 
-namespace _func39
+namespace _func40
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -555,11 +569,11 @@ namespace _func39
 float AnimationTracker::GetAlphaLevel(bool reverse)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(AnimationTracker *this_arg, bool reverse_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func39::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func40::func;
 	return execfunc(this, reverse);
 }
 
-namespace _func40
+namespace _func41
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -569,11 +583,11 @@ namespace _func40
 bool ArmamentControl::Dragging()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ArmamentControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func40::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func41::func;
 	return execfunc(this);
 }
 
-namespace _func41
+namespace _func42
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -583,11 +597,11 @@ namespace _func41
 void ArmamentControl::SetPosition(Point loc)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ArmamentControl *this_arg, Point loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func41::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func42::func;
 	return execfunc(this, loc);
 }
 
-namespace _func42
+namespace _func43
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -597,11 +611,11 @@ namespace _func42
 bool ArmamentControl::KeyDown(SDLKey key)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ArmamentControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func42::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func43::func;
 	return execfunc(this, key);
 }
 
-namespace _func43
+namespace _func44
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -611,11 +625,11 @@ namespace _func43
 void ArmamentControl::CreateHolderTab()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ArmamentControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func43::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func44::func;
 	return execfunc(this);
 }
 
-namespace _func44
+namespace _func45
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -625,11 +639,11 @@ namespace _func44
 void ArmamentControl::LinkShip(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ArmamentControl *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func44::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func45::func;
 	return execfunc(this, ship);
 }
 
-namespace _func45
+namespace _func46
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -639,11 +653,11 @@ namespace _func45
 void ArtilleryBox::constructor(Point pos, ArtillerySystem *sys)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ArtilleryBox *this_arg, Point pos_arg, ArtillerySystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func45::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func46::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func46
+namespace _func47
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -653,11 +667,11 @@ namespace _func46
 void ArtilleryBox::OnRender(bool ignoreStatus)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ArtilleryBox *this_arg, bool ignoreStatus_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func46::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func47::func;
 	return execfunc(this, ignoreStatus);
 }
 
-namespace _func47
+namespace _func48
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -665,20 +679,6 @@ namespace _func47
 }
 
 void ArtillerySystem::OnLoop()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ArtillerySystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func47::func;
-	return execfunc(this);
-}
-
-namespace _func48
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ArtillerySystem::Jump", typeid(void (ArtillerySystem::*)()), "8b81c0010000c7400800000000c7802c06000000000000c3", argdata, 1, 5, &func);
-}
-
-void ArtillerySystem::Jump()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ArtillerySystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func48::func;
@@ -689,17 +689,31 @@ namespace _func49
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ArtillerySystem::Jump", typeid(void (ArtillerySystem::*)()), "8b81c0010000c7400800000000c7802c06000000000000c3", argdata, 1, 5, &func);
+}
+
+void ArtillerySystem::Jump()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ArtillerySystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func49::func;
+	return execfunc(this);
+}
+
+namespace _func50
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("Asteroid::OnUpdate", typeid(void (Asteroid::*)()), "578d7c240883e4f0ff77fc5589e5575389cb83ec4080b9b0000000007415c783a402000000000000", argdata, 1, 5, &func);
 }
 
 void Asteroid::OnUpdate()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Asteroid *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func49::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func50::func;
 	return execfunc(this);
 }
 
-namespace _func50
+namespace _func51
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -709,11 +723,11 @@ namespace _func50
 void Asteroid::constructor(Pointf pos, int destinationSpace)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Asteroid *this_arg, Pointf pos_arg, int destinationSpace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func50::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func51::func;
 	return execfunc(this, pos, destinationSpace);
 }
 
-namespace _func51
+namespace _func52
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -723,11 +737,11 @@ namespace _func51
 void AsteroidGenerator::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func51::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func52::func;
 	return execfunc(this);
 }
 
-namespace _func52
+namespace _func53
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -737,11 +751,11 @@ namespace _func52
 float AsteroidGenerator::Initialize(int numberOfShips, int shieldCount, bool defense)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg, int numberOfShips_arg, int shieldCount_arg, bool defense_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func52::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func53::func;
 	return execfunc(this, numberOfShips, shieldCount, defense);
 }
 
-namespace _func53
+namespace _func54
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -751,11 +765,11 @@ namespace _func53
 void AsteroidGenerator::SetNumShips(int ships)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg, int ships_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func53::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func54::func;
 	return execfunc(this, ships);
 }
 
-namespace _func54
+namespace _func55
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -765,20 +779,6 @@ namespace _func54
 Projectile *AsteroidGenerator::GetNextAsteroid()
 {
 	typedef Projectile *__attribute__((thiscall)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func54::func;
-	return execfunc(this);
-}
-
-namespace _func55
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("AsteroidGenerator::OnLoop", typeid(void (AsteroidGenerator::*)()), ".80b9880000000075??c38db600000000578d7c240883e4f0", argdata, 1, 5, &func);
-}
-
-void AsteroidGenerator::OnLoop()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func55::func;
 	return execfunc(this);
 }
@@ -787,10 +787,10 @@ namespace _func56
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("AsteroidGenerator::GetNextState", typeid(void (AsteroidGenerator::*)()), ".5589e5538b417489cb83e4f085c075??803d??????????", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("AsteroidGenerator::OnLoop", typeid(void (AsteroidGenerator::*)()), ".80b9880000000075??c38db600000000578d7c240883e4f0", argdata, 1, 5, &func);
 }
 
-void AsteroidGenerator::GetNextState()
+void AsteroidGenerator::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func56::func;
@@ -801,10 +801,10 @@ namespace _func57
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("AsteroidGenerator::UpdateState", typeid(void (AsteroidGenerator::*)()), ".5589e55389cbb9????????83e4f083ec10e8????????d95c240c", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("AsteroidGenerator::GetNextState", typeid(void (AsteroidGenerator::*)()), ".5589e5538b417489cb83e4f085c075??803d??????????", argdata, 1, 5, &func);
 }
 
-void AsteroidGenerator::UpdateState()
+void AsteroidGenerator::GetNextState()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func57::func;
@@ -814,6 +814,20 @@ void AsteroidGenerator::UpdateState()
 namespace _func58
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("AsteroidGenerator::UpdateState", typeid(void (AsteroidGenerator::*)()), ".5589e55389cbb9????????83e4f083ec10e8????????d95c240c", argdata, 1, 5, &func);
+}
+
+void AsteroidGenerator::UpdateState()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func58::func;
+	return execfunc(this);
+}
+
+namespace _func59
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("AsteroidGenerator::SaveAsteroids", typeid(bool (AsteroidGenerator::*)(void *)), ".5589e5565389ce83e4f083ec108b5d08", argdata, 2, 1, &func);
 }
@@ -821,11 +835,11 @@ namespace _func58
 bool AsteroidGenerator::SaveAsteroids(void *file)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg, void *file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func58::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func59::func;
 	return execfunc(this, file);
 }
 
-namespace _func59
+namespace _func60
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -835,11 +849,11 @@ namespace _func59
 void AsteroidGenerator::LoadAsteroids(void *file)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AsteroidGenerator *this_arg, void *file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func59::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func60::func;
 	return execfunc(this, file);
 }
 
-namespace _func60
+namespace _func61
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -847,20 +861,6 @@ namespace _func60
 }
 
 void AugmentEquipBox::RenderIcon()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AugmentEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func60::func;
-	return execfunc(this);
-}
-
-namespace _func61
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("AugmentEquipBox::CheckContents", typeid(void (AugmentEquipBox::*)()), "8b818400000085c074??578d7c240883e4f0ff77fc5589e557565389cb8d4dc4", argdata, 1, 5, &func);
-}
-
-void AugmentEquipBox::CheckContents()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AugmentEquipBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func61::func;
@@ -871,10 +871,10 @@ namespace _func62
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("AugmentEquipBox::RemoveItem", typeid(void (AugmentEquipBox::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec4c8b818400000085c074??", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("AugmentEquipBox::CheckContents", typeid(void (AugmentEquipBox::*)()), "8b818400000085c074??578d7c240883e4f0ff77fc5589e557565389cb8d4dc4", argdata, 1, 5, &func);
 }
 
-void AugmentEquipBox::RemoveItem()
+void AugmentEquipBox::CheckContents()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AugmentEquipBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func62::func;
@@ -884,6 +884,20 @@ void AugmentEquipBox::RemoveItem()
 namespace _func63
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("AugmentEquipBox::RemoveItem", typeid(void (AugmentEquipBox::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec4c8b818400000085c074??", argdata, 1, 5, &func);
+}
+
+void AugmentEquipBox::RemoveItem()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AugmentEquipBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func63::func;
+	return execfunc(this);
+}
+
+namespace _func64
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("AugmentStoreBox::constructor", typeid(void (AugmentStoreBox::*)(ShipManager *, const AugmentBlueprint *)), "578d7c240883e4f0ff77fc5589f889e557565389cb8d4dd083ec4c8b70048d45d88b3fc7442404000000008945d08d45cc", argdata, 3, 5, &func);
 }
@@ -891,11 +905,11 @@ namespace _func63
 void AugmentStoreBox::constructor(ShipManager *ship, const AugmentBlueprint *bp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(AugmentStoreBox *this_arg, ShipManager *ship_arg, const AugmentBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func63::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func64::func;
 	return execfunc(this, ship, bp);
 }
 
-namespace _func64
+namespace _func65
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -905,11 +919,11 @@ namespace _func64
 void BatteryBox::constructor(Point pos, BatterySystem *sys)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BatteryBox *this_arg, Point pos_arg, BatterySystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func64::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func65::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func65
+namespace _func66
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -919,11 +933,11 @@ namespace _func65
 void BeamWeapon::OnRenderSpecific(int spaceId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BeamWeapon *this_arg, int spaceId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func65::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func66::func;
 	return execfunc(this, spaceId);
 }
 
-namespace _func66
+namespace _func67
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff, 0x2ff, 0x2ff, 0x1ff, 0x1ff, 0x1ff};
@@ -933,11 +947,11 @@ namespace _func66
 void BeamWeapon::constructor(Pointf _position, int _ownerId, int _targetId, Pointf _target, Pointf _target2, int _length, Targetable *_targetable, float heading)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BeamWeapon *this_arg, Pointf _position_arg, int _ownerId_arg, int _targetId_arg, Pointf _target_arg, Pointf _target2_arg, int _length_arg, Targetable *_targetable_arg, float heading_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func66::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func67::func;
 	return execfunc(this, _position, _ownerId, _targetId, _target, _target2, _length, _targetable, heading);
 }
 
-namespace _func67
+namespace _func68
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -947,11 +961,11 @@ namespace _func67
 void BeamWeapon::CollisionCheck(Collideable *other)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BeamWeapon *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func67::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func68::func;
 	return execfunc(this, other);
 }
 
-namespace _func68
+namespace _func69
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -961,11 +975,11 @@ namespace _func68
 void BeamWeapon::OnUpdate()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BeamWeapon *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func68::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func69::func;
 	return execfunc(this);
 }
 
-namespace _func69
+namespace _func70
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -975,11 +989,11 @@ namespace _func69
 void Blueprint::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Blueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func69::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func70::func;
 	return execfunc(this);
 }
 
-namespace _func70
+namespace _func71
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -989,11 +1003,11 @@ namespace _func70
 std::string Blueprint::GetNameShort()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(Blueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func70::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func71::func;
 	return execfunc(this);
 }
 
-namespace _func71
+namespace _func72
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -1003,11 +1017,11 @@ namespace _func71
 std::vector<std::string> BlueprintManager::GetBlueprintList(const std::string &name)
 {
 	typedef std::vector<std::string> __attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func71::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func72::func;
 	return execfunc(this, name);
 }
 
-namespace _func72
+namespace _func73
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -1017,11 +1031,11 @@ namespace _func72
 ShipBlueprint *BlueprintManager::GetShipBlueprint(const std::string &name, int sector)
 {
 	typedef ShipBlueprint *__attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg, int sector_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func72::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func73::func;
 	return execfunc(this, name, sector);
 }
 
-namespace _func73
+namespace _func74
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1031,11 +1045,11 @@ namespace _func73
 DroneBlueprint *BlueprintManager::GetDroneBlueprint(const std::string &name)
 {
 	typedef DroneBlueprint *__attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func73::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func74::func;
 	return execfunc(this, name);
 }
 
-namespace _func74
+namespace _func75
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1045,11 +1059,11 @@ namespace _func74
 float BlueprintManager::GetAugmentValue(const std::string &name)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func74::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func75::func;
 	return execfunc(this, name);
 }
 
-namespace _func75
+namespace _func76
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1059,11 +1073,11 @@ namespace _func75
 AugmentBlueprint *BlueprintManager::GetAugmentBlueprint(const std::string &name)
 {
 	typedef AugmentBlueprint *__attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func75::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func76::func;
 	return execfunc(this, name);
 }
 
-namespace _func76
+namespace _func77
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1073,11 +1087,11 @@ namespace _func76
 ItemBlueprint *BlueprintManager::GetItemBlueprint(const std::string &name)
 {
 	typedef ItemBlueprint *__attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func76::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func77::func;
 	return execfunc(this, name);
 }
 
-namespace _func77
+namespace _func78
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -1087,11 +1101,11 @@ namespace _func77
 WeaponBlueprint BlueprintManager::ProcessWeaponBlueprint(rapidxml::xml_node<char> *node)
 {
 	typedef WeaponBlueprint __attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func77::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func78::func;
 	return execfunc(this, node);
 }
 
-namespace _func78
+namespace _func79
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -1101,11 +1115,11 @@ namespace _func78
 Description BlueprintManager::ProcessDescription(rapidxml::xml_node<char> *node)
 {
 	typedef Description __attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func78::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func79::func;
 	return execfunc(this, node);
 }
 
-namespace _func79
+namespace _func80
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -1115,11 +1129,11 @@ namespace _func79
 EffectsBlueprint BlueprintManager::ProcessEffectsBlueprint(rapidxml::xml_node<char> *node)
 {
 	typedef EffectsBlueprint __attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func79::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func80::func;
 	return execfunc(this, node);
 }
 
-namespace _func80
+namespace _func81
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -1129,11 +1143,11 @@ namespace _func80
 CrewBlueprint BlueprintManager::GetCrewBlueprint(const std::string &name)
 {
 	typedef CrewBlueprint __attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func80::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func81::func;
 	return execfunc(this, name);
 }
 
-namespace _func81
+namespace _func82
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1143,11 +1157,11 @@ namespace _func81
 WeaponBlueprint *BlueprintManager::GetWeaponBlueprint(const std::string &name)
 {
 	typedef WeaponBlueprint *__attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func81::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func82::func;
 	return execfunc(this, name);
 }
 
-namespace _func82
+namespace _func83
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -1157,11 +1171,11 @@ namespace _func82
 std::vector<AugmentBlueprint*> BlueprintManager::GetRandomAugment(int count, bool demo_lock)
 {
 	typedef std::vector<AugmentBlueprint*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, int count_arg, bool demo_lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func82::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func83::func;
 	return execfunc(this, count, demo_lock);
 }
 
-namespace _func83
+namespace _func84
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1171,11 +1185,11 @@ namespace _func83
 SystemBlueprint *BlueprintManager::GetSystemBlueprint(const std::string &name)
 {
 	typedef SystemBlueprint *__attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func83::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func84::func;
 	return execfunc(this, name);
 }
 
-namespace _func84
+namespace _func85
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -1185,11 +1199,11 @@ namespace _func84
 std::string BlueprintManager::GetUnusedCrewName(bool *isMale_ret)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, bool *isMale_ret_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func84::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func85::func;
 	return execfunc(this, isMale_ret);
 }
 
-namespace _func85
+namespace _func86
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -1199,11 +1213,11 @@ namespace _func85
 std::string BlueprintManager::GetCrewName(bool *isMale_ret)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, bool *isMale_ret_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func85::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func86::func;
 	return execfunc(this, isMale_ret);
 }
 
-namespace _func86
+namespace _func87
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -1213,11 +1227,11 @@ namespace _func86
 std::vector<WeaponBlueprint*> BlueprintManager::GetRandomWeapon(int count, bool demo_lock)
 {
 	typedef std::vector<WeaponBlueprint*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, int count_arg, bool demo_lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func86::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func87::func;
 	return execfunc(this, count, demo_lock);
 }
 
-namespace _func87
+namespace _func88
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -1227,11 +1241,11 @@ namespace _func87
 std::vector<DroneBlueprint*> BlueprintManager::GetRandomDrone(int count, bool demo_lock)
 {
 	typedef std::vector<DroneBlueprint*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, int count_arg, bool demo_lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func87::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func88::func;
 	return execfunc(this, count, demo_lock);
 }
 
-namespace _func88
+namespace _func89
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -1241,11 +1255,11 @@ namespace _func88
 ShipBlueprint BlueprintManager::ProcessShipBlueprint(rapidxml::xml_node<char> *node)
 {
 	typedef ShipBlueprint __attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func88::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func89::func;
 	return execfunc(this, node);
 }
 
-namespace _func89
+namespace _func90
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -1255,11 +1269,11 @@ namespace _func89
 DroneBlueprint BlueprintManager::ProcessDroneBlueprint(rapidxml::xml_node<char> *node)
 {
 	typedef DroneBlueprint __attribute__((thiscall)) (*custom_arg_funcptr_t)(BlueprintManager *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func89::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func90::func;
 	return execfunc(this, node);
 }
 
-namespace _func90
+namespace _func91
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -1269,18 +1283,18 @@ namespace _func90
 GL_Texture *BlueprintManager::GetSkillIcon(int skill, bool outline)
 {
 	typedef GL_Texture *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int skill_arg, bool outline_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func90::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func91::func;
 	return execfunc(skill, outline);
 }
 
 BlueprintManager *Global_BlueprintManager_Blueprints;
 
-namespace _var91
+namespace _var92
 {
     static VariableDefinition varObj("Global_BlueprintManager_Blueprints", "!8b85c0feffff83ec04b9(???????\?)83b83401000003", &Global_BlueprintManager_Blueprints);
 }
 
-namespace _func92
+namespace _func93
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -1290,11 +1304,11 @@ namespace _func92
 void BoarderPodDrone::constructor(int _iShipId, int _selfId, const DroneBlueprint &_bp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg, int _iShipId_arg, int _selfId_arg, const DroneBlueprint &_bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func92::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func93::func;
 	return execfunc(this, _iShipId, _selfId, _bp);
 }
 
-namespace _func93
+namespace _func94
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1304,11 +1318,11 @@ namespace _func93
 void BoarderPodDrone::SetMovementTarget(Targetable *target)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func93::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func94::func;
 	return execfunc(this, target);
 }
 
-namespace _func94
+namespace _func95
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1318,11 +1332,11 @@ namespace _func94
 bool BoarderPodDrone::CanBeDeployed()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func94::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func95::func;
 	return execfunc(this);
 }
 
-namespace _func95
+namespace _func96
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1332,11 +1346,11 @@ namespace _func95
 void BoarderPodDrone::SetDeployed(bool _deployed)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg, bool _deployed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func95::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func96::func;
 	return execfunc(this, _deployed);
 }
 
-namespace _func96
+namespace _func97
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -1346,11 +1360,11 @@ namespace _func96
 CollisionResponse BoarderPodDrone::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((thiscall)) (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func96::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func97::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func97
+namespace _func98
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1360,11 +1374,11 @@ namespace _func97
 void BoarderPodDrone::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BoarderPodDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func97::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func98::func;
 	return execfunc(this);
 }
 
-namespace _func98
+namespace _func99
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff, 0x2ff};
@@ -1374,11 +1388,11 @@ namespace _func98
 void BombProjectile::constructor(Pointf _position, int _ownerId, int _targetId, Pointf _target)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BombProjectile *this_arg, Pointf _position_arg, int _ownerId_arg, int _targetId_arg, Pointf _target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func98::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func99::func;
 	return execfunc(this, _position, _ownerId, _targetId, _target);
 }
 
-namespace _func99
+namespace _func100
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1388,11 +1402,11 @@ namespace _func99
 void BombProjectile::CollisionCheck(Collideable *other)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BombProjectile *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func99::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func100::func;
 	return execfunc(this, other);
 }
 
-namespace _func100
+namespace _func101
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1402,11 +1416,11 @@ namespace _func100
 void BombProjectile::OnUpdate()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BombProjectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func100::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func101::func;
 	return execfunc(this);
 }
 
-namespace _func101
+namespace _func102
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1416,11 +1430,11 @@ namespace _func101
 void BossShip::Restart()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func101::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func102::func;
 	return execfunc(this);
 }
 
-namespace _func102
+namespace _func103
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1430,11 +1444,11 @@ namespace _func102
 bool BossShip::IncomingFire()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func102::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func103::func;
 	return execfunc(this);
 }
 
-namespace _func103
+namespace _func104
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1444,11 +1458,11 @@ namespace _func103
 void BossShip::constructor(SpaceManager *space)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BossShip *this_arg, SpaceManager *space_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func103::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func104::func;
 	return execfunc(this, space);
 }
 
-namespace _func104
+namespace _func105
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1458,11 +1472,11 @@ namespace _func104
 void BossShip::SaveBoss(int file)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BossShip *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func104::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func105::func;
 	return execfunc(this, file);
 }
 
-namespace _func105
+namespace _func106
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1472,11 +1486,11 @@ namespace _func105
 void BossShip::LoadBoss(int file)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BossShip *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func105::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func106::func;
 	return execfunc(this, file);
 }
 
-namespace _func106
+namespace _func107
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1486,11 +1500,11 @@ namespace _func106
 void BossShip::ClearLocation()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func106::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func107::func;
 	return execfunc(this);
 }
 
-namespace _func107
+namespace _func108
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1500,11 +1514,11 @@ namespace _func107
 bool BossShip::Defeated()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func107::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func108::func;
 	return execfunc(this);
 }
 
-namespace _func108
+namespace _func109
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1514,11 +1528,11 @@ namespace _func108
 LocationEvent *BossShip::GetSubEvent()
 {
 	typedef LocationEvent *__attribute__((thiscall)) (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func108::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func109::func;
 	return execfunc(this);
 }
 
-namespace _func109
+namespace _func110
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1528,11 +1542,11 @@ namespace _func109
 void BossShip::StartStage()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func109::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func110::func;
 	return execfunc(this);
 }
 
-namespace _func110
+namespace _func111
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1542,11 +1556,11 @@ namespace _func110
 LocationEvent *BossShip::GetEvent()
 {
 	typedef LocationEvent *__attribute__((thiscall)) (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func110::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func111::func;
 	return execfunc(this);
 }
 
-namespace _func111
+namespace _func112
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1556,11 +1570,11 @@ namespace _func111
 void BossShip::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(BossShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func111::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func112::func;
 	return execfunc(this);
 }
 
-namespace _func112
+namespace _func113
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -1570,11 +1584,11 @@ namespace _func112
 void Button::SetLocation(const Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Button *this_arg, const Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func112::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func113::func;
 	return execfunc(this, pos);
 }
 
-namespace _func113
+namespace _func114
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff};
@@ -1584,11 +1598,11 @@ namespace _func113
 void Button::OnInit(const std::string &img, Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Button *this_arg, const std::string &img_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func113::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func114::func;
 	return execfunc(this, img, pos);
 }
 
-namespace _func114
+namespace _func115
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1598,11 +1612,11 @@ namespace _func114
 void Button::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Button *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func114::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func115::func;
 	return execfunc(this);
 }
 
-namespace _func115
+namespace _func116
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1612,11 +1626,11 @@ namespace _func115
 void Button::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Button *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func115::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func116::func;
 	return execfunc(this);
 }
 
-namespace _func116
+namespace _func117
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1624,20 +1638,6 @@ namespace _func116
 }
 
 void Button::SetInactiveImage(GL_Texture *texture)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Button *this_arg, GL_Texture *texture_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func116::func;
-	return execfunc(this, texture);
-}
-
-namespace _func117
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("Button::SetActiveImage", typeid(void (Button::*)(GL_Texture *)), ".5589e5565383e4f083ec108b450839414c74??89414c8b018b40303d????????75??8d59548d7160", argdata, 2, 5, &func);
-}
-
-void Button::SetActiveImage(GL_Texture *texture)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Button *this_arg, GL_Texture *texture_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func117::func;
@@ -1648,17 +1648,31 @@ namespace _func118
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("Button::SetActiveImage", typeid(void (Button::*)(GL_Texture *)), ".5589e5565383e4f083ec108b450839414c74??89414c8b018b40303d????????75??8d59548d7160", argdata, 2, 5, &func);
+}
+
+void Button::SetActiveImage(GL_Texture *texture)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Button *this_arg, GL_Texture *texture_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func118::func;
+	return execfunc(this, texture);
+}
+
+namespace _func119
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("Button::SetImageBase", typeid(void (Button::*)(const std::string &)), "578d7c240883e4f0ff77fc5589e55756538d45a889cb83ec7c8b3f8945a08b178b770489d0", argdata, 2, 5, &func);
 }
 
 void Button::SetImageBase(const std::string &imageBase)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Button *this_arg, const std::string &imageBase_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func118::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func119::func;
 	return execfunc(this, imageBase);
 }
 
-namespace _func119
+namespace _func120
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -1668,11 +1682,11 @@ namespace _func119
 void CAchievement::OnRender(Point pos, int selected, bool showNew)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CAchievement *this_arg, Point pos_arg, int selected_arg, bool showNew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func119::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func120::func;
 	return execfunc(this, pos, selected, showNew);
 }
 
-namespace _func120
+namespace _func121
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1682,20 +1696,6 @@ namespace _func120
 void CAchievement::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CAchievement *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func120::func;
-	return execfunc(this);
-}
-
-namespace _func121
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CApp::OnInputFocus", typeid(void (CApp::*)()), "578d7c240883e4f0ff77fc5589e5575389cb83ec1080b9f734000000", argdata, 1, 5, &func);
-}
-
-void CApp::OnInputFocus()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func121::func;
 	return execfunc(this);
 }
@@ -1704,10 +1704,10 @@ namespace _func122
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CApp::OnInputBlur", typeid(void (CApp::*)()), ".5789c88d7c240883e4f0ff77fc5589e5575383ec10c681f7340000008b4908803d??????????", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CApp::OnInputFocus", typeid(void (CApp::*)()), "578d7c240883e4f0ff77fc5589e5575389cb83ec1080b9f734000000", argdata, 1, 5, &func);
 }
 
-void CApp::OnInputBlur()
+void CApp::OnInputFocus()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func122::func;
@@ -1718,10 +1718,10 @@ namespace _func123
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CApp::OnExit", typeid(void (CApp::*)()), ".578d7c240883e4f0ff77fc5589e5575389cb83ec10e8????????c70424????????", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CApp::OnInputBlur", typeid(void (CApp::*)()), ".5789c88d7c240883e4f0ff77fc5589e5575383ec10c681f7340000008b4908803d??????????", argdata, 1, 5, &func);
 }
 
-void CApp::OnExit()
+void CApp::OnInputBlur()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func123::func;
@@ -1731,6 +1731,20 @@ void CApp::OnExit()
 namespace _func124
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CApp::OnExit", typeid(void (CApp::*)()), ".578d7c240883e4f0ff77fc5589e5575389cb83ec10e8????????c70424????????", argdata, 1, 5, &func);
+}
+
+void CApp::OnExit()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func124::func;
+	return execfunc(this);
+}
+
+namespace _func125
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CApp::OnMButtonDown", typeid(void (CApp::*)(int , int )), ".80b9bc3400000074??c208008d74260080791000", argdata, 3, 5, &func);
 }
@@ -1738,11 +1752,11 @@ namespace _func124
 void CApp::OnMButtonDown(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func124::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func125::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func125
+namespace _func126
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1752,11 +1766,11 @@ namespace _func125
 void CApp::OnTextEvent(CEvent::TextEvent textEvent)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg, CEvent::TextEvent textEvent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func125::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func126::func;
 	return execfunc(this, textEvent);
 }
 
-namespace _func126
+namespace _func127
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1766,11 +1780,11 @@ namespace _func126
 void CApp::OnTextInput(int ch)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg, int ch_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func126::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func127::func;
 	return execfunc(this, ch);
 }
 
-namespace _func127
+namespace _func128
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1780,11 +1794,11 @@ namespace _func127
 void CApp::OnRequestExit()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func127::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func128::func;
 	return execfunc(this);
 }
 
-namespace _func128
+namespace _func129
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -1794,11 +1808,11 @@ namespace _func128
 void CApp::OnMouseMove(int x, int y, int xdiff, int ydiff, bool holdingLMB, bool holdingRMB, bool holdingMMB)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg, int xdiff_arg, int ydiff_arg, bool holdingLMB_arg, bool holdingRMB_arg, bool holdingMMB_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func128::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func129::func;
 	return execfunc(this, x, y, xdiff, ydiff, holdingLMB, holdingRMB, holdingMMB);
 }
 
-namespace _func129
+namespace _func130
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -1806,20 +1820,6 @@ namespace _func129
 }
 
 void CApp::OnRButtonUp(int x, int y)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func129::func;
-	return execfunc(this, x, y);
-}
-
-namespace _func130
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CApp::OnLButtonUp", typeid(void (CApp::*)(int , int )), ".57660fefc08d7c240883e4f0ff77fc5589e557", argdata, 3, 5, &func);
-}
-
-void CApp::OnLButtonUp(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func130::func;
@@ -1830,10 +1830,10 @@ namespace _func131
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CApp::OnRButtonDown", typeid(void (CApp::*)(int , int )), ".57660fefc08d7c240883e4f0ff77fc5589e55753", argdata, 3, 5, &func);
+	static FunctionDefinition funcObj("CApp::OnLButtonUp", typeid(void (CApp::*)(int , int )), ".57660fefc08d7c240883e4f0ff77fc5589e557", argdata, 3, 5, &func);
 }
 
-void CApp::OnRButtonDown(int x, int y)
+void CApp::OnLButtonUp(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func131::func;
@@ -1844,10 +1844,10 @@ namespace _func132
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CApp::OnLButtonDown", typeid(void (CApp::*)(int , int )), ".57660fefc08d7c240883e4f0ff77fc5589e5", argdata, 3, 5, &func);
+	static FunctionDefinition funcObj("CApp::OnRButtonDown", typeid(void (CApp::*)(int , int )), ".57660fefc08d7c240883e4f0ff77fc5589e55753", argdata, 3, 5, &func);
 }
 
-void CApp::OnLButtonDown(int x, int y)
+void CApp::OnRButtonDown(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func132::func;
@@ -1857,6 +1857,20 @@ void CApp::OnLButtonDown(int x, int y)
 namespace _func133
 {
     static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("CApp::OnLButtonDown", typeid(void (CApp::*)(int , int )), ".57660fefc08d7c240883e4f0ff77fc5589e5", argdata, 3, 5, &func);
+}
+
+void CApp::OnLButtonDown(int x, int y)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func133::func;
+	return execfunc(this, x, y);
+}
+
+namespace _func134
+{
+    static void *func = 0;
 	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("CApp::OnLanguageChange", typeid(void (CApp::*)()), ".578d7c240883e4f0ff77fc5589e55756", argdata, 1, 5, &func);
 }
@@ -1864,11 +1878,11 @@ namespace _func133
 void CApp::OnLanguageChange()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func133::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func134::func;
 	return execfunc(this);
 }
 
-namespace _func134
+namespace _func135
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1878,11 +1892,11 @@ namespace _func134
 void CApp::OnKeyUp(SDLKey key)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func134::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func135::func;
 	return execfunc(this, key);
 }
 
-namespace _func135
+namespace _func136
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -1892,11 +1906,11 @@ namespace _func135
 void CApp::OnKeyDown(SDLKey key)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func135::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func136::func;
 	return execfunc(this, key);
 }
 
-namespace _func136
+namespace _func137
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1906,11 +1920,11 @@ namespace _func136
 void CApp::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func136::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func137::func;
 	return execfunc(this);
 }
 
-namespace _func137
+namespace _func138
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -1920,11 +1934,11 @@ namespace _func137
 void CApp::ParseArgs(int argc, const char **argv)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg, int argc_arg, const char **argv_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func137::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func138::func;
 	return execfunc(this, argc, argv);
 }
 
-namespace _func138
+namespace _func139
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1934,11 +1948,11 @@ namespace _func138
 void CApp::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func138::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func139::func;
 	return execfunc(this);
 }
 
-namespace _func139
+namespace _func140
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -1948,20 +1962,6 @@ namespace _func139
 int CApp::SetupWindow()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func139::func;
-	return execfunc(this);
-}
-
-namespace _func140
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CApp::OnCleanup", typeid(void (CApp::*)()), ".5589e5565389cb83e4f083ec10", argdata, 1, 5, &func);
-}
-
-void CApp::OnCleanup()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func140::func;
 	return execfunc(this);
 }
@@ -1970,10 +1970,10 @@ namespace _func141
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CApp::GenInputEvents", typeid(void (CApp::*)()), ".578d7c240883e4f0ff77fc5589e5575389cb", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CApp::OnCleanup", typeid(void (CApp::*)()), ".5589e5565389cb83e4f083ec10", argdata, 1, 5, &func);
 }
 
-void CApp::GenInputEvents()
+void CApp::OnCleanup()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func141::func;
@@ -1984,10 +1984,10 @@ namespace _func142
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CApp::OnSuspend", typeid(void (CApp::*)()), ".578d7c240883e4f0ff77fc5589e557", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CApp::GenInputEvents", typeid(void (CApp::*)()), ".578d7c240883e4f0ff77fc5589e5575389cb", argdata, 1, 5, &func);
 }
 
-void CApp::OnSuspend()
+void CApp::GenInputEvents()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func142::func;
@@ -1998,10 +1998,10 @@ namespace _func143
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CApp::OnResume", typeid(void (CApp::*)()), "!.80b9bc3400000075??8079100074??c35589e55389cb8b4908", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CApp::OnSuspend", typeid(void (CApp::*)()), ".578d7c240883e4f0ff77fc5589e557", argdata, 1, 5, &func);
 }
 
-void CApp::OnResume()
+void CApp::OnSuspend()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func143::func;
@@ -2011,6 +2011,20 @@ void CApp::OnResume()
 namespace _func144
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CApp::OnResume", typeid(void (CApp::*)()), "!.80b9bc3400000075??8079100074??c35589e55389cb8b4908", argdata, 1, 5, &func);
+}
+
+void CApp::OnResume()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func144::func;
+	return execfunc(this);
+}
+
+namespace _func145
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CApp::TranslateMouse", typeid(Point (CApp::*)(int , int )), ".57660fefc08d7c240883e4f0ff77fc5589e55783ec248b072b8110350000", argdata, 3, 9, &func);
 }
@@ -2018,11 +2032,11 @@ namespace _func144
 Point CApp::TranslateMouse(int x, int y)
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func144::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func145::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func145
+namespace _func146
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -2030,20 +2044,6 @@ namespace _func145
 }
 
 void CApp::UpdateFullScreen()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func145::func;
-	return execfunc(this);
-}
-
-namespace _func146
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CApp::UpdateWindowSettings", typeid(void (CApp::*)()), ".80b90c35000000c781ec34000000000000c781f034000000000000c7811035000000000000", argdata, 1, 5, &func);
-}
-
-void CApp::UpdateWindowSettings()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func146::func;
@@ -2054,10 +2054,10 @@ namespace _func147
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CApp::OnRender", typeid(void (CApp::*)()), ".578d7c240883e4f0ff77fc5589e55756", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CApp::UpdateWindowSettings", typeid(void (CApp::*)()), ".80b90c35000000c781ec34000000000000c781f034000000000000c7811035000000000000", argdata, 1, 5, &func);
 }
 
-void CApp::OnRender()
+void CApp::UpdateWindowSettings()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func147::func;
@@ -2068,12 +2068,12 @@ namespace _func148
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CApp::OnInit", typeid(int (CApp::*)()), ".578d7c240883e4f0ff77fc5589e557", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("CApp::OnRender", typeid(void (CApp::*)()), ".578d7c240883e4f0ff77fc5589e55756", argdata, 1, 5, &func);
 }
 
-int CApp::OnInit()
+void CApp::OnRender()
 {
-	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func148::func;
 	return execfunc(this);
 }
@@ -2082,10 +2082,10 @@ namespace _func149
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CApp::OnExecute", typeid(int (CApp::*)()), ".578d7c240883e4f0ff77fc5589e557565389cfb9????????81ec????????c70424????????e8????????89f9", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("CApp::OnInit", typeid(int (CApp::*)()), ".578d7c240883e4f0ff77fc5589e557", argdata, 1, 1, &func);
 }
 
-int CApp::OnExecute()
+int CApp::OnInit()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func149::func;
@@ -2095,6 +2095,20 @@ int CApp::OnExecute()
 namespace _func150
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CApp::OnExecute", typeid(int (CApp::*)()), ".578d7c240883e4f0ff77fc5589e557565389cfb9????????81ec????????c70424????????e8????????89f9", argdata, 1, 1, &func);
+}
+
+int CApp::OnExecute()
+{
+	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CApp *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func150::func;
+	return execfunc(this);
+}
+
+namespace _func151
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("CEvent::OnEvent", typeid(void (CEvent::*)(const InputEvent *)), "578d7c240883e4f0ff77fc5589e557565383ec4c8b1f8b4304f20f104308f20f1105????????83e80783f81b77??", argdata, 2, 5, &func);
 }
@@ -2102,11 +2116,11 @@ namespace _func150
 void CEvent::OnEvent(const InputEvent *event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CEvent *this_arg, const InputEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func150::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func151::func;
 	return execfunc(this, event);
 }
 
-namespace _func151
+namespace _func152
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -2116,11 +2130,11 @@ namespace _func151
 float CFPS::GetSpeedFactor()
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(CFPS *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func151::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func152::func;
 	return execfunc(this);
 }
 
-namespace _func152
+namespace _func153
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -2130,18 +2144,18 @@ namespace _func152
 void CFPS::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CFPS *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func152::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func153::func;
 	return execfunc(this);
 }
 
 CFPS *Global_CFPS_FPSControl;
 
-namespace _var153
+namespace _var154
 {
     static VariableDefinition varObj("Global_CFPS_FPSControl", "!5589e557565389cbb9(???????\?)83ec4c", &Global_CFPS_FPSControl);
 }
 
-namespace _func154
+namespace _func155
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -2151,11 +2165,11 @@ namespace _func154
 GL_Color CSurface::GL_GetColor()
 {
 	typedef GL_Color __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func154::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func155::func;
 	return execfunc();
 }
 
-namespace _func155
+namespace _func156
 {
     static void *func = 0;
 	static short argdata[] = {0x4ff};
@@ -2165,11 +2179,11 @@ namespace _func155
 void CSurface::GL_SetColorTint(GL_Color color)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func155::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func156::func;
 	return execfunc(color);
 }
 
-namespace _func156
+namespace _func157
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -2179,11 +2193,11 @@ namespace _func156
 void CSurface::GL_Rotate2(float angle, float x, float y, float z)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(float angle_arg, float x_arg, float y_arg, float z_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func156::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func157::func;
 	return execfunc(angle, x, y, z);
 }
 
-namespace _func157
+namespace _func158
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -2193,20 +2207,6 @@ namespace _func157
 bool CSurface::IsFrameBufferSupported()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func157::func;
-	return execfunc();
-}
-
-namespace _func158
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("CSurface::StartFrame", typeid(void (*)()), ".5589e583e4f0e8????????e8????????", argdata, 0, 6, &func);
-}
-
-void CSurface::StartFrame()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func158::func;
 	return execfunc();
 }
@@ -2215,10 +2215,10 @@ namespace _func159
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("CSurface::FinishFrame", typeid(void (*)()), ".5589e583e4f0e8????????", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("CSurface::StartFrame", typeid(void (*)()), ".5589e583e4f0e8????????e8????????", argdata, 0, 6, &func);
 }
 
-void CSurface::FinishFrame()
+void CSurface::StartFrame()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func159::func;
@@ -2229,10 +2229,10 @@ namespace _func160
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("CSurface::GL_ClearAll", typeid(void (*)()), ".55660fefc089e583e4f083ec20f30f1144240cc744241400000000", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("CSurface::FinishFrame", typeid(void (*)()), ".5589e583e4f0e8????????", argdata, 0, 6, &func);
 }
 
-void CSurface::GL_ClearAll()
+void CSurface::FinishFrame()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func160::func;
@@ -2243,10 +2243,10 @@ namespace _func161
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("CSurface::GL_ClearColor", typeid(void (*)()), ".55660fefc089e583e4f083ec10f30f1144240cf30f11442408", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("CSurface::GL_ClearAll", typeid(void (*)()), ".55660fefc089e583e4f083ec20f30f1144240cc744241400000000", argdata, 0, 6, &func);
 }
 
-void CSurface::GL_ClearColor()
+void CSurface::GL_ClearAll()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func161::func;
@@ -2256,6 +2256,20 @@ void CSurface::GL_ClearColor()
 namespace _func162
 {
     static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("CSurface::GL_ClearColor", typeid(void (*)()), ".55660fefc089e583e4f083ec10f30f1144240cf30f11442408", argdata, 0, 6, &func);
+}
+
+void CSurface::GL_ClearColor()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func162::func;
+	return execfunc();
+}
+
+namespace _func163
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CSurface::SetViewPort", typeid(int (*)(int , int , int , int )), ".5589e583e4f083ec108b45148944240c8b4510894424088b450c89442404", argdata, 4, 2, &func);
 }
@@ -2263,11 +2277,11 @@ namespace _func162
 int CSurface::SetViewPort(int left, int bottom, int h, int w)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int left_arg, int bottom_arg, int h_arg, int w_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func162::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func163::func;
 	return execfunc(left, bottom, h, w);
 }
 
-namespace _func163
+namespace _func164
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -2277,11 +2291,11 @@ namespace _func163
 void CSurface::GL_PopScissor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func163::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func164::func;
 	return execfunc();
 }
 
-namespace _func164
+namespace _func165
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -2291,11 +2305,11 @@ namespace _func164
 void CSurface::GL_SetStencilMode(GL_StencilMode stencilMode, int ref, int mask)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_StencilMode stencilMode_arg, int ref_arg, int mask_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func164::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func165::func;
 	return execfunc(stencilMode, ref, mask);
 }
 
-namespace _func165
+namespace _func166
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -2305,11 +2319,11 @@ namespace _func165
 void CSurface::GL_PopStencilMode()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func165::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func166::func;
 	return execfunc();
 }
 
-namespace _func166
+namespace _func167
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -2319,11 +2333,11 @@ namespace _func166
 int CSurface::GL_OrthoProjection(float mx1, float mx2, float mx3, float mx4, float mx5, float mx6)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(float mx1_arg, float mx2_arg, float mx3_arg, float mx4_arg, float mx5_arg, float mx6_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func166::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func167::func;
 	return execfunc(mx1, mx2, mx3, mx4, mx5, mx6);
 }
 
-namespace _func167
+namespace _func168
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -2331,20 +2345,6 @@ namespace _func167
 }
 
 int CSurface::GL_LoadIdentity()
-{
-	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func167::func;
-	return execfunc();
-}
-
-namespace _func168
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("CSurface::GL_PushMatrix", typeid(int (*)()), ".a1????????83f80f77??89c10f2805????????c1e106", argdata, 0, 2, &func);
-}
-
-int CSurface::GL_PushMatrix()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func168::func;
@@ -2355,10 +2355,10 @@ namespace _func169
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("CSurface::GL_PopMatrix", typeid(int (*)()), ".5589e583e4f083ec30a1????????85c0", argdata, 0, 2, &func);
+	static FunctionDefinition funcObj("CSurface::GL_PushMatrix", typeid(int (*)()), ".a1????????83f80f77??89c10f2805????????c1e106", argdata, 0, 2, &func);
 }
 
-int CSurface::GL_PopMatrix()
+int CSurface::GL_PushMatrix()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func169::func;
@@ -2368,6 +2368,20 @@ int CSurface::GL_PopMatrix()
 namespace _func170
 {
     static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("CSurface::GL_PopMatrix", typeid(int (*)()), ".5589e583e4f083ec30a1????????85c0", argdata, 0, 2, &func);
+}
+
+int CSurface::GL_PopMatrix()
+{
+	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func170::func;
+	return execfunc();
+}
+
+namespace _func171
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CSurface::GL_Rotate", typeid(void (*)(float , float , float , float )), ".55660fefe489e5565383e4f081ec????????f30f1055080f2ed4f30f104d0cf30f104510f30f105d147a??", argdata, 4, 6, &func);
 }
@@ -2375,11 +2389,11 @@ namespace _func170
 void CSurface::GL_Rotate(float angle, float x, float y, float z)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(float angle_arg, float x_arg, float y_arg, float z_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func170::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func171::func;
 	return execfunc(angle, x, y, z);
 }
 
-namespace _func171
+namespace _func172
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -2389,11 +2403,11 @@ namespace _func171
 void CSurface::GL_Scale(float x, float y, float z)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(float x_arg, float y_arg, float z_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func171::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func172::func;
 	return execfunc(x, y, z);
 }
 
-namespace _func172
+namespace _func173
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -2403,11 +2417,11 @@ namespace _func172
 bool CSurface::GL_Translate(float x, float y, float z)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(float x_arg, float y_arg, float z_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func172::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func173::func;
 	return execfunc(x, y, z);
 }
 
-namespace _func173
+namespace _func174
 {
     static void *func = 0;
 	static short argdata[] = {0x4ff};
@@ -2417,11 +2431,11 @@ namespace _func173
 int CSurface::GL_SetColor(GL_Color color)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func173::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func174::func;
 	return execfunc(color);
 }
 
-namespace _func174
+namespace _func175
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -2431,11 +2445,11 @@ namespace _func174
 void CSurface::GL_RemoveColorTint()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func174::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func175::func;
 	return execfunc();
 }
 
-namespace _func175
+namespace _func176
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -2445,11 +2459,11 @@ namespace _func175
 GL_Color CSurface::GetColorTint()
 {
 	typedef GL_Color __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func175::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func176::func;
 	return execfunc();
 }
 
-namespace _func176
+namespace _func177
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -2459,11 +2473,11 @@ namespace _func176
 bool CSurface::GL_EnableBlend()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func176::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func177::func;
 	return execfunc();
 }
 
-namespace _func177
+namespace _func178
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -2473,11 +2487,11 @@ namespace _func177
 bool CSurface::GL_DisableBlend()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func177::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func178::func;
 	return execfunc();
 }
 
-namespace _func178
+namespace _func179
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -2487,11 +2501,11 @@ namespace _func178
 void CSurface::GL_ForceAntialias(bool on)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(bool on_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func178::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func179::func;
 	return execfunc(on);
 }
 
-namespace _func179
+namespace _func180
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff};
@@ -2501,11 +2515,11 @@ namespace _func179
 bool CSurface::GL_DrawLine(float x1, float y1, float x2, float y2, float lineWidth, GL_Color color)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(float x1_arg, float y1_arg, float x2_arg, float y2_arg, float lineWidth_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func179::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func180::func;
 	return execfunc(x1, y1, x2, y2, lineWidth, color);
 }
 
-namespace _func180
+namespace _func181
 {
     static void *func = 0;
 	static short argdata[] = {0x2ff, 0x2ff, 0x2ff, 0x4ff};
@@ -2515,11 +2529,11 @@ namespace _func180
 bool CSurface::GL_DrawTriangle(Point vertex1, Point vertex2, Point vertex3, GL_Color color)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Point vertex1_arg, Point vertex2_arg, Point vertex3_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func180::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func181::func;
 	return execfunc(vertex1, vertex2, vertex3, color);
 }
 
-namespace _func181
+namespace _func182
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff};
@@ -2529,11 +2543,11 @@ namespace _func181
 bool CSurface::GL_DrawRect(float x1, float y1, float x2, float y2, GL_Color color)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(float x1_arg, float y1_arg, float x2_arg, float y2_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func181::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func182::func;
 	return execfunc(x1, y1, x2, y2, color);
 }
 
-namespace _func182
+namespace _func183
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -2543,11 +2557,11 @@ namespace _func182
 bool CSurface::GL_DrawRectOutline(int x1, int y1, int x2, int y2, GL_Color color, float lineWidth)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int x1_arg, int y1_arg, int x2_arg, int y2_arg, GL_Color color_arg, float lineWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func182::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func183::func;
 	return execfunc(x1, y1, x2, y2, color, lineWidth);
 }
 
-namespace _func183
+namespace _func184
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -2557,11 +2571,11 @@ namespace _func183
 bool CSurface::GL_BlitImage(GL_Texture *tex, float x, float y, float x2, float y2, float rotation, GL_Color color, bool mirror)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, float x2_arg, float y2_arg, float rotation_arg, GL_Color color_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func183::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func184::func;
 	return execfunc(tex, x, y, x2, y2, rotation, color, mirror);
 }
 
-namespace _func184
+namespace _func185
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -2571,11 +2585,11 @@ namespace _func184
 bool CSurface::GL_BlitPixelImage(GL_Texture *tex, float x, float y, float x2, float y2, float rotation, GL_Color color, bool mirror)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, float x2_arg, float y2_arg, float rotation_arg, GL_Color color_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func184::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func185::func;
 	return execfunc(tex, x, y, x2, y2, rotation, color, mirror);
 }
 
-namespace _func185
+namespace _func186
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -2585,11 +2599,11 @@ namespace _func185
 bool CSurface::GL_BlitImagePartial(GL_Texture *tex, float x, float y, float size_x, float size_y, float start_x, float end_x, float start_y, float end_y, float alpha, GL_Color color, bool mirror)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, float size_x_arg, float size_y_arg, float start_x_arg, float end_x_arg, float start_y_arg, float end_y_arg, float alpha_arg, GL_Color color_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func185::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func186::func;
 	return execfunc(tex, x, y, size_x, size_y, start_x, end_x, start_y, end_y, alpha, color, mirror);
 }
 
-namespace _func186
+namespace _func187
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -2599,11 +2613,11 @@ namespace _func186
 bool CSurface::GL_BlitPixelImageWide(GL_Texture *tex, float x, float y, int x2, int y2, float opacity, GL_Color color, bool mirror)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, int x2_arg, int y2_arg, float opacity_arg, GL_Color color_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func186::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func187::func;
 	return execfunc(tex, x, y, x2, y2, opacity, color, mirror);
 }
 
-namespace _func187
+namespace _func188
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -2613,11 +2627,11 @@ namespace _func187
 void CSurface::GL_RenderPrimitive(GL_Primitive *primitive)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Primitive *primitive_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func187::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func188::func;
 	return execfunc(primitive);
 }
 
-namespace _func188
+namespace _func189
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -2627,11 +2641,11 @@ namespace _func188
 void CSurface::GL_RenderPrimitiveWithAlpha(GL_Primitive *primitive, float alpha)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Primitive *primitive_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func188::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func189::func;
 	return execfunc(primitive, alpha);
 }
 
-namespace _func189
+namespace _func190
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff};
@@ -2641,11 +2655,11 @@ namespace _func189
 void CSurface::GL_RenderPrimitiveWithColor(GL_Primitive *primitive, GL_Color color)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Primitive *primitive_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func189::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func190::func;
 	return execfunc(primitive, color);
 }
 
-namespace _func190
+namespace _func191
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -2655,11 +2669,11 @@ namespace _func190
 void CSurface::GL_DestroyPrimitive(GL_Primitive *primitive)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Primitive *primitive_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func190::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func191::func;
 	return execfunc(primitive);
 }
 
-namespace _func191
+namespace _func192
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff};
@@ -2669,11 +2683,11 @@ namespace _func191
 GL_Primitive *CSurface::GL_CreateRectPrimitive(float x, float y, float w, float h, GL_Color color)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(float x_arg, float y_arg, float w_arg, float h_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func191::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func192::func;
 	return execfunc(x, y, w, h, color);
 }
 
-namespace _func192
+namespace _func193
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -2683,11 +2697,11 @@ namespace _func192
 GL_Primitive *CSurface::GL_CreateRectOutlinePrimitive(int x, int y, int w, int h, GL_Color color, float lineWidth)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int x_arg, int y_arg, int w_arg, int h_arg, GL_Color color_arg, float lineWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func192::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func193::func;
 	return execfunc(x, y, w, h, color, lineWidth);
 }
 
-namespace _func193
+namespace _func194
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -2697,11 +2711,11 @@ namespace _func193
 void CSurface::AddTexVertices(std::vector<GL_TexVertex> *vec, float x1, float y1, float u1, float v1, float x2, float y2, float u2, float v2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(std::vector<GL_TexVertex> *vec_arg, float x1_arg, float y1_arg, float u1_arg, float v1_arg, float x2_arg, float y2_arg, float u2_arg, float v2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func193::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func194::func;
 	return execfunc(vec, x1, y1, u1, v1, x2, y2, u2, v2);
 }
 
-namespace _func194
+namespace _func195
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -2711,11 +2725,11 @@ namespace _func194
 bool CSurface::GL_DrawShield(int x, int y, float a1, float b1, int angle1, int angle2, GL_Color color, float thickness)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int x_arg, int y_arg, float a1_arg, float b1_arg, int angle1_arg, int angle2_arg, GL_Color color_arg, float thickness_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func194::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func195::func;
 	return execfunc(x, y, a1, b1, angle1, angle2, color, thickness);
 }
 
-namespace _func195
+namespace _func196
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff};
@@ -2725,11 +2739,11 @@ namespace _func195
 bool CSurface::GL_DrawLaser(int x, int y, int w, int h, GL_Color color)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int x_arg, int y_arg, int w_arg, int h_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func195::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func196::func;
 	return execfunc(x, y, w, h, color);
 }
 
-namespace _func196
+namespace _func197
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x4ff};
@@ -2739,11 +2753,11 @@ namespace _func196
 bool CSurface::GL_DrawCircle(int x, int y, float radius, GL_Color color)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int x_arg, int y_arg, float radius_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func196::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func197::func;
 	return execfunc(x, y, radius, color);
 }
 
-namespace _func197
+namespace _func198
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x4ff};
@@ -2753,11 +2767,11 @@ namespace _func197
 GL_Primitive *CSurface::GL_CreateMultiImagePrimitive(GL_Texture *tex, std::vector<GL_TexVertex> *vec, GL_Color color)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, std::vector<GL_TexVertex> *vec_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func197::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func198::func;
 	return execfunc(tex, vec, color);
 }
 
-namespace _func198
+namespace _func199
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -2767,11 +2781,11 @@ namespace _func198
 void CSurface::GL_PushStencilMode()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func198::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func199::func;
 	return execfunc();
 }
 
-namespace _func199
+namespace _func200
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff};
@@ -2781,11 +2795,11 @@ namespace _func199
 GL_Primitive *CSurface::GL_CreateImagePrimitive(GL_Texture *tex, float x, float y, float size_x, float size_y, float rotate, GL_Color color)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, float size_x_arg, float size_y_arg, float rotate_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func199::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func200::func;
 	return execfunc(tex, x, y, size_x, size_y, rotate, color);
 }
 
-namespace _func200
+namespace _func201
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff};
@@ -2795,11 +2809,11 @@ namespace _func200
 GL_Primitive *CSurface::GL_CreatePixelImagePrimitive(GL_Texture *tex, float x, float y, float size_x, float size_y, float rotate, GL_Color color, bool unk)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, float x_arg, float y_arg, float size_x_arg, float size_y_arg, float rotate_arg, GL_Color color_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func200::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func201::func;
 	return execfunc(tex, x, y, size_x, size_y, rotate, color, unk);
 }
 
-namespace _func201
+namespace _func202
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -2809,11 +2823,11 @@ namespace _func201
 void CSurface::GL_BlitMultiColorImage(GL_Texture *tex, const std::vector<GL_ColorTexVertex> &texVertices, bool antialias)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, const std::vector<GL_ColorTexVertex> &texVertices_arg, bool antialias_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func201::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func202::func;
 	return execfunc(tex, texVertices, antialias);
 }
 
-namespace _func202
+namespace _func203
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -2823,11 +2837,11 @@ namespace _func202
 void CSurface::GL_BlitMultiImage(GL_Texture *tex, const std::vector<GL_TexVertex> &texVertices, bool antialias)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GL_Texture *tex_arg, const std::vector<GL_TexVertex> &texVertices_arg, bool antialias_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func202::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func203::func;
 	return execfunc(tex, texVertices, antialias);
 }
 
-namespace _func203
+namespace _func204
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff, 0x1ff};
@@ -2837,11 +2851,11 @@ namespace _func203
 GL_Primitive *CSurface::GL_CreateMultiLinePrimitive(std::vector<GL_Line> &vec, GL_Color color, float thickness)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(std::vector<GL_Line> &vec_arg, GL_Color color_arg, float thickness_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func203::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func204::func;
 	return execfunc(vec, color, thickness);
 }
 
-namespace _func204
+namespace _func205
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff};
@@ -2851,11 +2865,11 @@ namespace _func204
 GL_Primitive *CSurface::GL_CreateMultiRectPrimitive(std::vector<Globals::Rect> &vec, GL_Color color)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(std::vector<Globals::Rect> &vec_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func204::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func205::func;
 	return execfunc(vec, color);
 }
 
-namespace _func205
+namespace _func206
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff};
@@ -2865,11 +2879,11 @@ namespace _func205
 GL_Primitive *CSurface::GL_CreatePiePartialPrimitive(int x, int y, float radius, float deg1, float deg2, float thickness, GL_Color color)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int x_arg, int y_arg, float radius_arg, float deg1_arg, float deg2_arg, float thickness_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func205::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func206::func;
 	return execfunc(x, y, radius, deg1, deg2, thickness, color);
 }
 
-namespace _func206
+namespace _func207
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -2879,11 +2893,11 @@ namespace _func206
 void CachedImage::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CachedImage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func206::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func207::func;
 	return execfunc(this);
 }
 
-namespace _func207
+namespace _func208
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -2893,11 +2907,11 @@ namespace _func207
 void CachedImage::SetImagePath(const std::string &imagePath)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CachedImage *this_arg, const std::string &imagePath_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func207::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func208::func;
 	return execfunc(this, imagePath);
 }
 
-namespace _func208
+namespace _func209
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -2907,11 +2921,11 @@ namespace _func208
 void CachedImage::constructor1(const std::string &path, int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CachedImage *this_arg, const std::string &path_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func208::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func209::func;
 	return execfunc(this, path, x, y);
 }
 
-namespace _func209
+namespace _func210
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -2921,11 +2935,11 @@ namespace _func209
 void CachedImage::constructor2(const std::string &path, CachedImage::Centered centered)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CachedImage *this_arg, const std::string &path_arg, CachedImage::Centered centered_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func209::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func210::func;
 	return execfunc(this, path, centered);
 }
 
-namespace _func210
+namespace _func211
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -2935,11 +2949,11 @@ namespace _func210
 void CachedImage::constructor_copy(const CachedImage &other)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CachedImage *this_arg, const CachedImage &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func210::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func211::func;
 	return execfunc(this, other);
 }
 
-namespace _func211
+namespace _func212
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -2949,11 +2963,11 @@ namespace _func211
 void CachedImage::SetPosition(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CachedImage *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func211::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func212::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func212
+namespace _func213
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -2963,11 +2977,11 @@ namespace _func212
 void CachedImage::SetRotation(float _rotation)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CachedImage *this_arg, float _rotation_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func212::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func213::func;
 	return execfunc(this, _rotation);
 }
 
-namespace _func213
+namespace _func214
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -2977,11 +2991,11 @@ namespace _func213
 void CachedImage::SetMirrored(bool _mirrored)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CachedImage *this_arg, bool _mirrored_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func213::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func214::func;
 	return execfunc(this, _mirrored);
 }
 
-namespace _func214
+namespace _func215
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -2991,11 +3005,11 @@ namespace _func214
 void CachedImage::SetScale(float wScale, float hScale)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CachedImage *this_arg, float wScale_arg, float hScale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func214::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func215::func;
 	return execfunc(this, wScale, hScale);
 }
 
-namespace _func215
+namespace _func216
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3005,11 +3019,11 @@ namespace _func215
 void CachedImage::CreatePrimitive()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CachedImage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func215::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func216::func;
 	return execfunc(this);
 }
 
-namespace _func216
+namespace _func217
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -3019,11 +3033,11 @@ namespace _func216
 void CachedImage::SetPartial(float x_start, float y_start, float x_size, float y_size)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CachedImage *this_arg, float x_start_arg, float y_start_arg, float x_size_arg, float y_size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func216::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func217::func;
 	return execfunc(this, x_start, y_start, x_size, y_size);
 }
 
-namespace _func217
+namespace _func218
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -3033,11 +3047,11 @@ namespace _func217
 void CachedPrimitive::OnRender(const GL_Color &color)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CachedPrimitive *this_arg, const GL_Color &color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func217::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func218::func;
 	return execfunc(this, color);
 }
 
-namespace _func218
+namespace _func219
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3047,11 +3061,11 @@ namespace _func218
 void CachedPrimitive::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CachedPrimitive *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func218::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func219::func;
 	return execfunc(this);
 }
 
-namespace _func219
+namespace _func220
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -3061,11 +3075,11 @@ namespace _func219
 void CachedRect::SetPosition(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CachedRect *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func219::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func220::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func220
+namespace _func221
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -3075,11 +3089,11 @@ namespace _func220
 void CachedRect::SetSize(int w, int h)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CachedRect *this_arg, int w_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func220::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func221::func;
 	return execfunc(this, w, h);
 }
 
-namespace _func221
+namespace _func222
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3089,11 +3103,11 @@ namespace _func221
 void ChoiceBox::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ChoiceBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func221::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func222::func;
 	return execfunc(this);
 }
 
-namespace _func222
+namespace _func223
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -3103,11 +3117,11 @@ namespace _func222
 void ChoiceBox::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ChoiceBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func222::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func223::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func223
+namespace _func224
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -3117,11 +3131,11 @@ namespace _func223
 void ChoiceBox::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ChoiceBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func223::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func224::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func224
+namespace _func225
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -3131,11 +3145,11 @@ namespace _func224
 void CloakingBox::constructor(Point pos, CloakingSystem *sys)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CloakingBox *this_arg, Point pos_arg, CloakingSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func224::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func225::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func225
+namespace _func226
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3145,11 +3159,11 @@ namespace _func225
 void CloakingSystem::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CloakingSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func225::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func226::func;
 	return execfunc(this);
 }
 
-namespace _func226
+namespace _func227
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3159,11 +3173,11 @@ namespace _func226
 void CloakingSystem::FiredWeapon()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CloakingSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func226::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func227::func;
 	return execfunc(this);
 }
 
-namespace _func227
+namespace _func228
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -3173,11 +3187,11 @@ namespace _func227
 void CloneBox::constructor(Point pos, CloneSystem *sys)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CloneBox *this_arg, Point pos_arg, CloneSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func227::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func228::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func228
+namespace _func229
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3187,11 +3201,11 @@ namespace _func228
 void CloneSystem::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CloneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func228::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func229::func;
 	return execfunc(this);
 }
 
-namespace _func229
+namespace _func230
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -3201,11 +3215,11 @@ namespace _func229
 void CombatAI::UpdateMindControl(bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatAI *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func229::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func230::func;
 	return execfunc(this, unk);
 }
 
-namespace _func230
+namespace _func231
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3215,11 +3229,11 @@ namespace _func230
 void CombatAI::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func230::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func231::func;
 	return execfunc(this);
 }
 
-namespace _func231
+namespace _func232
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3229,11 +3243,11 @@ namespace _func231
 void CombatControl::RenderTarget()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func231::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func232::func;
 	return execfunc(this);
 }
 
-namespace _func232
+namespace _func233
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3243,20 +3257,6 @@ namespace _func232
 ShipManager *CombatControl::GetCurrentTarget()
 {
 	typedef ShipManager *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func232::func;
-	return execfunc(this);
-}
-
-namespace _func233
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CombatControl::CurrentTargetIsBoss", typeid(char (CombatControl::*)()), "8b895c07000085c974??558b0189e583e4f0ff5010c9c389f68dbc270000000031c0c3908db6000000008dbf00000000578d7c240883e4f0ff77fc5589f889e5", argdata, 1, 1, &func);
-}
-
-char CombatControl::CurrentTargetIsBoss()
-{
-	typedef char __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func233::func;
 	return execfunc(this);
 }
@@ -3265,10 +3265,10 @@ namespace _func234
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CombatControl::CanTargetSelf", typeid(char (CombatControl::*)()), "578d7c240883e4f0ff77fc5589e557565383ec5c8b81a400000085c074??8b401c83b8b80000000374??", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("CombatControl::CurrentTargetIsBoss", typeid(char (CombatControl::*)()), "8b895c07000085c974??558b0189e583e4f0ff5010c9c389f68dbc270000000031c0c3908db6000000008dbf00000000578d7c240883e4f0ff77fc5589f889e5", argdata, 1, 1, &func);
 }
 
-char CombatControl::CanTargetSelf()
+char CombatControl::CurrentTargetIsBoss()
 {
 	typedef char __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func234::func;
@@ -3279,17 +3279,31 @@ namespace _func235
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CombatControl::CanTargetSelf", typeid(char (CombatControl::*)()), "578d7c240883e4f0ff77fc5589e557565383ec5c8b81a400000085c074??8b401c83b8b80000000374??", argdata, 1, 1, &func);
+}
+
+char CombatControl::CanTargetSelf()
+{
+	typedef char __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func235::func;
+	return execfunc(this);
+}
+
+namespace _func236
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("CombatControl::OnRenderCombat", typeid(void (CombatControl::*)()), "80b9a80e0000000f84????????578d7c240883e4f0ff77fc5589e557565389cb83ec6c8bb15c07000085f6", argdata, 1, 5, &func);
 }
 
 void CombatControl::OnRenderCombat()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func235::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func236::func;
 	return execfunc(this);
 }
 
-namespace _func236
+namespace _func237
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -3299,11 +3313,11 @@ namespace _func236
 void CombatControl::AddEnemyShip(CompleteShip *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg, CompleteShip *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func236::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func237::func;
 	return execfunc(this, ship);
 }
 
-namespace _func237
+namespace _func238
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3313,11 +3327,11 @@ namespace _func237
 void CombatControl::UpdateAiming()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func237::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func238::func;
 	return execfunc(this);
 }
 
-namespace _func238
+namespace _func239
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3327,11 +3341,11 @@ namespace _func238
 bool CombatControl::UpdateTarget()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func238::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func239::func;
 	return execfunc(this);
 }
 
-namespace _func239
+namespace _func240
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x4ff, 0x1ff};
@@ -3341,11 +3355,11 @@ namespace _func239
 void CombatControl::DrawHostileBox(GL_Color color, int stencilBit)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg, GL_Color color_arg, int stencilBit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func239::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func240::func;
 	return execfunc(this, color, stencilBit);
 }
 
-namespace _func240
+namespace _func241
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -3355,11 +3369,11 @@ namespace _func240
 void CombatControl::OnInit(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func240::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func241::func;
 	return execfunc(this, pos);
 }
 
-namespace _func241
+namespace _func242
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3367,20 +3381,6 @@ namespace _func241
 }
 
 void CombatControl::OnLoop()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func241::func;
-	return execfunc(this);
-}
-
-namespace _func242
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CombatControl::SetMouseCursor", typeid(void (CombatControl::*)()), "578d7c240883e4f0ff77fc5589e5575389cb83ec108b89a400000085c974??0fb683a8000000f30f1005????????3205????????8b93c00300000f2e83b40e00000fb6c0", argdata, 1, 5, &func);
-}
-
-void CombatControl::SetMouseCursor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func242::func;
@@ -3391,10 +3391,10 @@ namespace _func243
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CombatControl::DisarmAll", typeid(void (CombatControl::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec1c8b915c07000085d274??8b4904c70424????????e8????????83ec0484c0", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CombatControl::SetMouseCursor", typeid(void (CombatControl::*)()), "578d7c240883e4f0ff77fc5589e5575389cb83ec108b89a400000085c974??0fb683a8000000f30f1005????????3205????????8b93c00300000f2e83b40e00000fb6c0", argdata, 1, 5, &func);
 }
 
-void CombatControl::DisarmAll()
+void CombatControl::SetMouseCursor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func243::func;
@@ -3405,17 +3405,31 @@ namespace _func244
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CombatControl::DisarmAll", typeid(void (CombatControl::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec1c8b915c07000085d274??8b4904c70424????????e8????????83ec0484c0", argdata, 1, 5, &func);
+}
+
+void CombatControl::DisarmAll()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func244::func;
+	return execfunc(this);
+}
+
+namespace _func245
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("CombatControl::SelectTarget", typeid(bool (CombatControl::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec6c8b4904c70424????????e8????????83ec0484c0", argdata, 1, 1, &func);
 }
 
 bool CombatControl::SelectTarget()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func244::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func245::func;
 	return execfunc(this);
 }
 
-namespace _func245
+namespace _func246
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -3425,11 +3439,11 @@ namespace _func245
 bool CombatControl::MouseRClick(int x, int y)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func245::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func246::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func246
+namespace _func247
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3439,11 +3453,11 @@ namespace _func246
 bool CombatControl::WeaponsArmed()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func246::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func247::func;
 	return execfunc(this);
 }
 
-namespace _func247
+namespace _func248
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -3453,11 +3467,11 @@ namespace _func247
 void CombatControl::KeyDown(SDLKey key)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func247::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func248::func;
 	return execfunc(this, key);
 }
 
-namespace _func248
+namespace _func249
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3465,20 +3479,6 @@ namespace _func248
 }
 
 void CombatControl::DisarmTeleporter()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func248::func;
-	return execfunc(this);
-}
-
-namespace _func249
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CombatControl::constructor", typeid(void (CombatControl::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83c1088d5d9c81ec????????c741f800000000c741fc00000000e8????????8d4e14c7461000000000e8????????8d8ec4030000", argdata, 1, 5, &func);
-}
-
-void CombatControl::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func249::func;
@@ -3489,10 +3489,10 @@ namespace _func250
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CombatControl::OnRenderSelfAiming", typeid(void (CombatControl::*)()), "578d7c240883e4f0ff77fc5589e5575389cb83c11483ec30e8????????8b4b04c70424????????e8????????83ec0484c00f84????????8b4b04", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CombatControl::constructor", typeid(void (CombatControl::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83c1088d5d9c81ec????????c741f800000000c741fc00000000e8????????8d4e14c7461000000000e8????????8d8ec4030000", argdata, 1, 5, &func);
 }
 
-void CombatControl::OnRenderSelfAiming()
+void CombatControl::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func250::func;
@@ -3502,6 +3502,20 @@ void CombatControl::OnRenderSelfAiming()
 namespace _func251
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CombatControl::OnRenderSelfAiming", typeid(void (CombatControl::*)()), "578d7c240883e4f0ff77fc5589e5575389cb83c11483ec30e8????????8b4b04c70424????????e8????????83ec0484c00f84????????8b4b04", argdata, 1, 5, &func);
+}
+
+void CombatControl::OnRenderSelfAiming()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func251::func;
+	return execfunc(this);
+}
+
+namespace _func252
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x4ff};
 	static FunctionDefinition funcObj("CombatControl::RenderShipStatus", typeid(void (CombatControl::*)(Pointf , GL_Color )), "578d7c240883e4f0ff77fc5589f889e557565389cf81ec????????8b188b7004898564ffffffe8????????89742404891c248d75d0c744240800000000", argdata, 3, 5, &func);
 }
@@ -3509,11 +3523,11 @@ namespace _func251
 void CombatControl::RenderShipStatus(Pointf pos, GL_Color color)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg, Pointf pos_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func251::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func252::func;
 	return execfunc(this, pos, color);
 }
 
-namespace _func252
+namespace _func253
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -3523,11 +3537,11 @@ namespace _func252
 std::string CombatControl::GetCrewTooltip(int x, int y)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func252::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func253::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func253
+namespace _func254
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3537,11 +3551,11 @@ namespace _func253
 void CombatControl::Clear()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func253::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func254::func;
 	return execfunc(this);
 }
 
-namespace _func254
+namespace _func255
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -3551,11 +3565,11 @@ namespace _func254
 bool CombatControl::MouseMove(int mX, int mY)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func254::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func255::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func255
+namespace _func256
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -3565,11 +3579,11 @@ namespace _func255
 void CombatControl::MouseClick(int mX, int mY, bool shift)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg, int mX_arg, int mY_arg, bool shift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func255::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func256::func;
 	return execfunc(this, mX, mY, shift);
 }
 
-namespace _func256
+namespace _func257
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3579,11 +3593,11 @@ namespace _func256
 std::pair<int, int> CombatControl::GetTeleportationCommand()
 {
 	typedef std::pair<int, int> __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func256::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func257::func;
 	return execfunc(this);
 }
 
-namespace _func257
+namespace _func258
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -3593,11 +3607,11 @@ namespace _func257
 void CombatDrone::constructor(int iShipId, int selfId, const DroneBlueprint *bp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatDrone *this_arg, int iShipId_arg, int selfId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func257::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func258::func;
 	return execfunc(this, iShipId, selfId, bp);
 }
 
-namespace _func258
+namespace _func259
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -3607,11 +3621,11 @@ namespace _func258
 void CombatDrone::SetWeaponTarget(Targetable *target)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func258::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func259::func;
 	return execfunc(this, target);
 }
 
-namespace _func259
+namespace _func260
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3621,11 +3635,11 @@ namespace _func259
 void CombatDrone::PickTarget()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CombatDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func259::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func260::func;
 	return execfunc(this);
 }
 
-namespace _func260
+namespace _func261
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -3635,11 +3649,11 @@ namespace _func260
 void CommandGui::RunCommand(std::string &command)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg, std::string &command_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func260::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func261::func;
 	return execfunc(this, command);
 }
 
-namespace _func261
+namespace _func262
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -3649,11 +3663,11 @@ namespace _func261
 Store *CommandGui::CreateNewStore(int sectorNumber)
 {
 	typedef Store *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg, int sectorNumber_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func261::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func262::func;
 	return execfunc(this, sectorNumber);
 }
 
-namespace _func262
+namespace _func263
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -3663,11 +3677,11 @@ namespace _func262
 Point CommandGui::GetWorldCoordinates(Point point, bool fromTarget)
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg, Point point_arg, bool fromTarget_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func262::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func263::func;
 	return execfunc(this, point, fromTarget);
 }
 
-namespace _func263
+namespace _func264
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -3677,11 +3691,11 @@ namespace _func263
 void CommandGui::KeyDown(SDLKey key, bool shiftHeld)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg, SDLKey key_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func263::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func264::func;
 	return execfunc(this, key, shiftHeld);
 }
 
-namespace _func264
+namespace _func265
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3691,11 +3705,11 @@ namespace _func264
 void CommandGui::RenderStatic()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func264::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func265::func;
 	return execfunc(this);
 }
 
-namespace _func265
+namespace _func266
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -3705,11 +3719,11 @@ namespace _func265
 void CommandGui::RenderPlayerShip(Point &shipCenter, float jumpScale)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg, Point &shipCenter_arg, float jumpScale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func265::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func266::func;
 	return execfunc(this, shipCenter, jumpScale);
 }
 
-namespace _func266
+namespace _func267
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3719,11 +3733,11 @@ namespace _func266
 void CommandGui::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func266::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func267::func;
 	return execfunc(this);
 }
 
-namespace _func267
+namespace _func268
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -3733,11 +3747,11 @@ namespace _func267
 void CommandGui::AddEnemyShip(CompleteShip *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg, CompleteShip *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func267::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func268::func;
 	return execfunc(this, ship);
 }
 
-namespace _func268
+namespace _func269
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3747,11 +3761,11 @@ namespace _func268
 void CommandGui::Victory()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func268::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func269::func;
 	return execfunc(this);
 }
 
-namespace _func269
+namespace _func270
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3761,11 +3775,11 @@ namespace _func269
 void CommandGui::OnInit()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func269::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func270::func;
 	return execfunc(this);
 }
 
-namespace _func270
+namespace _func271
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -3775,11 +3789,11 @@ namespace _func270
 void CommandGui::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func270::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func271::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func271
+namespace _func272
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -3789,11 +3803,11 @@ namespace _func271
 void CommandGui::LButtonDown(int mX, int mY, bool shiftHeld)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg, int mX_arg, int mY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func271::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func272::func;
 	return execfunc(this, mX, mY, shiftHeld);
 }
 
-namespace _func272
+namespace _func273
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3801,20 +3815,6 @@ namespace _func272
 }
 
 void CommandGui::OnLoop()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func272::func;
-	return execfunc(this);
-}
-
-namespace _func273
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CommandGui::CheckGameover", typeid(void (CommandGui::*)()), "578d7c240883e4f0ff77fc5589e557565389cb8d45a883ec7c8b89081700008945a0c745a4000000008b7108c645a800", argdata, 1, 5, &func);
-}
-
-void CommandGui::CheckGameover()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func273::func;
@@ -3825,17 +3825,31 @@ namespace _func274
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CommandGui::CheckGameover", typeid(void (CommandGui::*)()), "578d7c240883e4f0ff77fc5589e557565389cb8d45a883ec7c8b89081700008945a0c745a4000000008b7108c645a800", argdata, 1, 5, &func);
+}
+
+void CommandGui::CheckGameover()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func274::func;
+	return execfunc(this);
+}
+
+namespace _func275
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("CommandGui::IsGameOver", typeid(bool (CommandGui::*)()), "803d??????????75??5589e55389cb8b890817000083e4f085c974??8b41088b108b524481fa????????75??80b8990400000075??e8????????84c0", argdata, 1, 1, &func);
 }
 
 bool CommandGui::IsGameOver()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func274::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func275::func;
 	return execfunc(this);
 }
 
-namespace _func275
+namespace _func276
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -3845,11 +3859,11 @@ namespace _func275
 void CommandGui::NewLocation(const std::string &mainText, std::vector<ChoiceText> *choices, ResourceEvent &resources, bool testingEvents)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg, const std::string &mainText_arg, std::vector<ChoiceText> *choices_arg, ResourceEvent &resources_arg, bool testingEvents_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func275::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func276::func;
 	return execfunc(this, mainText, choices, resources, testingEvents);
 }
 
-namespace _func276
+namespace _func277
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -3859,11 +3873,11 @@ namespace _func276
 void CommandGui::LButtonUp(int mX, int mY, bool shiftHeld)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg, int mX_arg, int mY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func276::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func277::func;
 	return execfunc(this, mX, mY, shiftHeld);
 }
 
-namespace _func277
+namespace _func278
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3873,11 +3887,11 @@ namespace _func277
 void CompleteShip::PauseLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func277::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func278::func;
 	return execfunc(this);
 }
 
-namespace _func278
+namespace _func279
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -3887,11 +3901,11 @@ namespace _func278
 void CompleteShip::Restart()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func278::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func279::func;
 	return execfunc(this);
 }
 
-namespace _func279
+namespace _func280
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -3901,11 +3915,11 @@ namespace _func279
 void CompleteShip::constructor(SpaceManager *space, bool unk, int unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, SpaceManager *space_arg, bool unk_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func279::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func280::func;
 	return execfunc(this, space, unk, unk2);
 }
 
-namespace _func280
+namespace _func281
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -3915,11 +3929,11 @@ namespace _func280
 void CompleteShip::SetShip(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func280::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func281::func;
 	return execfunc(this, ship);
 }
 
-namespace _func281
+namespace _func282
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -3929,11 +3943,11 @@ namespace _func281
 void CompleteShip::OnInit(const ShipBlueprint *blueprint, int unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, const ShipBlueprint *blueprint_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func281::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func282::func;
 	return execfunc(this, blueprint, unk);
 }
 
-namespace _func282
+namespace _func283
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -3943,11 +3957,11 @@ namespace _func282
 void CompleteShip::AddBoarders(int amount, const std::string &race, bool unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int amount_arg, const std::string &race_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func282::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func283::func;
 	return execfunc(this, amount, race, unk2);
 }
 
-namespace _func283
+namespace _func284
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -3957,11 +3971,11 @@ namespace _func283
 CrewMember *CompleteShip::AddCrewMember(const CrewBlueprint *blueprint, bool hostile)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, const CrewBlueprint *blueprint_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func283::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func284::func;
 	return execfunc(this, blueprint, hostile);
 }
 
-namespace _func284
+namespace _func285
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -3971,11 +3985,11 @@ namespace _func284
 CrewMember *CompleteShip::AddCrewMember1(const std::string &race, const std::string &name, bool hostile)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, const std::string &race_arg, const std::string &name_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func284::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func285::func;
 	return execfunc(this, race, name, hostile);
 }
 
-namespace _func285
+namespace _func286
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -3985,11 +3999,11 @@ namespace _func285
 Drone *CompleteShip::AddDrone(const DroneBlueprint *blueprint, int unk)
 {
 	typedef Drone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, const DroneBlueprint *blueprint_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func285::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func286::func;
 	return execfunc(this, blueprint, unk);
 }
 
-namespace _func286
+namespace _func287
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -3999,11 +4013,11 @@ namespace _func286
 CrewMember *CompleteShip::AddCrewMember2(CrewMember *member, int unk)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, CrewMember *member_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func286::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func287::func;
 	return execfunc(this, member, unk);
 }
 
-namespace _func287
+namespace _func288
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4013,11 +4027,11 @@ namespace _func287
 void CompleteShip::SaveState(int unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func287::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func288::func;
 	return execfunc(this, unk);
 }
 
-namespace _func288
+namespace _func289
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4027,11 +4041,11 @@ namespace _func288
 void CompleteShip::LoadState(int unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func288::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func289::func;
 	return execfunc(this, unk);
 }
 
-namespace _func289
+namespace _func290
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -4041,11 +4055,11 @@ namespace _func289
 void CompleteShip::InitiateTeleport(int targetRoom, int command)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int targetRoom_arg, int command_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func289::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func290::func;
 	return execfunc(this, targetRoom, command);
 }
 
-namespace _func290
+namespace _func291
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4055,11 +4069,11 @@ namespace _func290
 void CompleteShip::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func290::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func291::func;
 	return execfunc(this);
 }
 
-namespace _func291
+namespace _func292
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4069,11 +4083,11 @@ namespace _func291
 std::vector<CrewMember*> CompleteShip::GetTeleportingParty()
 {
 	typedef std::vector<CrewMember*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func291::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func292::func;
 	return execfunc(this);
 }
 
-namespace _func292
+namespace _func293
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4083,11 +4097,11 @@ namespace _func292
 void CompleteShip::KillRandomCrew()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func292::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func293::func;
 	return execfunc(this);
 }
 
-namespace _func293
+namespace _func294
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4097,11 +4111,11 @@ namespace _func293
 int CompleteShip::CountCrew(bool boarders)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, bool boarders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func293::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func294::func;
 	return execfunc(this, boarders);
 }
 
-namespace _func294
+namespace _func295
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4111,11 +4125,11 @@ namespace _func294
 void CompleteShip::Jump()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func294::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func295::func;
 	return execfunc(this);
 }
 
-namespace _func295
+namespace _func296
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4125,11 +4139,11 @@ namespace _func295
 void CompleteShip::SetEnemyShip(CompleteShip *other)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, CompleteShip *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func295::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func296::func;
 	return execfunc(this, other);
 }
 
-namespace _func296
+namespace _func297
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4139,11 +4153,11 @@ namespace _func296
 bool CompleteShip::DeadCrew()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func296::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func297::func;
 	return execfunc(this);
 }
 
-namespace _func297
+namespace _func298
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -4153,11 +4167,11 @@ namespace _func297
 std::vector<CrewMember*> CompleteShip::TeleportCrew(int roomId, bool intruders)
 {
 	typedef std::vector<CrewMember*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int roomId_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func297::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func298::func;
 	return execfunc(this, roomId, intruders);
 }
 
-namespace _func298
+namespace _func299
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4167,11 +4181,11 @@ namespace _func298
 void CompleteShip::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func298::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func299::func;
 	return execfunc(this);
 }
 
-namespace _func299
+namespace _func300
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4181,11 +4195,11 @@ namespace _func299
 void CompleteShip::OnRenderSpace()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func299::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func300::func;
 	return execfunc(this);
 }
 
-namespace _func300
+namespace _func301
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -4195,11 +4209,11 @@ namespace _func300
 void CompleteShip::OnRenderShip(bool unk1, bool unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, bool unk1_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func300::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func301::func;
 	return execfunc(this, unk1, unk2);
 }
 
-namespace _func301
+namespace _func302
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4209,11 +4223,11 @@ namespace _func301
 void ConfirmWindow::SetText(const TextString &text_, int minWidth, bool autoCenter, const TextString &yesText_, const TextString &noText_)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, const TextString &text__arg, int minWidth_arg, bool autoCenter_arg, const TextString &yesText__arg, const TextString &noText__arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func301::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func302::func;
 	return execfunc(this, text_, minWidth, autoCenter, yesText_, noText_);
 }
 
-namespace _func302
+namespace _func303
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4223,11 +4237,11 @@ namespace _func302
 void ConfirmWindow::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func302::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func303::func;
 	return execfunc(this);
 }
 
-namespace _func303
+namespace _func304
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -4237,11 +4251,11 @@ namespace _func303
 void ConfirmWindow::SetPosition(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func303::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func304::func;
 	return execfunc(this, pos);
 }
 
-namespace _func304
+namespace _func305
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4251,11 +4265,11 @@ namespace _func304
 void ConfirmWindow::Open()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func304::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func305::func;
 	return execfunc(this);
 }
 
-namespace _func305
+namespace _func306
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -4265,11 +4279,11 @@ namespace _func305
 void ConfirmWindow::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func305::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func306::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func306
+namespace _func307
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -4279,11 +4293,11 @@ namespace _func306
 void ConfirmWindow::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func306::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func307::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func307
+namespace _func308
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4291,20 +4305,6 @@ namespace _func307
 }
 
 void ConfirmWindow::constructor()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func307::func;
-	return execfunc(this);
-}
-
-namespace _func308
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ConfirmWindow::Close", typeid(void (ConfirmWindow::*)()), "5589e55389cb83e4f083ec108b8184000000890424e8????????c783840000000000000089d9e8????????8b5dfc", argdata, 1, 5, &func);
-}
-
-void ConfirmWindow::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func308::func;
@@ -4315,12 +4315,12 @@ namespace _func309
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ControlButton::OnRender", typeid(void (ControlButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cb81ec????????8b415c83f8010f84????????f30f102d????????83f802f30f1035????????f30f103d????????f30f116da0f30f1175a4", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ConfirmWindow::Close", typeid(void (ConfirmWindow::*)()), "5589e55389cb83e4f083ec108b8184000000890424e8????????c783840000000000000089d9e8????????8b5dfc", argdata, 1, 5, &func);
 }
 
-void ControlButton::OnRender()
+void ConfirmWindow::Close()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ControlButton *this_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func309::func;
 	return execfunc(this);
 }
@@ -4329,12 +4329,12 @@ namespace _func310
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ControlsScreen::OnInit", typeid(void (ControlsScreen::*)()), "578d7c240883e4f0ff77fc5589e557565381ec????????8b8144050000898d74feffff85c00f84????????8d8570ffffffbf????????8d8d4cffffff6689bd7cffffff", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ControlButton::OnRender", typeid(void (ControlButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cb81ec????????8b415c83f8010f84????????f30f102d????????83f802f30f1035????????f30f103d????????f30f116da0f30f1175a4", argdata, 1, 5, &func);
 }
 
-void ControlsScreen::OnInit()
+void ControlButton::OnRender()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ControlButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func310::func;
 	return execfunc(this);
 }
@@ -4343,10 +4343,10 @@ namespace _func311
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ControlsScreen::OnLoop", typeid(void (ControlsScreen::*)()), "578d7c240883e4f0ff77fc5589e55756538d45a889ce83ec7c8b79108b59148945a089f801d874??85ff", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ControlsScreen::OnInit", typeid(void (ControlsScreen::*)()), "578d7c240883e4f0ff77fc5589e557565381ec????????8b8144050000898d74feffff85c00f84????????8d8570ffffffbf????????8d8d4cffffff6689bd7cffffff", argdata, 1, 5, &func);
 }
 
-void ControlsScreen::OnLoop()
+void ControlsScreen::OnInit()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func311::func;
@@ -4357,10 +4357,10 @@ namespace _func312
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ControlsScreen::OnRender", typeid(void (ControlsScreen::*)()), "578d7c240883e4f0ff77fc5589e557565389cf81ec????????80b928010000000f85????????8d8520ffffff8d8d18ffffffc744240400000000c78500ffffff1d000000898518ffffff8d8500ffffff890424e8????????8b9500ffffff", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ControlsScreen::OnLoop", typeid(void (ControlsScreen::*)()), "578d7c240883e4f0ff77fc5589e55756538d45a889ce83ec7c8b79108b59148945a089f801d874??85ff", argdata, 1, 5, &func);
 }
 
-void ControlsScreen::OnRender()
+void ControlsScreen::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func312::func;
@@ -4370,6 +4370,20 @@ void ControlsScreen::OnRender()
 namespace _func313
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ControlsScreen::OnRender", typeid(void (ControlsScreen::*)()), "578d7c240883e4f0ff77fc5589e557565389cf81ec????????80b928010000000f85????????8d8520ffffff8d8d18ffffffc744240400000000c78500ffffff1d000000898518ffffff8d8500ffffff890424e8????????8b9500ffffff", argdata, 1, 5, &func);
+}
+
+void ControlsScreen::OnRender()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func313::func;
+	return execfunc(this);
+}
+
+namespace _func314
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CooldownSystemBox::constructor", typeid(void (CooldownSystemBox::*)(Point , ShipSystem *, bool )), "578d7c240883e4f0ff77fc5589e557565381ec????????8b1f8b77048b47088b7f0cc744240c01000000898db0fdffff891c248974240483c324", argdata, 4, 5, &func);
 }
@@ -4377,11 +4391,11 @@ namespace _func313
 void CooldownSystemBox::constructor(Point pos, ShipSystem *sys, bool roundDown)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CooldownSystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, bool roundDown_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func313::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func314::func;
 	return execfunc(this, pos, sys, roundDown);
 }
 
-namespace _func314
+namespace _func315
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4391,11 +4405,11 @@ namespace _func314
 void CooldownSystemBox::OnRender(bool ignoreStatus)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CooldownSystemBox *this_arg, bool ignoreStatus_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func314::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func315::func;
 	return execfunc(this, ignoreStatus);
 }
 
-namespace _func315
+namespace _func316
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4405,11 +4419,11 @@ namespace _func315
 void CreditScreen::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CreditScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func315::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func316::func;
 	return execfunc(this);
 }
 
-namespace _func316
+namespace _func317
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4419,11 +4433,11 @@ namespace _func316
 void CreditScreen::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CreditScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func316::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func317::func;
 	return execfunc(this);
 }
 
-namespace _func317
+namespace _func318
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -4433,11 +4447,11 @@ namespace _func317
 void CreditScreen::Start(const std::string &shipName, const std::vector<std::string> &crewNames)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CreditScreen *this_arg, const std::string &shipName_arg, const std::vector<std::string> &crewNames_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func317::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func318::func;
 	return execfunc(this, shipName, crewNames);
 }
 
-namespace _func318
+namespace _func319
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4447,11 +4461,11 @@ namespace _func318
 bool CreditScreen::Done()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CreditScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func318::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func319::func;
 	return execfunc(this);
 }
 
-namespace _func319
+namespace _func320
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4461,11 +4475,11 @@ namespace _func319
 void CrewAI::UpdateDrones()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func319::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func320::func;
 	return execfunc(this);
 }
 
-namespace _func320
+namespace _func321
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4475,11 +4489,11 @@ namespace _func320
 void CrewAI::AssignCrewmembers()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func320::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func321::func;
 	return execfunc(this);
 }
 
-namespace _func321
+namespace _func322
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x3ff, 0x1ff};
@@ -4489,11 +4503,11 @@ namespace _func321
 int CrewAI::PrioritizeTask(CrewTask task, int crewId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg, CrewTask task_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func321::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func322::func;
 	return execfunc(this, task, crewId);
 }
 
-namespace _func322
+namespace _func323
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4503,11 +4517,11 @@ namespace _func322
 void CrewAI::UpdateIntruders()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func322::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func323::func;
 	return execfunc(this);
 }
 
-namespace _func323
+namespace _func324
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -4517,11 +4531,11 @@ namespace _func323
 int CrewAI::PrioritizeIntruderRoom(CrewMember *crew, int roomId, int target)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg, CrewMember *crew_arg, int roomId_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func323::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func324::func;
 	return execfunc(this, crew, roomId, target);
 }
 
-namespace _func324
+namespace _func325
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4531,11 +4545,11 @@ namespace _func324
 void CrewAI::UpdateCrewMember(int crewId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func324::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func325::func;
 	return execfunc(this, crewId);
 }
 
-namespace _func325
+namespace _func326
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4543,20 +4557,6 @@ namespace _func325
 }
 
 void CrewAI::CheckForHealing()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func325::func;
-	return execfunc(this);
-}
-
-namespace _func326
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewAI::OnLoop", typeid(void (CrewAI::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec6c8b018d4dd0890424e8????????8b55d08b460c", argdata, 1, 5, &func);
-}
-
-void CrewAI::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func326::func;
@@ -4567,10 +4567,10 @@ namespace _func327
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewAI::CheckForProblems", typeid(void (CrewAI::*)()), "578d7c240883e4f0ff77fc5589e557565389cf83ec7c8b01c64108018b4004890424", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewAI::OnLoop", typeid(void (CrewAI::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec6c8b018d4dd0890424e8????????8b55d08b460c", argdata, 1, 5, &func);
 }
 
-void CrewAI::CheckForProblems()
+void CrewAI::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func327::func;
@@ -4580,6 +4580,20 @@ void CrewAI::CheckForProblems()
 namespace _func328
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewAI::CheckForProblems", typeid(void (CrewAI::*)()), "578d7c240883e4f0ff77fc5589e557565389cf83ec7c8b01c64108018b4004890424", argdata, 1, 5, &func);
+}
+
+void CrewAI::CheckForProblems()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func328::func;
+	return execfunc(this);
+}
+
+namespace _func329
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CrewAI::DangerRating", typeid(int (CrewAI::*)(int , int )), "578d7c240883e4f0ff77fc5589e557565389ce83ec5c8b47048b1f89c18945a88b460c8b0488f30f105028", argdata, 3, 1, &func);
 }
@@ -4587,11 +4601,11 @@ namespace _func328
 int CrewAI::DangerRating(int roomId, int crewId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg, int roomId_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func328::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func329::func;
 	return execfunc(this, roomId, crewId);
 }
 
-namespace _func329
+namespace _func330
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -4601,11 +4615,11 @@ namespace _func329
 void CrewAnimation::constructor(int shipId, const std::string &race, Pointf unk, bool hostile)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, int shipId_arg, const std::string &race_arg, Pointf unk_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func329::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func330::func;
 	return execfunc(this, shipId, race, unk, hostile);
 }
 
-namespace _func330
+namespace _func331
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4615,11 +4629,11 @@ namespace _func330
 std::string CrewAnimation::GetDeathSound()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func330::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func331::func;
 	return execfunc(this);
 }
 
-namespace _func331
+namespace _func332
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4629,11 +4643,11 @@ namespace _func331
 std::string CrewAnimation::GetShootingSound()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func331::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func332::func;
 	return execfunc(this);
 }
 
-namespace _func332
+namespace _func333
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -4643,11 +4657,11 @@ namespace _func332
 void CrewAnimation::OnRender(float scale, int selectedState, bool outlineOnly)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, float scale_arg, int selectedState_arg, bool outlineOnly_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func332::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func333::func;
 	return execfunc(this, scale, selectedState, outlineOnly);
 }
 
-namespace _func333
+namespace _func334
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4657,11 +4671,11 @@ namespace _func333
 void CrewAnimation::OnRenderProps()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func333::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func334::func;
 	return execfunc(this);
 }
 
-namespace _func334
+namespace _func335
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x1ff};
@@ -4671,11 +4685,11 @@ namespace _func334
 void CrewAnimation::OnInit(const std::string &name, Pointf position, bool enemy)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, const std::string &name_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func334::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func335::func;
 	return execfunc(this, name, position, enemy);
 }
 
-namespace _func335
+namespace _func336
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4685,11 +4699,11 @@ namespace _func335
 void CrewAnimation::SetupStrips()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func335::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func336::func;
 	return execfunc(this);
 }
 
-namespace _func336
+namespace _func337
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4699,11 +4713,11 @@ namespace _func336
 void CrewAnimation::OnUpdate(Pointf position, bool moving, bool fighting, bool repairing, bool dying, bool onFire)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, Pointf position_arg, bool moving_arg, bool fighting_arg, bool repairing_arg, bool dying_arg, bool onFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func336::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func337::func;
 	return execfunc(this, position, moving, fighting, repairing, dying, onFire);
 }
 
-namespace _func337
+namespace _func338
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4713,11 +4727,11 @@ namespace _func337
 void CrewAnimation::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func337::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func338::func;
 	return execfunc(this);
 }
 
-namespace _func338
+namespace _func339
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4727,11 +4741,11 @@ namespace _func338
 bool CrewAnimation::FireShot()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func338::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func339::func;
 	return execfunc(this);
 }
 
-namespace _func339
+namespace _func340
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4741,11 +4755,11 @@ namespace _func339
 int CrewAnimation::GetFiringFrame()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func339::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func340::func;
 	return execfunc(this);
 }
 
-namespace _func340
+namespace _func341
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4755,11 +4769,11 @@ namespace _func340
 void CrewAnimation::RenderIcon(bool border)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, bool border_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func340::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func341::func;
 	return execfunc(this, border);
 }
 
-namespace _func341
+namespace _func342
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4769,11 +4783,11 @@ namespace _func341
 void CrewAnimation::OnUpdateEffects()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func341::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func342::func;
 	return execfunc(this);
 }
 
-namespace _func342
+namespace _func343
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4783,11 +4797,11 @@ namespace _func342
 void CrewBlueprint::RandomSkills(int worldLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func342::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func343::func;
 	return execfunc(this, worldLevel);
 }
 
-namespace _func343
+namespace _func344
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4797,11 +4811,11 @@ namespace _func343
 void CrewBlueprint::RenderSkill(int x, int y, int length, int height, int skill)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int x_arg, int y_arg, int length_arg, int height_arg, int skill_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func343::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func344::func;
 	return execfunc(this, x, y, length, height, skill);
 }
 
-namespace _func344
+namespace _func345
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4811,11 +4825,11 @@ namespace _func344
 void CrewBlueprint::RenderIcon(float opacity)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, float opacity_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func344::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func345::func;
 	return execfunc(this, opacity);
 }
 
-namespace _func345
+namespace _func346
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4825,11 +4839,11 @@ namespace _func345
 void CrewBlueprint::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func345::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func346::func;
 	return execfunc(this);
 }
 
-namespace _func346
+namespace _func347
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4839,11 +4853,11 @@ namespace _func346
 std::string CrewBlueprint::GetNameShort()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func346::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func347::func;
 	return execfunc(this);
 }
 
-namespace _func347
+namespace _func348
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -4853,11 +4867,11 @@ namespace _func347
 GL_Color CrewBlueprint::GetCurrentSkillColor(int skill)
 {
 	typedef GL_Color __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int skill_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func347::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func348::func;
 	return execfunc(this, skill);
 }
 
-namespace _func348
+namespace _func349
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -4867,11 +4881,11 @@ namespace _func348
 void CrewBox::constructor(Point pos, CrewMember *crew, int number)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg, Point pos_arg, CrewMember *crew_arg, int number_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func348::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func349::func;
 	return execfunc(this, pos, crew, number);
 }
 
-namespace _func349
+namespace _func350
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4881,11 +4895,11 @@ namespace _func349
 void CrewBox::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func349::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func350::func;
 	return execfunc(this);
 }
 
-namespace _func350
+namespace _func351
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -4895,11 +4909,11 @@ namespace _func350
 CrewMember *CrewBox::GetSelected(int mouseX, int mouseY)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg, int mouseX_arg, int mouseY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func350::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func351::func;
 	return execfunc(this, mouseX, mouseY);
 }
 
-namespace _func351
+namespace _func352
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4909,11 +4923,11 @@ namespace _func351
 void CrewBox::OnLoop(bool selected)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg, bool selected_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func351::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func352::func;
 	return execfunc(this, selected);
 }
 
-namespace _func352
+namespace _func353
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4921,20 +4935,6 @@ namespace _func352
 }
 
 void CrewBox::OnRenderSkillLevel()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func352::func;
-	return execfunc(this);
-}
-
-namespace _func353
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewBox::destructor", typeid(void (CrewBox::*)()), "5589e557565389ce83e4f083ec208b813c010000894c2418890424e8????????8b8640010000890424e8????????8b8644010000890424e8????????8b8648010000890424", argdata, 1, 5, &func);
-}
-
-void CrewBox::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func353::func;
@@ -4945,12 +4945,12 @@ namespace _func354
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewBox::MouseClick", typeid(bool (CrewBox::*)()), "5589e5530fb6596883e4f084db74130fb6596984db740b8b49208b01ff90c400000089d88b5dfcc9", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("CrewBox::destructor", typeid(void (CrewBox::*)()), "5589e557565389ce83e4f083ec208b813c010000894c2418890424e8????????8b8640010000890424e8????????8b8644010000890424e8????????8b8648010000890424", argdata, 1, 5, &func);
 }
 
-bool CrewBox::MouseClick()
+void CrewBox::destructor()
 {
-	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func354::func;
 	return execfunc(this);
 }
@@ -4959,12 +4959,12 @@ namespace _func355
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewBox::RenderIcon", typeid(void (CrewBox::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b49208b01ff90c80000003c0119f6", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewBox::MouseClick", typeid(bool (CrewBox::*)()), "5589e5530fb6596883e4f084db74130fb6596984db740b8b49208b01ff90c400000089d88b5dfcc9", argdata, 1, 1, &func);
 }
 
-void CrewBox::RenderIcon()
+bool CrewBox::MouseClick()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
+	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func355::func;
 	return execfunc(this);
 }
@@ -4973,10 +4973,10 @@ namespace _func356
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewBox::RenderLabels", typeid(void (CrewBox::*)()), "578d7c240883e4f0ff77fc5589e55756538d5dd089ce83ec6c8b412089d9890424", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewBox::RenderIcon", typeid(void (CrewBox::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b49208b01ff90c80000003c0119f6", argdata, 1, 5, &func);
 }
 
-void CrewBox::RenderLabels()
+void CrewBox::RenderIcon()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func356::func;
@@ -4987,10 +4987,10 @@ namespace _func357
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewBox::RenderCloneDying", typeid(void (CrewBox::*)()), "80b91c010000000f859b0000008b4120f30f1080f00600000f2e05????????0f868300000055660fefd2660fefc989e583e4f083ec308b4108", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewBox::RenderLabels", typeid(void (CrewBox::*)()), "578d7c240883e4f0ff77fc5589e55756538d5dd089ce83ec6c8b412089d9890424", argdata, 1, 5, &func);
 }
 
-void CrewBox::RenderCloneDying()
+void CrewBox::RenderLabels()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func357::func;
@@ -5001,12 +5001,12 @@ namespace _func358
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewControl::OnRender", typeid(void (CrewControl::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec7c8b793c8b414029f8c1f80285c0", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewBox::RenderCloneDying", typeid(void (CrewBox::*)()), "80b91c010000000f859b0000008b4120f30f1080f00600000f2e05????????0f868300000055660fefd2660fefc989e583e4f083ec308b4108", argdata, 1, 5, &func);
 }
 
-void CrewControl::OnRender()
+void CrewBox::RenderCloneDying()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func358::func;
 	return execfunc(this);
 }
@@ -5015,10 +5015,10 @@ namespace _func359
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewControl::OnLoop", typeid(void (CrewControl::*)()), "578d7c240883e4f0ff77fc5589e557568db18c0000005389cb83ec6c89f1e8????????80bb9e000000000f85????????89d9", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewControl::OnRender", typeid(void (CrewControl::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec7c8b793c8b414029f8c1f80285c0", argdata, 1, 5, &func);
 }
 
-void CrewControl::OnLoop()
+void CrewControl::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func359::func;
@@ -5029,10 +5029,10 @@ namespace _func360
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewControl::UpdateCrewBoxes", typeid(void (CrewControl::*)()), "578d7c240883e4f0ff77fc5589e55756538d45dc89cbb9????????83ec5cc745dc00000000c745e000000000890424c744240400000000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewControl::OnLoop", typeid(void (CrewControl::*)()), "578d7c240883e4f0ff77fc5589e557568db18c0000005389cb83ec6c89f1e8????????80bb9e000000000f85????????89d9", argdata, 1, 5, &func);
 }
 
-void CrewControl::UpdateCrewBoxes()
+void CrewControl::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func360::func;
@@ -5042,6 +5042,20 @@ void CrewControl::UpdateCrewBoxes()
 namespace _func361
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewControl::UpdateCrewBoxes", typeid(void (CrewControl::*)()), "578d7c240883e4f0ff77fc5589e55756538d45dc89cbb9????????83ec5cc745dc00000000c745e000000000890424c744240400000000", argdata, 1, 5, &func);
+}
+
+void CrewControl::UpdateCrewBoxes()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func361::func;
+	return execfunc(this);
+}
+
+namespace _func362
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("CrewControl::LinkShip", typeid(void (CrewControl::*)(ShipManager *)), "5589e55389cb8b450883e4f08901e8????????c7432000000000c7431c000000008b5dfc", argdata, 2, 5, &func);
 }
@@ -5049,11 +5063,11 @@ namespace _func361
 void CrewControl::LinkShip(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func361::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func362::func;
 	return execfunc(this, ship);
 }
 
-namespace _func362
+namespace _func363
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5063,11 +5077,11 @@ namespace _func362
 void CrewControl::MouseMove(int mX, int mY, int wX, int wY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, int wX_arg, int wY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func362::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func363::func;
 	return execfunc(this, mX, mY, wX, wY);
 }
 
-namespace _func363
+namespace _func364
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5077,11 +5091,11 @@ namespace _func363
 void CrewControl::LButton(int mX, int mY, int wX, int wY, bool shiftHeld)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, int wX_arg, int wY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func363::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func364::func;
 	return execfunc(this, mX, mY, wX, wY, shiftHeld);
 }
 
-namespace _func364
+namespace _func365
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5091,11 +5105,11 @@ namespace _func364
 void CrewControl::ClearDeadCrew(std::vector<CrewMember*> *crew)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg, std::vector<CrewMember*> *crew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func364::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func365::func;
 	return execfunc(this, crew);
 }
 
-namespace _func365
+namespace _func366
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5105,11 +5119,11 @@ namespace _func365
 void CrewControl::ClearCrewBoxes()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func365::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func366::func;
 	return execfunc(this);
 }
 
-namespace _func366
+namespace _func367
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -5119,11 +5133,11 @@ namespace _func366
 void CrewControl::SelectPotentialCrew(CrewMember *crew, bool allowTeleportLeaving)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg, CrewMember *crew_arg, bool allowTeleportLeaving_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func366::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func367::func;
 	return execfunc(this, crew, allowTeleportLeaving);
 }
 
-namespace _func367
+namespace _func368
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5133,11 +5147,11 @@ namespace _func367
 void CrewControl::KeyDown(SDLKey key)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func367::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func368::func;
 	return execfunc(this, key);
 }
 
-namespace _func368
+namespace _func369
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -5147,11 +5161,11 @@ namespace _func368
 void CrewControl::RButton(int mX, int mY, bool shiftHeld)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func368::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func369::func;
 	return execfunc(this, mX, mY, shiftHeld);
 }
 
-namespace _func369
+namespace _func370
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5161,11 +5175,11 @@ namespace _func369
 void CrewControl::SelectCrew(bool keep_current)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg, bool keep_current_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func369::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func370::func;
 	return execfunc(this, keep_current);
 }
 
-namespace _func370
+namespace _func371
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5175,11 +5189,11 @@ namespace _func370
 void CrewCustomizeBox::CheckContents()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewCustomizeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func370::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func371::func;
 	return execfunc(this);
 }
 
-namespace _func371
+namespace _func372
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5189,11 +5203,11 @@ namespace _func371
 void CrewDrone::constructor(const std::string &type, const std::string &name, int shipId, const DroneBlueprint *blueprint, CrewAnimation *anim)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewDrone *this_arg, const std::string &type_arg, const std::string &name_arg, int shipId_arg, const DroneBlueprint *blueprint_arg, CrewAnimation *anim_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func371::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func372::func;
 	return execfunc(this, type, name, shipId, blueprint, anim);
 }
 
-namespace _func372
+namespace _func373
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5203,11 +5217,11 @@ namespace _func372
 void CrewDrone::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func372::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func373::func;
 	return execfunc(this);
 }
 
-namespace _func373
+namespace _func374
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5217,11 +5231,11 @@ namespace _func373
 bool CrewDrone::ProvidesVision()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func373::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func374::func;
 	return execfunc(this);
 }
 
-namespace _func374
+namespace _func375
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5231,11 +5245,11 @@ namespace _func374
 void CrewDrone::SetCurrentShip(int shipId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewDrone *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func374::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func375::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func375
+namespace _func376
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5245,11 +5259,11 @@ namespace _func375
 void CrewDrone::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func375::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func376::func;
 	return execfunc(this);
 }
 
-namespace _func376
+namespace _func377
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5259,11 +5273,11 @@ namespace _func376
 void CrewEquipBox::RemoveItem()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func376::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func377::func;
 	return execfunc(this);
 }
 
-namespace _func377
+namespace _func378
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -5273,11 +5287,11 @@ namespace _func377
 void CrewEquipBox::constructor(Point pos, ShipManager *ship, int slot)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, Point pos_arg, ShipManager *ship_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func377::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func378::func;
 	return execfunc(this, pos, ship, slot);
 }
 
-namespace _func378
+namespace _func379
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5287,11 +5301,11 @@ namespace _func378
 bool CrewEquipBox::GetConfirmDelete()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func378::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func379::func;
 	return execfunc(this);
 }
 
-namespace _func379
+namespace _func380
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -5301,11 +5315,11 @@ namespace _func379
 void CrewEquipBox::RenderLabels(bool dragging, bool isNew)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, bool dragging_arg, bool isNew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func379::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func380::func;
 	return execfunc(this, dragging, isNew);
 }
 
-namespace _func380
+namespace _func381
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5315,11 +5329,11 @@ namespace _func380
 void CrewEquipBox::OnRender(bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func380::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func381::func;
 	return execfunc(this, unk);
 }
 
-namespace _func381
+namespace _func382
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5329,11 +5343,11 @@ namespace _func381
 void CrewEquipBox::OnTextInput(SDLKey key)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func381::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func382::func;
 	return execfunc(this, key);
 }
 
-namespace _func382
+namespace _func383
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5343,11 +5357,11 @@ namespace _func382
 void CrewEquipBox::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func382::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func383::func;
 	return execfunc(this, event);
 }
 
-namespace _func383
+namespace _func384
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5357,11 +5371,11 @@ namespace _func383
 void CrewEquipBox::MouseClick()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func383::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func384::func;
 	return execfunc(this);
 }
 
-namespace _func384
+namespace _func385
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5371,11 +5385,11 @@ namespace _func384
 void CrewEquipBox::CloseRename()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func384::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func385::func;
 	return execfunc(this);
 }
 
-namespace _func385
+namespace _func386
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5385,11 +5399,11 @@ namespace _func385
 void CrewManifest::OnInit(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func385::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func386::func;
 	return execfunc(this, ship);
 }
 
-namespace _func386
+namespace _func387
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5397,20 +5411,6 @@ namespace _func386
 }
 
 void CrewManifest::OnRender()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func386::func;
-	return execfunc(this);
-}
-
-namespace _func387
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewManifest::constructor", typeid(void (CrewManifest::*)()), "578d7c240883e4f0ff77fc5589e557565389cb8d7d948d75d481ec????????e8????????8d4320c703????????89c1898554ffffff", argdata, 1, 5, &func);
-}
-
-void CrewManifest::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func387::func;
@@ -5421,10 +5421,10 @@ namespace _func388
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewManifest::Update", typeid(void (CrewManifest::*)()), "578d7c240883e4f0ff77fc5589e55756538d45cc89ceb9????????83ec3cc745cc00000000c745d000000000890424c744240800000000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewManifest::constructor", typeid(void (CrewManifest::*)()), "578d7c240883e4f0ff77fc5589e557565389cb8d7d948d75d481ec????????e8????????8d4320c703????????89c1898554ffffff", argdata, 1, 5, &func);
 }
 
-void CrewManifest::Update()
+void CrewManifest::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func388::func;
@@ -5434,25 +5434,25 @@ void CrewManifest::Update()
 namespace _func389
 {
     static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("CrewManifest::OnKeyDown", typeid(void (CrewManifest::*)(SDLKey )), "578d7c240883e4f0ff77fc5589e557565383ec1c8b91d40000008b81d80000008b3729d0c1f80285c074??89cf31db", argdata, 2, 5, &func);
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewManifest::Update", typeid(void (CrewManifest::*)()), "578d7c240883e4f0ff77fc5589e55756538d45cc89ceb9????????83ec3cc745cc00000000c745d000000000890424c744240800000000", argdata, 1, 5, &func);
 }
 
-void CrewManifest::OnKeyDown(SDLKey key)
+void CrewManifest::Update()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func389::func;
-	return execfunc(this, key);
+	return execfunc(this);
 }
 
 namespace _func390
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("CrewManifest::OnKeyUp", typeid(void (CrewManifest::*)(SDLKey )), ".578d7c240883e4f0ff77fc5589e557565383ec1c8b91d40000008b81d80000008b3729d0c1f80285c074??", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("CrewManifest::OnKeyDown", typeid(void (CrewManifest::*)(SDLKey )), "578d7c240883e4f0ff77fc5589e557565383ec1c8b91d40000008b81d80000008b3729d0c1f80285c074??89cf31db", argdata, 2, 5, &func);
 }
 
-void CrewManifest::OnKeyUp(SDLKey key)
+void CrewManifest::OnKeyDown(SDLKey key)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func390::func;
@@ -5463,10 +5463,10 @@ namespace _func391
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("CrewManifest::OnTextInput", typeid(void (CrewManifest::*)(SDLKey )), ".578d7c240883e4f0ff77fc5589e557565383ec1c8b91d40000008b81d80000008b3729d0c1f80285c074??89cf31db", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("CrewManifest::OnKeyUp", typeid(void (CrewManifest::*)(SDLKey )), ".578d7c240883e4f0ff77fc5589e557565383ec1c8b91d40000008b81d80000008b3729d0c1f80285c074??", argdata, 2, 5, &func);
 }
 
-void CrewManifest::OnTextInput(SDLKey key)
+void CrewManifest::OnKeyUp(SDLKey key)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func391::func;
@@ -5477,17 +5477,31 @@ namespace _func392
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("CrewManifest::OnTextInput", typeid(void (CrewManifest::*)(SDLKey )), ".578d7c240883e4f0ff77fc5589e557565383ec1c8b91d40000008b81d80000008b3729d0c1f80285c074??89cf31db", argdata, 2, 5, &func);
+}
+
+void CrewManifest::OnTextInput(SDLKey key)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func392::func;
+	return execfunc(this, key);
+}
+
+namespace _func393
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("CrewManifest::OnTextEvent", typeid(void (CrewManifest::*)(CEvent::TextEvent )), ".578d7c240883e4f0ff77fc5589e557565383ec1c8b91d40000008b81d80000008b3729d0c1f80285c074??89cf31db", argdata, 2, 5, &func);
 }
 
 void CrewManifest::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func392::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func393::func;
 	return execfunc(this, event);
 }
 
-namespace _func393
+namespace _func394
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5497,11 +5511,11 @@ namespace _func393
 void CrewManifest::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func393::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func394::func;
 	return execfunc(this);
 }
 
-namespace _func394
+namespace _func395
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -5511,11 +5525,11 @@ namespace _func394
 void CrewManifest::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func394::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func395::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func395
+namespace _func396
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -5525,11 +5539,11 @@ namespace _func395
 void CrewManifest::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func395::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func396::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func396
+namespace _func397
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5537,20 +5551,6 @@ namespace _func396
 }
 
 bool CrewMember::CanSabotage()
-{
-	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func396::func;
-	return execfunc(this);
-}
-
-namespace _func397
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::CanRepair", typeid(bool (CrewMember::*)()), "80b9980000000074??31c0c38d7426008b015589e55389cb8b8088000000", argdata, 1, 1, &func);
-}
-
-bool CrewMember::CanRepair()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func397::func;
@@ -5561,10 +5561,10 @@ namespace _func398
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::CanMan", typeid(bool (CrewMember::*)()), "0fb6819800000084c075??f30f1081080700000f2e05????????76??f3c3", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("CrewMember::CanRepair", typeid(bool (CrewMember::*)()), "80b9980000000074??31c0c38d7426008b015589e55389cb8b8088000000", argdata, 1, 1, &func);
 }
 
-bool CrewMember::CanMan()
+bool CrewMember::CanRepair()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func398::func;
@@ -5575,10 +5575,10 @@ namespace _func399
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::CanHeal", typeid(bool (CrewMember::*)()), "f30f1041280f2e412c7a??75??5589e55389cb83e4f080796c0075??8b8300020000", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("CrewMember::CanMan", typeid(bool (CrewMember::*)()), "0fb6819800000084c075??f30f1081080700000f2e05????????76??f3c3", argdata, 1, 1, &func);
 }
 
-bool CrewMember::CanHeal()
+bool CrewMember::CanMan()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func399::func;
@@ -5588,6 +5588,20 @@ bool CrewMember::CanHeal()
 namespace _func400
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewMember::CanHeal", typeid(bool (CrewMember::*)()), "f30f1041280f2e412c7a??75??5589e55389cb83e4f080796c0075??8b8300020000", argdata, 1, 1, &func);
+}
+
+bool CrewMember::CanHeal()
+{
+	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func400::func;
+	return execfunc(this);
+}
+
+namespace _func401
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("CrewMember::OnRender", typeid(void (CrewMember::*)(bool )), ".578d7c240883e4f0ff77fc5589e5575383ec3080b9fc010000008b3f74??8d65f85b5f5d8d67f8", argdata, 2, 5, &func);
 }
@@ -5595,11 +5609,11 @@ namespace _func400
 void CrewMember::OnRender(bool outlineOnly)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool outlineOnly_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func400::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func401::func;
 	return execfunc(this, outlineOnly);
 }
 
-namespace _func401
+namespace _func402
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5609,11 +5623,11 @@ namespace _func401
 Damage CrewMember::GetRoomDamage()
 {
 	typedef Damage __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func401::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func402::func;
 	return execfunc(this);
 }
 
-namespace _func402
+namespace _func403
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5623,11 +5637,11 @@ namespace _func402
 void CrewMember::constructor(CrewBlueprint &blueprint, int shipId, bool intruder, CrewAnimation *animation)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewBlueprint &blueprint_arg, int shipId_arg, bool intruder_arg, CrewAnimation *animation_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func402::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func403::func;
 	return execfunc(this, blueprint, shipId, intruder, animation);
 }
 
-namespace _func403
+namespace _func404
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5637,11 +5651,11 @@ namespace _func403
 void CrewMember::Jump()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func403::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func404::func;
 	return execfunc(this);
 }
 
-namespace _func404
+namespace _func405
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5651,11 +5665,11 @@ namespace _func404
 bool CrewMember::GetIntruder()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func404::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func405::func;
 	return execfunc(this);
 }
 
-namespace _func405
+namespace _func406
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5665,11 +5679,11 @@ namespace _func405
 void CrewMember::SetOutOfGame()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func405::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func406::func;
 	return execfunc(this);
 }
 
-namespace _func406
+namespace _func407
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5679,11 +5693,11 @@ namespace _func406
 float CrewMember::PositionShift()
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func406::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func407::func;
 	return execfunc(this);
 }
 
-namespace _func407
+namespace _func408
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5693,11 +5707,11 @@ namespace _func407
 void CrewMember::SaveState(int fileHelper)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func407::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func408::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func408
+namespace _func409
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5707,11 +5721,11 @@ namespace _func408
 bool CrewMember::CanTeleport()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func408::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func409::func;
 	return execfunc(this);
 }
 
-namespace _func409
+namespace _func410
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5721,11 +5735,11 @@ namespace _func409
 void CrewMember::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func409::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func410::func;
 	return execfunc(this);
 }
 
-namespace _func410
+namespace _func411
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5735,11 +5749,11 @@ namespace _func410
 void CrewMember::Cleanup()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func410::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func411::func;
 	return execfunc(this);
 }
 
-namespace _func411
+namespace _func412
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5749,11 +5763,11 @@ namespace _func411
 void CrewMember::LoadState(int fileHelper)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func411::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func412::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func412
+namespace _func413
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5763,11 +5777,11 @@ namespace _func412
 void CrewMember::SetCurrentSystem(ShipSystem *sys)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, ShipSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func412::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func413::func;
 	return execfunc(this, sys);
 }
 
-namespace _func413
+namespace _func414
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5777,11 +5791,11 @@ namespace _func413
 bool CrewMember::IsManningArtillery()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func413::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func414::func;
 	return execfunc(this);
 }
 
-namespace _func414
+namespace _func415
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5791,11 +5805,11 @@ namespace _func414
 void CrewMember::IncreaseSkill(int skillId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func414::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func415::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func415
+namespace _func416
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5805,11 +5819,11 @@ namespace _func415
 void CrewMember::CheckSkills()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func415::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func416::func;
 	return execfunc(this);
 }
 
-namespace _func416
+namespace _func417
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5819,11 +5833,11 @@ namespace _func416
 void CrewMember::MasterSkill(int skillId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func416::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func417::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func417
+namespace _func418
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5833,11 +5847,11 @@ namespace _func417
 int CrewMember::GetSkillFromSystem(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func417::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func418::func;
 	return execfunc(systemId);
 }
 
-namespace _func418
+namespace _func419
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5847,11 +5861,11 @@ namespace _func418
 void CrewMember::SetResisted(bool resisted)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool resisted_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func418::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func419::func;
 	return execfunc(this, resisted);
 }
 
-namespace _func419
+namespace _func420
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5861,11 +5875,11 @@ namespace _func419
 bool CrewMember::GetResisted()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func419::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func420::func;
 	return execfunc(this);
 }
 
-namespace _func420
+namespace _func421
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -5875,11 +5889,11 @@ namespace _func420
 void CrewMember::SetSkillProgress(int skillId, int skillLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg, int skillLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func420::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func421::func;
 	return execfunc(this, skillId, skillLevel);
 }
 
-namespace _func421
+namespace _func422
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5889,11 +5903,11 @@ namespace _func421
 int CrewMember::GetSkillLevel(int skillId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func421::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func422::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func422
+namespace _func423
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5903,11 +5917,11 @@ namespace _func422
 std::pair<int, int> CrewMember::GetSkillProgress(int skillId)
 {
 	typedef std::pair<int, int> __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func422::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func423::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func423
+namespace _func424
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5917,11 +5931,11 @@ namespace _func423
 float CrewMember::GetSkillModifier(int skillId)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func423::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func424::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func424
+namespace _func425
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5931,11 +5945,11 @@ namespace _func424
 bool CrewMember::BadAtCombat()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func424::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func425::func;
 	return execfunc(this);
 }
 
-namespace _func425
+namespace _func426
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5945,11 +5959,11 @@ namespace _func425
 void CrewMember::EmptySlot()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func425::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func426::func;
 	return execfunc(this);
 }
 
-namespace _func426
+namespace _func427
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5959,11 +5973,11 @@ namespace _func426
 bool CrewMember::NeedsSlot()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func426::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func427::func;
 	return execfunc(this);
 }
 
-namespace _func427
+namespace _func428
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5973,11 +5987,11 @@ namespace _func427
 bool CrewMember::DirectModifyHealth(float health)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func427::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func428::func;
 	return execfunc(this, health);
 }
 
-namespace _func428
+namespace _func429
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5987,11 +6001,11 @@ namespace _func428
 void CrewMember::ModifyHealth(float health)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func428::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func429::func;
 	return execfunc(this, health);
 }
 
-namespace _func429
+namespace _func430
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6001,11 +6015,11 @@ namespace _func429
 bool CrewMember::ApplyDamage(float damage)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func429::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func430::func;
 	return execfunc(this, damage);
 }
 
-namespace _func430
+namespace _func431
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6013,20 +6027,6 @@ namespace _func430
 }
 
 bool CrewMember::RepairingSystem()
-{
-	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func430::func;
-	return execfunc(this);
-}
-
-namespace _func431
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::Sabotaging", typeid(bool (CrewMember::*)()), ".8b416885c074??5589e5538b10", argdata, 1, 1, &func);
-}
-
-bool CrewMember::Sabotaging()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func431::func;
@@ -6037,10 +6037,10 @@ namespace _func432
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::RepairingFire", typeid(bool (CrewMember::*)()), ".8b516831c085d274??8b9100020000", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("CrewMember::Sabotaging", typeid(bool (CrewMember::*)()), ".8b416885c074??5589e5538b10", argdata, 1, 1, &func);
 }
 
-bool CrewMember::RepairingFire()
+bool CrewMember::Sabotaging()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func432::func;
@@ -6051,17 +6051,31 @@ namespace _func433
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewMember::RepairingFire", typeid(bool (CrewMember::*)()), ".8b516831c085d274??8b9100020000", argdata, 1, 1, &func);
+}
+
+bool CrewMember::RepairingFire()
+{
+	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func433::func;
+	return execfunc(this);
+}
+
+namespace _func434
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("CrewMember::SelectSabotageTarget", typeid(Pointf (CrewMember::*)()), ".578d7c240883e4f0ff77fc5589e5", argdata, 1, 9, &func);
 }
 
 Pointf CrewMember::SelectSabotageTarget()
 {
 	typedef Pointf __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func433::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func434::func;
 	return execfunc(this);
 }
 
-namespace _func434
+namespace _func435
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6071,11 +6085,11 @@ namespace _func434
 void CrewMember::SavePosition()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func434::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func435::func;
 	return execfunc(this);
 }
 
-namespace _func435
+namespace _func436
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6085,11 +6099,11 @@ namespace _func435
 void CrewMember::ClearPosition()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func435::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func436::func;
 	return execfunc(this);
 }
 
-namespace _func436
+namespace _func437
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6099,11 +6113,11 @@ namespace _func436
 Slot CrewMember::GetSavedPosition()
 {
 	typedef Slot __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func436::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func437::func;
 	return execfunc(this);
 }
 
-namespace _func437
+namespace _func438
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x4ff};
@@ -6113,11 +6127,11 @@ namespace _func437
 void CrewMember::SetSavePosition(Slot position)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Slot position_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func437::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func438::func;
 	return execfunc(this, position);
 }
 
-namespace _func438
+namespace _func439
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6127,11 +6141,11 @@ namespace _func438
 void CrewMember::StopRepairing()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func438::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func439::func;
 	return execfunc(this);
 }
 
-namespace _func439
+namespace _func440
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6141,11 +6155,11 @@ namespace _func439
 bool CrewMember::Repairing()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func439::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func440::func;
 	return execfunc(this);
 }
 
-namespace _func440
+namespace _func441
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6155,11 +6169,11 @@ namespace _func440
 void CrewMember::SetFrozen(bool frozen)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool frozen_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func440::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func441::func;
 	return execfunc(this, frozen);
 }
 
-namespace _func441
+namespace _func442
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6169,11 +6183,11 @@ namespace _func441
 void CrewMember::SetFrozenLocation(bool frozenLocation)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool frozenLocation_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func441::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func442::func;
 	return execfunc(this, frozenLocation);
 }
 
-namespace _func442
+namespace _func443
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x3ff};
@@ -6183,11 +6197,11 @@ namespace _func442
 void CrewMember::SetTask(CrewTask task)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewTask task_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func442::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func443::func;
 	return execfunc(this, task);
 }
 
-namespace _func443
+namespace _func444
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -6197,11 +6211,11 @@ namespace _func443
 Slot CrewMember::FindSlot(int roomId, int slotId, bool closeEnough)
 {
 	typedef Slot __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg, int slotId_arg, bool closeEnough_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func443::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func444::func;
 	return execfunc(this, roomId, slotId, closeEnough);
 }
 
-namespace _func444
+namespace _func445
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6211,11 +6225,11 @@ namespace _func444
 bool CrewMember::CheckRoomPath(int roomId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func444::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func445::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func445
+namespace _func446
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -6225,11 +6239,11 @@ namespace _func445
 void CrewMember::SetPosition(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func445::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func446::func;
 	return execfunc(this, pos);
 }
 
-namespace _func446
+namespace _func447
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6239,11 +6253,11 @@ namespace _func446
 void CrewMember::ClearTask()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func446::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func447::func;
 	return execfunc(this);
 }
 
-namespace _func447
+namespace _func448
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6253,11 +6267,11 @@ namespace _func447
 void CrewMember::ClearPath()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func447::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func448::func;
 	return execfunc(this);
 }
 
-namespace _func448
+namespace _func449
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6267,11 +6281,11 @@ namespace _func448
 void CrewMember::SetRoom(int roomId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func448::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func449::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func449
+namespace _func450
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6279,20 +6293,6 @@ namespace _func449
 }
 
 bool CrewMember::IsBusy()
-{
-	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func449::func;
-	return execfunc(this);
-}
-
-namespace _func450
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::OnInit", typeid(bool (CrewMember::*)()), ".c741201e000000c7416400000000b8????????", argdata, 1, 1, &func);
-}
-
-bool CrewMember::OnInit()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func450::func;
@@ -6303,12 +6303,12 @@ namespace _func451
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::GetFinalGoal", typeid(Point (CrewMember::*)()), ".f30f1005????????0f2e41547a??74??8b414c8b5150", argdata, 1, 9, &func);
+	static FunctionDefinition funcObj("CrewMember::OnInit", typeid(bool (CrewMember::*)()), ".c741201e000000c7416400000000b8????????", argdata, 1, 1, &func);
 }
 
-Point CrewMember::GetFinalGoal()
+bool CrewMember::OnInit()
 {
-	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func451::func;
 	return execfunc(this);
 }
@@ -6317,10 +6317,10 @@ namespace _func452
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::GetNextGoal", typeid(Point (CrewMember::*)()), ".578d7c240883e4f0ff77fc5589e55753", argdata, 1, 9, &func);
+	static FunctionDefinition funcObj("CrewMember::GetFinalGoal", typeid(Point (CrewMember::*)()), ".f30f1005????????0f2e41547a??74??8b414c8b5150", argdata, 1, 9, &func);
 }
 
-Point CrewMember::GetNextGoal()
+Point CrewMember::GetFinalGoal()
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func452::func;
@@ -6330,6 +6330,20 @@ Point CrewMember::GetNextGoal()
 namespace _func453
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewMember::GetNextGoal", typeid(Point (CrewMember::*)()), ".578d7c240883e4f0ff77fc5589e55753", argdata, 1, 9, &func);
+}
+
+Point CrewMember::GetNextGoal()
+{
+	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func453::func;
+	return execfunc(this);
+}
+
+namespace _func454
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("CrewMember::CloseDoorBehind", typeid(void (CrewMember::*)(Door *)), ".8b442404894164", argdata, 2, 5, &func);
 }
@@ -6337,11 +6351,11 @@ namespace _func453
 void CrewMember::CloseDoorBehind(Door *door)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Door *door_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func453::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func454::func;
 	return execfunc(this, door);
 }
 
-namespace _func454
+namespace _func455
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6351,11 +6365,11 @@ namespace _func454
 float CrewMember::GetMoveSpeed()
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func454::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func455::func;
 	return execfunc(this);
 }
 
-namespace _func455
+namespace _func456
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6365,11 +6379,11 @@ namespace _func455
 void CrewMember::Restart()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func455::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func456::func;
 	return execfunc(this);
 }
 
-namespace _func456
+namespace _func457
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6379,11 +6393,11 @@ namespace _func456
 void CrewMember::SetDamageBoost(float damageBoost)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float damageBoost_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func456::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func457::func;
 	return execfunc(this, damageBoost);
 }
 
-namespace _func457
+namespace _func458
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6393,11 +6407,11 @@ namespace _func457
 void CrewMember::SetHealthBoost(int healthBoost)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int healthBoost_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func457::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func458::func;
 	return execfunc(this, healthBoost);
 }
 
-namespace _func458
+namespace _func459
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6407,11 +6421,11 @@ namespace _func458
 void CrewMember::InitializeSkills()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func458::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func459::func;
 	return execfunc(this);
 }
 
-namespace _func459
+namespace _func460
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6421,11 +6435,11 @@ namespace _func459
 void CrewMember::SetCloneReady(bool cloneReady)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool cloneReady_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func459::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func460::func;
 	return execfunc(this, cloneReady);
 }
 
-namespace _func460
+namespace _func461
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6435,11 +6449,11 @@ namespace _func460
 void CrewMember::Kill(bool noClone)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool noClone_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func460::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func461::func;
 	return execfunc(this, noClone);
 }
 
-namespace _func461
+namespace _func462
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6449,11 +6463,11 @@ namespace _func461
 bool CrewMember::NeedFrozenLocation()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func461::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func462::func;
 	return execfunc(this);
 }
 
-namespace _func462
+namespace _func463
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6463,11 +6477,11 @@ namespace _func462
 void CrewMember::SetCurrentShip(int shipId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func462::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func463::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func463
+namespace _func464
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6477,11 +6491,11 @@ namespace _func463
 void CrewMember::CheckFighting()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func463::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func464::func;
 	return execfunc(this);
 }
 
-namespace _func464
+namespace _func465
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6491,11 +6505,11 @@ namespace _func464
 void CrewMember::SetDeathNumber(int deathNum)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int deathNum_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func464::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func465::func;
 	return execfunc(this, deathNum);
 }
 
-namespace _func465
+namespace _func466
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6505,11 +6519,11 @@ namespace _func465
 void CrewMember::ForceMindControl(bool force)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func465::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func466::func;
 	return execfunc(this, force);
 }
 
-namespace _func466
+namespace _func467
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -6519,11 +6533,11 @@ namespace _func466
 void CrewMember::RenderSkillUpAnimation(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func466::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func467::func;
 	return execfunc(this, pos);
 }
 
-namespace _func467
+namespace _func468
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6531,20 +6545,6 @@ namespace _func467
 }
 
 void CrewMember::Clone()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func467::func;
-	return execfunc(this);
-}
-
-namespace _func468
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::UpdateHealth", typeid(void (CrewMember::*)()), ".578d7c240883e4f0ff77fc55", argdata, 1, 5, &func);
-}
-
-void CrewMember::UpdateHealth()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func468::func;
@@ -6555,10 +6555,10 @@ namespace _func469
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::OnRenderPath", typeid(void (CrewMember::*)()), ".8b410485c00f85????????660fefc9f30f104108f30f1015????????", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewMember::UpdateHealth", typeid(void (CrewMember::*)()), ".578d7c240883e4f0ff77fc55", argdata, 1, 5, &func);
 }
 
-void CrewMember::OnRenderPath()
+void CrewMember::UpdateHealth()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func469::func;
@@ -6568,6 +6568,20 @@ void CrewMember::OnRenderPath()
 namespace _func470
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewMember::OnRenderPath", typeid(void (CrewMember::*)()), ".8b410485c00f85????????660fefc9f30f104108f30f1015????????", argdata, 1, 5, &func);
+}
+
+void CrewMember::OnRenderPath()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func470::func;
+	return execfunc(this);
+}
+
+namespace _func471
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("CrewMember::SetPath", typeid(bool (CrewMember::*)(Path *)), ".578d7c240883e4f0ff77fc5589e557565389cb", argdata, 2, 1, &func);
 }
@@ -6575,11 +6589,11 @@ namespace _func470
 bool CrewMember::SetPath(Path *path)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Path *path_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func470::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func471::func;
 	return execfunc(this, path);
 }
 
-namespace _func471
+namespace _func472
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -6589,11 +6603,11 @@ namespace _func471
 void CrewMember::SetRoomPath(int slotId, int roomId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int slotId_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func471::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func472::func;
 	return execfunc(this, slotId, roomId);
 }
 
-namespace _func472
+namespace _func473
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6603,20 +6617,6 @@ namespace _func472
 Point CrewMember::GetLocation()
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func472::func;
-	return execfunc(this);
-}
-
-namespace _func473
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::AtGoal", typeid(bool (CrewMember::*)()), ".f30f104918f30f101d????????f30f10410855f30f5cc1f30f1015????????", argdata, 1, 1, &func);
-}
-
-bool CrewMember::AtGoal()
-{
-	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func473::func;
 	return execfunc(this);
 }
@@ -6625,10 +6625,10 @@ namespace _func474
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::AtFinalGoal", typeid(bool (CrewMember::*)()), ".660fefc9f30f1015????????f30f10410831c055f30f2a899000000089e5", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("CrewMember::AtGoal", typeid(bool (CrewMember::*)()), ".f30f104918f30f101d????????f30f10410855f30f5cc1f30f1015????????", argdata, 1, 1, &func);
 }
 
-bool CrewMember::AtFinalGoal()
+bool CrewMember::AtGoal()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func474::func;
@@ -6639,17 +6639,31 @@ namespace _func475
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewMember::AtFinalGoal", typeid(bool (CrewMember::*)()), ".660fefc9f30f1015????????f30f10410831c055f30f2a899000000089e5", argdata, 1, 1, &func);
+}
+
+bool CrewMember::AtFinalGoal()
+{
+	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func475::func;
+	return execfunc(this);
+}
+
+namespace _func476
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("CrewMember::OnRenderHealth", typeid(void (CrewMember::*)()), ".80b9fc0100000074??f3c3908d7426008b819c000000837838030f84????????57", argdata, 1, 5, &func);
 }
 
 void CrewMember::OnRenderHealth()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func475::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func476::func;
 	return execfunc(this);
 }
 
-namespace _func476
+namespace _func477
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6659,11 +6673,11 @@ namespace _func476
 int CrewMember::GetIntegerHealth()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func476::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func477::func;
 	return execfunc(this);
 }
 
-namespace _func477
+namespace _func478
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6673,11 +6687,11 @@ namespace _func477
 int CrewMember::GetRepairingId()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func477::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func478::func;
 	return execfunc(this);
 }
 
-namespace _func478
+namespace _func479
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -6687,11 +6701,11 @@ namespace _func478
 bool CrewMember::WithinRect(int x, int y, int w, int h)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int x_arg, int y_arg, int w_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func478::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func479::func;
 	return execfunc(this, x, y, w, h);
 }
 
-namespace _func479
+namespace _func480
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6701,11 +6715,11 @@ namespace _func479
 std::string CrewMember::GetLongName()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func479::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func480::func;
 	return execfunc(this);
 }
 
-namespace _func480
+namespace _func481
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -6715,11 +6729,11 @@ namespace _func480
 void CrewMember::SetName(TextString *name, bool force)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, TextString *name_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func480::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func481::func;
 	return execfunc(this, name, force);
 }
 
-namespace _func481
+namespace _func482
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6729,11 +6743,11 @@ namespace _func481
 std::string CrewMember::GetName()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func481::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func482::func;
 	return execfunc(this);
 }
 
-namespace _func482
+namespace _func483
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -6743,11 +6757,11 @@ namespace _func482
 void CrewMember::SetCurrentTarget(CrewTarget *target, bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewTarget *target_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func482::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func483::func;
 	return execfunc(this, target, unk);
 }
 
-namespace _func483
+namespace _func484
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6757,11 +6771,11 @@ namespace _func483
 void CrewMember::CheckForTeleport()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func483::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func484::func;
 	return execfunc(this);
 }
 
-namespace _func484
+namespace _func485
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6771,11 +6785,11 @@ namespace _func484
 bool CrewMember::GetNewGoal()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func484::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func485::func;
 	return execfunc(this);
 }
 
-namespace _func485
+namespace _func486
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -6785,11 +6799,11 @@ namespace _func485
 bool CrewMember::MoveToRoom(int roomId, int slotId, bool forceMove)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg, int slotId_arg, bool forceMove_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func485::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func486::func;
 	return execfunc(this, roomId, slotId, forceMove);
 }
 
-namespace _func486
+namespace _func487
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6799,11 +6813,11 @@ namespace _func486
 void CrewMember::SetMindControl(bool controlled)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool controlled_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func486::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func487::func;
 	return execfunc(this, controlled);
 }
 
-namespace _func487
+namespace _func488
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6813,11 +6827,11 @@ namespace _func487
 bool CrewMember::RestorePosition()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func487::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func488::func;
 	return execfunc(this);
 }
 
-namespace _func488
+namespace _func489
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -6827,11 +6841,11 @@ namespace _func488
 bool CrewMember::ContainsPoint(int x, int y)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func488::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func489::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func489
+namespace _func490
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6841,11 +6855,11 @@ namespace _func489
 void CrewMember::SetMedbay(float health)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func489::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func490::func;
 	return execfunc(this, health);
 }
 
-namespace _func490
+namespace _func491
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6855,11 +6869,11 @@ namespace _func490
 void CrewMember::StartTeleport()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func490::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func491::func;
 	return execfunc(this);
 }
 
-namespace _func491
+namespace _func492
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6869,11 +6883,11 @@ namespace _func491
 void CrewMember::StartTeleportArrive()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func491::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func492::func;
 	return execfunc(this);
 }
 
-namespace _func492
+namespace _func493
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6883,11 +6897,11 @@ namespace _func492
 void CrewMember::StartRepair(Repairable *toRepair)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Repairable *toRepair_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func492::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func493::func;
 	return execfunc(this, toRepair);
 }
 
-namespace _func493
+namespace _func494
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6895,20 +6909,6 @@ namespace _func493
 }
 
 void CrewMember::UpdateRepair()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func493::func;
-	return execfunc(this);
-}
-
-namespace _func494
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::UpdateMovement", typeid(void (CrewMember::*)()), ".8b819c0000008b403883f8060f84????????660fefc00f2e41280f83????????578d7c2408", argdata, 1, 5, &func);
-}
-
-void CrewMember::UpdateMovement()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func494::func;
@@ -6919,10 +6919,10 @@ namespace _func495
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::OnLoop", typeid(void (CrewMember::*)()), ".578d7c240883e4f0ff77fc5589e55756", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewMember::UpdateMovement", typeid(void (CrewMember::*)()), ".8b819c0000008b403883f8060f84????????660fefc00f2e41280f83????????578d7c2408", argdata, 1, 5, &func);
 }
 
-void CrewMember::OnLoop()
+void CrewMember::UpdateMovement()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func495::func;
@@ -6932,6 +6932,20 @@ void CrewMember::OnLoop()
 namespace _func496
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewMember::OnLoop", typeid(void (CrewMember::*)()), ".578d7c240883e4f0ff77fc5589e55756", argdata, 1, 5, &func);
+}
+
+void CrewMember::OnLoop()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func496::func;
+	return execfunc(this);
+}
+
+namespace _func497
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("CrewMember::SetSex", typeid(void (CrewMember::*)(bool )), ".5589e556538b750889cb8b899c00000083e4f089f08881c4090000e8????????89f08883100300008d65f85b", argdata, 2, 5, &func);
 }
@@ -6939,11 +6953,11 @@ namespace _func496
 void CrewMember::SetSex(bool male)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool male_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func496::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func497::func;
 	return execfunc(this, male);
 }
 
-namespace _func497
+namespace _func498
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6953,11 +6967,11 @@ namespace _func497
 void CrewMember::CycleColorLayer(int unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func497::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func498::func;
 	return execfunc(this, unk);
 }
 
-namespace _func498
+namespace _func499
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6967,11 +6981,11 @@ namespace _func498
 bool CrewMember::Functional()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func498::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func499::func;
 	return execfunc(this);
 }
 
-namespace _func499
+namespace _func500
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6981,11 +6995,11 @@ namespace _func499
 bool CrewMember::InsideRoom(int roomId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func499::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func500::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func500
+namespace _func501
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6995,11 +7009,11 @@ namespace _func500
 bool CrewMember::GetControllable()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func500::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func501::func;
 	return execfunc(this);
 }
 
-namespace _func501
+namespace _func502
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7009,11 +7023,11 @@ namespace _func501
 std::string CrewMember::GetUniqueRepairing()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func501::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func502::func;
 	return execfunc(this);
 }
 
-namespace _func502
+namespace _func503
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7023,11 +7037,11 @@ namespace _func502
 std::string CrewMember::GetTooltip()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func502::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func503::func;
 	return execfunc(this);
 }
 
-namespace _func503
+namespace _func504
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -7037,11 +7051,11 @@ namespace _func503
 std::string CrewMember::GetSkillTooltip(int skillId, int skillLevel, std::pair<int, int> progress, bool infoScreen)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(int skillId_arg, int skillLevel_arg, std::pair<int, int> progress_arg, bool infoScreen_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func503::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func504::func;
 	return execfunc(skillId, skillLevel, progress, infoScreen);
 }
 
-namespace _func504
+namespace _func505
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7051,11 +7065,11 @@ namespace _func504
 bool CrewMember::CountForVictory()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func504::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func505::func;
 	return execfunc(this);
 }
 
-namespace _func505
+namespace _func506
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7065,11 +7079,11 @@ namespace _func505
 void CrewMemberFactory::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func505::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func506::func;
 	return execfunc(this);
 }
 
-namespace _func506
+namespace _func507
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7079,11 +7093,11 @@ namespace _func506
 void CrewMemberFactory::Restart()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func506::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func507::func;
 	return execfunc(this);
 }
 
-namespace _func507
+namespace _func508
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7093,11 +7107,11 @@ namespace _func507
 int CrewMemberFactory::CountCloneReadyCrew(bool player)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, bool player_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func507::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func508::func;
 	return execfunc(this, player);
 }
 
-namespace _func508
+namespace _func509
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7107,11 +7121,11 @@ namespace _func508
 int CrewMemberFactory::GetPlayerCrewCount()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func508::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func509::func;
 	return execfunc(this);
 }
 
-namespace _func509
+namespace _func510
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7121,11 +7135,11 @@ namespace _func509
 int CrewMemberFactory::GetEnemyCloneCount()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func509::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func510::func;
 	return execfunc(this);
 }
 
-namespace _func510
+namespace _func511
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7135,11 +7149,11 @@ namespace _func510
 int CrewMemberFactory::GetCrewCount(bool enemy)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func510::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func511::func;
 	return execfunc(this, enemy);
 }
 
-namespace _func511
+namespace _func512
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7149,11 +7163,11 @@ namespace _func511
 int CrewMemberFactory::GetEnemyCrewCount()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func511::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func512::func;
 	return execfunc(this);
 }
 
-namespace _func512
+namespace _func513
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7163,11 +7177,11 @@ namespace _func512
 bool CrewMemberFactory::IsRace(const std::string &species)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &species_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func512::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func513::func;
 	return execfunc(species);
 }
 
-namespace _func513
+namespace _func514
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7177,11 +7191,11 @@ namespace _func513
 std::pair<std::string, bool> CrewMemberFactory::GetRandomFriendlyName(const std::string &race)
 {
 	typedef std::pair<std::string, bool> __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, const std::string &race_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func513::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func514::func;
 	return execfunc(this, race);
 }
 
-namespace _func514
+namespace _func515
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7191,11 +7205,11 @@ namespace _func514
 std::vector<std::string> CrewMemberFactory::GetCrewNames()
 {
 	typedef std::vector<std::string> __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func514::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func515::func;
 	return execfunc(this);
 }
 
-namespace _func515
+namespace _func516
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7205,11 +7219,11 @@ namespace _func515
 RepairDrone *CrewMemberFactory::CreateRepairDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef RepairDrone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func515::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func516::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func516
+namespace _func517
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7219,11 +7233,11 @@ namespace _func516
 void CrewMemberFactory::GetCrewPortraitList(std::vector<CrewMember*> *vec, int teamId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> *vec_arg, int teamId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func516::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func517::func;
 	return execfunc(this, vec, teamId);
 }
 
-namespace _func517
+namespace _func518
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7233,11 +7247,11 @@ namespace _func517
 void CrewMemberFactory::GetCloneReadyList(std::vector<CrewMember*> &vec, bool player)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> &vec_arg, bool player_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func517::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func518::func;
 	return execfunc(this, vec, player);
 }
 
-namespace _func518
+namespace _func519
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7247,11 +7261,11 @@ namespace _func518
 BattleDrone *CrewMemberFactory::CreateBattleDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef BattleDrone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func518::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func519::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func519
+namespace _func520
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -7261,11 +7275,11 @@ namespace _func519
 void CrewMemberFactory::GetCrewList(std::vector<CrewMember*> *vec, int unk, bool unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> *vec_arg, int unk_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func519::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func520::func;
 	return execfunc(this, vec, unk, unk2);
 }
 
-namespace _func520
+namespace _func521
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7275,11 +7289,11 @@ namespace _func520
 BoarderDrone *CrewMemberFactory::CreateBoarderDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef BoarderDrone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func520::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func521::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func521
+namespace _func522
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7289,11 +7303,11 @@ namespace _func521
 void CrewMemberFactory::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func521::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func522::func;
 	return execfunc(this);
 }
 
-namespace _func522
+namespace _func523
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7303,11 +7317,11 @@ namespace _func522
 void CrewMemberFactory::RemoveExcessCrew()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func522::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func523::func;
 	return execfunc(this);
 }
 
-namespace _func523
+namespace _func524
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -7317,18 +7331,18 @@ namespace _func523
 CrewMember *CrewMemberFactory::CreateCrewMember(CrewBlueprint *bp, int shipId, bool intruder)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, CrewBlueprint *bp_arg, int shipId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func523::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func524::func;
 	return execfunc(this, bp, shipId, intruder);
 }
 
 CrewMemberFactory *Global_CrewMemberFactory_Factory;
 
-namespace _var524
+namespace _var525
 {
     static VariableDefinition varObj("Global_CrewMemberFactory_Factory", "!b9(???????\?)e8????????29c6", &Global_CrewMemberFactory_Factory);
 }
 
-namespace _func525
+namespace _func526
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7338,11 +7352,11 @@ namespace _func525
 bool CrewStoreBox::CanHold()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func525::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func526::func;
 	return execfunc(this);
 }
 
-namespace _func526
+namespace _func527
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -7352,11 +7366,11 @@ namespace _func526
 void CrewStoreBox::constructor(ShipManager *ship, int worldLevel, const std::string &type)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewStoreBox *this_arg, ShipManager *ship_arg, int worldLevel_arg, const std::string &type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func526::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func527::func;
 	return execfunc(this, ship, worldLevel, type);
 }
 
-namespace _func527
+namespace _func528
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7366,11 +7380,11 @@ namespace _func527
 void CrewStoreBox::Purchase()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func527::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func528::func;
 	return execfunc(this);
 }
 
-namespace _func528
+namespace _func529
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7380,11 +7394,11 @@ namespace _func528
 void CrewStoreBox::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewStoreBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func528::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func529::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func529
+namespace _func530
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x1ff};
@@ -7394,11 +7408,11 @@ namespace _func529
 void DamageMessage::constructor(float length, Pointf pos, DamageMessage::MessageType type)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DamageMessage *this_arg, float length_arg, Pointf pos_arg, DamageMessage::MessageType type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func529::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func530::func;
 	return execfunc(this, length, pos, type);
 }
 
-namespace _func530
+namespace _func531
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -7408,11 +7422,11 @@ namespace _func530
 void DamageMessage::constructor2(float length, int amount, Pointf pos, bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DamageMessage *this_arg, float length_arg, int amount_arg, Pointf pos_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func530::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func531::func;
 	return execfunc(this, length, amount, pos, unk);
 }
 
-namespace _func531
+namespace _func532
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7422,11 +7436,11 @@ namespace _func531
 int DebugHelper::CrashCatcher(void *exception_pointers)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(void *exception_pointers_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func531::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func532::func;
 	return execfunc(exception_pointers);
 }
 
-namespace _func532
+namespace _func533
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7436,11 +7450,11 @@ namespace _func532
 bool DefenseDrone::ValidTargetObject(Targetable *target)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func532::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func533::func;
 	return execfunc(this, target);
 }
 
-namespace _func533
+namespace _func534
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7450,11 +7464,11 @@ namespace _func533
 void DefenseDrone::SetWeaponTarget(Targetable *target)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func533::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func534::func;
 	return execfunc(this, target);
 }
 
-namespace _func534
+namespace _func535
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7464,11 +7478,11 @@ namespace _func534
 void DefenseDrone::PickTarget()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func534::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func535::func;
 	return execfunc(this);
 }
 
-namespace _func535
+namespace _func536
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7478,11 +7492,11 @@ namespace _func535
 std::string DefenseDrone::GetTooltip()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func535::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func536::func;
 	return execfunc(this);
 }
 
-namespace _func536
+namespace _func537
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7492,11 +7506,11 @@ namespace _func536
 void DefenseDrone::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func536::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func537::func;
 	return execfunc(this);
 }
 
-namespace _func537
+namespace _func538
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7506,11 +7520,11 @@ namespace _func537
 void Description::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Description *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func537::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func538::func;
 	return execfunc(this);
 }
 
-namespace _func538
+namespace _func539
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7520,11 +7534,11 @@ namespace _func538
 Description &Description::copy_assign_1(Description &other)
 {
 	typedef Description &__attribute__((thiscall)) (*custom_arg_funcptr_t)(Description *this_arg, Description &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func538::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func539::func;
 	return execfunc(this, other);
 }
 
-namespace _func539
+namespace _func540
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7534,11 +7548,11 @@ namespace _func539
 Description &Description::copy_assign_2(const Description &other)
 {
 	typedef Description &__attribute__((thiscall)) (*custom_arg_funcptr_t)(Description *this_arg, const Description &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func539::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func540::func;
 	return execfunc(this, other);
 }
 
-namespace _func540
+namespace _func541
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7548,11 +7562,11 @@ namespace _func540
 void Description::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Description *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func540::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func541::func;
 	return execfunc(this);
 }
 
-namespace _func541
+namespace _func542
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7562,11 +7576,11 @@ namespace _func541
 void Door::FakeClose()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func541::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func542::func;
 	return execfunc(this);
 }
 
-namespace _func542
+namespace _func543
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7576,11 +7590,11 @@ namespace _func542
 bool Door::IsSealed(int shipId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Door *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func542::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func543::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func543
+namespace _func544
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7588,20 +7602,6 @@ namespace _func543
 }
 
 void Door::FakeOpen()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func543::func;
-	return execfunc(this);
-}
-
-namespace _func544
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("Door::OnLoop", typeid(void (Door::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec2c8b813c02000085c0", argdata, 1, 5, &func);
-}
-
-void Door::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Door *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func544::func;
@@ -7612,17 +7612,31 @@ namespace _func545
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("Door::OnLoop", typeid(void (Door::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec2c8b813c02000085c0", argdata, 1, 5, &func);
+}
+
+void Door::OnLoop()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Door *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func545::func;
+	return execfunc(this);
+}
+
+namespace _func546
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("Door::GetPosition", typeid(Point (Door::*)()), "578d7c240883e4f0ff77fc5589e55783ec248b8144020000894424048b81400200008d4df0890424e8????????8b45f483ec088d4df083c008894424048b45f0890424", argdata, 1, 9, &func);
 }
 
 Point Door::GetPosition()
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func545::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func546::func;
 	return execfunc(this);
 }
 
-namespace _func546
+namespace _func547
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7632,11 +7646,11 @@ namespace _func546
 bool Door::ApplyDamage(float amount)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Door *this_arg, float amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func546::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func547::func;
 	return execfunc(this, amount);
 }
 
-namespace _func547
+namespace _func548
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -7646,11 +7660,11 @@ namespace _func547
 void DoorBox::constructor(Point pos, ShipSystem *sys, ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DoorBox *this_arg, Point pos_arg, ShipSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func547::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func548::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func548
+namespace _func549
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7660,11 +7674,11 @@ namespace _func548
 void DroneBlueprint::RenderIcon(float scale)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneBlueprint *this_arg, float scale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func548::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func549::func;
 	return execfunc(this, scale);
 }
 
-namespace _func549
+namespace _func550
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7674,11 +7688,11 @@ namespace _func549
 TextString DroneControl::HolderLabel()
 {
 	typedef TextString __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func549::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func550::func;
 	return execfunc(this);
 }
 
-namespace _func550
+namespace _func551
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7688,11 +7702,11 @@ namespace _func550
 SDLKey DroneControl::ArmamentHotkey(unsigned int i)
 {
 	typedef SDLKey __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneControl *this_arg, unsigned int i_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func550::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func551::func;
 	return execfunc(this, i);
 }
 
-namespace _func551
+namespace _func552
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7702,11 +7716,11 @@ namespace _func551
 void DroneControl::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func551::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func552::func;
 	return execfunc(this);
 }
 
-namespace _func552
+namespace _func553
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -7716,11 +7730,11 @@ namespace _func552
 void DroneStoreBox::constructor(ShipManager *ship, Equipment *equip, const DroneBlueprint *bp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneStoreBox *this_arg, ShipManager *ship_arg, Equipment *equip_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func552::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func553::func;
 	return execfunc(this, ship, equip, bp);
 }
 
-namespace _func553
+namespace _func554
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7730,11 +7744,11 @@ namespace _func553
 void DroneSystem::RemoveDrone(int slot)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneSystem *this_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func553::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func554::func;
 	return execfunc(this, slot);
 }
 
-namespace _func554
+namespace _func555
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7744,11 +7758,11 @@ namespace _func554
 void DroneSystem::UpdateBonusPower()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func554::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func555::func;
 	return execfunc(this);
 }
 
-namespace _func555
+namespace _func556
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7758,11 +7772,11 @@ namespace _func555
 void DroneSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func555::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func556::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func556
+namespace _func557
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7772,11 +7786,11 @@ namespace _func556
 void DroneSystem::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func556::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func557::func;
 	return execfunc(this);
 }
 
-namespace _func557
+namespace _func558
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7786,11 +7800,11 @@ namespace _func557
 bool DroneSystem::DePowerDrone(Drone *drone, bool unk)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneSystem *this_arg, Drone *drone_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func557::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func558::func;
 	return execfunc(this, drone, unk);
 }
 
-namespace _func558
+namespace _func559
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7800,11 +7814,11 @@ namespace _func558
 void DroneSystem::Jump()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func558::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func559::func;
 	return execfunc(this);
 }
 
-namespace _func559
+namespace _func560
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7814,11 +7828,11 @@ namespace _func559
 int DroneSystem::StringToDrone(std::string &name)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func559::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func560::func;
 	return execfunc(name);
 }
 
-namespace _func560
+namespace _func561
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7828,11 +7842,11 @@ namespace _func560
 void DropBox::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DropBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func560::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func561::func;
 	return execfunc(this);
 }
 
-namespace _func561
+namespace _func562
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7842,11 +7856,11 @@ namespace _func561
 int DropBox::GetHeight()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(DropBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func561::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func562::func;
 	return execfunc(this);
 }
 
-namespace _func562
+namespace _func563
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7856,11 +7870,11 @@ namespace _func562
 void EnergyAlien::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EnergyAlien *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func562::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func563::func;
 	return execfunc(this);
 }
 
-namespace _func563
+namespace _func564
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7870,11 +7884,11 @@ namespace _func563
 Damage EnergyAlien::GetRoomDamage()
 {
 	typedef Damage __attribute__((thiscall)) (*custom_arg_funcptr_t)(EnergyAlien *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func563::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func564::func;
 	return execfunc(this);
 }
 
-namespace _func564
+namespace _func565
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7884,11 +7898,11 @@ namespace _func564
 void Equipment::OnInit(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func564::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func565::func;
 	return execfunc(this, ship);
 }
 
-namespace _func565
+namespace _func566
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7898,11 +7912,11 @@ namespace _func565
 void Equipment::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func565::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func566::func;
 	return execfunc(this);
 }
 
-namespace _func566
+namespace _func567
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7912,11 +7926,11 @@ namespace _func566
 void Equipment::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func566::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func567::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func567
+namespace _func568
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7926,11 +7940,11 @@ namespace _func567
 void Equipment::MouseUp(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func567::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func568::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func568
+namespace _func569
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -7940,11 +7954,11 @@ namespace _func568
 void Equipment::AddWeapon(WeaponBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, WeaponBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func568::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func569::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func569
+namespace _func570
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -7954,11 +7968,11 @@ namespace _func569
 void Equipment::AddDrone(DroneBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, DroneBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func569::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func570::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func570
+namespace _func571
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -7968,11 +7982,11 @@ namespace _func570
 void Equipment::AddAugment(AugmentBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, AugmentBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func570::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func571::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func571
+namespace _func572
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7982,11 +7996,11 @@ namespace _func571
 void Equipment::AddToCargo(const std::string &name)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func571::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func572::func;
 	return execfunc(this, name);
 }
 
-namespace _func572
+namespace _func573
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7996,11 +8010,11 @@ namespace _func572
 std::vector<std::string> Equipment::GetCargoHold()
 {
 	typedef std::vector<std::string> __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func572::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func573::func;
 	return execfunc(this);
 }
 
-namespace _func573
+namespace _func574
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8010,11 +8024,11 @@ namespace _func573
 void Equipment::Open()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func573::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func574::func;
 	return execfunc(this);
 }
 
-namespace _func574
+namespace _func575
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8024,11 +8038,11 @@ namespace _func574
 void Equipment::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func574::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func575::func;
 	return execfunc(this);
 }
 
-namespace _func575
+namespace _func576
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -8038,11 +8052,11 @@ namespace _func575
 void EquipmentBox::constructor(Point pos, int slot)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, Point pos_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func575::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func576::func;
 	return execfunc(this, pos, slot);
 }
 
-namespace _func576
+namespace _func577
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8052,11 +8066,11 @@ namespace _func576
 Blueprint *EquipmentBox::GetBlueprint()
 {
 	typedef Blueprint *__attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func576::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func577::func;
 	return execfunc(this);
 }
 
-namespace _func577
+namespace _func578
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8066,11 +8080,11 @@ namespace _func577
 void EquipmentBox::SetBlueprint(InfoBox *infoBox, bool detailedBox)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, InfoBox *infoBox_arg, bool detailedBox_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func577::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func578::func;
 	return execfunc(this, infoBox, detailedBox);
 }
 
-namespace _func578
+namespace _func579
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8080,20 +8094,6 @@ namespace _func578
 void EquipmentBox::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func578::func;
-	return execfunc(this);
-}
-
-namespace _func579
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("EquipmentBox::CanHoldWeapon", typeid(bool (EquipmentBox::*)()), ".8b416085c074??85c00f95c0", argdata, 1, 1, &func);
-}
-
-bool EquipmentBox::CanHoldWeapon()
-{
-	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func579::func;
 	return execfunc(this);
 }
@@ -8102,10 +8102,10 @@ namespace _func580
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("EquipmentBox::CanHoldDrone", typeid(bool (EquipmentBox::*)()), ".8b416085c08b416474??85c0", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("EquipmentBox::CanHoldWeapon", typeid(bool (EquipmentBox::*)()), ".8b416085c074??85c00f95c0", argdata, 1, 1, &func);
 }
 
-bool EquipmentBox::CanHoldDrone()
+bool EquipmentBox::CanHoldWeapon()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func580::func;
@@ -8116,17 +8116,31 @@ namespace _func581
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("EquipmentBox::CanHoldDrone", typeid(bool (EquipmentBox::*)()), ".8b416085c08b416474??85c0", argdata, 1, 1, &func);
+}
+
+bool EquipmentBox::CanHoldDrone()
+{
+	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func581::func;
+	return execfunc(this);
+}
+
+namespace _func582
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("EquipmentBox::GetType", typeid(int (EquipmentBox::*)()), ".8b51608b44240485d274??3c01", argdata, 1, 1, &func);
 }
 
 int EquipmentBox::GetType()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func581::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func582::func;
 	return execfunc(this);
 }
 
-namespace _func582
+namespace _func583
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8136,11 +8150,11 @@ namespace _func582
 void EquipmentBox::OnRender(bool isEmpty)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool isEmpty_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func582::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func583::func;
 	return execfunc(this, isEmpty);
 }
 
-namespace _func583
+namespace _func584
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8150,11 +8164,11 @@ namespace _func583
 void EquipmentBox::UpdateBoxImage(bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func583::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func584::func;
 	return execfunc(this, unk);
 }
 
-namespace _func584
+namespace _func585
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8164,11 +8178,11 @@ namespace _func584
 void EquipmentBox::RenderLabels(bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func584::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func585::func;
 	return execfunc(this, unk);
 }
 
-namespace _func585
+namespace _func586
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8178,11 +8192,11 @@ namespace _func585
 void EquipmentBox::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func585::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func586::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func586
+namespace _func587
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x4ff};
@@ -8192,11 +8206,11 @@ namespace _func586
 void EquipmentBox::AddItem(EquipmentBoxItem item)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, EquipmentBoxItem item_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func586::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func587::func;
 	return execfunc(this, item);
 }
 
-namespace _func587
+namespace _func588
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8206,11 +8220,11 @@ namespace _func587
 void EquipmentBox::Restart()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func587::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func588::func;
 	return execfunc(this);
 }
 
-namespace _func588
+namespace _func589
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -8220,11 +8234,11 @@ namespace _func588
 void EquipmentBox::SetPosition(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func588::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func589::func;
 	return execfunc(this, pos);
 }
 
-namespace _func589
+namespace _func590
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8234,11 +8248,11 @@ namespace _func589
 int EquipmentBox::GetItemValue()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func589::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func590::func;
 	return execfunc(this);
 }
 
-namespace _func590
+namespace _func591
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8248,11 +8262,11 @@ namespace _func590
 LocationEvent *EventGenerator::GetBaseEvent(const std::string &name, int worldLevel, char ignoreUnique, int seed)
 {
 	typedef LocationEvent *__attribute__((thiscall)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg, int worldLevel_arg, char ignoreUnique_arg, int seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func590::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func591::func;
 	return execfunc(this, name, worldLevel, ignoreUnique, seed);
 }
 
-namespace _func591
+namespace _func592
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -8262,11 +8276,11 @@ namespace _func591
 LocationEvent *EventGenerator::CreateEvent(const std::string &name, int worldLevel, bool ignoreUnique)
 {
 	typedef LocationEvent *__attribute__((thiscall)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg, int worldLevel_arg, bool ignoreUnique_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func591::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func592::func;
 	return execfunc(this, name, worldLevel, ignoreUnique);
 }
 
-namespace _func592
+namespace _func593
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8276,11 +8290,11 @@ namespace _func592
 SectorDescription EventGenerator::GetSpecificSector(const std::string &name)
 {
 	typedef SectorDescription __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func592::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func593::func;
 	return execfunc(this, name);
 }
 
-namespace _func593
+namespace _func594
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8290,11 +8304,11 @@ namespace _func593
 std::string EventGenerator::GetImageFromList(const std::string &listName)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &listName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func593::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func594::func;
 	return execfunc(this, listName);
 }
 
-namespace _func594
+namespace _func595
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -8304,11 +8318,11 @@ namespace _func594
 SectorDescription EventGenerator::GetSectorDescription(const std::string &type, int level)
 {
 	typedef SectorDescription __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &type_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func594::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func595::func;
 	return execfunc(this, type, level);
 }
 
-namespace _func595
+namespace _func596
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8318,18 +8332,18 @@ namespace _func595
 ShipEvent EventGenerator::GetShipEvent(const std::string &event)
 {
 	typedef ShipEvent __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func595::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func596::func;
 	return execfunc(this, event);
 }
 
 EventGenerator *Global_EventGenerator_Generator;
 
-namespace _var596
+namespace _var597
 {
     static VariableDefinition varObj("Global_EventGenerator_Generator", "!8b8318120000c744240800000000b9(???????\?)8944240c8b8334080000", &Global_EventGenerator_Generator);
 }
 
-namespace _func597
+namespace _func598
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8339,11 +8353,11 @@ namespace _func597
 void EventSystem::AddEvent(int id)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventSystem *this_arg, int id_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func597::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func598::func;
 	return execfunc(this, id);
 }
 
-namespace _func598
+namespace _func599
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8353,18 +8367,18 @@ namespace _func598
 bool EventSystem::PollEvent(int id)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventSystem *this_arg, int id_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func598::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func599::func;
 	return execfunc(this, id);
 }
 
 EventSystem *Global_EventSystem_EventManager;
 
-namespace _var599
+namespace _var600
 {
     static VariableDefinition varObj("Global_EventSystem_EventManager", "!c704240c000000b9(???????\?)e8????????31c0", &Global_EventSystem_EventManager);
 }
 
-namespace _func600
+namespace _func601
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -8374,11 +8388,11 @@ namespace _func600
 RandomAmount EventsParser::PullMinMax(rapidxml::xml_node<char> *node, const std::string &name)
 {
 	typedef RandomAmount __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func600::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func601::func;
 	return execfunc(this, node, name);
 }
 
-namespace _func601
+namespace _func602
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -8388,11 +8402,11 @@ namespace _func601
 std::string EventsParser::ProcessEvent(rapidxml::xml_node<char> *node, const std::string &eventName)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &eventName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func601::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func602::func;
 	return execfunc(this, node, eventName);
 }
 
-namespace _func602
+namespace _func603
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8402,11 +8416,11 @@ namespace _func602
 ShipTemplate EventsParser::ProcessShipEvent(rapidxml::xml_node<char> *node)
 {
 	typedef ShipTemplate __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func602::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func603::func;
 	return execfunc(this, node);
 }
 
-namespace _func603
+namespace _func604
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8416,11 +8430,11 @@ namespace _func603
 ResourcesTemplate EventsParser::ProcessModifyItem(ResourcesTemplate &resources, rapidxml::xml_node<char> *node, const std::string &unk)
 {
 	typedef ResourcesTemplate __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg, ResourcesTemplate &resources_arg, rapidxml::xml_node<char> *node_arg, const std::string &unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func603::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func604::func;
 	return execfunc(this, resources, node, unk);
 }
 
-namespace _func604
+namespace _func605
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8430,11 +8444,11 @@ namespace _func604
 void EventsParser::AddAllEvents()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func604::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func605::func;
 	return execfunc(this);
 }
 
-namespace _func605
+namespace _func606
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -8444,11 +8458,11 @@ namespace _func605
 void EventsParser::AddEvents(EventGenerator &generator, char *file, const std::string &fileName)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg, EventGenerator &generator_arg, char *file_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func605::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func606::func;
 	return execfunc(this, generator, file, fileName);
 }
 
-namespace _func606
+namespace _func607
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -8458,11 +8472,11 @@ namespace _func606
 std::vector<std::string> EventsParser::ProcessEventList(rapidxml::xml_node<char> *node, const std::string &listName)
 {
 	typedef std::vector<std::string> __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &listName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func606::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func607::func;
 	return execfunc(this, node, listName);
 }
 
-namespace _func607
+namespace _func608
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8472,18 +8486,18 @@ namespace _func607
 void EventsParser::ProcessBaseNode(rapidxml::xml_node<char> *node, EventGenerator &generator)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, EventGenerator &generator_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func607::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func608::func;
 	return execfunc(this, node, generator);
 }
 
 EventsParser *Global_EventsParser_Parser;
 
-namespace _var608
+namespace _var609
 {
     static VariableDefinition varObj("Global_EventsParser_Parser", "!b9(???????\?)8974240889442404", &Global_EventsParser_Parser);
 }
 
-namespace _func609
+namespace _func610
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x2ff};
@@ -8493,11 +8507,11 @@ namespace _func609
 void ExplosionAnimation::OnInit(rapidxml::xml_node<char> *node, const std::string &name, Point glowOffset)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &name_arg, Point glowOffset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func609::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func610::func;
 	return execfunc(this, node, name, glowOffset);
 }
 
-namespace _func610
+namespace _func611
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x7ff, 0x1ff};
@@ -8507,11 +8521,11 @@ namespace _func610
 void ExplosionAnimation::OnRender(Globals::Rect *shipRect, ImageDesc shipImage, GL_Primitive *shipImagePrimitive)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg, Globals::Rect *shipRect_arg, ImageDesc shipImage_arg, GL_Primitive *shipImagePrimitive_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func610::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func611::func;
 	return execfunc(this, shipRect, shipImage, shipImagePrimitive);
 }
 
-namespace _func611
+namespace _func612
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8521,11 +8535,11 @@ namespace _func611
 void ExplosionAnimation::LoadGibs()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func611::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func612::func;
 	return execfunc(this);
 }
 
-namespace _func612
+namespace _func613
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8535,11 +8549,11 @@ namespace _func612
 void FTLButton::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(FTLButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func612::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func613::func;
 	return execfunc(this);
 }
 
-namespace _func613
+namespace _func614
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -8549,11 +8563,11 @@ namespace _func613
 void FTLButton::MouseMove(int mX, int mY, bool silent)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(FTLButton *this_arg, int mX_arg, int mY_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func613::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func614::func;
 	return execfunc(this, mX, mY, silent);
 }
 
-namespace _func614
+namespace _func615
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8563,11 +8577,11 @@ namespace _func614
 void FileHelper::deleteFile(const std::string &fileName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func614::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func615::func;
 	return execfunc(fileName);
 }
 
-namespace _func615
+namespace _func616
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8575,20 +8589,6 @@ namespace _func615
 }
 
 std::string FileHelper::getResourceFile()
-{
-	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func615::func;
-	return execfunc();
-}
-
-namespace _func616
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("FileHelper::getUserFolder", typeid(std::string (*)()), ".8d4c240483e4f0ff71fc5589e5575653", argdata, 1, 2, &func);
-}
-
-std::string FileHelper::getUserFolder()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func616::func;
@@ -8599,10 +8599,10 @@ namespace _func617
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("FileHelper::getSaveFile", typeid(std::string (*)()), ".8d4c240483e4f0ff71fc5589e557565351", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("FileHelper::getUserFolder", typeid(std::string (*)()), ".8d4c240483e4f0ff71fc5589e5575653", argdata, 1, 2, &func);
 }
 
-std::string FileHelper::getSaveFile()
+std::string FileHelper::getUserFolder()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func617::func;
@@ -8612,6 +8612,20 @@ std::string FileHelper::getSaveFile()
 namespace _func618
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("FileHelper::getSaveFile", typeid(std::string (*)()), ".8d4c240483e4f0ff71fc5589e557565351", argdata, 1, 2, &func);
+}
+
+std::string FileHelper::getSaveFile()
+{
+	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func618::func;
+	return execfunc();
+}
+
+namespace _func619
+{
+    static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("FileHelper::initFileHelper", typeid(void (*)()), ".8d4c240483e4f0ff71fc5589e5575653", argdata, 0, 6, &func);
 }
@@ -8619,11 +8633,11 @@ namespace _func618
 void FileHelper::initFileHelper()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func618::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func619::func;
 	return execfunc();
 }
 
-namespace _func619
+namespace _func620
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8633,11 +8647,11 @@ namespace _func619
 int FileHelper::fileLength(int file)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func619::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func620::func;
 	return execfunc(file);
 }
 
-namespace _func620
+namespace _func621
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8647,11 +8661,11 @@ namespace _func620
 bool FileHelper::fileExists(const std::string &fileName)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func620::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func621::func;
 	return execfunc(fileName);
 }
 
-namespace _func621
+namespace _func622
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8661,11 +8675,11 @@ namespace _func621
 void FileHelper::renameFile(const std::string &fileName, const std::string &newName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg, const std::string &newName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func621::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func622::func;
 	return execfunc(fileName, newName);
 }
 
-namespace _func622
+namespace _func623
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8675,11 +8689,11 @@ namespace _func622
 int FileHelper::createBinaryFile(const std::string &fileName)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func622::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func623::func;
 	return execfunc(fileName);
 }
 
-namespace _func623
+namespace _func624
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -8687,20 +8701,6 @@ namespace _func623
 }
 
 int FileHelper::createSaveFile()
-{
-	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func623::func;
-	return execfunc();
-}
-
-namespace _func624
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::createStatsFile", typeid(int (*)()), ".a1????????a3????????b8????????", argdata, 0, 2, &func);
-}
-
-int FileHelper::createStatsFile()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func624::func;
@@ -8711,12 +8711,12 @@ namespace _func625
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::deleteSaveFile", typeid(void (*)()), ".5589e55383e4f083ec10c70424????????e8????????", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("FileHelper::createStatsFile", typeid(int (*)()), ".a1????????a3????????b8????????", argdata, 0, 2, &func);
 }
 
-void FileHelper::deleteSaveFile()
+int FileHelper::createStatsFile()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func625::func;
 	return execfunc();
 }
@@ -8725,10 +8725,10 @@ namespace _func626
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::deleteAllSaveFiles", typeid(void (*)()), ".8d4c240483e4f0ff71fc5589e5575653518d45b8", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("FileHelper::deleteSaveFile", typeid(void (*)()), ".5589e55383e4f083ec10c70424????????e8????????", argdata, 0, 6, &func);
 }
 
-void FileHelper::deleteAllSaveFiles()
+void FileHelper::deleteSaveFile()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func626::func;
@@ -8738,6 +8738,20 @@ void FileHelper::deleteAllSaveFiles()
 namespace _func627
 {
     static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("FileHelper::deleteAllSaveFiles", typeid(void (*)()), ".8d4c240483e4f0ff71fc5589e5575653518d45b8", argdata, 0, 6, &func);
+}
+
+void FileHelper::deleteAllSaveFiles()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func627::func;
+	return execfunc();
+}
+
+namespace _func628
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("FileHelper::getPosition", typeid(int (*)(int )), ".8d4c240483e4f0ff71fc5589e55183ec14", argdata, 1, 2, &func);
 }
@@ -8745,11 +8759,11 @@ namespace _func627
 int FileHelper::getPosition(int file)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func627::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func628::func;
 	return execfunc(file);
 }
 
-namespace _func628
+namespace _func629
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8759,11 +8773,11 @@ namespace _func628
 int FileHelper::readBinaryFile(const std::string &fileName)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func628::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func629::func;
 	return execfunc(fileName);
 }
 
-namespace _func629
+namespace _func630
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8773,11 +8787,11 @@ namespace _func629
 void FileHelper::closeBinaryFile(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func629::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func630::func;
 	return execfunc(file);
 }
 
-namespace _func630
+namespace _func631
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8787,11 +8801,11 @@ namespace _func630
 std::string FileHelper::readString(int file)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func630::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func631::func;
 	return execfunc(file);
 }
 
-namespace _func631
+namespace _func632
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8801,11 +8815,11 @@ namespace _func631
 float FileHelper::readFloat(int file)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func631::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func632::func;
 	return execfunc(file);
 }
 
-namespace _func632
+namespace _func633
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8815,11 +8829,11 @@ namespace _func632
 int FileHelper::readInteger(int file)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func632::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func633::func;
 	return execfunc(file);
 }
 
-namespace _func633
+namespace _func634
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8829,11 +8843,11 @@ namespace _func633
 bool FileHelper::seekPosition(int file, int pos)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, int pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func633::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func634::func;
 	return execfunc(file, pos);
 }
 
-namespace _func634
+namespace _func635
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8843,11 +8857,11 @@ namespace _func634
 char *FileHelper::readBuffer(int file, int len, bool nullTerminate)
 {
 	typedef char *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, int len_arg, bool nullTerminate_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func634::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func635::func;
 	return execfunc(file, len, nullTerminate);
 }
 
-namespace _func635
+namespace _func636
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8857,11 +8871,11 @@ namespace _func635
 void FileHelper::readData(int file, void *data, int len)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, void *data_arg, int len_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func635::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func636::func;
 	return execfunc(file, data, len);
 }
 
-namespace _func636
+namespace _func637
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8871,11 +8885,11 @@ namespace _func636
 bool FileHelper::writeData(int file, void *data, int len)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, void *data_arg, int len_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func636::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func637::func;
 	return execfunc(file, data, len);
 }
 
-namespace _func637
+namespace _func638
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -8883,20 +8897,6 @@ namespace _func637
 }
 
 int FileHelper::readSaveFile()
-{
-	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func637::func;
-	return execfunc();
-}
-
-namespace _func638
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::readStatsFile", typeid(int (*)()), ".8d4c240483e4f0ff71fc5589e553518d45f483ec20", argdata, 0, 2, &func);
-}
-
-int FileHelper::readStatsFile()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func638::func;
@@ -8907,17 +8907,31 @@ namespace _func639
 {
     static void *func = 0;
 	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("FileHelper::readStatsFile", typeid(int (*)()), ".8d4c240483e4f0ff71fc5589e553518d45f483ec20", argdata, 0, 2, &func);
+}
+
+int FileHelper::readStatsFile()
+{
+	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func639::func;
+	return execfunc();
+}
+
+namespace _func640
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("FileHelper::saveFileExists", typeid(bool (*)()), ".8d4c240483e4f0ff71fc5589e553518d45f483ec2089442408", argdata, 0, 2, &func);
 }
 
 bool FileHelper::saveFileExists()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func639::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func640::func;
 	return execfunc();
 }
 
-namespace _func640
+namespace _func641
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8927,11 +8941,11 @@ namespace _func640
 bool FileHelper::writeFloat(int file, float data)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, float data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func640::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func641::func;
 	return execfunc(file, data);
 }
 
-namespace _func641
+namespace _func642
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8941,11 +8955,11 @@ namespace _func641
 bool FileHelper::writeString(int file, const std::string &data)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, const std::string &data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func641::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func642::func;
 	return execfunc(file, data);
 }
 
-namespace _func642
+namespace _func643
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8955,11 +8969,11 @@ namespace _func642
 bool FileHelper::writeInt(int file, int data)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, int data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func642::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func643::func;
 	return execfunc(file, data);
 }
 
-namespace _func643
+namespace _func644
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8969,11 +8983,11 @@ namespace _func643
 void Fire::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Fire *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func643::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func644::func;
 	return execfunc(this);
 }
 
-namespace _func644
+namespace _func645
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8983,11 +8997,11 @@ namespace _func644
 void Fire::UpdateStartTimer(int doorLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Fire *this_arg, int doorLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func644::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func645::func;
 	return execfunc(this, doorLevel);
 }
 
-namespace _func645
+namespace _func646
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8997,11 +9011,11 @@ namespace _func645
 void Fire::UpdateDeathTimer(int connectedFires)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Fire *this_arg, int connectedFires_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func645::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func646::func;
 	return execfunc(this, connectedFires);
 }
 
-namespace _func646
+namespace _func647
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -9011,11 +9025,11 @@ namespace _func646
 void FocusWindow::MouseClick(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(FocusWindow *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func646::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func647::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func647
+namespace _func648
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -9025,11 +9039,11 @@ namespace _func647
 void FocusWindow::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(FocusWindow *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func647::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func648::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func648
+namespace _func649
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -9039,11 +9053,11 @@ namespace _func648
 void GameOver::OpenText(const std::string &text)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GameOver *this_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func648::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func649::func;
 	return execfunc(this, text);
 }
 
-namespace _func649
+namespace _func650
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9053,11 +9067,11 @@ namespace _func649
 void GameOver::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GameOver *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func649::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func650::func;
 	return execfunc(this);
 }
 
-namespace _func650
+namespace _func651
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9067,11 +9081,11 @@ namespace _func650
 void GameOver::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GameOver *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func650::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func651::func;
 	return execfunc(this);
 }
 
-namespace _func651
+namespace _func652
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -9081,11 +9095,11 @@ namespace _func651
 void GenericButton::SetLocation(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GenericButton *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func651::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func652::func;
 	return execfunc(this, pos);
 }
 
-namespace _func652
+namespace _func653
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -9095,11 +9109,11 @@ namespace _func652
 void GenericButton::SetActive(bool active)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GenericButton *this_arg, bool active_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func652::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func653::func;
 	return execfunc(this, active);
 }
 
-namespace _func653
+namespace _func654
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -9109,11 +9123,11 @@ namespace _func653
 void GenericButton::MouseMove(int x, int y, bool silent)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GenericButton *this_arg, int x_arg, int y_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func653::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func654::func;
 	return execfunc(this, x, y, silent);
 }
 
-namespace _func654
+namespace _func655
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9121,20 +9135,6 @@ namespace _func654
 }
 
 void GenericButton::OnRightClick()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GenericButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func654::func;
-	return execfunc(this);
-}
-
-namespace _func655
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("GenericButton::ResetPrimitives", typeid(void (GenericButton::*)()), ".f3c39090909090909090909090909090", argdata, 1, 5, &func);
-}
-
-void GenericButton::ResetPrimitives()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GenericButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func655::func;
@@ -9145,10 +9145,10 @@ namespace _func656
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("GenericButton::OnClick", typeid(void (GenericButton::*)()), ".f3c39090909090909090909090909090", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("GenericButton::ResetPrimitives", typeid(void (GenericButton::*)()), ".f3c39090909090909090909090909090", argdata, 1, 5, &func);
 }
 
-void GenericButton::OnClick()
+void GenericButton::ResetPrimitives()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GenericButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func656::func;
@@ -9158,6 +9158,20 @@ void GenericButton::OnClick()
 namespace _func657
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("GenericButton::OnClick", typeid(void (GenericButton::*)()), ".f3c39090909090909090909090909090", argdata, 1, 5, &func);
+}
+
+void GenericButton::OnClick()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GenericButton *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func657::func;
+	return execfunc(this);
+}
+
+namespace _func658
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("font_text_width", typeid(float (*)(freetype::font_data &, const char *, float )), "5589e557565383e4f083ec408b4d088b750c85c9", argdata, 3, 2, &func);
 }
@@ -9165,11 +9179,11 @@ namespace _func657
 float __stdcall font_text_width(freetype::font_data &fontData, const char *str, float size)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(freetype::font_data &fontData_arg, const char *str_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func657::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func658::func;
 	return execfunc(fontData, str, size);
 }
 
-namespace _func658
+namespace _func659
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -9179,11 +9193,11 @@ namespace _func658
 int __stdcall random32()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func658::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func659::func;
 	return execfunc();
 }
 
-namespace _func659
+namespace _func660
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9193,11 +9207,11 @@ namespace _func659
 void __stdcall srandom32(unsigned int seed)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(unsigned int seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func659::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func660::func;
 	return execfunc(seed);
 }
 
-namespace _func660
+namespace _func661
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9207,11 +9221,11 @@ namespace _func660
 float __stdcall getSkillBonus(int skill, int level)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(int skill_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func660::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func661::func;
 	return execfunc(skill, level);
 }
 
-namespace _func661
+namespace _func662
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9221,11 +9235,11 @@ namespace _func661
 void __stdcall GenerateReward(ResourceEvent &ref, RewardDesc &reward, int worldLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceEvent &ref_arg, RewardDesc &reward_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func661::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func662::func;
 	return execfunc(ref, reward, worldLevel);
 }
 
-namespace _func662
+namespace _func663
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9235,11 +9249,11 @@ namespace _func662
 void __stdcall GetValue(ResourceEvent &ref, const std::string &type, int level, int worldLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceEvent &ref_arg, const std::string &type_arg, int level_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func662::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func663::func;
 	return execfunc(ref, type, level, worldLevel);
 }
 
-namespace _func663
+namespace _func664
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9249,11 +9263,11 @@ namespace _func663
 void __stdcall sys_graphics_set_window_title(char *title)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(char *title_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func663::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func664::func;
 	return execfunc(title);
 }
 
-namespace _func664
+namespace _func665
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9263,11 +9277,11 @@ namespace _func664
 void __stdcall graphics_clear(float r, float g, float b, float a, float depth, unsigned int stencil)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(float r_arg, float g_arg, float b_arg, float a_arg, float depth_arg, unsigned int stencil_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func664::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func665::func;
 	return execfunc(r, g, b, a, depth, stencil);
 }
 
-namespace _func665
+namespace _func666
 {
     static void *func = 0;
 	static short argdata[] = {0x2ff, 0x2ff, 0x1ff};
@@ -9277,11 +9291,11 @@ namespace _func665
 float Globals::AimAhead(Pointf delta, Pointf vr, float muzzleV)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf delta_arg, Pointf vr_arg, float muzzleV_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func665::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func666::func;
 	return execfunc(delta, vr, muzzleV);
 }
 
-namespace _func666
+namespace _func667
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -9291,11 +9305,11 @@ namespace _func666
 int Globals::GetNextSpaceId()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func666::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func667::func;
 	return execfunc();
 }
 
-namespace _func667
+namespace _func668
 {
     static void *func = 0;
 	static short argdata[] = {0x2ff, 0x1ff, 0x1ff};
@@ -9305,11 +9319,11 @@ namespace _func667
 Pointf Globals::GetNextPoint(Pointf current, float mag_speed, float heading)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf current_arg, float mag_speed_arg, float heading_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func667::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func668::func;
 	return execfunc(current, mag_speed, heading);
 }
 
-namespace _func668
+namespace _func669
 {
     static void *func = 0;
 	static short argdata[] = {0x2ff, 0x1ff, 0x2ff};
@@ -9319,39 +9333,39 @@ namespace _func668
 Pointf Globals::GetNextPoint(Pointf current, float mag_speed, Pointf dest)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf current_arg, float mag_speed_arg, Pointf dest_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func668::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func669::func;
 	return execfunc(current, mag_speed, dest);
 }
 
 TextLibrary *Global_Globals_Library;
 
-namespace _var669
+namespace _var670
 {
     static VariableDefinition varObj("Global_Globals_Library", "!899d8ccaffffc6041800b9(???????\?)", &Global_Globals_Library);
 }
 
 int *Globals_GetNextSpaceId_id;
 
-namespace _var670
+namespace _var671
 {
     static VariableDefinition varObj("Globals_GetNextSpaceId_id", "8b15(???????\?)8d420185d2ba650000000f44c2a3????????c3", &Globals_GetNextSpaceId_id);
 }
 
 bool *Globals_RNG;
 
-namespace _var671
+namespace _var672
 {
     static VariableDefinition varObj("Globals_RNG", "!578d7c240883e4f0ff77fc5589e557565389cb83ec4cc7042400000000e8????????803d(???????\?)00890424", &Globals_RNG);
 }
 
 FILE *ftl_log_logfile;
 
-namespace _var672
+namespace _var673
 {
     static VariableDefinition varObj("ftl_log_logfile", "5589e556538d750c83e4f083ec108b5d0889742404891c24e8????????a1(???????\?)85c0", &ftl_log_logfile);
 }
 
-namespace _func673
+namespace _func674
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -9361,11 +9375,11 @@ namespace _func673
 void HackBox::constructor(Point pos, HackingSystem *sys, ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(HackBox *this_arg, Point pos_arg, HackingSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func673::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func674::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func674
+namespace _func675
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9375,11 +9389,11 @@ namespace _func674
 void HackingDrone::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(HackingDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func674::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func675::func;
 	return execfunc(this);
 }
 
-namespace _func675
+namespace _func676
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -9389,11 +9403,11 @@ namespace _func675
 void HackingDrone::SetMovementTarget(Targetable *target)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(HackingDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func675::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func676::func;
 	return execfunc(this, target);
 }
 
-namespace _func676
+namespace _func677
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -9403,11 +9417,11 @@ namespace _func676
 CollisionResponse HackingDrone::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((thiscall)) (*custom_arg_funcptr_t)(HackingDrone *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func676::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func677::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func677
+namespace _func678
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9415,20 +9429,6 @@ namespace _func677
 }
 
 void HackingSystem::BlowHackingDrone()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(HackingSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func677::func;
-	return execfunc(this);
-}
-
-namespace _func678
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("HackingSystem::OnLoop", typeid(void (HackingSystem::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec4ce8????????80bbe4010000000f84????????80bbc0010000000f84????????8b8bac070000", argdata, 1, 5, &func);
-}
-
-void HackingSystem::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(HackingSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func678::func;
@@ -9439,17 +9439,31 @@ namespace _func679
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("HackingSystem::OnLoop", typeid(void (HackingSystem::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec4ce8????????80bbe4010000000f84????????80bbc0010000000f84????????8b8bac070000", argdata, 1, 5, &func);
+}
+
+void HackingSystem::OnLoop()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(HackingSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func679::func;
+	return execfunc(this);
+}
+
+namespace _func680
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("HackingSystem::SoundLoop", typeid(bool (HackingSystem::*)()), "80b9c00100000075??31c0c38d7426005589e55389cb83e4??e8????????83f8??74??", argdata, 1, 1, &func);
 }
 
 bool HackingSystem::SoundLoop()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(HackingSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func679::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func680::func;
 	return execfunc(this);
 }
 
-namespace _func680
+namespace _func681
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9459,11 +9473,11 @@ namespace _func680
 void InfoBox::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func680::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func681::func;
 	return execfunc(this);
 }
 
-namespace _func681
+namespace _func682
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9473,11 +9487,11 @@ namespace _func681
 void InfoBox::Clear()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func681::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func682::func;
 	return execfunc(this);
 }
 
-namespace _func682
+namespace _func683
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9487,11 +9501,11 @@ namespace _func682
 void InfoBox::SetDescription(Description *desc, int width, int height, InfoBox::ExpandDir dir)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, Description *desc_arg, int width_arg, int height_arg, InfoBox::ExpandDir dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func682::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func683::func;
 	return execfunc(this, desc, width, height, dir);
 }
 
-namespace _func683
+namespace _func684
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9501,11 +9515,11 @@ namespace _func683
 void InfoBox::SetText(const std::string &title, const std::string &text, int width, int height, InfoBox::ExpandDir dir)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const std::string &title_arg, const std::string &text_arg, int width_arg, int height_arg, InfoBox::ExpandDir dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func683::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func684::func;
 	return execfunc(this, title, text, width, height, dir);
 }
 
-namespace _func684
+namespace _func685
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9515,11 +9529,11 @@ namespace _func684
 void InfoBox::SetBlueprintWeapon(const WeaponBlueprint *bp, int status, bool hasWeaponSystem, int yShift)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const WeaponBlueprint *bp_arg, int status_arg, bool hasWeaponSystem_arg, int yShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func684::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func685::func;
 	return execfunc(this, bp, status, hasWeaponSystem, yShift);
 }
 
-namespace _func685
+namespace _func686
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9529,11 +9543,11 @@ namespace _func685
 void InfoBox::SetBlueprintDrone(const DroneBlueprint *bp, int status, bool hasDroneSystem, int yShift)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const DroneBlueprint *bp_arg, int status_arg, bool hasDroneSystem_arg, int yShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func685::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func686::func;
 	return execfunc(this, bp, status, hasDroneSystem, yShift);
 }
 
-namespace _func686
+namespace _func687
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -9543,11 +9557,11 @@ namespace _func686
 void InfoBox::SetBlueprint(const ItemBlueprint *bp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const ItemBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func686::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func687::func;
 	return execfunc(this, bp);
 }
 
-namespace _func687
+namespace _func688
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -9557,11 +9571,11 @@ namespace _func687
 void InfoBox::SetBlueprintCrew(const CrewBlueprint *bp, int yShift, bool detailedCrew)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const CrewBlueprint *bp_arg, int yShift_arg, bool detailedCrew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func687::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func688::func;
 	return execfunc(this, bp, yShift, detailedCrew);
 }
 
-namespace _func688
+namespace _func689
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -9571,11 +9585,11 @@ namespace _func688
 void InfoBox::SetBlueprintAugment(const AugmentBlueprint *bp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const AugmentBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func688::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func689::func;
 	return execfunc(this, bp);
 }
 
-namespace _func689
+namespace _func690
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9585,11 +9599,11 @@ namespace _func689
 int InfoBox::CalcBoxHeight()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func689::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func690::func;
 	return execfunc(this);
 }
 
-namespace _func690
+namespace _func691
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9599,11 +9613,11 @@ namespace _func690
 bool InfoBox::IsEmpty()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func690::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func691::func;
 	return execfunc(this);
 }
 
-namespace _func691
+namespace _func692
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9613,11 +9627,11 @@ namespace _func691
 void InfoBox::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func691::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func692::func;
 	return execfunc(this);
 }
 
-namespace _func692
+namespace _func693
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9627,11 +9641,11 @@ namespace _func692
 void InfoBox::SetSystemId(int systemId, int maxPower, int currentLevel, int upgrade, int yShift, int forceSystemWidth)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, int systemId_arg, int maxPower_arg, int currentLevel_arg, int upgrade_arg, int yShift_arg, int forceSystemWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func692::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func693::func;
 	return execfunc(this, systemId, maxPower, currentLevel, upgrade, yShift, forceSystemWidth);
 }
 
-namespace _func693
+namespace _func694
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9641,25 +9655,25 @@ namespace _func693
 void InfoBox::SetSystem(ShipSystem *system, int upgrade, int yShift, int forceSystemWidth)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, ShipSystem *system_arg, int upgrade_arg, int yShift_arg, int forceSystemWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func693::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func694::func;
 	return execfunc(this, system, upgrade, yShift, forceSystemWidth);
 }
 
 GL_Color *Global_InfoBox_detailsBarOn;
 
-namespace _var694
+namespace _var695
 {
     static VariableDefinition varObj("Global_InfoBox_detailsBarOn", "!83ec083bb514fdffffba(???????\?)b8(???????\?)", &Global_InfoBox_detailsBarOn);
 }
 
 GL_Color *Global_InfoBox_detailsBarOff;
 
-namespace _var695
+namespace _var696
 {
     static VariableDefinition varObj("Global_InfoBox_detailsBarOff", "", &Global_InfoBox_detailsBarOff);
 }
 
-namespace _func696
+namespace _func697
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -9669,11 +9683,11 @@ namespace _func696
 void InputBox::TextEvent(CEvent::TextEvent event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InputBox *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func696::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func697::func;
 	return execfunc(this, event);
 }
 
-namespace _func697
+namespace _func698
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9683,11 +9697,11 @@ namespace _func697
 void InputBox::StartInput()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InputBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func697::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func698::func;
 	return execfunc(this);
 }
 
-namespace _func698
+namespace _func699
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9697,11 +9711,11 @@ namespace _func698
 void InputBox::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InputBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func698::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func699::func;
 	return execfunc(this);
 }
 
-namespace _func699
+namespace _func700
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -9711,11 +9725,11 @@ namespace _func699
 void InputBox::TextInput(int ch)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InputBox *this_arg, int ch_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func699::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func700::func;
 	return execfunc(this, ch);
 }
 
-namespace _func700
+namespace _func701
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -9725,11 +9739,11 @@ namespace _func700
 Damage IonDrone::GetRoomDamage()
 {
 	typedef Damage __attribute__((thiscall)) (*custom_arg_funcptr_t)(IonDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func700::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func701::func;
 	return execfunc(this);
 }
 
-namespace _func701
+namespace _func702
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -9739,11 +9753,11 @@ namespace _func701
 void IonDrone::constructor(int iShipId, DroneBlueprint *blueprint)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(IonDrone *this_arg, int iShipId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func701::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func702::func;
 	return execfunc(this, iShipId, blueprint);
 }
 
-namespace _func702
+namespace _func703
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x1ff};
@@ -9753,11 +9767,11 @@ namespace _func702
 void IonDroneAnimation::constructor(int iShipId, Pointf position, bool enemy)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(IonDroneAnimation *this_arg, int iShipId_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func702::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func703::func;
 	return execfunc(this, iShipId, position, enemy);
 }
 
-namespace _func703
+namespace _func704
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9767,11 +9781,11 @@ namespace _func703
 void IonDroneAnimation::UpdateShooting()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(IonDroneAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func703::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func704::func;
 	return execfunc(this);
 }
 
-namespace _func704
+namespace _func705
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -9781,11 +9795,11 @@ namespace _func704
 void ItemStoreBox::constructor(ShipManager *ship, const std::string &resourceName)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ItemStoreBox *this_arg, ShipManager *ship_arg, const std::string &resourceName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func704::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func705::func;
 	return execfunc(this, ship, resourceName);
 }
 
-namespace _func705
+namespace _func706
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9795,18 +9809,18 @@ namespace _func705
 void LanguageChooser::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(LanguageChooser *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func705::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func706::func;
 	return execfunc(this);
 }
 
 std::vector<std::string> *Global_OptionsScreen_languageList;
 
-namespace _var706
+namespace _var707
 {
     static VariableDefinition varObj("Global_OptionsScreen_languageList", "!83ec1ca1(???????\?)c1e30301d8", &Global_OptionsScreen_languageList);
 }
 
-namespace _func707
+namespace _func708
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9816,11 +9830,11 @@ namespace _func707
 void LaserBlast::OnUpdate()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(LaserBlast *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func707::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func708::func;
 	return execfunc(this);
 }
 
-namespace _func708
+namespace _func709
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9830,25 +9844,25 @@ namespace _func708
 void LaserBlast::OnInit()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(LaserBlast *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func708::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func709::func;
 	return execfunc(this);
 }
 
 void **VTable_LaserBlast;
 
-namespace _var709
+namespace _var710
 {
     static VariableDefinition varObj("VTable_LaserBlast", "!660fefc989c3660fefd28b45b48b5598f30f2a4da4f30f2a55ac8b480489542410897c240c894da88b4d9c894c24148b4da8894c240889d90f28d9660f7ed0660f7e1c2489442404e8????????89f0ba????????83ec18f7ea660fefc089d9c703(???????\?)c74304(???????\?)c783a002000000000000c783a402000000000000", &VTable_LaserBlast);
 }
 
 void **VTable_Targetable_LaserBlast;
 
-namespace _var710
+namespace _var711
 {
     static VariableDefinition varObj("VTable_Targetable_LaserBlast", "", &VTable_Targetable_LaserBlast);
 }
 
-namespace _func711
+namespace _func712
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -9858,11 +9872,11 @@ namespace _func711
 void LocationEvent::ClearEvent(bool force)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(LocationEvent *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func711::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func712::func;
 	return execfunc(this, force);
 }
 
-namespace _func712
+namespace _func713
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9872,11 +9886,11 @@ namespace _func712
 void LocationEvent::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(LocationEvent *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func712::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func713::func;
 	return execfunc(this);
 }
 
-namespace _func713
+namespace _func714
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9886,11 +9900,11 @@ namespace _func713
 void LockdownShard::Update()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(LockdownShard *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func713::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func714::func;
 	return execfunc(this);
 }
 
-namespace _func714
+namespace _func715
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9900,11 +9914,11 @@ namespace _func714
 void MainMenu::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func714::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func715::func;
 	return execfunc(this);
 }
 
-namespace _func715
+namespace _func716
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9914,11 +9928,11 @@ namespace _func715
 bool MainMenu::Open()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func715::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func716::func;
 	return execfunc(this);
 }
 
-namespace _func716
+namespace _func717
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9928,11 +9942,11 @@ namespace _func716
 void MainMenu::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func716::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func717::func;
 	return execfunc(this);
 }
 
-namespace _func717
+namespace _func718
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9942,11 +9956,11 @@ namespace _func717
 void MainMenu::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func717::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func718::func;
 	return execfunc(this);
 }
 
-namespace _func718
+namespace _func719
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -9956,11 +9970,11 @@ namespace _func718
 void MainMenu::MouseClick(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MainMenu *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func718::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func719::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func719
+namespace _func720
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -9970,18 +9984,18 @@ namespace _func719
 void MainMenu::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MainMenu *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func719::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func720::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func720
+namespace _func721
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("MantisAnimation::__DO_NOT_HOOK", typeid(void (MantisAnimation::*)()), "5e5f5d8d67f85fc20400908d742600e8????????89c1e9????????8d7426000f1040080f114308eb??", argdata, 0, 4, &func);
 }
 
-namespace _func721
+namespace _func722
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -9991,18 +10005,18 @@ namespace _func721
 std::string MantisAnimation::GetShootingSound()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func721::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func722::func;
 	return execfunc(this);
 }
 
-namespace _func722
+namespace _func723
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("MantisAnimation::__DO_NOT_HOOK2", typeid(void (MantisAnimation::*)()), "578d41088d7c240883e4f0ff77fc5589e5575389cb83ec108901", argdata, 0, 4, &func);
 }
 
-namespace _func723
+namespace _func724
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10012,11 +10026,11 @@ namespace _func723
 std::string MantisAnimation::GetDeathSound()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func723::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func724::func;
 	return execfunc(this);
 }
 
-namespace _func724
+namespace _func725
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10026,20 +10040,6 @@ namespace _func724
 bool MantisAnimation::FireShot()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func724::func;
-	return execfunc(this);
-}
-
-namespace _func725
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("MenuScreen::OnLanguageChange", typeid(void (MenuScreen::*)()), "578d7c240883e4f0ff77fc5589e557565389cb81ec????????8b511c89d085c0", argdata, 1, 5, &func);
-}
-
-void MenuScreen::OnLanguageChange()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func725::func;
 	return execfunc(this);
 }
@@ -10048,10 +10048,10 @@ namespace _func726
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("MenuScreen::constructor", typeid(void (MenuScreen::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb8db564ffffff81ec????????e8????????8d4b44c703????????c7432000000000c7432800000000c7432c00000000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("MenuScreen::OnLanguageChange", typeid(void (MenuScreen::*)()), "578d7c240883e4f0ff77fc5589e557565389cb81ec????????8b511c89d085c0", argdata, 1, 5, &func);
 }
 
-void MenuScreen::constructor()
+void MenuScreen::OnLanguageChange()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func726::func;
@@ -10062,10 +10062,10 @@ namespace _func727
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("MenuScreen::OnRender", typeid(void (MenuScreen::*)()), ".578d7c240883e4f0ff77fc5589e557565381ec????????80b9c0020000000f84????????", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("MenuScreen::constructor", typeid(void (MenuScreen::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb8db564ffffff81ec????????e8????????8d4b44c703????????c7432000000000c7432800000000c7432c00000000", argdata, 1, 5, &func);
 }
 
-void MenuScreen::OnRender()
+void MenuScreen::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func727::func;
@@ -10076,10 +10076,10 @@ namespace _func728
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("MenuScreen::Open", typeid(void (MenuScreen::*)()), ".578d7c240883e4f0ff77fc5589e557565389cf83c14c8d75d883ec5cc641b801", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("MenuScreen::OnRender", typeid(void (MenuScreen::*)()), ".578d7c240883e4f0ff77fc5589e557565381ec????????80b9c0020000000f84????????", argdata, 1, 5, &func);
 }
 
-void MenuScreen::Open()
+void MenuScreen::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func728::func;
@@ -10089,6 +10089,20 @@ void MenuScreen::Open()
 namespace _func729
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("MenuScreen::Open", typeid(void (MenuScreen::*)()), ".578d7c240883e4f0ff77fc5589e557565389cf83c14c8d75d883ec5cc641b801", argdata, 1, 5, &func);
+}
+
+void MenuScreen::Open()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func729::func;
+	return execfunc(this);
+}
+
+namespace _func730
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
 	static FunctionDefinition funcObj("MindBox::constructor", typeid(void (MindBox::*)(Point , MindSystem *)), "578d7c240883e4f0ff77fc5589e557565389cb81ec????????8b078b77088b5704c744240c000000008d7db4890424", argdata, 3, 5, &func);
 }
@@ -10096,11 +10110,11 @@ namespace _func729
 void MindBox::constructor(Point pos, MindSystem *sys)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MindBox *this_arg, Point pos_arg, MindSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func729::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func730::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func730
+namespace _func731
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10110,11 +10124,11 @@ namespace _func730
 void MindSystem::ReleaseCrew()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MindSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func730::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func731::func;
 	return execfunc(this);
 }
 
-namespace _func731
+namespace _func732
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10124,11 +10138,11 @@ namespace _func731
 void MindSystem::SetArmed(int armed)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MindSystem *this_arg, int armed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func731::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func732::func;
 	return execfunc(this, armed);
 }
 
-namespace _func732
+namespace _func733
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10138,11 +10152,11 @@ namespace _func732
 void MindSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MindSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func732::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func733::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func733
+namespace _func734
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10152,11 +10166,11 @@ namespace _func733
 void MindSystem::InitiateMindControl()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MindSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func733::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func734::func;
 	return execfunc(this);
 }
 
-namespace _func734
+namespace _func735
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10166,11 +10180,11 @@ namespace _func734
 void MindSystem::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MindSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func734::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func735::func;
 	return execfunc(this);
 }
 
-namespace _func735
+namespace _func736
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -10180,11 +10194,11 @@ namespace _func735
 void Missile::constructor(Pointf _position, int _ownerId, int _targetId, Pointf _target, float _heading)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Missile *this_arg, Pointf _position_arg, int _ownerId_arg, int _targetId_arg, Pointf _target_arg, float _heading_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func735::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func736::func;
 	return execfunc(this, _position, _ownerId, _targetId, _target, _heading);
 }
 
-namespace _func736
+namespace _func737
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10192,20 +10206,6 @@ namespace _func736
 }
 
 void MouseControl::SetTooltip(const std::string &tooltip)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func736::func;
-	return execfunc(this, tooltip);
-}
-
-namespace _func737
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("MouseControl::SetTooltipTitle", typeid(void (MouseControl::*)(const std::string &)), "578d7c240883e4f0ff77fc5589e55783ec148b91300100008b0785d2751181c12c010000890424", argdata, 2, 5, &func);
-}
-
-void MouseControl::SetTooltipTitle(const std::string &tooltip)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltip_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func737::func;
@@ -10216,17 +10216,31 @@ namespace _func738
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("MouseControl::SetTooltipTitle", typeid(void (MouseControl::*)(const std::string &)), "578d7c240883e4f0ff77fc5589e55783ec148b91300100008b0785d2751181c12c010000890424", argdata, 2, 5, &func);
+}
+
+void MouseControl::SetTooltipTitle(const std::string &tooltip)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltip_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func738::func;
+	return execfunc(this, tooltip);
+}
+
+namespace _func739
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("MouseControl::MeasureTooltip", typeid(Point (MouseControl::*)(int )), "578d7c240883e4f0ff77fc5589e557565389cb8d4dd883ec4c8b37", argdata, 2, 9, &func);
 }
 
 Point MouseControl::MeasureTooltip(int unk)
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func738::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func739::func;
 	return execfunc(this, unk);
 }
 
-namespace _func739
+namespace _func740
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -10236,11 +10250,11 @@ namespace _func739
 void MouseControl::QueueStaticTooltip(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func739::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func740::func;
 	return execfunc(this, pos);
 }
 
-namespace _func740
+namespace _func741
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10248,20 +10262,6 @@ namespace _func740
 }
 
 void MouseControl::OnLoop()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func740::func;
-	return execfunc(this);
-}
-
-namespace _func741
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("MouseControl::InstantTooltip", typeid(void (MouseControl::*)()), ".c6812801000001", argdata, 1, 5, &func);
-}
-
-void MouseControl::InstantTooltip()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func741::func;
@@ -10272,10 +10272,10 @@ namespace _func742
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("MouseControl::OnRender", typeid(void (MouseControl::*)()), "80b91d010000000f85????????578d7c240883e4f0ff77fc5589e557565389cf81ec????????0fb6411d8b592884c00f84????????", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("MouseControl::InstantTooltip", typeid(void (MouseControl::*)()), ".c6812801000001", argdata, 1, 5, &func);
 }
 
-void MouseControl::OnRender()
+void MouseControl::InstantTooltip()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func742::func;
@@ -10285,6 +10285,20 @@ void MouseControl::OnRender()
 namespace _func743
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("MouseControl::OnRender", typeid(void (MouseControl::*)()), "80b91d010000000f85????????578d7c240883e4f0ff77fc5589e557565389cf81ec????????0fb6411d8b592884c00f84????????", argdata, 1, 5, &func);
+}
+
+void MouseControl::OnRender()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func743::func;
+	return execfunc(this);
+}
+
+namespace _func744
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("MouseControl::SetDoor", typeid(void (MouseControl::*)(int )), "578d7c240883e4f0ff77fc5589e557565389ce83ec1c8b1f83fb0174??", argdata, 2, 5, &func);
 }
@@ -10292,11 +10306,11 @@ namespace _func743
 void MouseControl::SetDoor(int state)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, int state_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func743::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func744::func;
 	return execfunc(this, state);
 }
 
-namespace _func744
+namespace _func745
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -10306,11 +10320,11 @@ namespace _func744
 void MouseControl::RenderTooltip(Point tooltipPoint, bool staticPos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, Point tooltipPoint_arg, bool staticPos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func744::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func745::func;
 	return execfunc(this, tooltipPoint, staticPos);
 }
 
-namespace _func745
+namespace _func746
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10320,11 +10334,11 @@ namespace _func745
 void MouseControl::ResetArmed()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func745::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func746::func;
 	return execfunc(this);
 }
 
-namespace _func746
+namespace _func747
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10334,11 +10348,11 @@ namespace _func746
 void MouseControl::Reset()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func746::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func747::func;
 	return execfunc(this);
 }
 
-namespace _func747
+namespace _func748
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10348,18 +10362,18 @@ namespace _func747
 void MouseControl::LoadTooltip(const std::string &tooltipName)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltipName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func747::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func748::func;
 	return execfunc(this, tooltipName);
 }
 
 MouseControl *Global_MouseControl_Mouse;
 
-namespace _var748
+namespace _var749
 {
     static VariableDefinition varObj("Global_MouseControl_Mouse", "!e8????????e8????????b9(???????\?)", &Global_MouseControl_Mouse);
 }
 
-namespace _func749
+namespace _func750
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10369,11 +10383,11 @@ namespace _func749
 void OptionsScreen::OnInit()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OptionsScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func749::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func750::func;
 	return execfunc(this);
 }
 
-namespace _func750
+namespace _func751
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10383,11 +10397,11 @@ namespace _func750
 void OptionsScreen::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OptionsScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func750::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func751::func;
 	return execfunc(this);
 }
 
-namespace _func751
+namespace _func752
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10397,18 +10411,18 @@ namespace _func751
 void OptionsScreen::Open(bool mainMenu)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OptionsScreen *this_arg, bool mainMenu_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func751::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func752::func;
 	return execfunc(this, mainMenu);
 }
 
 void **VTable_OuterHull;
 
-namespace _var752
+namespace _var753
 {
     static VariableDefinition varObj("VTable_OuterHull", "578d7c240883e4f0ff77fc5589f889e557565389cf8db7840000008d9f9c00000081ec4c0100008b00890424e8????????8d4f7c83ec04c707(???????\?)", &VTable_OuterHull);
 }
 
-namespace _func753
+namespace _func754
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -10418,11 +10432,11 @@ namespace _func753
 void OxygenSystem::UpdateBreach(int roomId, int hasBreach, bool unk3)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, int hasBreach_arg, bool unk3_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func753::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func754::func;
 	return execfunc(this, roomId, hasBreach, unk3);
 }
 
-namespace _func754
+namespace _func755
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -10432,11 +10446,11 @@ namespace _func754
 void OxygenSystem::UpdateAirlock(int roomId, int unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func754::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func755::func;
 	return execfunc(this, roomId, unk);
 }
 
-namespace _func755
+namespace _func756
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10446,11 +10460,11 @@ namespace _func755
 void OxygenSystem::EmptyOxygen(int roomId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func755::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func756::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func756
+namespace _func757
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -10460,11 +10474,11 @@ namespace _func756
 void OxygenSystem::ModifyRoomOxygen(int roomId, float value)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, float value_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func756::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func757::func;
 	return execfunc(this, roomId, value);
 }
 
-namespace _func757
+namespace _func758
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -10474,11 +10488,11 @@ namespace _func757
 void OxygenSystem::ComputeAirLoss(int roomId, float value, bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, float value_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func757::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func758::func;
 	return execfunc(this, roomId, value, unk);
 }
 
-namespace _func758
+namespace _func759
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10488,11 +10502,11 @@ namespace _func758
 float OxygenSystem::GetRefillSpeed()
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func758::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func759::func;
 	return execfunc(this);
 }
 
-namespace _func759
+namespace _func760
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10502,11 +10516,11 @@ namespace _func759
 void OxygenSystem::constructor(int numRooms, int roomId, int shipId, int startingPower)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int numRooms_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func759::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func760::func;
 	return execfunc(this, numRooms, roomId, shipId, startingPower);
 }
 
-namespace _func760
+namespace _func761
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10516,11 +10530,11 @@ namespace _func760
 void PDSFire::CollisionCheck(Collideable *other)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(PDSFire *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func760::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func761::func;
 	return execfunc(this, other);
 }
 
-namespace _func761
+namespace _func762
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10530,11 +10544,11 @@ namespace _func761
 void PDSFire::OnUpdate()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(PDSFire *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func761::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func762::func;
 	return execfunc(this);
 }
 
-namespace _func762
+namespace _func763
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x2ff};
@@ -10544,11 +10558,11 @@ namespace _func762
 void PDSFire::constructor(Point pos, int destinationSpace, Pointf destination)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(PDSFire *this_arg, Point pos_arg, int destinationSpace_arg, Pointf destination_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func762::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func763::func;
 	return execfunc(this, pos, destinationSpace, destination);
 }
 
-namespace _func763
+namespace _func764
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -10558,11 +10572,11 @@ namespace _func763
 int Point::RelativeDistance(Point other)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Point *this_arg, Point other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func763::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func764::func;
 	return execfunc(this, other);
 }
 
-namespace _func764
+namespace _func765
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -10572,11 +10586,11 @@ namespace _func764
 int Point::Distance(Point other)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Point *this_arg, Point other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func764::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func765::func;
 	return execfunc(this, other);
 }
 
-namespace _func765
+namespace _func766
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -10586,11 +10600,11 @@ namespace _func765
 void Pointf::constructor(float x, float y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Pointf *this_arg, float x_arg, float y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func765::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func766::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func766
+namespace _func767
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -10600,11 +10614,11 @@ namespace _func766
 float Pointf::RelativeDistance(Pointf other)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(Pointf *this_arg, Pointf other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func766::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func767::func;
 	return execfunc(this, other);
 }
 
-namespace _func767
+namespace _func768
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10614,11 +10628,11 @@ namespace _func767
 Pointf Pointf::Normalize()
 {
 	typedef Pointf __attribute__((thiscall)) (*custom_arg_funcptr_t)(Pointf *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func767::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func768::func;
 	return execfunc(this);
 }
 
-namespace _func768
+namespace _func769
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10628,11 +10642,11 @@ namespace _func768
 void PowerManager::SetHacked(bool val)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(PowerManager *this_arg, bool val_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func768::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func769::func;
 	return execfunc(this, val);
 }
 
-namespace _func769
+namespace _func770
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10642,11 +10656,11 @@ namespace _func769
 PowerManager *PowerManager::GetPowerManager(int iShipId)
 {
 	typedef PowerManager *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int iShipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func769::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func770::func;
 	return execfunc(iShipId);
 }
 
-namespace _func770
+namespace _func771
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10656,11 +10670,11 @@ namespace _func770
 void Projectile::CollisionCheck(Collideable *other)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Projectile *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func770::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func771::func;
 	return execfunc(this, other);
 }
 
-namespace _func771
+namespace _func772
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff, 0x2ff};
@@ -10670,11 +10684,11 @@ namespace _func771
 void Projectile::constructor(Pointf position, int ownerId, int targetId, Pointf target)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Projectile *this_arg, Pointf position_arg, int ownerId_arg, int targetId_arg, Pointf target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func771::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func772::func;
 	return execfunc(this, position, ownerId, targetId, target);
 }
 
-namespace _func772
+namespace _func773
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10684,11 +10698,11 @@ namespace _func772
 void Projectile::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func772::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func773::func;
 	return execfunc(this);
 }
 
-namespace _func773
+namespace _func774
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10698,11 +10712,11 @@ namespace _func773
 void Projectile::Initialize(const WeaponBlueprint &bp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Projectile *this_arg, const WeaponBlueprint &bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func773::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func774::func;
 	return execfunc(this, bp);
 }
 
-namespace _func774
+namespace _func775
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10712,11 +10726,11 @@ namespace _func774
 bool Projectile::ValidTarget()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func774::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func775::func;
 	return execfunc(this);
 }
 
-namespace _func775
+namespace _func776
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10726,11 +10740,11 @@ namespace _func775
 int Projectile::ForceRenderLayer()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func775::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func776::func;
 	return execfunc(this);
 }
 
-namespace _func776
+namespace _func777
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10740,11 +10754,11 @@ namespace _func776
 void Projectile::OnUpdate()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func776::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func777::func;
 	return execfunc(this);
 }
 
-namespace _func777
+namespace _func778
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -10754,11 +10768,11 @@ namespace _func777
 CollisionResponse Projectile::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((thiscall)) (*custom_arg_funcptr_t)(Projectile *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func777::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func778::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func778
+namespace _func779
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10768,11 +10782,11 @@ namespace _func778
 Pointf Projectile::RandomSidePoint(int side)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int side_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func778::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func779::func;
 	return execfunc(side);
 }
 
-namespace _func779
+namespace _func780
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -10782,11 +10796,11 @@ namespace _func779
 void ProjectileFactory::constructor(const WeaponBlueprint *bp, int shipId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, const WeaponBlueprint *bp_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func779::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func780::func;
 	return execfunc(this, bp, shipId);
 }
 
-namespace _func780
+namespace _func781
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10796,11 +10810,11 @@ namespace _func780
 void ProjectileFactory::SelectChargeGoal()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func780::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func781::func;
 	return execfunc(this);
 }
 
-namespace _func781
+namespace _func782
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10810,11 +10824,11 @@ namespace _func781
 bool ProjectileFactory::IsChargedGoal()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func781::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func782::func;
 	return execfunc(this);
 }
 
-namespace _func782
+namespace _func783
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10824,11 +10838,11 @@ namespace _func782
 void ProjectileFactory::SetHacked(int hacked)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, int hacked_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func782::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func783::func;
 	return execfunc(this, hacked);
 }
 
-namespace _func783
+namespace _func784
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10838,11 +10852,11 @@ namespace _func783
 void ProjectileFactory::SetCurrentShip(Targetable *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, Targetable *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func783::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func784::func;
 	return execfunc(this, ship);
 }
 
-namespace _func784
+namespace _func785
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10852,11 +10866,11 @@ namespace _func784
 void ProjectileFactory::SetCooldownModifier(float mod)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float mod_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func784::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func785::func;
 	return execfunc(this, mod);
 }
 
-namespace _func785
+namespace _func786
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10866,11 +10880,11 @@ namespace _func785
 void ProjectileFactory::ForceCoolup()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func785::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func786::func;
 	return execfunc(this);
 }
 
-namespace _func786
+namespace _func787
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10880,11 +10894,11 @@ namespace _func786
 void ProjectileFactory::RenderChargeBar(float unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func786::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func787::func;
 	return execfunc(this, unk);
 }
 
-namespace _func787
+namespace _func788
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10894,11 +10908,11 @@ namespace _func787
 int ProjectileFactory::StringToWeapon(const std::string &str)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &str_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func787::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func788::func;
 	return execfunc(str);
 }
 
-namespace _func788
+namespace _func789
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -10908,11 +10922,11 @@ namespace _func788
 void ProjectileFactory::Fire(std::vector<Pointf> &points, int target)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, std::vector<Pointf> &points_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func788::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func789::func;
 	return execfunc(this, points, target);
 }
 
-namespace _func789
+namespace _func790
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10922,11 +10936,11 @@ namespace _func789
 bool ProjectileFactory::FireNextShot()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func789::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func790::func;
 	return execfunc(this);
 }
 
-namespace _func790
+namespace _func791
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10936,11 +10950,11 @@ namespace _func790
 int ProjectileFactory::SpendMissiles()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func790::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func791::func;
 	return execfunc(this);
 }
 
-namespace _func791
+namespace _func792
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -10950,11 +10964,11 @@ namespace _func791
 void ProjectileFactory::OnRender(float alpha, bool forceVisual)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float alpha_arg, bool forceVisual_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func791::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func792::func;
 	return execfunc(this, alpha, forceVisual);
 }
 
-namespace _func792
+namespace _func793
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10964,11 +10978,11 @@ namespace _func792
 int ProjectileFactory::NumTargetsRequired()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func792::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func793::func;
 	return execfunc(this);
 }
 
-namespace _func793
+namespace _func794
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10978,11 +10992,11 @@ namespace _func793
 void ProjectileFactory::Update()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func793::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func794::func;
 	return execfunc(this);
 }
 
-namespace _func794
+namespace _func795
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10992,20 +11006,6 @@ namespace _func794
 Projectile *ProjectileFactory::GetProjectile()
 {
 	typedef Projectile *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func794::func;
-	return execfunc(this);
-}
-
-namespace _func795
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ProjectileFactory::ClearAiming", typeid(void (ProjectileFactory::*)()), "8b91fc0000008b81000100005329d0c1f80385c07e2a8b591c83bbd8010000017e3e8b992c06000085db", argdata, 1, 5, &func);
-}
-
-void ProjectileFactory::ClearAiming()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func795::func;
 	return execfunc(this);
 }
@@ -11014,10 +11014,10 @@ namespace _func796
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ProjectileFactory::ClearProjectiles", typeid(void (ProjectileFactory::*)()), "8b8100060000898104060000c3", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ProjectileFactory::ClearAiming", typeid(void (ProjectileFactory::*)()), "8b91fc0000008b81000100005329d0c1f80385c07e2a8b591c83bbd8010000017e3e8b992c06000085db", argdata, 1, 5, &func);
 }
 
-void ProjectileFactory::ClearProjectiles()
+void ProjectileFactory::ClearAiming()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func796::func;
@@ -11028,10 +11028,10 @@ namespace _func797
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ProjectileFactory::destructor", typeid(void (ProjectileFactory::*)()), "5589e557565389cf83e4f083ec208b8100060000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ProjectileFactory::ClearProjectiles", typeid(void (ProjectileFactory::*)()), "8b8100060000898104060000c3", argdata, 1, 5, &func);
 }
 
-void ProjectileFactory::destructor()
+void ProjectileFactory::ClearProjectiles()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func797::func;
@@ -11041,6 +11041,20 @@ void ProjectileFactory::destructor()
 namespace _func798
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ProjectileFactory::destructor", typeid(void (ProjectileFactory::*)()), "5589e557565389cf83e4f083ec208b8100060000", argdata, 1, 5, &func);
+}
+
+void ProjectileFactory::destructor()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func798::func;
+	return execfunc(this);
+}
+
+namespace _func799
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("ProjectileFactory::LoadProjectile", typeid(Projectile *(*)(int )), "8d4c240483e4f0ff71fc5589e556535183ec6c8b19891c24", argdata, 1, 2, &func);
 }
@@ -11048,11 +11062,11 @@ namespace _func798
 Projectile *ProjectileFactory::LoadProjectile(int fd)
 {
 	typedef Projectile *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func798::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func799::func;
 	return execfunc(fd);
 }
 
-namespace _func799
+namespace _func800
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11062,11 +11076,11 @@ namespace _func799
 void ProjectileFactory::SaveProjectile(Projectile *p, int fd)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *p_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func799::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func800::func;
 	return execfunc(p, fd);
 }
 
-namespace _func800
+namespace _func801
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11074,20 +11088,6 @@ namespace _func800
 }
 
 void ReactorButton::Accept()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func800::func;
-	return execfunc(this);
-}
-
-namespace _func801
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ReactorButton::OnClick", typeid(void (ReactorButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b4970e8????????03536c83fa180f8f????????807b40000f84????????", argdata, 1, 5, &func);
-}
-
-void ReactorButton::OnClick()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func801::func;
@@ -11098,10 +11098,10 @@ namespace _func802
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ReactorButton::OnRightClick", typeid(void (ReactorButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b496c85c97e??807b410075??", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ReactorButton::OnClick", typeid(void (ReactorButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b4970e8????????03536c83fa180f8f????????807b40000f84????????", argdata, 1, 5, &func);
 }
 
-void ReactorButton::OnRightClick()
+void ReactorButton::OnClick()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func802::func;
@@ -11112,24 +11112,38 @@ namespace _func803
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ReactorButton::OnRender", typeid(void (ReactorButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cf81ec????????898db4fbffffe8????????807f410074??807f40000f85????????", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ReactorButton::OnRightClick", typeid(void (ReactorButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b496c85c97e??807b410075??", argdata, 1, 5, &func);
 }
 
-void ReactorButton::OnRender()
+void ReactorButton::OnRightClick()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func803::func;
 	return execfunc(this);
 }
 
+namespace _func804
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ReactorButton::OnRender", typeid(void (ReactorButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cf81ec????????898db4fbffffe8????????807f410074??807f40000f85????????", argdata, 1, 5, &func);
+}
+
+void ReactorButton::OnRender()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func804::func;
+	return execfunc(this);
+}
+
 void **VTable_RepairAnimation;
 
-namespace _var804
+namespace _var805
 {
     static VariableDefinition varObj("VTable_RepairAnimation", "894424088d45ccc645da0089442404e8????????8b45cc83ec1439f874??890424e8????????8b4584c700(???????\?)c680ee09000001c7042438090000", &VTable_RepairAnimation);
 }
 
-namespace _func805
+namespace _func806
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -11139,11 +11153,11 @@ namespace _func805
 void RepairStoreBox::constructor(ShipManager *ship, bool repairAll, int price)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(RepairStoreBox *this_arg, ShipManager *ship_arg, bool repairAll_arg, int price_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func805::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func806::func;
 	return execfunc(this, ship, repairAll, price);
 }
 
-namespace _func806
+namespace _func807
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11153,11 +11167,11 @@ namespace _func806
 void ResourceControl::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func806::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func807::func;
 	return execfunc(this);
 }
 
-namespace _func807
+namespace _func808
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -11167,11 +11181,11 @@ namespace _func807
 GL_Primitive *ResourceControl::CreateImagePrimitive(GL_Texture *tex, int unk1, int unk2, int unk3, GL_Color color, float alpha, bool mirror)
 {
 	typedef GL_Primitive *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg, int unk1_arg, int unk2_arg, int unk3_arg, GL_Color color_arg, float alpha_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func807::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func808::func;
 	return execfunc(this, tex, unk1, unk2, unk3, color, alpha, mirror);
 }
 
-namespace _func808
+namespace _func809
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11181,11 +11195,11 @@ namespace _func808
 void ResourceControl::OnInit(int imageSwappingMode)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, int imageSwappingMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func808::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func809::func;
 	return execfunc(this, imageSwappingMode);
 }
 
-namespace _func809
+namespace _func810
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11195,11 +11209,11 @@ namespace _func809
 char *ResourceControl::LoadFile(const std::string &fileName)
 {
 	typedef char *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func809::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func810::func;
 	return execfunc(this, fileName);
 }
 
-namespace _func810
+namespace _func811
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -11209,11 +11223,11 @@ namespace _func810
 char *ResourceControl::LoadFromResourceFile(const std::string &fileName, std::size_t &fileSize, const std::string *unused_resourceFile)
 {
 	typedef char *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &fileName_arg, std::size_t &fileSize_arg, const std::string *unused_resourceFile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func810::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func811::func;
 	return execfunc(this, fileName, fileSize, unused_resourceFile);
 }
 
-namespace _func811
+namespace _func812
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11223,11 +11237,11 @@ namespace _func811
 GL_Texture *ResourceControl::GetImageId(const std::string &dir)
 {
 	typedef GL_Texture *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func811::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func812::func;
 	return execfunc(this, dir);
 }
 
-namespace _func812
+namespace _func813
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -11237,11 +11251,11 @@ namespace _func812
 int ResourceControl::RenderImage(GL_Texture *tex, int x, int y, int rotation, GL_Color color, float opacity, bool mirror)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float opacity_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func812::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func813::func;
 	return execfunc(this, tex, x, y, rotation, color, opacity, mirror);
 }
 
-namespace _func813
+namespace _func814
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -11251,11 +11265,11 @@ namespace _func813
 int ResourceControl::RenderImageString(std::string &tex, int x, int y, int rotation, GL_Color color, float opacity, bool mirror)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, std::string &tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float opacity_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func813::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func814::func;
 	return execfunc(this, tex, x, y, rotation, color, opacity, mirror);
 }
 
-namespace _func814
+namespace _func815
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -11265,11 +11279,11 @@ namespace _func814
 GL_Primitive *ResourceControl::CreateImagePrimitiveString(const std::string &tex, int x, int y, int rotation, GL_Color color, float alpha, bool mirror)
 {
 	typedef GL_Primitive *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float alpha_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func814::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func815::func;
 	return execfunc(this, tex, x, y, rotation, color, alpha, mirror);
 }
 
-namespace _func815
+namespace _func816
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11279,11 +11293,11 @@ namespace _func815
 freetype::font_data &ResourceControl::GetFontData(int size, bool ignoreLanguage)
 {
 	typedef freetype::font_data &__attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, int size_arg, bool ignoreLanguage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func815::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func816::func;
 	return execfunc(this, size, ignoreLanguage);
 }
 
-namespace _func816
+namespace _func817
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11293,11 +11307,11 @@ namespace _func816
 ImageDesc ResourceControl::GetImageData(GL_Texture *tex)
 {
 	typedef ImageDesc __attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func816::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func817::func;
 	return execfunc(this, tex);
 }
 
-namespace _func817
+namespace _func818
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11307,11 +11321,11 @@ namespace _func817
 bool ResourceControl::PreloadResources(bool unk)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func817::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func818::func;
 	return execfunc(this, unk);
 }
 
-namespace _func818
+namespace _func819
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11321,11 +11335,11 @@ namespace _func818
 void ResourceControl::RenderLoadingBar(float initialProgress, float finalProgress)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, float initialProgress_arg, float finalProgress_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func818::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func819::func;
 	return execfunc(this, initialProgress, finalProgress);
 }
 
-namespace _func819
+namespace _func820
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11335,18 +11349,18 @@ namespace _func819
 bool ResourceControl::ImageExists(const std::string &name)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func819::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func820::func;
 	return execfunc(this, name);
 }
 
 ResourceControl *Global_ResourceControl_GlobalResources;
 
-namespace _var820
+namespace _var821
 {
     static VariableDefinition varObj("Global_ResourceControl_GlobalResources", "!8b45b8890424e8????????b9(???????\?)", &Global_ResourceControl_GlobalResources);
 }
 
-namespace _func821
+namespace _func822
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -11356,25 +11370,25 @@ namespace _func821
 void RockAnimation::constructor(const std::string &subRace, int iShipId, Pointf position, bool enemy)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(RockAnimation *this_arg, const std::string &subRace_arg, int iShipId_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func821::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func822::func;
 	return execfunc(this, subRace, iShipId, position, enemy);
-}
-
-namespace _func822
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK", typeid(void (RockAnimation::*)()), "5f5d8d67f85fc20400908d742600e8????????89c1e9????????8d7426000f1040080f114308", argdata, 0, 4, &func);
 }
 
 namespace _func823
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK2", typeid(void (RockAnimation::*)()), ".5f5d8d67f85fc20400908d742600e8????????89c1e9????????8d7426000f1040080f114308", argdata, 0, 4, &func);
+	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK", typeid(void (RockAnimation::*)()), "5f5d8d67f85fc20400908d742600e8????????89c1e9????????8d7426000f1040080f114308", argdata, 0, 4, &func);
 }
 
 namespace _func824
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK2", typeid(void (RockAnimation::*)()), ".5f5d8d67f85fc20400908d742600e8????????89c1e9????????8d7426000f1040080f114308", argdata, 0, 4, &func);
+}
+
+namespace _func825
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11384,25 +11398,25 @@ namespace _func824
 std::string RockAnimation::GetShootingSound()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(RockAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func824::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func825::func;
 	return execfunc(this);
-}
-
-namespace _func825
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK3", typeid(void (RockAnimation::*)()), "578d41088d7c240883e4f0ff77fc5589e5575389cb83ec108901", argdata, 0, 4, &func);
 }
 
 namespace _func826
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK4", typeid(void (RockAnimation::*)()), ".578d41088d7c240883e4f0ff77fc5589e5575389cb83ec108901", argdata, 0, 4, &func);
+	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK3", typeid(void (RockAnimation::*)()), "578d41088d7c240883e4f0ff77fc5589e5575389cb83ec108901", argdata, 0, 4, &func);
 }
 
 namespace _func827
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK4", typeid(void (RockAnimation::*)()), ".578d41088d7c240883e4f0ff77fc5589e5575389cb83ec108901", argdata, 0, 4, &func);
+}
+
+namespace _func828
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11412,11 +11426,11 @@ namespace _func827
 std::string RockAnimation::GetDeathSound()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(RockAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func827::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func828::func;
 	return execfunc(this);
 }
 
-namespace _func828
+namespace _func829
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11426,11 +11440,11 @@ namespace _func828
 int Room::GetEmptySlots(bool intruder)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func828::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func829::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func829
+namespace _func830
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -11440,11 +11454,11 @@ namespace _func829
 void Room::constructor(int iShipId, int x, int y, int w, int h, int roomId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Room *this_arg, int iShipId_arg, int x_arg, int y_arg, int w_arg, int h_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func829::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func830::func;
 	return execfunc(this, iShipId, x, y, w, h, roomId);
 }
 
-namespace _func830
+namespace _func831
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11454,11 +11468,11 @@ namespace _func830
 void Room::OnRenderFloor(float alpha, bool experimental)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Room *this_arg, float alpha_arg, bool experimental_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func830::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func831::func;
 	return execfunc(this, alpha, experimental);
 }
 
-namespace _func831
+namespace _func832
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11468,18 +11482,18 @@ namespace _func831
 void Room::OnRenderWalls(float alpha)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Room *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func831::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func832::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func832
+namespace _func833
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("Room::__DO_NOT_HOOK", typeid(void (Room::*)()), "890424e8????????89742404893c2489c1c744240800000000e8????????89433883ec0c8d65f45b5e5f5d", argdata, 0, 4, &func);
 }
 
-namespace _func833
+namespace _func834
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11489,11 +11503,11 @@ namespace _func833
 void Room::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Room *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func833::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func834::func;
 	return execfunc(this);
 }
 
-namespace _func834
+namespace _func835
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11503,11 +11517,11 @@ namespace _func834
 int Room::GetEmptySlot(bool intruder)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func834::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func835::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func835
+namespace _func836
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11517,11 +11531,11 @@ namespace _func835
 bool Room::Full(bool intruder)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func835::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func836::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func836
+namespace _func837
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11531,11 +11545,11 @@ namespace _func836
 void Room::FillSlot(int slot, bool intruder)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Room *this_arg, int slot_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func836::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func837::func;
 	return execfunc(this, slot, intruder);
 }
 
-namespace _func837
+namespace _func838
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11545,11 +11559,11 @@ namespace _func837
 bool ScoreKeeper::GetShipUnlocked(int shipId, int shipVariant)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int shipId_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func837::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func838::func;
 	return execfunc(this, shipId, shipVariant);
 }
 
-namespace _func838
+namespace _func839
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11559,11 +11573,11 @@ namespace _func838
 std::string ScoreKeeper::GetShipBlueprint(int index)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int index_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func838::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func839::func;
 	return execfunc(this, index);
 }
 
-namespace _func839
+namespace _func840
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11573,11 +11587,11 @@ namespace _func839
 void ScoreKeeper::OnInit()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func839::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func840::func;
 	return execfunc(this);
 }
 
-namespace _func840
+namespace _func841
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11587,11 +11601,11 @@ namespace _func840
 void ScoreKeeper::Save(bool newHighScore)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool newHighScore_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func840::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func841::func;
 	return execfunc(this, newHighScore);
 }
 
-namespace _func841
+namespace _func842
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11601,11 +11615,11 @@ namespace _func841
 void ScoreKeeper::OnRender(bool lastPlaythrough)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool lastPlaythrough_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func841::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func842::func;
 	return execfunc(this, lastPlaythrough);
 }
 
-namespace _func842
+namespace _func843
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -11615,11 +11629,11 @@ namespace _func842
 void ScoreKeeper::UnlockShip(int shipType, int shipVariant, bool save, bool hidePopup)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int shipType_arg, int shipVariant_arg, bool save_arg, bool hidePopup_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func842::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func843::func;
 	return execfunc(this, shipType, shipVariant, save, hidePopup);
 }
 
-namespace _func843
+namespace _func844
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11629,11 +11643,11 @@ namespace _func843
 void ScoreKeeper::SetVictory(bool victory)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool victory_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func843::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func844::func;
 	return execfunc(this, victory);
 }
 
-namespace _func844
+namespace _func845
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11643,11 +11657,11 @@ namespace _func844
 void ScoreKeeper::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func844::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func845::func;
 	return execfunc(this);
 }
 
-namespace _func845
+namespace _func846
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11657,11 +11671,11 @@ namespace _func845
 std::pair<int, int> ScoreKeeper::GetShipId(const std::string &blueprintName)
 {
 	typedef std::pair<int, int> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, const std::string &blueprintName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func845::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func846::func;
 	return execfunc(this, blueprintName);
 }
 
-namespace _func846
+namespace _func847
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11671,11 +11685,11 @@ namespace _func846
 void ScoreKeeper::LoadVersionFour(int file, int version)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int file_arg, int version_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func846::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func847::func;
 	return execfunc(this, file, version);
 }
 
-namespace _func847
+namespace _func848
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11685,11 +11699,11 @@ namespace _func847
 void ScoreKeeper::WipeProfile(bool permanent)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool permanent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func847::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func848::func;
 	return execfunc(this, permanent);
 }
 
-namespace _func848
+namespace _func849
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11699,11 +11713,11 @@ namespace _func848
 void ScoreKeeper::MouseClick(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func848::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func849::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func849
+namespace _func850
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11713,11 +11727,11 @@ namespace _func849
 void ScoreKeeper::SetupTopShip(int variant)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int variant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func849::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func850::func;
 	return execfunc(this, variant);
 }
 
-namespace _func850
+namespace _func851
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11727,11 +11741,11 @@ namespace _func850
 void ScoreKeeper::CheckTypes()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func850::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func851::func;
 	return execfunc(this);
 }
 
-namespace _func851
+namespace _func852
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11741,11 +11755,11 @@ namespace _func851
 void ScoreKeeper::AddTopScoreType(TopScore &topScore, int type)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, TopScore &topScore_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func851::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func852::func;
 	return execfunc(this, topScore, type);
 }
 
-namespace _func852
+namespace _func853
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11755,11 +11769,11 @@ namespace _func852
 int ScoreKeeper::AddTopScoreList(TopScore &score, std::vector<TopScore> &topScoreList)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, TopScore &score_arg, std::vector<TopScore> &topScoreList_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func852::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func853::func;
 	return execfunc(this, score, topScoreList);
 }
 
-namespace _func853
+namespace _func854
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x1ff};
@@ -11769,11 +11783,11 @@ namespace _func853
 void ScoreKeeper::RenderTopScores(const std::vector<TopScore> &topScoreList, Point position, int newHighScore)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, const std::vector<TopScore> &topScoreList_arg, Point position_arg, int newHighScore_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func853::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func854::func;
 	return execfunc(this, topScoreList, position, newHighScore);
 }
 
-namespace _func854
+namespace _func855
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11783,11 +11797,11 @@ namespace _func854
 void ScoreKeeper::CycleLeft()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func854::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func855::func;
 	return execfunc(this);
 }
 
-namespace _func855
+namespace _func856
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11797,11 +11811,11 @@ namespace _func855
 void ScoreKeeper::CycleRight()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func855::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func856::func;
 	return execfunc(this);
 }
 
-namespace _func856
+namespace _func857
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11811,11 +11825,11 @@ namespace _func856
 void ScoreKeeper::Open(bool fromGameOver)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool fromGameOver_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func856::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func857::func;
 	return execfunc(this, fromGameOver);
 }
 
-namespace _func857
+namespace _func858
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11825,11 +11839,11 @@ namespace _func857
 bool ScoreKeeper::KeyDown(SDLKey key)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func857::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func858::func;
 	return execfunc(this, key);
 }
 
-namespace _func858
+namespace _func859
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11839,11 +11853,11 @@ namespace _func858
 void ScoreKeeper::AddScrapCollected(int scrap)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int scrap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func858::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func859::func;
 	return execfunc(this, scrap);
 }
 
-namespace _func859
+namespace _func860
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11853,11 +11867,11 @@ namespace _func859
 void ScoreKeeper::SaveScores(int file, std::vector<TopScore> &topScores)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int file_arg, std::vector<TopScore> &topScores_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func859::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func860::func;
 	return execfunc(this, file, topScores);
 }
 
-namespace _func860
+namespace _func861
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11867,11 +11881,11 @@ namespace _func860
 void ScoreKeeper::SaveGame(int fd)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func860::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func861::func;
 	return execfunc(this, fd);
 }
 
-namespace _func861
+namespace _func862
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11881,11 +11895,11 @@ namespace _func861
 void ScoreKeeper::LoadGame(int fd)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func861::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func862::func;
 	return execfunc(this, fd);
 }
 
-namespace _func862
+namespace _func863
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11895,11 +11909,11 @@ namespace _func862
 void ScoreKeeper::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func862::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func863::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func863
+namespace _func864
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11909,18 +11923,18 @@ namespace _func863
 void ScoreKeeper::SetSector(int sector)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int sector_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func863::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func864::func;
 	return execfunc(this, sector);
 }
 
 ScoreKeeper *Global_ScoreKeeper_Keeper;
 
-namespace _var864
+namespace _var865
 {
     static VariableDefinition varObj("Global_ScoreKeeper_Keeper", "!8b430cb9(???????\?)c6804412000000c7042401000000", &Global_ScoreKeeper_Keeper);
 }
 
-namespace _func865
+namespace _func866
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -11930,11 +11944,11 @@ namespace _func865
 char Settings::GetCommandConsole()
 {
 	typedef char __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func865::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func866::func;
 	return execfunc();
 }
 
-namespace _func866
+namespace _func867
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -11944,11 +11958,11 @@ namespace _func866
 bool Settings::GetDlcEnabled()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func866::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func867::func;
 	return execfunc();
 }
 
-namespace _func867
+namespace _func868
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11958,11 +11972,11 @@ namespace _func867
 std::string Settings::GetHotkeyName(const std::string &name)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func867::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func868::func;
 	return execfunc(name);
 }
 
-namespace _func868
+namespace _func869
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11972,11 +11986,11 @@ namespace _func868
 SDLKey Settings::GetHotkey(const std::string &hotkeyName)
 {
 	typedef SDLKey __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &hotkeyName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func868::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func869::func;
 	return execfunc(hotkeyName);
 }
 
-namespace _func869
+namespace _func870
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11986,11 +12000,11 @@ namespace _func869
 void Settings::SetHotkey(const std::string &hotkeyName, SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &hotkeyName_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func869::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func870::func;
 	return execfunc(hotkeyName, key);
 }
 
-namespace _func870
+namespace _func871
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -11998,20 +12012,6 @@ namespace _func870
 }
 
 void Settings::SaveSettings()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func870::func;
-	return execfunc();
-}
-
-namespace _func871
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("Settings::ResetHotkeys", typeid(void (*)()), ".8d4c240483e4f0ff71fc5589e557565351be????????83ec688b465c8b5e6039d88945a489c774??90", argdata, 0, 6, &func);
-}
-
-void Settings::ResetHotkeys()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func871::func;
@@ -12022,24 +12022,38 @@ namespace _func872
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("Settings::LoadSettings", typeid(void (*)()), ".8d4c240483e4f0ff71fc5589e5575653518d9d24ffffff81ec????????e8????????8d8d60ffffffe8????????a1????????c645d400", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("Settings::ResetHotkeys", typeid(void (*)()), ".8d4c240483e4f0ff71fc5589e557565351be????????83ec688b465c8b5e6039d88945a489c774??90", argdata, 0, 6, &func);
 }
 
-void Settings::LoadSettings()
+void Settings::ResetHotkeys()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func872::func;
 	return execfunc();
 }
 
+namespace _func873
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("Settings::LoadSettings", typeid(void (*)()), ".8d4c240483e4f0ff71fc5589e5575653518d9d24ffffff81ec????????e8????????8d8d60ffffffe8????????a1????????c645d400", argdata, 0, 6, &func);
+}
+
+void Settings::LoadSettings()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func873::func;
+	return execfunc();
+}
+
 SettingValues *Global_Settings_Settings;
 
-namespace _var873
+namespace _var874
 {
     static VariableDefinition varObj("Global_Settings_Settings", "!5756535183ec588b01c745a8(???????\?)", &Global_Settings_Settings);
 }
 
-namespace _func874
+namespace _func875
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0xdff, 0x1ff};
@@ -12049,11 +12063,11 @@ namespace _func874
 CollisionResponse Shields::CollisionReal(float x, float y, Damage damage, bool force)
 {
 	typedef CollisionResponse __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg, float x_arg, float y_arg, Damage damage_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func874::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func875::func;
 	return execfunc(this, x, y, damage, force);
 }
 
-namespace _func875
+namespace _func876
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -12063,11 +12077,11 @@ namespace _func875
 void Shields::constructor(int roomId, int shipId, int startingPower, const std::string &shieldFile)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg, int roomId_arg, int shipId_arg, int startingPower_arg, const std::string &shieldFile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func875::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func876::func;
 	return execfunc(this, roomId, shipId, startingPower, shieldFile);
 }
 
-namespace _func876
+namespace _func877
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x4ff};
@@ -12077,11 +12091,11 @@ namespace _func876
 void Shields::SetBaseEllipse(Globals::Ellipse ellipse)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg, Globals::Ellipse ellipse_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func876::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func877::func;
 	return execfunc(this, ellipse);
 }
 
-namespace _func877
+namespace _func878
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12091,11 +12105,11 @@ namespace _func877
 void Shields::SetHackingLevel(int hackingLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func877::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func878::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func878
+namespace _func879
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12103,20 +12117,6 @@ namespace _func878
 }
 
 void Shields::InstantCharge()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func878::func;
-	return execfunc(this);
-}
-
-namespace _func879
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("Shields::Jump", typeid(void (Shields::*)()), "578d7c240883e4f0ff77fc5589e557565389cb8d7dd883ec3ce8????????f30f1015????????8b83040200000f28ca8d4b08f30f108314020000897dd0", argdata, 1, 5, &func);
-}
-
-void Shields::Jump()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func879::func;
@@ -12127,10 +12127,10 @@ namespace _func880
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("Shields::OnLoop", typeid(void (Shields::*)()), "578d7c240883e4f0ff77fc5589e557565389ce8d7dd083ec4ce8????????8d45d8893c24c745d8454e4552c745dc47595f53c745e04849454c8945d0", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("Shields::Jump", typeid(void (Shields::*)()), "578d7c240883e4f0ff77fc5589e557565389cb8d7dd883ec3ce8????????f30f1015????????8b83040200000f28ca8d4b08f30f108314020000897dd0", argdata, 1, 5, &func);
 }
 
-void Shields::OnLoop()
+void Shields::Jump()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func880::func;
@@ -12140,6 +12140,20 @@ void Shields::OnLoop()
 namespace _func881
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("Shields::OnLoop", typeid(void (Shields::*)()), "578d7c240883e4f0ff77fc5589e557565389ce8d7dd083ec4ce8????????8d45d8893c24c745d8454e4552c745dc47595f53c745e04849454c8945d0", argdata, 1, 5, &func);
+}
+
+void Shields::OnLoop()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func881::func;
+	return execfunc(this);
+}
+
+namespace _func882
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
 	static FunctionDefinition funcObj("Shields::AddSuperShield", typeid(void (Shields::*)(Point )), "57ba????????8d7c240883e4f0ff77fc5589e557565383ec1c8b81f40100008b378b7f0483c001", argdata, 2, 5, &func);
 }
@@ -12147,11 +12161,11 @@ namespace _func881
 void Shields::AddSuperShield(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func881::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func882::func;
 	return execfunc(this, pos);
 }
 
-namespace _func882
+namespace _func883
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12161,11 +12175,11 @@ namespace _func882
 void Shields::RenderBase(float alpha, float superShieldOverwrite)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg, float alpha_arg, float superShieldOverwrite_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func882::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func883::func;
 	return execfunc(this, alpha, superShieldOverwrite);
 }
 
-namespace _func883
+namespace _func884
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0xdff};
@@ -12175,18 +12189,18 @@ namespace _func883
 CollisionResponse Shields::CollisionTest(float x, float y, Damage damage)
 {
 	typedef CollisionResponse __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg, float x_arg, float y_arg, Damage damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func883::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func884::func;
 	return execfunc(this, x, y, damage);
 }
 
 GL_Color *Global_COLOR_GREEN;
 
-namespace _var884
+namespace _var885
 {
     static VariableDefinition varObj("Global_COLOR_GREEN", "!f30f1015(???????\?)f30f5ee6", &Global_COLOR_GREEN);
 }
 
-namespace _func885
+namespace _func886
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -12196,11 +12210,11 @@ namespace _func885
 int Ship::GetSelectedRoomId(int x, int y, bool unk)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int x_arg, int y_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func885::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func886::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func886
+namespace _func887
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff};
@@ -12210,11 +12224,11 @@ namespace _func886
 void Ship::LockdownRoom(int roomId, Pointf pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, Pointf pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func886::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func887::func;
 	return execfunc(this, roomId, pos);
 }
 
-namespace _func887
+namespace _func888
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12224,11 +12238,11 @@ namespace _func887
 bool Ship::RoomLocked(int roomId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func887::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func888::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func888
+namespace _func889
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12238,11 +12252,11 @@ namespace _func888
 bool Ship::DestroyedDone()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func888::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func889::func;
 	return execfunc(this);
 }
 
-namespace _func889
+namespace _func890
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12252,11 +12266,11 @@ namespace _func889
 bool Ship::FullRoom(int roomId, bool intruder)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func889::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func890::func;
 	return execfunc(this, roomId, intruder);
 }
 
-namespace _func890
+namespace _func891
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12266,11 +12280,11 @@ namespace _func890
 int Ship::EmptySlots(int roomId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func890::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func891::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func891
+namespace _func892
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12280,11 +12294,11 @@ namespace _func891
 int Ship::GetAvailableRoomSlot(int roomId, bool intruder)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func891::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func892::func;
 	return execfunc(this, roomId, intruder);
 }
 
-namespace _func892
+namespace _func893
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12294,11 +12308,11 @@ namespace _func892
 void Ship::OnRenderBreaches()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func892::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func893::func;
 	return execfunc(this);
 }
 
-namespace _func893
+namespace _func894
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12308,11 +12322,11 @@ namespace _func893
 void Ship::OnRenderWalls(bool forceView, bool doorControlMode)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, bool forceView_arg, bool doorControlMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func893::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func894::func;
 	return execfunc(this, forceView, doorControlMode);
 }
 
-namespace _func894
+namespace _func895
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12322,11 +12336,11 @@ namespace _func894
 void Ship::OnInit(ShipBlueprint &bp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, ShipBlueprint &bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func894::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func895::func;
 	return execfunc(this, bp);
 }
 
-namespace _func895
+namespace _func896
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12336,11 +12350,11 @@ namespace _func895
 void Ship::OnRenderSparks()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func895::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func896::func;
 	return execfunc(this);
 }
 
-namespace _func896
+namespace _func897
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12350,11 +12364,11 @@ namespace _func896
 void Ship::SetRoomBlackout(int roomId, bool blackout)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool blackout_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func896::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func897::func;
 	return execfunc(this, roomId, blackout);
 }
 
-namespace _func897
+namespace _func898
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12362,20 +12376,6 @@ namespace _func897
 }
 
 void Ship::OnRenderBase(bool unk)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func897::func;
-	return execfunc(this, unk);
-}
-
-namespace _func898
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("Ship::OnRenderFloor", typeid(void (Ship::*)(bool )), "578d7c240883e4f0ff77fc5589f889e557565389cf83ec2c80b9b803000000", argdata, 2, 5, &func);
-}
-
-void Ship::OnRenderFloor(bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func898::func;
@@ -12386,17 +12386,31 @@ namespace _func899
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("Ship::OnRenderFloor", typeid(void (Ship::*)(bool )), "578d7c240883e4f0ff77fc5589f889e557565389cf83ec2c80b9b803000000", argdata, 2, 5, &func);
+}
+
+void Ship::OnRenderFloor(bool unk)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func899::func;
+	return execfunc(this, unk);
+}
+
+namespace _func900
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("Ship::OnRenderJump", typeid(void (Ship::*)(float )), "578d7c240883e4f0ff77fc5589e557565389cb83ec5c8b4104f30f1027f30f1165d4890424", argdata, 2, 5, &func);
 }
 
 void Ship::OnRenderJump(float progress)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, float progress_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func899::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func900::func;
 	return execfunc(this, progress);
 }
 
-namespace _func900
+namespace _func901
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12406,11 +12420,11 @@ namespace _func900
 Globals::Ellipse Ship::GetBaseEllipse()
 {
 	typedef Globals::Ellipse __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func900::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func901::func;
 	return execfunc(this);
 }
 
-namespace _func901
+namespace _func902
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12420,11 +12434,11 @@ namespace _func901
 void Ship::SetSelectedRoom(int roomId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func901::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func902::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func902
+namespace _func903
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12434,11 +12448,11 @@ namespace _func902
 void Ship::OnLoop(std::vector<float> &oxygenLevels)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, std::vector<float> &oxygenLevels_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func902::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func903::func;
 	return execfunc(this, oxygenLevels);
 }
 
-namespace _func903
+namespace _func904
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12448,11 +12462,11 @@ namespace _func903
 void Ship::BreachRandomHull(int roomId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func903::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func904::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func904
+namespace _func905
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12462,11 +12476,11 @@ namespace _func904
 void Ship::BreachSpecificHull(int grid_x, int grid_y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int grid_x_arg, int grid_y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func904::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func905::func;
 	return execfunc(this, grid_x, grid_y);
 }
 
-namespace _func905
+namespace _func906
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12476,11 +12490,11 @@ namespace _func905
 int Ship::GetAvailableRoom(int preferred, bool intruder)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int preferred_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func905::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func906::func;
 	return execfunc(this, preferred, intruder);
 }
 
-namespace _func906
+namespace _func907
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12490,31 +12504,31 @@ namespace _func906
 std::vector<Repairable*> Ship::GetHullBreaches(bool onlyDamaged)
 {
 	typedef std::vector<Repairable*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, bool onlyDamaged_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func906::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func907::func;
 	return execfunc(this, onlyDamaged);
-}
-
-namespace _noop907
-{
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_0", "!1ef7ffff(c6841d5afefeff01)");
 }
 
 namespace _noop908
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_1", "!89ca7d08(c6841d58fefeff01)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_0", "!1ef7ffff(c6841d5afefeff01)");
 }
 
 namespace _noop909
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_2", "!89c87ddf(c6841d56fefeff01)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_1", "!89ca7d08(c6841d58fefeff01)");
 }
 
 namespace _noop910
 {
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_2", "!89c87ddf(c6841d56fefeff01)");
+}
+
+namespace _noop911
+{
     static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_3", "!89c87d08(c6841d54fefeff01)");
 }
 
-namespace _func911
+namespace _func912
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12524,11 +12538,11 @@ namespace _func911
 void ShipAI::constructor(bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipAI *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func911::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func912::func;
 	return execfunc(this, unk);
 }
 
-namespace _func912
+namespace _func913
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12538,11 +12552,11 @@ namespace _func912
 void ShipAI::SetStalemate(bool stalemate)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipAI *this_arg, bool stalemate_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func912::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func913::func;
 	return execfunc(this, stalemate);
 }
 
-namespace _func913
+namespace _func914
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12552,11 +12566,11 @@ namespace _func913
 void ShipAI::OnLoop(bool hostile)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipAI *this_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func913::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func914::func;
 	return execfunc(this, hostile);
 }
 
-namespace _func914
+namespace _func915
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12566,11 +12580,11 @@ namespace _func914
 std::pair<int, int> ShipAI::GetTeleportCommand()
 {
 	typedef std::pair<int, int> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func914::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func915::func;
 	return execfunc(this);
 }
 
-namespace _func915
+namespace _func916
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12580,11 +12594,11 @@ namespace _func915
 void ShipBlueprint::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func915::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func916::func;
 	return execfunc(this);
 }
 
-namespace _func916
+namespace _func917
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12594,11 +12608,11 @@ namespace _func916
 void ShipBuilder::CheckTypes()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func916::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func917::func;
 	return execfunc(this);
 }
 
-namespace _func917
+namespace _func918
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12608,11 +12622,11 @@ namespace _func917
 void ShipBuilder::MouseClick(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func917::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func918::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func918
+namespace _func919
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12622,11 +12636,11 @@ namespace _func918
 void ShipBuilder::SwitchShip(int shipType, int shipVariant)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int shipType_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func918::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func919::func;
 	return execfunc(this, shipType, shipVariant);
 }
 
-namespace _func919
+namespace _func920
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12634,20 +12648,6 @@ namespace _func919
 }
 
 void ShipBuilder::CreateEquipmentBoxes()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func919::func;
-	return execfunc(this);
-}
-
-namespace _func920
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::CreateSystemBoxes", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec4c8bb9941000008b919010000089f829d0c1f802", argdata, 1, 5, &func);
-}
-
-void ShipBuilder::CreateSystemBoxes()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func920::func;
@@ -12658,10 +12658,10 @@ namespace _func921
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::SetupShipAchievements", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec5c8b816c1c0000c781781c0000ffffffff8981701c0000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CreateSystemBoxes", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec4c8bb9941000008b919010000089f829d0c1f802", argdata, 1, 5, &func);
 }
 
-void ShipBuilder::SetupShipAchievements()
+void ShipBuilder::CreateSystemBoxes()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func921::func;
@@ -12672,10 +12672,10 @@ namespace _func922
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::ClearShipAchievements", typeid(void (ShipBuilder::*)()), "8b816c1c0000c781781c0000ffffffff8981701c0000c390908db426000000005589e5575653", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipBuilder::SetupShipAchievements", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec5c8b816c1c0000c781781c0000ffffffff8981701c0000", argdata, 1, 5, &func);
 }
 
-void ShipBuilder::ClearShipAchievements()
+void ShipBuilder::SetupShipAchievements()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func922::func;
@@ -12685,6 +12685,20 @@ void ShipBuilder::ClearShipAchievements()
 namespace _func923
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ShipBuilder::ClearShipAchievements", typeid(void (ShipBuilder::*)()), "8b816c1c0000c781781c0000ffffffff8981701c0000c390908db426000000005589e5575653", argdata, 1, 5, &func);
+}
+
+void ShipBuilder::ClearShipAchievements()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func923::func;
+	return execfunc(this);
+}
+
+namespace _func924
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("ShipBuilder::SwapType", typeid(void (ShipBuilder::*)(int )), "578d7c240883e4f0ff77fc5589e557565389cb83ec1c8b098b3785c9", argdata, 2, 5, &func);
 }
@@ -12692,11 +12706,11 @@ namespace _func923
 void ShipBuilder::SwapType(int variant)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int variant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func923::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func924::func;
 	return execfunc(this, variant);
 }
 
-namespace _func924
+namespace _func925
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12704,20 +12718,6 @@ namespace _func924
 }
 
 void ShipBuilder::CycleShipNext()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func924::func;
-	return execfunc(this);
-}
-
-namespace _func925
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::CycleShipPrevious", typeid(void (ShipBuilder::*)()), ".578d7c240883e4f0ff77fc5589e557565389ce83ec2c8b0985c974??", argdata, 1, 5, &func);
-}
-
-void ShipBuilder::CycleShipPrevious()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func925::func;
@@ -12728,10 +12728,10 @@ namespace _func926
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::Open", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565381ec????????898d38fbffff", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CycleShipPrevious", typeid(void (ShipBuilder::*)()), ".578d7c240883e4f0ff77fc5589e557565389ce83ec2c8b0985c974??", argdata, 1, 5, &func);
 }
 
-void ShipBuilder::Open()
+void ShipBuilder::CycleShipPrevious()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func926::func;
@@ -12742,10 +12742,10 @@ namespace _func927
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::OnRender", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389cb81ec????????80b960120000000f85????????e8????????8b831c0f00008d7dd0", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipBuilder::Open", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565381ec????????898d38fbffff", argdata, 1, 5, &func);
 }
 
-void ShipBuilder::OnRender()
+void ShipBuilder::Open()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func927::func;
@@ -12756,10 +12756,10 @@ namespace _func928
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::OnLoop", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389cbb9????????81ec????????e8????????84c0", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipBuilder::OnRender", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389cb81ec????????80b960120000000f85????????e8????????8b831c0f00008d7dd0", argdata, 1, 5, &func);
 }
 
-void ShipBuilder::OnLoop()
+void ShipBuilder::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func928::func;
@@ -12770,10 +12770,10 @@ namespace _func929
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::constructor", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83c10c8d7dd08d75d883ec3cc741f800000000c741fc00000000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipBuilder::OnLoop", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389cbb9????????81ec????????e8????????84c0", argdata, 1, 5, &func);
 }
 
-void ShipBuilder::constructor()
+void ShipBuilder::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func929::func;
@@ -12783,6 +12783,20 @@ void ShipBuilder::constructor()
 namespace _func930
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ShipBuilder::constructor", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83c10c8d7dd08d75d883ec3cc741f800000000c741fc00000000", argdata, 1, 5, &func);
+}
+
+void ShipBuilder::constructor()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func930::func;
+	return execfunc(this);
+}
+
+namespace _func931
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipBuilder::MouseMove", typeid(void (ShipBuilder::*)(int , int )), "578d7c240883e4f0ff77fc5589f889e557565389cf81ec????????8b308b4004898570feffff8d81540f000089b574feffff", argdata, 3, 5, &func);
 }
@@ -12790,11 +12804,11 @@ namespace _func930
 void ShipBuilder::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func930::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func931::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func931
+namespace _func932
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12804,11 +12818,11 @@ namespace _func931
 void ShipBuilder::OnKeyDown(SDLKey key)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func931::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func932::func;
 	return execfunc(this, key);
 }
 
-namespace _func932
+namespace _func933
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12818,11 +12832,11 @@ namespace _func932
 void ShipButton::constructor(int shipType, int shipVariant)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipButton *this_arg, int shipType_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func932::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func933::func;
 	return execfunc(this, shipType, shipVariant);
 }
 
-namespace _func933
+namespace _func934
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff};
@@ -12832,11 +12846,11 @@ namespace _func933
 void ShipButton::OnInit(const std::string &imgName, Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipButton *this_arg, const std::string &imgName_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func933::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func934::func;
 	return execfunc(this, imgName, pos);
 }
 
-namespace _func934
+namespace _func935
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12846,11 +12860,11 @@ namespace _func934
 void ShipButton::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipButton *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func934::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func935::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func935
+namespace _func936
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12860,11 +12874,11 @@ namespace _func935
 void ShipButton::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func935::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func936::func;
 	return execfunc(this);
 }
 
-namespace _func936
+namespace _func937
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12874,11 +12888,11 @@ namespace _func936
 void ShipEvent::constructor(const ShipEvent &event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipEvent *this_arg, const ShipEvent &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func936::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func937::func;
 	return execfunc(this, event);
 }
 
-namespace _func937
+namespace _func938
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12888,11 +12902,11 @@ namespace _func937
 ShipManager *ShipGenerator::CreateShip(const std::string &name, int sector, ShipEvent &event)
 {
 	typedef ShipManager *__attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &name_arg, int sector_arg, ShipEvent &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func937::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func938::func;
 	return execfunc(name, sector, event);
 }
 
-namespace _func938
+namespace _func939
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12902,11 +12916,11 @@ namespace _func938
 std::vector<int> ShipGenerator::GenerateSystemMaxes(const ShipBlueprint &ship, int level)
 {
 	typedef std::vector<int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(const ShipBlueprint &ship_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func938::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func939::func;
 	return execfunc(ship, level);
 }
 
-namespace _func939
+namespace _func940
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12916,11 +12930,11 @@ namespace _func939
 bool ShipGenerator::UpgradeSystem(ShipManager *ship, std::vector<int> &systemMaxes, unsigned int sysId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, unsigned int sysId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func939::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func940::func;
 	return execfunc(ship, systemMaxes, sysId);
 }
 
-namespace _func940
+namespace _func941
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -12930,20 +12944,6 @@ namespace _func940
 std::vector<int> ShipGenerator::GetPossibleSystemUpgrades(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func940::func;
-	return execfunc(ship, systemMaxes, scrap, type);
-}
-
-namespace _func941
-{
-    static void *func = 0;
-	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades0", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), "578d7c240883e4f0ff77fc5589e557565389ce83ec6c8945c0c70000000000c7400400000000c740080000000031c08955bcc745c8000000008db42600000000", argdata, 5, 2, &func);
-}
-
-std::vector<int> ShipGenerator::GetPossibleSystemUpgrades0(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
-{
-	typedef std::vector<int> __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func941::func;
 	return execfunc(ship, systemMaxes, scrap, type);
 }
@@ -12952,10 +12952,10 @@ namespace _func942
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades1", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), "578d7c240883e4f0ff77fc5589e557565389ce83ec6c8945c0c70000000000c7400400000000c740080000000031c08955bcc745c800000000eb1c", argdata, 5, 2, &func);
+	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades0", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), "578d7c240883e4f0ff77fc5589e557565389ce83ec6c8945c0c70000000000c7400400000000c740080000000031c08955bcc745c8000000008db42600000000", argdata, 5, 2, &func);
 }
 
-std::vector<int> ShipGenerator::GetPossibleSystemUpgrades1(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
+std::vector<int> ShipGenerator::GetPossibleSystemUpgrades0(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func942::func;
@@ -12966,10 +12966,10 @@ namespace _func943
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades2", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), "578d7c240883e4f0ff77fc5589e557565389ce83ec6c8945c0c70000000000c7400400000000c740080000000031c08955bcc745c800000000eb1f", argdata, 5, 2, &func);
+	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades1", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), "578d7c240883e4f0ff77fc5589e557565389ce83ec6c8945c0c70000000000c7400400000000c740080000000031c08955bcc745c800000000eb1c", argdata, 5, 2, &func);
 }
 
-std::vector<int> ShipGenerator::GetPossibleSystemUpgrades2(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
+std::vector<int> ShipGenerator::GetPossibleSystemUpgrades1(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func943::func;
@@ -12979,6 +12979,20 @@ std::vector<int> ShipGenerator::GetPossibleSystemUpgrades2(ShipManager *ship, st
 namespace _func944
 {
     static void *func = 0;
+	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades2", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), "578d7c240883e4f0ff77fc5589e557565389ce83ec6c8945c0c70000000000c7400400000000c740080000000031c08955bcc745c800000000eb1f", argdata, 5, 2, &func);
+}
+
+std::vector<int> ShipGenerator::GetPossibleSystemUpgrades2(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
+{
+	typedef std::vector<int> __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func944::func;
+	return execfunc(ship, systemMaxes, scrap, type);
+}
+
+namespace _func945
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipGenerator::GetPossibleWeaponList", typeid(std::vector<WeaponBlueprint*> (*)(ShipManager *, const std::string &, int , unsigned int )), "8d4c240483e4f0ff71fc5589c889e55756535181ec880000008b198b78088b49048b4010895da0897d9489459c", argdata, 5, 2, &func);
 }
@@ -12986,11 +13000,11 @@ namespace _func944
 std::vector<WeaponBlueprint*> ShipGenerator::GetPossibleWeaponList(ShipManager *ship, const std::string &weaponList, int scrap, unsigned int flags)
 {
 	typedef std::vector<WeaponBlueprint*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &weaponList_arg, int scrap_arg, unsigned int flags_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func944::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func945::func;
 	return execfunc(ship, weaponList, scrap, flags);
 }
 
-namespace _func945
+namespace _func946
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13000,11 +13014,11 @@ namespace _func945
 std::vector<DroneBlueprint*> ShipGenerator::GetPossibleDroneList(ShipManager *ship, const std::string &droneList, int scrap, unsigned int flags, bool repeat)
 {
 	typedef std::vector<DroneBlueprint*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &droneList_arg, int scrap_arg, unsigned int flags_arg, bool repeat_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func945::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func946::func;
 	return execfunc(ship, droneList, scrap, flags, repeat);
 }
 
-namespace _func946
+namespace _func947
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13014,11 +13028,11 @@ namespace _func946
 std::vector<CrewBlueprint> ShipGenerator::GetPossibleCrewList(ShipManager *ship, const std::string &crewList, unsigned int flags)
 {
 	typedef std::vector<CrewBlueprint> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &crewList_arg, unsigned int flags_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func946::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func947::func;
 	return execfunc(ship, crewList, flags);
 }
 
-namespace _func947
+namespace _func948
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13028,11 +13042,11 @@ namespace _func947
 ShipGraph *ShipGraph::GetShipInfo(int shipId)
 {
 	typedef ShipGraph *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func947::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func948::func;
 	return execfunc(shipId);
 }
 
-namespace _func948
+namespace _func949
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -13061,11 +13075,11 @@ FUNC_NAKED __int64 ShipGraph::GetSlotRenderPosition_DO_NOT_USE_DIRECTLY(int slot
 		"movl %%ebp, %%esp\n\t"
 		"popl %%ebp\n\t"
 		"ret $12\n\t"
-		 :: "m"(_func948::func)
+		 :: "m"(_func949::func)
 	);
 }
 
-namespace _func949
+namespace _func950
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13075,11 +13089,11 @@ namespace _func949
 int ShipGraph::DoorCount(int roomId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func949::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func950::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func950
+namespace _func951
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13089,11 +13103,11 @@ namespace _func950
 std::vector<Door*> ShipGraph::GetDoors(int roomId)
 {
 	typedef std::vector<Door*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func950::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func951::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func951
+namespace _func952
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13103,11 +13117,11 @@ namespace _func951
 bool ShipGraph::IsRoomConnected(int room1, int room2)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room1_arg, int room2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func951::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func952::func;
 	return execfunc(this, room1, room2);
 }
 
-namespace _func952
+namespace _func953
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13117,11 +13131,11 @@ namespace _func952
 Door *ShipGraph::ConnectingDoor(int x1, int y1, int x2, int y2)
 {
 	typedef Door *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x1_arg, int y1_arg, int x2_arg, int y2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func952::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func953::func;
 	return execfunc(this, x1, y1, x2, y2);
 }
 
-namespace _func953
+namespace _func954
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13131,11 +13145,11 @@ namespace _func953
 int ShipGraph::ConnectedGridSquares(int x1, int y1, int x2, int y2)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x1_arg, int y1_arg, int x2_arg, int y2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func953::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func954::func;
 	return execfunc(this, x1, y1, x2, y2);
 }
 
-namespace _func954
+namespace _func955
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x2ff};
@@ -13145,11 +13159,11 @@ namespace _func954
 int ShipGraph::ConnectedGridSquaresPoint(Point p1, Point p2)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func954::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func955::func;
 	return execfunc(this, p1, p2);
 }
 
-namespace _func955
+namespace _func956
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x2ff};
@@ -13159,11 +13173,11 @@ namespace _func955
 Door *ShipGraph::ConnectingDoor(Point p1, Point p2)
 {
 	typedef Door *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func955::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func956::func;
 	return execfunc(this, p1, p2);
 }
 
-namespace _func956
+namespace _func957
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13173,11 +13187,11 @@ namespace _func956
 int ShipGraph::GetNumSlots(int room)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func956::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func957::func;
 	return execfunc(this, room);
 }
 
-namespace _func957
+namespace _func958
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13187,11 +13201,11 @@ namespace _func957
 int ShipGraph::PopClosestDoor(std::vector<int> &doors, std::vector<float> &distances)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, std::vector<int> &doors_arg, std::vector<float> &distances_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func957::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func958::func;
 	return execfunc(this, doors, distances);
 }
 
-namespace _func958
+namespace _func959
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x2ff, 0x1ff};
@@ -13201,11 +13215,11 @@ namespace _func958
 Path ShipGraph::Dijkstra(Point start, Point goal, int shipId)
 {
 	typedef Path __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point start_arg, Point goal_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func958::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func959::func;
 	return execfunc(this, start, goal, shipId);
 }
 
-namespace _func959
+namespace _func960
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x2ff, 0x1ff};
@@ -13215,11 +13229,11 @@ namespace _func959
 Path ShipGraph::FindPath(Point p1, Point p2, int shipId)
 {
 	typedef Path __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func959::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func960::func;
 	return execfunc(this, p1, p2, shipId);
 }
 
-namespace _func960
+namespace _func961
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13229,11 +13243,11 @@ namespace _func960
 float ShipGraph::ConvertToWorldAngle(float ang)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, float ang_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func960::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func961::func;
 	return execfunc(this, ang);
 }
 
-namespace _func961
+namespace _func962
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13243,11 +13257,11 @@ namespace _func961
 float ShipGraph::ConvertToLocalAngle(float ang)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, float ang_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func961::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func962::func;
 	return execfunc(this, ang);
 }
 
-namespace _func962
+namespace _func963
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -13275,11 +13289,11 @@ FUNC_NAKED __int64 ShipGraph::ConvertToWorldPosition_DO_NOT_USE_DIRECTLY(Pointf 
 		"movl %%ebp, %%esp\n\t"
 		"popl %%ebp\n\t"
 		"ret $8\n\t"
-		 :: "m"(_func962::func)
+		 :: "m"(_func963::func)
 	);
 }
 
-namespace _func963
+namespace _func964
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -13308,11 +13322,11 @@ FUNC_NAKED __int64 ShipGraph::ConvertToLocalPosition_DO_NOT_USE_DIRECTLY(Pointf 
 		"movl %%ebp, %%esp\n\t"
 		"popl %%ebp\n\t"
 		"ret $12\n\t"
-		 :: "m"(_func963::func)
+		 :: "m"(_func964::func)
 	);
 }
 
-namespace _func964
+namespace _func965
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13322,11 +13336,11 @@ namespace _func964
 void ShipGraph::ComputeCenter()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func964::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func965::func;
 	return execfunc(this);
 }
 
-namespace _func965
+namespace _func966
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13336,11 +13350,11 @@ namespace _func965
 bool ShipGraph::ContainsPoint(int x, int y)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func965::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func966::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func966
+namespace _func967
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -13350,11 +13364,11 @@ namespace _func966
 int ShipGraph::GetSelectedRoom(int x, int y, bool unk)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x_arg, int y_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func966::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func967::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func967
+namespace _func968
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13364,11 +13378,11 @@ namespace _func967
 int ShipGraph::RoomCount()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func967::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func968::func;
 	return execfunc(this);
 }
 
-namespace _func968
+namespace _func969
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13378,11 +13392,11 @@ namespace _func968
 Globals::Rect ShipGraph::GetRoomShape(int room)
 {
 	typedef Globals::Rect __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func968::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func969::func;
 	return execfunc(this, room);
 }
 
-namespace _func969
+namespace _func970
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13392,11 +13406,11 @@ namespace _func969
 float ShipGraph::GetRoomOxygen(int room)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func969::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func970::func;
 	return execfunc(this, room);
 }
 
-namespace _func970
+namespace _func971
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13406,11 +13420,11 @@ namespace _func970
 bool ShipGraph::GetRoomBlackedOut(int room)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func970::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func971::func;
 	return execfunc(this, room);
 }
 
-namespace _func971
+namespace _func972
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -13420,11 +13434,11 @@ namespace _func971
 Slot ShipGraph::GetClosestSlot(Point pos, int shipId, bool intruder)
 {
 	typedef Slot __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point pos_arg, int shipId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func971::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func972::func;
 	return execfunc(this, pos, shipId, intruder);
 }
 
-namespace _func972
+namespace _func973
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13434,11 +13448,11 @@ namespace _func972
 Point ShipGraph::GetSlotWorldPosition(int slotId, int roomId)
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int slotId_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func972::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func973::func;
 	return execfunc(this, slotId, roomId);
 }
 
-namespace _func973
+namespace _func974
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13448,11 +13462,11 @@ namespace _func973
 char ShipInfo::AddAugmentation(const std::string &augment)
 {
 	typedef char __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func973::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func974::func;
 	return execfunc(this, augment);
 }
 
-namespace _func974
+namespace _func975
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13462,11 +13476,11 @@ namespace _func974
 bool ShipInfo::HasAugmentation(const std::string &augment)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func974::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func975::func;
 	return execfunc(this, augment);
 }
 
-namespace _func975
+namespace _func976
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13476,11 +13490,11 @@ namespace _func975
 float ShipInfo::GetAugmentationValue(const std::string &augment)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func975::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func976::func;
 	return execfunc(this, augment);
 }
 
-namespace _func976
+namespace _func977
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13490,11 +13504,11 @@ namespace _func976
 int ShipManager::constructor(int shipId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func976::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func977::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func977
+namespace _func978
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13504,11 +13518,11 @@ namespace _func977
 void ShipManager::AddInitialCrew(std::vector<CrewBlueprint> &blueprints)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, std::vector<CrewBlueprint> &blueprints_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func977::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func978::func;
 	return execfunc(this, blueprints);
 }
 
-namespace _func978
+namespace _func979
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13518,11 +13532,11 @@ namespace _func978
 int ShipManager::GetDodgeFactor()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func978::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func979::func;
 	return execfunc(this);
 }
 
-namespace _func979
+namespace _func980
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13532,11 +13546,11 @@ namespace _func979
 void ShipManager::OnRender(bool showInterior, bool doorControlMode)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool showInterior_arg, bool doorControlMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func979::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func980::func;
 	return execfunc(this, showInterior, doorControlMode);
 }
 
-namespace _func980
+namespace _func981
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13546,11 +13560,11 @@ namespace _func980
 int ShipManager::CountCrew(bool boarders)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool boarders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func980::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func981::func;
 	return execfunc(this, boarders);
 }
 
-namespace _func981
+namespace _func982
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -13560,11 +13574,11 @@ namespace _func981
 std::vector<CrewMember*> ShipManager::TeleportCrew(int roomId, bool intruders)
 {
 	typedef std::vector<CrewMember*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func981::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func982::func;
 	return execfunc(this, roomId, intruders);
 }
 
-namespace _func982
+namespace _func983
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13574,11 +13588,11 @@ namespace _func982
 int ShipManager::OnInit(ShipBlueprint *bp, int shipLevel)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, ShipBlueprint *bp_arg, int shipLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func982::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func983::func;
 	return execfunc(this, bp, shipLevel);
 }
 
-namespace _func983
+namespace _func984
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13588,11 +13602,11 @@ namespace _func983
 bool ShipManager::HasSystem(int systemId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func983::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func984::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func984
+namespace _func985
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13602,11 +13616,11 @@ namespace _func984
 ShipSystem *ShipManager::GetSystemInRoom(int roomId)
 {
 	typedef ShipSystem *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func984::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func985::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func985
+namespace _func986
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13616,11 +13630,11 @@ namespace _func985
 void ShipManager::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func985::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func986::func;
 	return execfunc(this);
 }
 
-namespace _func986
+namespace _func987
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13630,11 +13644,11 @@ namespace _func986
 void ShipManager::SetSystemPowerLoss(int systemId, int powerLoss)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int powerLoss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func986::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func987::func;
 	return execfunc(this, systemId, powerLoss);
 }
 
-namespace _func987
+namespace _func988
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13644,11 +13658,11 @@ namespace _func987
 int ShipManager::CreateSystems()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func987::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func988::func;
 	return execfunc(this);
 }
 
-namespace _func988
+namespace _func989
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13658,11 +13672,11 @@ namespace _func988
 int ShipManager::AddSystem(int systemId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func988::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func989::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func989
+namespace _func990
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13672,11 +13686,11 @@ namespace _func989
 void ShipManager::UpdateCrewMembers()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func989::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func990::func;
 	return execfunc(this);
 }
 
-namespace _func990
+namespace _func991
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13686,11 +13700,11 @@ namespace _func990
 bool ShipManager::PowerDrone(Drone *drone, int roomId, bool userDriven, bool force)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Drone *drone_arg, int roomId_arg, bool userDriven_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func990::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func991::func;
 	return execfunc(this, drone, roomId, userDriven, force);
 }
 
-namespace _func991
+namespace _func992
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13700,11 +13714,11 @@ namespace _func991
 void ShipManager::UpdateEnvironment()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func991::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func992::func;
 	return execfunc(this);
 }
 
-namespace _func992
+namespace _func993
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13714,11 +13728,11 @@ namespace _func992
 CrewMember *ShipManager::AddCrewMemberFromBlueprint(CrewBlueprint *bp, int slot, bool init, int roomId, bool intruder)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewBlueprint *bp_arg, int slot_arg, bool init_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func992::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func993::func;
 	return execfunc(this, bp, slot, init, roomId, intruder);
 }
 
-namespace _func993
+namespace _func994
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13728,11 +13742,11 @@ namespace _func993
 CrewMember *ShipManager::AddCrewMemberFromString(const std::string &name, const std::string &race, bool intruder, int roomId, bool init, bool male)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const std::string &name_arg, const std::string &race_arg, bool intruder_arg, int roomId_arg, bool init_arg, bool male_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func993::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func994::func;
 	return execfunc(this, name, race, intruder, roomId, init, male);
 }
 
-namespace _func994
+namespace _func995
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13742,11 +13756,11 @@ namespace _func994
 void ShipManager::AddCrewMember(CrewMember *crew, int roomId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func994::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func995::func;
 	return execfunc(this, crew, roomId);
 }
 
-namespace _func995
+namespace _func996
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13756,11 +13770,11 @@ namespace _func995
 int ShipManager::GetOxygenPercentage()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func995::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func996::func;
 	return execfunc(this);
 }
 
-namespace _func996
+namespace _func997
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0xdff};
@@ -13770,11 +13784,11 @@ namespace _func996
 bool ShipManager::DamageCrew(CrewMember *crew, Damage dmg)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, Damage dmg_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func996::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func997::func;
 	return execfunc(this, crew, dmg);
 }
 
-namespace _func997
+namespace _func998
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13784,11 +13798,11 @@ namespace _func997
 void ShipManager::RemoveItem(const std::string &name)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func997::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func998::func;
 	return execfunc(this, name);
 }
 
-namespace _func998
+namespace _func999
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0xdff, 0x1ff};
@@ -13798,11 +13812,11 @@ namespace _func998
 bool ShipManager::DamageArea(Pointf location, Damage dmg, bool forceHit)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf location_arg, Damage dmg_arg, bool forceHit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func998::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func999::func;
 	return execfunc(this, location, dmg, forceHit);
 }
 
-namespace _func999
+namespace _func1000
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x2ff, 0xdff};
@@ -13812,11 +13826,11 @@ namespace _func999
 bool ShipManager::DamageBeam(Pointf location1, Pointf location2, Damage dmg)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf location1_arg, Pointf location2_arg, Damage dmg_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func999::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1000::func;
 	return execfunc(this, location1, location2, dmg);
 }
 
-namespace _func1000
+namespace _func1001
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -13826,11 +13840,11 @@ namespace _func1000
 CrewBlueprint ShipManager::SelectRandomCrew(int seed, const std::string &racePref)
 {
 	typedef CrewBlueprint __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int seed_arg, const std::string &racePref_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1000::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1001::func;
 	return execfunc(this, seed, racePref);
 }
 
-namespace _func1001
+namespace _func1002
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13838,20 +13852,6 @@ namespace _func1001
 }
 
 void ShipManager::ClearStatusAll()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1001::func;
-	return execfunc(this);
-}
-
-namespace _func1002
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipManager::PrepareSuperDrones", typeid(void (ShipManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec7c8b816c0800003b81700800000f84????????8b0d????????ba????????83f90274??83f901", argdata, 1, 5, &func);
-}
-
-void ShipManager::PrepareSuperDrones()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1002::func;
@@ -13862,10 +13862,10 @@ namespace _func1003
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipManager::JumpLeave", typeid(void (ShipManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec3c83a994040000018b51188b8194040000c681d80400000185c0", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipManager::PrepareSuperDrones", typeid(void (ShipManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec7c8b816c0800003b81700800000f84????????8b0d????????ba????????83f90274??83f901", argdata, 1, 5, &func);
 }
 
-void ShipManager::JumpLeave()
+void ShipManager::PrepareSuperDrones()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1003::func;
@@ -13875,6 +13875,20 @@ void ShipManager::JumpLeave()
 namespace _func1004
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ShipManager::JumpLeave", typeid(void (ShipManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec3c83a994040000018b51188b8194040000c681d80400000185c0", argdata, 1, 5, &func);
+}
+
+void ShipManager::JumpLeave()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1004::func;
+	return execfunc(this);
+}
+
+namespace _func1005
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipManager::ModifyScrapCount", typeid(void (ShipManager::*)(int , bool )), "578d7c240883e4f0ff77fc5589e557565389cb83ec4c8b378b470485f6", argdata, 3, 5, &func);
 }
@@ -13882,11 +13896,11 @@ namespace _func1004
 void ShipManager::ModifyScrapCount(int scrap, bool income)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int scrap_arg, bool income_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1004::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1005::func;
 	return execfunc(this, scrap, income);
 }
 
-namespace _func1005
+namespace _func1006
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13896,11 +13910,11 @@ namespace _func1005
 void ShipManager::ModifyMissileCount(int missiles)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int missiles_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1005::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1006::func;
 	return execfunc(this, missiles);
 }
 
-namespace _func1006
+namespace _func1007
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13910,11 +13924,11 @@ namespace _func1006
 int ShipManager::GetMissileCount()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1006::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1007::func;
 	return execfunc(this);
 }
 
-namespace _func1007
+namespace _func1008
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13924,11 +13938,11 @@ namespace _func1007
 void ShipManager::ModifyDroneCount(int drones)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int drones_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1007::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1008::func;
 	return execfunc(this, drones);
 }
 
-namespace _func1008
+namespace _func1009
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13938,11 +13952,11 @@ namespace _func1008
 bool ShipManager::DoSensorsProvide(int vision)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int vision_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1008::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1009::func;
 	return execfunc(this, vision);
 }
 
-namespace _func1009
+namespace _func1010
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13952,11 +13966,11 @@ namespace _func1009
 bool ShipManager::IsCrewFull()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1009::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1010::func;
 	return execfunc(this);
 }
 
-namespace _func1010
+namespace _func1011
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13966,11 +13980,11 @@ namespace _func1010
 bool ShipManager::IsCrewOverFull()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1010::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1011::func;
 	return execfunc(this);
 }
 
-namespace _func1011
+namespace _func1012
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13980,11 +13994,11 @@ namespace _func1011
 CrewDrone *ShipManager::CreateCrewDrone(const DroneBlueprint *bp)
 {
 	typedef CrewDrone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1011::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1012::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1012
+namespace _func1013
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13994,11 +14008,11 @@ namespace _func1012
 SpaceDrone *ShipManager::CreateSpaceDrone(const DroneBlueprint *bp)
 {
 	typedef SpaceDrone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1012::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1013::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1013
+namespace _func1014
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14008,11 +14022,11 @@ namespace _func1013
 bool ShipManager::CommandCrewMoveRoom(CrewMember *crew, int roomId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1013::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1014::func;
 	return execfunc(this, crew, roomId);
 }
 
-namespace _func1014
+namespace _func1015
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14022,11 +14036,11 @@ namespace _func1014
 int ShipManager::GetSystemRoom(int sysId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int sysId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1014::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1015::func;
 	return execfunc(this, sysId);
 }
 
-namespace _func1015
+namespace _func1016
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14036,11 +14050,11 @@ namespace _func1015
 std::vector<ProjectileFactory*> ShipManager::GetWeaponList()
 {
 	typedef std::vector<ProjectileFactory*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1015::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1016::func;
 	return execfunc(this);
 }
 
-namespace _func1016
+namespace _func1017
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14050,11 +14064,11 @@ namespace _func1016
 Drone *ShipManager::AddDrone(const DroneBlueprint *bp, int slot)
 {
 	typedef Drone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1016::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1017::func;
 	return execfunc(this, bp, slot);
 }
 
-namespace _func1017
+namespace _func1018
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14064,11 +14078,11 @@ namespace _func1017
 void ShipManager::Restart()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1017::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1018::func;
 	return execfunc(this);
 }
 
-namespace _func1018
+namespace _func1019
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14078,11 +14092,11 @@ namespace _func1018
 int ShipManager::GetSystemPower(int systemId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1018::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1019::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1019
+namespace _func1020
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14092,11 +14106,11 @@ namespace _func1019
 int ShipManager::CountCrewShipId(int roomId, int shipId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1019::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1020::func;
 	return execfunc(this, roomId, shipId);
 }
 
-namespace _func1020
+namespace _func1021
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14106,11 +14120,11 @@ namespace _func1020
 ShipSystem *ShipManager::GetSystem(int systemId)
 {
 	typedef ShipSystem *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1020::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1021::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1021
+namespace _func1022
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14120,11 +14134,11 @@ namespace _func1021
 void ShipManager::ExportShip(int file)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1021::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1022::func;
 	return execfunc(this, file);
 }
 
-namespace _func1022
+namespace _func1023
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14134,11 +14148,11 @@ namespace _func1022
 void ShipManager::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1022::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1023::func;
 	return execfunc(this);
 }
 
-namespace _func1023
+namespace _func1024
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14148,11 +14162,11 @@ namespace _func1023
 void ShipManager::destructor2()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1023::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1024::func;
 	return execfunc(this);
 }
 
-namespace _func1024
+namespace _func1025
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14162,11 +14176,11 @@ namespace _func1024
 void ShipManager::ImportShip(int file)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1024::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1025::func;
 	return execfunc(this, file);
 }
 
-namespace _func1025
+namespace _func1026
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14176,11 +14190,11 @@ namespace _func1025
 void ShipManager::CheckVision()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1025::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1026::func;
 	return execfunc(this);
 }
 
-namespace _func1026
+namespace _func1027
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14190,11 +14204,11 @@ namespace _func1026
 int ShipManager::IsSystemHacked(int systemId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1026::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1027::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1027
+namespace _func1028
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -14204,11 +14218,11 @@ namespace _func1027
 CrewMember *ShipManager::GetSelectedCrewPoint(int x, int y, bool intruder)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int x_arg, int y_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1027::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1028::func;
 	return execfunc(this, x, y, intruder);
 }
 
-namespace _func1028
+namespace _func1029
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14218,11 +14232,11 @@ namespace _func1028
 void ShipManager::RenderWeapons()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1028::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1029::func;
 	return execfunc(this);
 }
 
-namespace _func1029
+namespace _func1030
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14232,11 +14246,11 @@ namespace _func1029
 void ShipManager::ClearStatusSystem(int system)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int system_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1029::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1030::func;
 	return execfunc(this, system);
 }
 
-namespace _func1030
+namespace _func1031
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14244,20 +14258,6 @@ namespace _func1030
 }
 
 void ShipManager::ResetScrapLevel()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1030::func;
-	return execfunc(this);
-}
-
-namespace _func1031
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipManager::JumpArrive", typeid(void (ShipManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce81c1????????83ec3c8b411cc741ec000000008941208b812cfcffff89810c040000c70424????????", argdata, 1, 5, &func);
-}
-
-void ShipManager::JumpArrive()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1031::func;
@@ -14268,10 +14268,10 @@ namespace _func1032
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipManager::CheckSpreadDamage", typeid(void (ShipManager::*)()), "578d7c240883e4f0ff77fc5589e557565383ec4c8b51188b411cc745b80000000029d0c1f80285c00f84????????89cf", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipManager::JumpArrive", typeid(void (ShipManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce81c1????????83ec3c8b411cc741ec000000008941208b812cfcffff89810c040000c70424????????", argdata, 1, 5, &func);
 }
 
-void ShipManager::CheckSpreadDamage()
+void ShipManager::JumpArrive()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1032::func;
@@ -14281,6 +14281,20 @@ void ShipManager::CheckSpreadDamage()
 namespace _func1033
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ShipManager::CheckSpreadDamage", typeid(void (ShipManager::*)()), "578d7c240883e4f0ff77fc5589e557565383ec4c8b51188b411cc745b80000000029d0c1f80285c00f84????????89cf", argdata, 1, 5, &func);
+}
+
+void ShipManager::CheckSpreadDamage()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1033::func;
+	return execfunc(this);
+}
+
+namespace _func1034
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("ShipManager::ForceDecreaseSystemPower", typeid(bool (ShipManager::*)(int )), "5731c08d7c240883e4f0ff77fc5589e55783ec148b1783faff74??8bb9c80400008b149783faff74??8b4918", argdata, 2, 1, &func);
 }
@@ -14288,11 +14302,11 @@ namespace _func1033
 bool ShipManager::ForceDecreaseSystemPower(int sys)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1033::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1034::func;
 	return execfunc(this, sys);
 }
 
-namespace _func1034
+namespace _func1035
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14302,11 +14316,11 @@ namespace _func1034
 ShieldPower ShipManager::GetShieldPower()
 {
 	typedef ShieldPower __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1034::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1035::func;
 	return execfunc(this);
 }
 
-namespace _func1035
+namespace _func1036
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14316,11 +14330,11 @@ namespace _func1035
 int ShipManager::AddWeapon(const WeaponBlueprint *bp, int slot)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const WeaponBlueprint *bp_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1035::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1036::func;
 	return execfunc(this, bp, slot);
 }
 
-namespace _func1036
+namespace _func1037
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14330,11 +14344,11 @@ namespace _func1036
 void ShipManager::AddEquipmentFromList(std::vector<std::string> *equipmentList)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, std::vector<std::string> *equipmentList_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1036::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1037::func;
 	return execfunc(this, equipmentList);
 }
 
-namespace _func1037
+namespace _func1038
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14344,11 +14358,11 @@ namespace _func1037
 void ShipManager::RenderChargeBars()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1037::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1038::func;
 	return execfunc(this);
 }
 
-namespace _func1038
+namespace _func1039
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14356,20 +14370,6 @@ namespace _func1038
 }
 
 void ShipManager::ExportBattleState(int file)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1038::func;
-	return execfunc(this, file);
-}
-
-namespace _func1039
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("ShipManager::ImportBattleState", typeid(void (ShipManager::*)(int )), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b81c80400008b37837810ff0f84????????8b414c8d4ddc05????????", argdata, 2, 5, &func);
-}
-
-void ShipManager::ImportBattleState(int file)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1039::func;
@@ -14380,17 +14380,31 @@ namespace _func1040
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("ShipManager::ImportBattleState", typeid(void (ShipManager::*)(int )), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b81c80400008b37837810ff0f84????????8b414c8d4ddc05????????", argdata, 2, 5, &func);
+}
+
+void ShipManager::ImportBattleState(int file)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1040::func;
+	return execfunc(this, file);
+}
+
+namespace _func1041
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("ShipManager::SystemFunctions", typeid(bool (ShipManager::*)(int )), "558b81c804000089e583e4f08b55088b149031c083faff74??8b41188b0c908b01ff502c", argdata, 2, 1, &func);
 }
 
 bool ShipManager::SystemFunctions(int systemId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1040::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1041::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1041
+namespace _func1042
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14400,11 +14414,11 @@ namespace _func1041
 bool ShipManager::CanFitSystem(int systemId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1041::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1042::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1042
+namespace _func1043
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14434,11 +14448,11 @@ FUNC_NAKED bool ShipManager::CanFitSubsystem(int systemId)
 		"movl %%ebp, %%esp\n\t"
 		"popl %%ebp\n\t"
 		"ret $4\n\t"
-		 :: "m"(_func1042::func)
+		 :: "m"(_func1043::func)
 	);
 }
 
-namespace _func1043
+namespace _func1044
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14448,11 +14462,11 @@ namespace _func1043
 int ShipManager::DamageHull(int dmg, bool force)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int dmg_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1043::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1044::func;
 	return execfunc(this, dmg, force);
 }
 
-namespace _func1044
+namespace _func1045
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0xdff};
@@ -14462,11 +14476,11 @@ namespace _func1044
 void ShipManager::DamageSystem(int systemId, Damage damage)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, Damage damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1044::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1045::func;
 	return execfunc(this, systemId, damage);
 }
 
-namespace _func1045
+namespace _func1046
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14476,11 +14490,11 @@ namespace _func1045
 void ShipManager::StartFire(int roomId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1045::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1046::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1046
+namespace _func1047
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14490,11 +14504,11 @@ namespace _func1046
 CrewMember *ShipManager::FindCrew(const CrewBlueprint *bp)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const CrewBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1046::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1047::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1047
+namespace _func1048
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14504,11 +14518,11 @@ namespace _func1047
 bool ShipManager::GetDodged()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1047::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1048::func;
 	return execfunc(this);
 }
 
-namespace _func1048
+namespace _func1049
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14518,11 +14532,11 @@ namespace _func1048
 void ShipManager::PrepareSuperBarrage()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1048::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1049::func;
 	return execfunc(this);
 }
 
-namespace _func1049
+namespace _func1050
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -14532,11 +14546,11 @@ namespace _func1049
 std::string ShipManager::GetTooltip(int x, int y)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1049::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1050::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1050
+namespace _func1051
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14546,11 +14560,11 @@ namespace _func1050
 bool ShipManager::RestoreCrewPositions()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1050::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1051::func;
 	return execfunc(this);
 }
 
-namespace _func1051
+namespace _func1052
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14560,11 +14574,11 @@ namespace _func1051
 CrewMember *ShipManager::GetCrewmember(int slot, bool present)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int slot_arg, bool present_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1051::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1052::func;
 	return execfunc(this, slot, present);
 }
 
-namespace _func1052
+namespace _func1053
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14574,11 +14588,11 @@ namespace _func1052
 int ShipManager::CanUpgrade(int systemId, int amount)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1052::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1053::func;
 	return execfunc(this, systemId, amount);
 }
 
-namespace _func1053
+namespace _func1054
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14588,11 +14602,11 @@ namespace _func1053
 ShipBlueprint ShipManager::SaveToBlueprint(bool unk)
 {
 	typedef ShipBlueprint __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1053::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1054::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1054
+namespace _func1055
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -14602,11 +14616,11 @@ namespace _func1054
 void ShipManager::CheckCrystalAugment(Pointf pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1054::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1055::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1055
+namespace _func1056
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -14616,11 +14630,11 @@ namespace _func1055
 CollisionResponse ShipManager::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1055::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1056::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func1056
+namespace _func1057
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14630,11 +14644,11 @@ namespace _func1056
 int ShipManager::GetSystemPowerMax(int systemId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1056::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1057::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1057
+namespace _func1058
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14644,11 +14658,11 @@ namespace _func1057
 std::vector<Drone*> ShipManager::GetDroneList()
 {
 	typedef std::vector<Drone*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1057::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1058::func;
 	return execfunc(this);
 }
 
-namespace _func1058
+namespace _func1059
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14658,11 +14672,11 @@ namespace _func1058
 int ShipManager::GetDroneCount()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1058::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1059::func;
 	return execfunc(this);
 }
 
-namespace _func1059
+namespace _func1060
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14672,11 +14686,11 @@ namespace _func1059
 void ShipManager::InstantPowerShields()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1059::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1060::func;
 	return execfunc(this);
 }
 
-namespace _func1060
+namespace _func1061
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14686,11 +14700,11 @@ namespace _func1060
 void ShipManager::SetDestroyed()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1060::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1061::func;
 	return execfunc(this);
 }
 
-namespace _func1061
+namespace _func1062
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14700,11 +14714,11 @@ namespace _func1061
 int ShipManager::GetFireCount(int roomId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1061::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1062::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1062
+namespace _func1063
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14714,11 +14728,11 @@ namespace _func1062
 bool ShipManager::DoorsFunction()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1062::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1063::func;
 	return execfunc(this);
 }
 
-namespace _func1063
+namespace _func1064
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14728,11 +14742,11 @@ namespace _func1063
 std::vector<CrewMember*> ShipManager::GetLeavingCrew(bool intruders)
 {
 	typedef std::vector<CrewMember*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1063::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1064::func;
 	return execfunc(this, intruders);
 }
 
-namespace _func1064
+namespace _func1065
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -14742,11 +14756,11 @@ namespace _func1064
 CollisionResponse ShipManager::CollisionShield(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1064::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1065::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func1065
+namespace _func1066
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14756,11 +14770,11 @@ namespace _func1065
 bool ShipManager::IsCloaked()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1065::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1066::func;
 	return execfunc(this);
 }
 
-namespace _func1066
+namespace _func1067
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14770,11 +14784,11 @@ namespace _func1066
 void ShipManager::UpgradeSystem(int id, int amount)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int id_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1066::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1067::func;
 	return execfunc(this, id, amount);
 }
 
-namespace _func1067
+namespace _func1068
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14784,11 +14798,11 @@ namespace _func1067
 int ShipManager::CountPlayerCrew()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1067::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1068::func;
 	return execfunc(this);
 }
 
-namespace _func1068
+namespace _func1069
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14798,11 +14812,11 @@ namespace _func1068
 void ShipManager::Wait()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1068::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1069::func;
 	return execfunc(this);
 }
 
-namespace _func1069
+namespace _func1070
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14812,11 +14826,11 @@ namespace _func1069
 int ShipObject::HasAugmentation(const std::string &augment)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1069::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1070::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1070
+namespace _func1071
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14826,11 +14840,11 @@ namespace _func1070
 float ShipObject::GetAugmentationValue(const std::string &augment)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1070::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1071::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1071
+namespace _func1072
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14840,11 +14854,11 @@ namespace _func1071
 void ShipObject::RemoveAugmentation(const std::string &augment)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1071::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1072::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1072
+namespace _func1073
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14854,11 +14868,11 @@ namespace _func1072
 int ShipObject::HasEquipment(const std::string &equip)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1072::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1073::func;
 	return execfunc(this, equip);
 }
 
-namespace _func1073
+namespace _func1074
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14868,11 +14882,11 @@ namespace _func1073
 std::vector<std::string> ShipObject::GetAugmentationList()
 {
 	typedef std::vector<std::string> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1073::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1074::func;
 	return execfunc(this);
 }
 
-namespace _func1074
+namespace _func1075
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14882,18 +14896,18 @@ namespace _func1074
 bool ShipObject::AddAugmentation(const std::string &augment)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1074::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1075::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1075
+namespace _func1076
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("ShipObject::__DO_NOT_HOOK", typeid(void (ShipObject::*)()), "89b5a4feffffe9????????c70424????????e8????????89c60fb68590feffff89f1894424088b8594feffff894424048b858cfeffff890424", argdata, 0, 4, &func);
 }
 
-namespace _func1076
+namespace _func1077
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14903,11 +14917,11 @@ namespace _func1076
 int ShipObject::GetAugmentationCount()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1076::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1077::func;
 	return execfunc(this);
 }
 
-namespace _func1077
+namespace _func1078
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14917,18 +14931,18 @@ namespace _func1077
 void ShipObject::ClearShipInfo()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1077::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1078::func;
 	return execfunc(this);
 }
 
 ShipInfo **Global_ShipObject_ShipInfoList;
 
-namespace _var1078
+namespace _var1079
 {
     static VariableDefinition varObj("Global_ShipObject_ShipInfoList", "!6bc0340305(???????\?)8b4030c3", &Global_ShipObject_ShipInfoList);
 }
 
-namespace _func1079
+namespace _func1080
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14938,11 +14952,11 @@ namespace _func1079
 void ShipSelect::SelectShip(int shipType)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, int shipType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1079::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1080::func;
 	return execfunc(this, shipType);
 }
 
-namespace _func1080
+namespace _func1081
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14952,11 +14966,11 @@ namespace _func1080
 void ShipSelect::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1080::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1081::func;
 	return execfunc(this);
 }
 
-namespace _func1081
+namespace _func1082
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14966,11 +14980,11 @@ namespace _func1081
 void ShipSelect::ClearShipButtons()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1081::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1082::func;
 	return execfunc(this);
 }
 
-namespace _func1082
+namespace _func1083
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14980,11 +14994,11 @@ namespace _func1082
 void ShipSelect::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1082::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1083::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1083
+namespace _func1084
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14994,11 +15008,11 @@ namespace _func1083
 void ShipSelect::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1083::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1084::func;
 	return execfunc(this);
 }
 
-namespace _func1084
+namespace _func1085
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15008,11 +15022,11 @@ namespace _func1084
 int ShipSelect::KeyDown(SDLKey key)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1084::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1085::func;
 	return execfunc(this, key);
 }
 
-namespace _func1085
+namespace _func1086
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15022,11 +15036,11 @@ namespace _func1085
 void ShipSelect::MouseClick()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1085::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1086::func;
 	return execfunc(this);
 }
 
-namespace _func1086
+namespace _func1087
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15036,11 +15050,11 @@ namespace _func1086
 void ShipSelect::PreSelectShip(int shipType)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, int shipType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1086::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1087::func;
 	return execfunc(this, shipType);
 }
 
-namespace _func1087
+namespace _func1088
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15050,11 +15064,11 @@ namespace _func1087
 void ShipSelect::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1087::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1088::func;
 	return execfunc(this);
 }
 
-namespace _func1088
+namespace _func1089
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15064,11 +15078,11 @@ namespace _func1088
 int ShipSelect::GetSelectedShip()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1088::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1089::func;
 	return execfunc(this);
 }
 
-namespace _func1089
+namespace _func1090
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15078,11 +15092,11 @@ namespace _func1089
 void ShipSelect::Open(int currentId, int currentType)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, int currentId_arg, int currentType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1089::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1090::func;
 	return execfunc(this, currentId, currentType);
 }
 
-namespace _func1090
+namespace _func1091
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15092,11 +15106,11 @@ namespace _func1090
 void ShipSelect::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1090::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1091::func;
 	return execfunc(this);
 }
 
-namespace _func1091
+namespace _func1092
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15106,11 +15120,11 @@ namespace _func1091
 void ShipStatus::RenderHealth(bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1091::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1092::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1092
+namespace _func1093
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -15120,11 +15134,11 @@ namespace _func1092
 void ShipStatus::OnInit(Point unk, float unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipStatus *this_arg, Point unk_arg, float unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1092::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1093::func;
 	return execfunc(this, unk, unk2);
 }
 
-namespace _func1093
+namespace _func1094
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15134,11 +15148,11 @@ namespace _func1093
 void ShipStatus::RenderEvadeOxygen(bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1093::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1094::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1094
+namespace _func1095
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15148,11 +15162,11 @@ namespace _func1094
 void ShipStatus::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1094::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1095::func;
 	return execfunc(this);
 }
 
-namespace _func1095
+namespace _func1096
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15184,11 +15198,11 @@ FUNC_NAKED void ShipStatus::RenderShields(bool renderText)
 		"movl %%ebp, %%esp\n\t"
 		"popl %%ebp\n\t"
 		"ret $4\n\t"
-		 :: "m"(_func1095::func)
+		 :: "m"(_func1096::func)
 	);
 }
 
-namespace _func1096
+namespace _func1097
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15198,11 +15212,11 @@ namespace _func1096
 void ShipStatus::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1096::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1097::func;
 	return execfunc(this);
 }
 
-namespace _func1097
+namespace _func1098
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15212,11 +15226,11 @@ namespace _func1097
 bool ShipSystem::DamageOverTime(float unk)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, float unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1097::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1098::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1098
+namespace _func1099
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15226,11 +15240,11 @@ namespace _func1098
 void ShipSystem::CheckForRepower()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1098::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1099::func;
 	return execfunc(this);
 }
 
-namespace _func1099
+namespace _func1100
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15240,11 +15254,11 @@ namespace _func1099
 int ShipSystem::NameToSystemId(const std::string &name)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1099::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1100::func;
 	return execfunc(name);
 }
 
-namespace _func1100
+namespace _func1101
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15254,11 +15268,11 @@ namespace _func1100
 int ShipSystem::IsMannedBoost()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1100::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1101::func;
 	return execfunc(this);
 }
 
-namespace _func1101
+namespace _func1102
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15268,11 +15282,11 @@ namespace _func1101
 std::string ShipSystem::SystemIdToName(int systemId)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1101::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1102::func;
 	return execfunc(systemId);
 }
 
-namespace _func1102
+namespace _func1103
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15282,11 +15296,11 @@ namespace _func1102
 void ShipSystem::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1102::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1103::func;
 	return execfunc(this);
 }
 
-namespace _func1103
+namespace _func1104
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15296,11 +15310,11 @@ namespace _func1103
 bool ShipSystem::Ioned(int num)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int num_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1103::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1104::func;
 	return execfunc(this, num);
 }
 
-namespace _func1104
+namespace _func1105
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15310,11 +15324,11 @@ namespace _func1104
 int ShipSystem::SetPowerLoss(int power)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int power_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1104::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1105::func;
 	return execfunc(this, power);
 }
 
-namespace _func1105
+namespace _func1106
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -15324,11 +15338,11 @@ namespace _func1105
 void ShipSystem::constructor(int systemId, int roomId, int shipId, int startingPower)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int systemId_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1105::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1106::func;
 	return execfunc(this, systemId, roomId, shipId, startingPower);
 }
 
-namespace _func1106
+namespace _func1107
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15338,11 +15352,11 @@ namespace _func1106
 int ShipSystem::GetPowerCap()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1106::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1107::func;
 	return execfunc(this);
 }
 
-namespace _func1107
+namespace _func1108
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15352,11 +15366,11 @@ namespace _func1107
 void ShipSystem::SetPowerCap(int cap)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int cap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1107::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1108::func;
 	return execfunc(this, cap);
 }
 
-namespace _func1108
+namespace _func1109
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15366,11 +15380,11 @@ namespace _func1108
 void ShipSystem::LockSystem(int lock)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1108::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1109::func;
 	return execfunc(this, lock);
 }
 
-namespace _func1109
+namespace _func1110
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15380,11 +15394,11 @@ namespace _func1109
 bool ShipSystem::ForceDecreasePower(int powerLoss)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int powerLoss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1109::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1110::func;
 	return execfunc(this, powerLoss);
 }
 
-namespace _func1110
+namespace _func1111
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15394,11 +15408,11 @@ namespace _func1110
 int ShipSystem::GetEffectivePower()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1110::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1111::func;
 	return execfunc(this);
 }
 
-namespace _func1111
+namespace _func1112
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15408,11 +15422,11 @@ namespace _func1111
 int ShipSystem::GetMaxPower()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1111::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1112::func;
 	return execfunc(this);
 }
 
-namespace _func1112
+namespace _func1113
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15422,11 +15436,11 @@ namespace _func1112
 void ShipSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1112::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1113::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func1113
+namespace _func1114
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15436,18 +15450,18 @@ namespace _func1113
 void ShipSystem::CheckMaxPower()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1113::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1114::func;
 	return execfunc(this);
 }
 
-namespace _func1114
+namespace _func1115
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("ShipSystem::__DO_NOT_HOOK", typeid(void (ShipSystem::*)()), "55c701????????89e583e4f0e8????????c9c390909090909090909090909090b8????????", argdata, 1, 5, &func);
 }
 
-namespace _func1115
+namespace _func1116
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15457,11 +15471,11 @@ namespace _func1115
 bool ShipSystem::PartialDamage(float amount)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, float amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1115::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1116::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1116
+namespace _func1117
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15471,11 +15485,11 @@ namespace _func1116
 void ShipSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1116::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1117::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func1117
+namespace _func1118
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15485,11 +15499,11 @@ namespace _func1117
 bool ShipSystem::IsSubsystem(int systemType)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int systemType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1117::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1118::func;
 	return execfunc(systemType);
 }
 
-namespace _func1118
+namespace _func1119
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15499,11 +15513,11 @@ namespace _func1118
 void ShipSystem::ClearStatus()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1118::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1119::func;
 	return execfunc(this);
 }
 
-namespace _func1119
+namespace _func1120
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -15513,11 +15527,11 @@ namespace _func1119
 std::string ShipSystem::GetLevelDescription(int systemId, int level, bool tooltip)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(int systemId_arg, int level_arg, bool tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1119::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1120::func;
 	return execfunc(systemId, level, tooltip);
 }
 
-namespace _func1120
+namespace _func1121
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15527,11 +15541,11 @@ namespace _func1120
 bool ShipSystem::GetLocked()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1120::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1121::func;
 	return execfunc(this);
 }
 
-namespace _func1121
+namespace _func1122
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15541,11 +15555,11 @@ namespace _func1121
 void ShipSystem::AddLock(int lock)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1121::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1122::func;
 	return execfunc(this, lock);
 }
 
-namespace _func1122
+namespace _func1123
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15555,11 +15569,11 @@ namespace _func1122
 void ShipSystem::StopHacking()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1122::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1123::func;
 	return execfunc(this);
 }
 
-namespace _func1123
+namespace _func1124
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15567,20 +15581,6 @@ namespace _func1123
 }
 
 void ShipSystem::SaveState(int file)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1123::func;
-	return execfunc(this, file);
-}
-
-namespace _func1124
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("ShipSystem::LoadState", typeid(void (ShipSystem::*)(int )), "5589e5565389cb83e4f083ec108b7508893424e8????????89342489831c010000e8????????893424898320010000e8????????8983240100008d65f85b", argdata, 2, 5, &func);
-}
-
-void ShipSystem::LoadState(int file)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1124::func;
@@ -15591,17 +15591,31 @@ namespace _func1125
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("ShipSystem::LoadState", typeid(void (ShipSystem::*)(int )), "5589e5565389cb83e4f083ec108b7508893424e8????????89342489831c010000e8????????893424898320010000e8????????8983240100008d65f85b", argdata, 2, 5, &func);
+}
+
+void ShipSystem::LoadState(int file)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1125::func;
+	return execfunc(this, file);
+}
+
+namespace _func1126
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("ShipSystem::UpgradeSystem", typeid(bool (ShipSystem::*)(int )), "8b015589e556538b401089cb8b750883e4f03d????????75??8b810001000085c00f94c001735401b304010000", argdata, 2, 1, &func);
 }
 
 bool ShipSystem::UpgradeSystem(int amount)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1125::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1126::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1126
+namespace _func1127
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15611,11 +15625,11 @@ namespace _func1126
 bool ShipSystem::IncreasePower(int amount, bool force)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1126::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1127::func;
 	return execfunc(this, amount, force);
 }
 
-namespace _func1127
+namespace _func1128
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15625,11 +15639,11 @@ namespace _func1127
 bool ShipSystem::DecreasePower(bool force)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1127::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1128::func;
 	return execfunc(this, force);
 }
 
-namespace _func1128
+namespace _func1129
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15639,11 +15653,11 @@ namespace _func1128
 bool ShipSystem::PartialRepair(float speed, bool autoRepair)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, float speed_arg, bool autoRepair_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1128::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1129::func;
 	return execfunc(this, speed, autoRepair);
 }
 
-namespace _func1129
+namespace _func1130
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -15653,11 +15667,11 @@ namespace _func1129
 int ShipSystem::RenderPowerBoxes(int x, int y, int width, int height, int gap, int heightMod, bool flash)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int x_arg, int y_arg, int width_arg, int height_arg, int gap_arg, int heightMod_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1129::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1130::func;
 	return execfunc(this, x, y, width, height, gap, heightMod, flash);
 }
 
-namespace _func1130
+namespace _func1131
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15667,11 +15681,11 @@ namespace _func1130
 void ShipSystem::AddDamage(int amount)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1130::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1131::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1131
+namespace _func1132
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15681,11 +15695,11 @@ namespace _func1131
 void ShipSystem::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1131::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1132::func;
 	return execfunc(this);
 }
 
-namespace _func1132
+namespace _func1133
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15695,11 +15709,11 @@ namespace _func1132
 bool ShipSystem::BlockedBoosted(bool countLimit)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool countLimit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1132::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1133::func;
 	return execfunc(this, countLimit);
 }
 
-namespace _func1133
+namespace _func1134
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -15709,11 +15723,11 @@ namespace _func1133
 int ShipSystem::RenderPowerBoxesPlain(int x, int y, int width, int height, int gap, int current, int temp, int max)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int x_arg, int y_arg, int width_arg, int height_arg, int gap_arg, int current_arg, int temp_arg, int max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1133::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1134::func;
 	return execfunc(x, y, width, height, gap, current, temp, max);
 }
 
-namespace _func1134
+namespace _func1135
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15723,11 +15737,11 @@ namespace _func1134
 void ShipSystem::RenderSystemSymbol(bool forPowerUI, int forceColor)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool forPowerUI_arg, int forceColor_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1134::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1135::func;
 	return execfunc(this, forPowerUI, forceColor);
 }
 
-namespace _func1135
+namespace _func1136
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15737,116 +15751,116 @@ namespace _func1135
 TimerHelper ShipSystem::GetLockTimer()
 {
 	typedef TimerHelper __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1135::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1136::func;
 	return execfunc(this);
 }
 
 GL_Primitive **ShipSystem__glowBlue;
 
-namespace _var1136
+namespace _var1137
 {
     static VariableDefinition varObj("ShipSystem__glowBlue", "f30f11542404c7042400000000e8????????a1(???????\?)890424e8????????e8????????", &ShipSystem__glowBlue);
 }
 
 GL_Primitive **ShipSystem__glowWhite;
 
-namespace _var1137
+namespace _var1138
 {
     static VariableDefinition varObj("ShipSystem__glowWhite", "c7042400000000f30f11442404e8????????a1(???????\?)890424", &ShipSystem__glowWhite);
 }
 
 GL_Primitive **ShipSystem__glowRed;
 
-namespace _var1138
+namespace _var1139
 {
     static VariableDefinition varObj("ShipSystem__glowRed", "f30f11742404c7042400000000e8????????a1(???????\?)890424", &ShipSystem__glowRed);
 }
 
 GL_Primitive **ShipSystem__manningOutline;
 
-namespace _var1139
+namespace _var1140
 {
     static VariableDefinition varObj("ShipSystem__manningOutline", "a1(???????\?)bef0ffffffbb10000000890424e8????????", &ShipSystem__manningOutline);
 }
 
 GL_Primitive **ShipSystem__manningWhite;
 
-namespace _var1140
+namespace _var1141
 {
     static VariableDefinition varObj("ShipSystem__manningWhite", "a1(???????\?)bef0ffffffbb10000000e9????????a1(???????\?)bee8ffffffbb18000000e9????????a1(???????\?)bee8ffffffbb18000000e9????????", &ShipSystem__manningWhite);
 }
 
 GL_Primitive **ShipSystem__manningGreen;
 
-namespace _var1141
+namespace _var1142
 {
     static VariableDefinition varObj("ShipSystem__manningGreen", "", &ShipSystem__manningGreen);
 }
 
 GL_Primitive **ShipSystem__manningYellow;
 
-namespace _var1142
+namespace _var1143
 {
     static VariableDefinition varObj("ShipSystem__manningYellow", "", &ShipSystem__manningYellow);
 }
 
 GL_Primitive **ShipSystem__manningBarOn;
 
-namespace _var1143
+namespace _var1144
 {
     static VariableDefinition varObj("ShipSystem__manningBarOn", "a1(???????\?)74??c704240100000089f9f30f114dcce8????????83ec0484c0a1(???????\?)0f4505(???????\?)f30f104dcc", &ShipSystem__manningBarOn);
 }
 
 GL_Primitive **ShipSystem__manningBarOff;
 
-namespace _var1144
+namespace _var1145
 {
     static VariableDefinition varObj("ShipSystem__manningBarOff", "", &ShipSystem__manningBarOff);
 }
 
 GL_Primitive **ShipSystem__manningBarIon;
 
-namespace _var1145
+namespace _var1146
 {
     static VariableDefinition varObj("ShipSystem__manningBarIon", "", &ShipSystem__manningBarIon);
 }
 
 GL_Primitive **ShipSystem__lockBlue;
 
-namespace _var1146
+namespace _var1147
 {
     static VariableDefinition varObj("ShipSystem__lockBlue", "8b1d(???????\?)83faff895dbc0f85????????8b1d(???????\?)c745c8ff000000baff000000c745ccff000000895dbce9????????a1(???????\?)", &ShipSystem__lockBlue);
 }
 
 GL_Primitive **ShipSystem__lockWhite;
 
-namespace _var1147
+namespace _var1148
 {
     static VariableDefinition varObj("ShipSystem__lockWhite", "", &ShipSystem__lockWhite);
 }
 
 GL_Primitive **ShipSystem__lockHack;
 
-namespace _var1148
+namespace _var1149
 {
     static VariableDefinition varObj("ShipSystem__lockHack", "", &ShipSystem__lockHack);
 }
 
 GL_Primitive **ShipSystem__sabotageImage;
 
-namespace _var1149
+namespace _var1150
 {
     static VariableDefinition varObj("ShipSystem__sabotageImage", "a1(???????\?)890424e8????????c744240800000000c74424040000c0c1c7042400000000", &ShipSystem__sabotageImage);
 }
 
 GL_Primitive **ShipSystem__fireImage;
 
-namespace _var1150
+namespace _var1151
 {
     static VariableDefinition varObj("ShipSystem__fireImage", "a1(???????\?)890424e8????????c744240800000000c74424040000b0c1c7042400000000e8????????f30f105dd4", &ShipSystem__fireImage);
 }
 
-namespace _func1151
+namespace _func1152
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -15856,11 +15870,11 @@ namespace _func1151
 int SoundControl::PlaySoundMix(const std::string &soundName, float volume, bool loop)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(SoundControl *this_arg, const std::string &soundName_arg, float volume_arg, bool loop_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1151::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1152::func;
 	return execfunc(this, soundName, volume, loop);
 }
 
-namespace _func1152
+namespace _func1153
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15870,11 +15884,11 @@ namespace _func1152
 void SoundControl::StopPlaylist(int fadeOut)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SoundControl *this_arg, int fadeOut_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1152::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1153::func;
 	return execfunc(this, fadeOut);
 }
 
-namespace _func1153
+namespace _func1154
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15884,11 +15898,11 @@ namespace _func1153
 void SoundControl::StartPlaylist(std::vector<std::string> &playlist)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SoundControl *this_arg, std::vector<std::string> &playlist_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1153::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1154::func;
 	return execfunc(this, playlist);
 }
 
-namespace _func1154
+namespace _func1155
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15898,18 +15912,18 @@ namespace _func1154
 void SoundControl::UpdateSoundLoop(const std::string &loopId, float count)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SoundControl *this_arg, const std::string &loopId_arg, float count_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1154::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1155::func;
 	return execfunc(this, loopId, count);
 }
 
 SoundControl *Global_SoundControl_Sounds;
 
-namespace _var1155
+namespace _var1156
 {
     static VariableDefinition varObj("Global_SoundControl_Sounds", "!8b4b08e8????????0fb6c0b9(???????\?)890424e8????????b9", &Global_SoundControl_Sounds);
 }
 
-namespace _func1156
+namespace _func1157
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -15919,11 +15933,11 @@ namespace _func1156
 float SpaceDrone::UpdateAimingAngle(Pointf location, float percentage, float forceDesired)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Pointf location_arg, float percentage_arg, float forceDesired_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1156::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1157::func;
 	return execfunc(this, location, percentage, forceDesired);
 }
 
-namespace _func1157
+namespace _func1158
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15933,11 +15947,11 @@ namespace _func1157
 void SpaceDrone::SetDeployed(bool deployed)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, bool deployed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1157::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1158::func;
 	return execfunc(this, deployed);
 }
 
-namespace _func1158
+namespace _func1159
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15947,11 +15961,11 @@ namespace _func1158
 void SpaceDrone::SetMovementTarget(Targetable *target)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1158::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1159::func;
 	return execfunc(this, target);
 }
 
-namespace _func1159
+namespace _func1160
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -15961,11 +15975,11 @@ namespace _func1159
 CollisionResponse SpaceDrone::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1159::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1160::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func1160
+namespace _func1161
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15975,11 +15989,11 @@ namespace _func1160
 Projectile *SpaceDrone::GetNextProjectile()
 {
 	typedef Projectile *__attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1160::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1161::func;
 	return execfunc(this);
 }
 
-namespace _func1161
+namespace _func1162
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -15989,11 +16003,11 @@ namespace _func1161
 void SpaceDrone::constructor(int iShipId, int selfId, DroneBlueprint *blueprint)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, int iShipId_arg, int selfId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1161::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1162::func;
 	return execfunc(this, iShipId, selfId, blueprint);
 }
 
-namespace _func1162
+namespace _func1163
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16003,11 +16017,11 @@ namespace _func1162
 void SpaceDrone::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1162::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1163::func;
 	return execfunc(this);
 }
 
-namespace _func1163
+namespace _func1164
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16017,11 +16031,11 @@ namespace _func1163
 void SpaceManager::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1163::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1164::func;
 	return execfunc(this);
 }
 
-namespace _func1164
+namespace _func1165
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16031,11 +16045,11 @@ namespace _func1164
 int SpaceManager::GetScreenShake()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1164::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1165::func;
 	return execfunc(this);
 }
 
-namespace _func1165
+namespace _func1166
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16045,11 +16059,11 @@ namespace _func1165
 void SpaceManager::SaveSpace(int fileHelper)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1165::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1166::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1166
+namespace _func1167
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16059,11 +16073,11 @@ namespace _func1166
 ImageDesc SpaceManager::SwitchBeacon()
 {
 	typedef ImageDesc __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1166::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1167::func;
 	return execfunc(this);
 }
 
-namespace _func1167
+namespace _func1168
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -16073,11 +16087,11 @@ namespace _func1167
 ImageDesc SpaceManager::SwitchPlanet(const std::string &name)
 {
 	typedef ImageDesc __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1167::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1168::func;
 	return execfunc(this, name);
 }
 
-namespace _func1168
+namespace _func1169
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16087,11 +16101,11 @@ namespace _func1168
 void SpaceManager::UpdatePlanetImage()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1168::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1169::func;
 	return execfunc(this);
 }
 
-namespace _func1169
+namespace _func1170
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x701, 0x701, 0x701};
@@ -16101,11 +16115,11 @@ namespace _func1169
 void SpaceManager::SwitchImages(ImageDesc planet, ImageDesc unk1, ImageDesc unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, ImageDesc planet_arg, ImageDesc unk1_arg, ImageDesc unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1169::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1170::func;
 	return execfunc(this, planet, unk1, unk2);
 }
 
-namespace _func1170
+namespace _func1171
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -16115,11 +16129,11 @@ namespace _func1170
 ImageDesc SpaceManager::SwitchBackground(const std::string &name)
 {
 	typedef ImageDesc __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1170::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1171::func;
 	return execfunc(this, name);
 }
 
-namespace _func1171
+namespace _func1172
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -16129,11 +16143,11 @@ namespace _func1171
 void SpaceManager::StartAsteroids(int shieldCount, bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int shieldCount_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1171::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1172::func;
 	return execfunc(this, shieldCount, unk);
 }
 
-namespace _func1172
+namespace _func1173
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -16143,11 +16157,11 @@ namespace _func1172
 void SpaceManager::SetPlanetaryDefense(char state, int target)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, char state_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1172::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1173::func;
 	return execfunc(this, state, target);
 }
 
-namespace _func1173
+namespace _func1174
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16157,11 +16171,11 @@ namespace _func1173
 void SpaceManager::SetPulsarLevel(bool pulsarLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool pulsarLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1173::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1174::func;
 	return execfunc(this, pulsarLevel);
 }
 
-namespace _func1174
+namespace _func1175
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16171,11 +16185,11 @@ namespace _func1174
 bool SpaceManager::DangerousEnvironment()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1174::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1175::func;
 	return execfunc(this);
 }
 
-namespace _func1175
+namespace _func1176
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -16185,11 +16199,11 @@ namespace _func1175
 void SpaceManager::MouseMove(int x, int y, int unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int x_arg, int y_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1175::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1176::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func1176
+namespace _func1177
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -16199,11 +16213,11 @@ namespace _func1176
 SpaceDrone *SpaceManager::GetSelectedDrone(int x, int y, int unk)
 {
 	typedef SpaceDrone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int x_arg, int y_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1176::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1177::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func1177
+namespace _func1178
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16213,11 +16227,11 @@ namespace _func1177
 float SpaceManager::GetFlashOpacity()
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1177::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1178::func;
 	return execfunc(this);
 }
 
-namespace _func1178
+namespace _func1179
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16227,20 +16241,6 @@ namespace _func1178
 GL_Color SpaceManager::GetColorTint()
 {
 	typedef GL_Color __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1178::func;
-	return execfunc(this);
-}
-
-namespace _func1179
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::OnRenderBackground", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e55756", argdata, 1, 5, &func);
-}
-
-void SpaceManager::OnRenderBackground()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1179::func;
 	return execfunc(this);
 }
@@ -16249,10 +16249,10 @@ namespace _func1180
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::OnRenderFleet", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e557", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnRenderBackground", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e55756", argdata, 1, 5, &func);
 }
 
-void SpaceManager::OnRenderFleet()
+void SpaceManager::OnRenderBackground()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1180::func;
@@ -16263,10 +16263,10 @@ namespace _func1181
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::OnRenderForeground", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e557", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnRenderFleet", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e557", argdata, 1, 5, &func);
 }
 
-void SpaceManager::OnRenderForeground()
+void SpaceManager::OnRenderFleet()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1181::func;
@@ -16276,6 +16276,20 @@ void SpaceManager::OnRenderForeground()
 namespace _func1182
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("SpaceManager::OnRenderForeground", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e557", argdata, 1, 5, &func);
+}
+
+void SpaceManager::OnRenderForeground()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1182::func;
+	return execfunc(this);
+}
+
+namespace _func1183
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("SpaceManager::SetDangerZone", typeid(void (SpaceManager::*)(int )), ".578d7c240883e4f0ff77fc5589e557", argdata, 2, 5, &func);
 }
@@ -16283,11 +16297,11 @@ namespace _func1182
 void SpaceManager::SetDangerZone(int fleetType)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fleetType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1182::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1183::func;
 	return execfunc(this, fleetType);
 }
 
-namespace _func1183
+namespace _func1184
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -16297,11 +16311,11 @@ namespace _func1183
 void SpaceManager::OnRenderAsteroids(int fieldLayers, float unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fieldLayers_arg, float unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1183::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1184::func;
 	return execfunc(this, fieldLayers, unk2);
 }
 
-namespace _func1184
+namespace _func1185
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -16311,11 +16325,11 @@ namespace _func1184
 void SpaceManager::OnRenderProjectiles(int iShipId, int layerCommand)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int iShipId_arg, int layerCommand_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1184::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1185::func;
 	return execfunc(this, iShipId, layerCommand);
 }
 
-namespace _func1185
+namespace _func1186
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16323,20 +16337,6 @@ namespace _func1185
 }
 
 void SpaceManager::OnInit()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1185::func;
-	return execfunc(this);
-}
-
-namespace _func1186
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::Restart", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e55756", argdata, 1, 5, &func);
-}
-
-void SpaceManager::Restart()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1186::func;
@@ -16347,10 +16347,10 @@ namespace _func1187
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::ClearEnvironment", typeid(void (SpaceManager::*)()), ".c6818802000000c6818902000000c6819802000000c7819c02000002000000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::Restart", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e55756", argdata, 1, 5, &func);
 }
 
-void SpaceManager::ClearEnvironment()
+void SpaceManager::Restart()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1187::func;
@@ -16361,10 +16361,10 @@ namespace _func1188
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::Clear", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e5575653", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::ClearEnvironment", typeid(void (SpaceManager::*)()), ".c6818802000000c6818902000000c6819802000000c7819c02000002000000", argdata, 1, 5, &func);
 }
 
-void SpaceManager::Clear()
+void SpaceManager::ClearEnvironment()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1188::func;
@@ -16375,10 +16375,10 @@ namespace _func1189
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::ClearProjectiles", typeid(void (SpaceManager::*)()), ".5589e55756538b1189ce", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::Clear", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e5575653", argdata, 1, 5, &func);
 }
 
-void SpaceManager::ClearProjectiles()
+void SpaceManager::Clear()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1189::func;
@@ -16388,25 +16388,25 @@ void SpaceManager::ClearProjectiles()
 namespace _func1190
 {
     static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::UpdateProjectile", typeid(void (SpaceManager::*)(Projectile *)), ".578d7c240883e4f0ff77fc5589e557", argdata, 2, 5, &func);
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("SpaceManager::ClearProjectiles", typeid(void (SpaceManager::*)()), ".5589e55756538b1189ce", argdata, 1, 5, &func);
 }
 
-void SpaceManager::UpdateProjectile(Projectile *proj)
+void SpaceManager::ClearProjectiles()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1190::func;
-	return execfunc(this, proj);
+	return execfunc(this);
 }
 
 namespace _func1191
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::TransferProjectile", typeid(void (SpaceManager::*)(Projectile *)), ".5589e556538b5d0883e4f0", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::UpdateProjectile", typeid(void (SpaceManager::*)(Projectile *)), ".578d7c240883e4f0ff77fc5589e557", argdata, 2, 5, &func);
 }
 
-void SpaceManager::TransferProjectile(Projectile *proj)
+void SpaceManager::UpdateProjectile(Projectile *proj)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1191::func;
@@ -16417,17 +16417,31 @@ namespace _func1192
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("SpaceManager::TransferProjectile", typeid(void (SpaceManager::*)(Projectile *)), ".5589e556538b5d0883e4f0", argdata, 2, 5, &func);
+}
+
+void SpaceManager::TransferProjectile(Projectile *proj)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1192::func;
+	return execfunc(this, proj);
+}
+
+namespace _func1193
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("SpaceManager::AddShip", typeid(void (SpaceManager::*)(ShipManager *)), ".578d7c240883e4f0ff77fc5589f8", argdata, 2, 5, &func);
 }
 
 void SpaceManager::AddShip(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1192::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1193::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1193
+namespace _func1194
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16437,11 +16451,11 @@ namespace _func1193
 void SpaceManager::AddProjectile(Projectile *proj)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1193::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1194::func;
 	return execfunc(this, proj);
 }
 
-namespace _func1194
+namespace _func1195
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16451,11 +16465,11 @@ namespace _func1194
 void SpaceManager::LoadSpace(int fileHelper)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1194::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1195::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1195
+namespace _func1196
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16463,20 +16477,6 @@ namespace _func1195
 }
 
 void SpaceManager::UpdatePDS()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1195::func;
-	return execfunc(this);
-}
-
-namespace _func1196
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::OnLoopNebulas", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e5", argdata, 1, 5, &func);
-}
-
-void SpaceManager::OnLoopNebulas()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1196::func;
@@ -16487,10 +16487,10 @@ namespace _func1197
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::OnLoop", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e557", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnLoopNebulas", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e5", argdata, 1, 5, &func);
 }
 
-void SpaceManager::OnLoop()
+void SpaceManager::OnLoopNebulas()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1197::func;
@@ -16500,25 +16500,25 @@ void SpaceManager::OnLoop()
 namespace _func1198
 {
     static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::SetNebula", typeid(void (SpaceManager::*)(bool )), ".578d7c240883e4f0ff77fc5589e55756", argdata, 2, 5, &func);
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("SpaceManager::OnLoop", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e557", argdata, 1, 5, &func);
 }
 
-void SpaceManager::SetNebula(bool state)
+void SpaceManager::OnLoop()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1198::func;
-	return execfunc(this, state);
+	return execfunc(this);
 }
 
 namespace _func1199
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::SetStorm", typeid(void (SpaceManager::*)(bool )), ".578d7c240883e4f0ff77fc5589e5", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::SetNebula", typeid(void (SpaceManager::*)(bool )), ".578d7c240883e4f0ff77fc5589e55756", argdata, 2, 5, &func);
 }
 
-void SpaceManager::SetStorm(bool state)
+void SpaceManager::SetNebula(bool state)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1199::func;
@@ -16529,10 +16529,10 @@ namespace _func1200
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::SetFireLevel", typeid(void (SpaceManager::*)(bool )), "578d7c240883e4f0ff77fc5589f889e55756538d99b802000089cf8d75d083ec3c8b0088818802000089d9", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::SetStorm", typeid(void (SpaceManager::*)(bool )), ".578d7c240883e4f0ff77fc5589e5", argdata, 2, 5, &func);
 }
 
-void SpaceManager::SetFireLevel(bool state)
+void SpaceManager::SetStorm(bool state)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1200::func;
@@ -16542,6 +16542,20 @@ void SpaceManager::SetFireLevel(bool state)
 namespace _func1201
 {
     static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("SpaceManager::SetFireLevel", typeid(void (SpaceManager::*)(bool )), "578d7c240883e4f0ff77fc5589f889e55756538d99b802000089cf8d75d083ec3c8b0088818802000089d9", argdata, 2, 5, &func);
+}
+
+void SpaceManager::SetFireLevel(bool state)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1201::func;
+	return execfunc(this, state);
+}
+
+namespace _func1202
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff};
 	static FunctionDefinition funcObj("SpaceStatus::OnInit", typeid(void (SpaceStatus::*)(SpaceManager *, Point )), "578d????0883e4??ff????5589e557565389cb89de81ec????????", argdata, 3, 5, &func);
 }
@@ -16549,11 +16563,11 @@ namespace _func1201
 void SpaceStatus::OnInit(SpaceManager *space, Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg, SpaceManager *space_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1201::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1202::func;
 	return execfunc(this, space, pos);
 }
 
-namespace _func1202
+namespace _func1203
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -16563,11 +16577,11 @@ namespace _func1202
 void SpaceStatus::RenderWarningText(int effect, int textOffset)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg, int effect_arg, int textOffset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1202::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1203::func;
 	return execfunc(this, effect, textOffset);
 }
 
-namespace _func1203
+namespace _func1204
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16577,11 +16591,11 @@ namespace _func1203
 void SpaceStatus::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1203::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1204::func;
 	return execfunc(this);
 }
 
-namespace _func1204
+namespace _func1205
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -16591,11 +16605,11 @@ namespace _func1204
 void SpaceStatus::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1204::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1205::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1205
+namespace _func1206
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -16605,11 +16619,11 @@ namespace _func1205
 void StarMap::SetPosition(Point unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1205::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1206::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1206
+namespace _func1207
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16619,11 +16633,11 @@ namespace _func1206
 void StarMap::KeyDown(int unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1206::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1207::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1207
+namespace _func1208
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16633,11 +16647,11 @@ namespace _func1207
 int StarMap::GetNextDangerMove()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1207::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1208::func;
 	return execfunc(this);
 }
 
-namespace _func1208
+namespace _func1209
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16647,11 +16661,11 @@ namespace _func1208
 void StarMap::Open()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1208::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1209::func;
 	return execfunc(this);
 }
 
-namespace _func1209
+namespace _func1210
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16661,11 +16675,11 @@ namespace _func1209
 void StarMap::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1209::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1210::func;
 	return execfunc(this);
 }
 
-namespace _func1210
+namespace _func1211
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16675,11 +16689,11 @@ namespace _func1210
 void StarMap::SetOpen(bool unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, bool unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1210::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1211::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1211
+namespace _func1212
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16687,20 +16701,6 @@ namespace _func1211
 }
 
 void StarMap::InitMapTitle()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1211::func;
-	return execfunc(this);
-}
-
-namespace _func1212
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::InitNoFuelText", typeid(void (StarMap::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb8d", argdata, 1, 5, &func);
-}
-
-void StarMap::InitNoFuelText()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1212::func;
@@ -16711,10 +16711,10 @@ namespace _func1213
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::InitBossMessageBox", typeid(void (StarMap::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb83", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("StarMap::InitNoFuelText", typeid(void (StarMap::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb8d", argdata, 1, 5, &func);
 }
 
-void StarMap::InitBossMessageBox()
+void StarMap::InitNoFuelText()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1213::func;
@@ -16725,10 +16725,10 @@ namespace _func1214
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::OnLanguageChange", typeid(void (StarMap::*)()), ".5589e55389cb83e4f0e812f7ffff89d9e8ebfaff", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("StarMap::InitBossMessageBox", typeid(void (StarMap::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb83", argdata, 1, 5, &func);
 }
 
-void StarMap::OnLanguageChange()
+void StarMap::InitBossMessageBox()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1214::func;
@@ -16739,17 +16739,31 @@ namespace _func1215
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("StarMap::OnLanguageChange", typeid(void (StarMap::*)()), ".5589e55389cb83e4f0e812f7ffff89d9e8ebfaff", argdata, 1, 5, &func);
+}
+
+void StarMap::OnLanguageChange()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1215::func;
+	return execfunc(this);
+}
+
+namespace _func1216
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("StarMap::GetRandomSectorChoice", typeid(int (StarMap::*)()), ".5589e583e4f0803d????????007435e8a46e1500", argdata, 1, 1, &func);
 }
 
 int StarMap::GetRandomSectorChoice()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1215::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1216::func;
 	return execfunc(this);
 }
 
-namespace _func1216
+namespace _func1217
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16759,11 +16773,11 @@ namespace _func1216
 void StarMap::NeighboringSector(int unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1216::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1217::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1217
+namespace _func1218
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -16773,11 +16787,11 @@ namespace _func1217
 void StarMap::GetSelectedSector(int unk0, int unk1, int unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg, int unk1_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1217::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1218::func;
 	return execfunc(this, unk0, unk1, unk2);
 }
 
-namespace _func1218
+namespace _func1219
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16787,11 +16801,11 @@ namespace _func1218
 void StarMap::StartSecretSector()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1218::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1219::func;
 	return execfunc(this);
 }
 
-namespace _func1219
+namespace _func1220
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16799,20 +16813,6 @@ namespace _func1219
 }
 
 void StarMap::ReachSector(Sector *unk0)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1219::func;
-	return execfunc(this, unk0);
-}
-
-namespace _func1220
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("StarMap::UpdateSectorMap", typeid(void (StarMap::*)(Sector *)), ".578d7c240883e4f0ff77fc5589f889e557565389", argdata, 2, 5, &func);
-}
-
-void StarMap::UpdateSectorMap(Sector *unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1220::func;
@@ -16823,17 +16823,31 @@ namespace _func1221
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("StarMap::UpdateSectorMap", typeid(void (StarMap::*)(Sector *)), ".578d7c240883e4f0ff77fc5589f889e557565389", argdata, 2, 5, &func);
+}
+
+void StarMap::UpdateSectorMap(Sector *unk0)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1221::func;
+	return execfunc(this, unk0);
+}
+
+namespace _func1222
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::SaveGame", typeid(void (StarMap::*)(int )), ".578d7c240883e4f0ff77fc5589f889e557565389", argdata, 2, 5, &func);
 }
 
 void StarMap::SaveGame(int file)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1221::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1222::func;
 	return execfunc(this, file);
 }
 
-namespace _func1222
+namespace _func1223
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16841,20 +16855,6 @@ namespace _func1222
 }
 
 void StarMap::InitStatistics()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1222::func;
-	return execfunc(this);
-}
-
-namespace _func1223
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::PrintStatistics", typeid(void (StarMap::*)()), ".f3c38db426000000008dbc2700000000f3c38db4", argdata, 1, 5, &func);
-}
-
-void StarMap::PrintStatistics()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1223::func;
@@ -16865,10 +16865,10 @@ namespace _func1224
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::AnalyzeMap", typeid(void (StarMap::*)()), ".f3c38db426000000008dbc27000000008b442404", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("StarMap::PrintStatistics", typeid(void (StarMap::*)()), ".f3c38db426000000008dbc2700000000f3c38db4", argdata, 1, 5, &func);
 }
 
-void StarMap::AnalyzeMap()
+void StarMap::PrintStatistics()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1224::func;
@@ -16878,6 +16878,20 @@ void StarMap::AnalyzeMap()
 namespace _func1225
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("StarMap::AnalyzeMap", typeid(void (StarMap::*)()), ".f3c38db426000000008dbc27000000008b442404", argdata, 1, 5, &func);
+}
+
+void StarMap::AnalyzeMap()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1225::func;
+	return execfunc(this);
+}
+
+namespace _func1226
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::ModifyPursuit", typeid(void (StarMap::*)(int )), ".8b442404018198040000c2040090669031c083b9", argdata, 2, 5, &func);
 }
@@ -16885,11 +16899,11 @@ namespace _func1225
 void StarMap::ModifyPursuit(int unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1225::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1226::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1226
+namespace _func1227
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16897,20 +16911,6 @@ namespace _func1226
 }
 
 void StarMap::AtBeacon()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1226::func;
-	return execfunc(this);
-}
-
-namespace _func1227
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::GetWaitLocation", typeid(void (StarMap::*)()), ".80797c00741a80b9ac060000007411c6417c00c6", argdata, 1, 5, &func);
-}
-
-void StarMap::GetWaitLocation()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1227::func;
@@ -16921,10 +16921,10 @@ namespace _func1228
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::StartBeacon", typeid(void (StarMap::*)()), ".8b919004000031c085d27e04c38d760056538b71", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("StarMap::GetWaitLocation", typeid(void (StarMap::*)()), ".80797c00741a80b9ac060000007411c6417c00c6", argdata, 1, 5, &func);
 }
 
-void StarMap::StartBeacon()
+void StarMap::GetWaitLocation()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1228::func;
@@ -16934,6 +16934,20 @@ void StarMap::StartBeacon()
 namespace _func1229
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("StarMap::StartBeacon", typeid(void (StarMap::*)()), ".8b919004000031c085d27e04c38d760056538b71", argdata, 1, 5, &func);
+}
+
+void StarMap::StartBeacon()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1229::func;
+	return execfunc(this);
+}
+
+namespace _func1230
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::LocationsConnected", typeid(void (StarMap::*)(Location *, Location *)), ".538b4424088b5c240c8b48088b500c29cac1fa02", argdata, 3, 5, &func);
 }
@@ -16941,11 +16955,11 @@ namespace _func1229
 void StarMap::LocationsConnected(Location *unk0, Location *unk1)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg, Location *unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1229::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1230::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1230
+namespace _func1231
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -16955,11 +16969,11 @@ namespace _func1230
 Point StarMap::PointToGrid(float x, float y)
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, float x_arg, float y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1230::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1231::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1231
+namespace _func1232
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16969,11 +16983,11 @@ namespace _func1231
 void StarMap::TravelToLocation(Location *unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1231::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1232::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1232
+namespace _func1233
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16983,11 +16997,11 @@ namespace _func1232
 void StarMap::ForceExitBeacon()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1232::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1233::func;
 	return execfunc(this);
 }
 
-namespace _func1233
+namespace _func1234
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16997,11 +17011,11 @@ namespace _func1233
 void StarMap::OnRenderFogEffect()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1233::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1234::func;
 	return execfunc(this);
 }
 
-namespace _func1234
+namespace _func1235
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17009,20 +17023,6 @@ namespace _func1234
 }
 
 void StarMap::LocationHasBoss(Location *unk0)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1234::func;
-	return execfunc(this, unk0);
-}
-
-namespace _func1235
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("StarMap::LocationHasStore", typeid(void (StarMap::*)(Location *)), ".56538b54240c8b422085c074258b801c06000085", argdata, 2, 5, &func);
-}
-
-void StarMap::LocationHasStore(Location *unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1235::func;
@@ -17033,10 +17033,10 @@ namespace _func1236
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("StarMap::LocationHasShip", typeid(void (StarMap::*)(Location *)), ".8b4424048b402085c074070fb6401cc2040031c0", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("StarMap::LocationHasStore", typeid(void (StarMap::*)(Location *)), ".56538b54240c8b422085c074258b801c06000085", argdata, 2, 5, &func);
 }
 
-void StarMap::LocationHasShip(Location *unk0)
+void StarMap::LocationHasStore(Location *unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1236::func;
@@ -17046,25 +17046,25 @@ void StarMap::LocationHasShip(Location *unk0)
 namespace _func1237
 {
     static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::AdvanceWorldLevel", typeid(void (StarMap::*)()), ".8b819004000083c00183f8038981900400007f01", argdata, 1, 5, &func);
+	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("StarMap::LocationHasShip", typeid(void (StarMap::*)(Location *)), ".8b4424048b402085c074070fb6401cc2040031c0", argdata, 2, 5, &func);
 }
 
-void StarMap::AdvanceWorldLevel()
+void StarMap::LocationHasShip(Location *unk0)
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1237::func;
-	return execfunc(this);
+	return execfunc(this, unk0);
 }
 
 namespace _func1238
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::ReverseBossPath", typeid(void (StarMap::*)()), ".568b8174080000538b997808000080b170080000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("StarMap::AdvanceWorldLevel", typeid(void (StarMap::*)()), ".8b819004000083c00183f8038981900400007f01", argdata, 1, 5, &func);
 }
 
-void StarMap::ReverseBossPath()
+void StarMap::AdvanceWorldLevel()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1238::func;
@@ -17075,10 +17075,10 @@ namespace _func1239
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::ForceBossJump", typeid(void (StarMap::*)()), ".80b97008000000c6817108000001751a8b817808", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("StarMap::ReverseBossPath", typeid(void (StarMap::*)()), ".568b8174080000538b997808000080b170080000", argdata, 1, 5, &func);
 }
 
-void StarMap::ForceBossJump()
+void StarMap::ReverseBossPath()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1239::func;
@@ -17089,10 +17089,10 @@ namespace _func1240
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::ClearBoss", typeid(void (StarMap::*)()), ".578d7c240883e4f0ff77fc5589e557565331db89", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("StarMap::ForceBossJump", typeid(void (StarMap::*)()), ".80b97008000000c6817108000001751a8b817808", argdata, 1, 5, &func);
 }
 
-void StarMap::ClearBoss()
+void StarMap::ForceBossJump()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1240::func;
@@ -17102,6 +17102,20 @@ void StarMap::ClearBoss()
 namespace _func1241
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("StarMap::ClearBoss", typeid(void (StarMap::*)()), ".578d7c240883e4f0ff77fc5589e557565331db89", argdata, 1, 5, &func);
+}
+
+void StarMap::ClearBoss()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1241::func;
+	return execfunc(this);
+}
+
+namespace _func1242
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::SetBossStage", typeid(void (StarMap::*)(int )), ".8b4424048981e4090000c2040090669031c083b9", argdata, 2, 5, &func);
 }
@@ -17109,11 +17123,11 @@ namespace _func1241
 void StarMap::SetBossStage(int stage)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int stage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1241::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1242::func;
 	return execfunc(this, stage);
 }
 
-namespace _func1242
+namespace _func1243
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17121,20 +17135,6 @@ namespace _func1242
 }
 
 void StarMap::CheckGameOver()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1242::func;
-	return execfunc(this);
-}
-
-namespace _func1243
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::RenderLabels", typeid(void (StarMap::*)()), ".578d7c240883e4f0ff77fc5589e557565389cf81", argdata, 1, 5, &func);
-}
-
-void StarMap::RenderLabels()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1243::func;
@@ -17145,10 +17145,10 @@ namespace _func1244
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::DeleteMap", typeid(void (StarMap::*)()), ".578d7c240883e4f0ff77fc5589e557565389ce83ec2c8b81d80900008b99dc09000039d8", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("StarMap::RenderLabels", typeid(void (StarMap::*)()), ".578d7c240883e4f0ff77fc5589e557565389cf81", argdata, 1, 5, &func);
 }
 
-void StarMap::DeleteMap()
+void StarMap::RenderLabels()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1244::func;
@@ -17158,6 +17158,20 @@ void StarMap::DeleteMap()
 namespace _func1245
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("StarMap::DeleteMap", typeid(void (StarMap::*)()), ".578d7c240883e4f0ff77fc5589e557565389ce83ec2c8b81d80900008b99dc09000039d8", argdata, 1, 5, &func);
+}
+
+void StarMap::DeleteMap()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1245::func;
+	return execfunc(this);
+}
+
+namespace _func1246
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::MouseClick", typeid(void (StarMap::*)(int , int )), ".578d7c240883e4f0ff77fc5589e557565389cb83", argdata, 3, 5, &func);
 }
@@ -17165,11 +17179,11 @@ namespace _func1245
 void StarMap::MouseClick(int unk0, int unk1)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg, int unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1245::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1246::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1246
+namespace _func1247
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17179,11 +17193,11 @@ namespace _func1246
 void StarMap::AddSectorColumn()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1246::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1247::func;
 	return execfunc(this);
 }
 
-namespace _func1247
+namespace _func1248
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17193,11 +17207,11 @@ namespace _func1247
 void StarMap::PushSectorColumn()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1247::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1248::func;
 	return execfunc(this);
 }
 
-namespace _func1248
+namespace _func1249
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17207,11 +17221,11 @@ namespace _func1248
 void StarMap::SelectNewSector(int unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1248::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1249::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1249
+namespace _func1250
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17221,11 +17235,11 @@ namespace _func1249
 void StarMap::GenerateSectorMap()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1249::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1250::func;
 	return execfunc(this);
 }
 
-namespace _func1250
+namespace _func1251
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17235,11 +17249,11 @@ namespace _func1250
 void StarMap::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1250::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1251::func;
 	return execfunc(this);
 }
 
-namespace _func1251
+namespace _func1252
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x4ff};
@@ -17249,11 +17263,11 @@ namespace _func1251
 void StarMap::RenderSectorName(Sector *unk0, GL_Color unk1)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg, GL_Color unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1251::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1252::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1252
+namespace _func1253
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17263,11 +17277,11 @@ namespace _func1252
 void StarMap::UpdateDangerZone()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1252::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1253::func;
 	return execfunc(this);
 }
 
-namespace _func1253
+namespace _func1254
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17277,11 +17291,11 @@ namespace _func1253
 Location *StarMap::GetNewLocation()
 {
 	typedef Location *__attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1253::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1254::func;
 	return execfunc(this);
 }
 
-namespace _func1254
+namespace _func1255
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17291,11 +17305,11 @@ namespace _func1254
 void StarMap::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1254::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1255::func;
 	return execfunc(this);
 }
 
-namespace _func1255
+namespace _func1256
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17305,11 +17319,11 @@ namespace _func1255
 void StarMap::GenerateEvents(bool tutorial)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, bool tutorial_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1255::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1256::func;
 	return execfunc(this, tutorial);
 }
 
-namespace _func1256
+namespace _func1257
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17319,11 +17333,11 @@ namespace _func1256
 void StarMap::AddConnections(Location *unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1256::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1257::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1257
+namespace _func1258
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17333,11 +17347,11 @@ namespace _func1257
 void StarMap::MapConnected()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1257::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1258::func;
 	return execfunc(this);
 }
 
-namespace _func1258
+namespace _func1259
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x2ff};
@@ -17347,11 +17361,11 @@ namespace _func1258
 void StarMap::ConnectLocations(Point unk0, Point unk1)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg, Point unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1258::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1259::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1259
+namespace _func1260
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -17361,11 +17375,11 @@ namespace _func1259
 void StarMap::PopulateGrid(Point unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1259::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1260::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1260
+namespace _func1261
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17375,11 +17389,11 @@ namespace _func1260
 Location *StarMap::PopClosestLoc(std::vector<Location*> &vec, std::map<Location*, int> &map)
 {
 	typedef Location *__attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, std::vector<Location*> &vec_arg, std::map<Location*, int> &map_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1260::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1261::func;
 	return execfunc(this, vec, map);
 }
 
-namespace _func1261
+namespace _func1262
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17389,11 +17403,11 @@ namespace _func1261
 bool StarMap::AddQuest(const std::string &questEvent, bool force)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, const std::string &questEvent_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1261::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1262::func;
 	return execfunc(this, questEvent, force);
 }
 
-namespace _func1262
+namespace _func1263
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17403,11 +17417,11 @@ namespace _func1262
 Location *StarMap::GenerateMap(bool tutorial, bool seed)
 {
 	typedef Location *__attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, bool tutorial_arg, bool seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1262::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1263::func;
 	return execfunc(this, tutorial, seed);
 }
 
-namespace _func1263
+namespace _func1264
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17417,11 +17431,11 @@ namespace _func1263
 Location *StarMap::NewGame(bool unk0)
 {
 	typedef Location *__attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, bool unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1263::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1264::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1264
+namespace _func1265
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -17431,11 +17445,11 @@ namespace _func1264
 std::vector<Location*> StarMap::Dijkstra(Location *start, Location *finish, bool include_unknown)
 {
 	typedef std::vector<Location*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *start_arg, Location *finish_arg, bool include_unknown_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1264::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1265::func;
 	return execfunc(this, start, finish, include_unknown);
 }
 
-namespace _func1265
+namespace _func1266
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17445,11 +17459,11 @@ namespace _func1265
 void StarMap::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1265::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1266::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1266
+namespace _func1267
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -17459,11 +17473,11 @@ namespace _func1266
 void StarMap::OnTouch(TouchAction unk0, int unk1, int unk2, int unk3, int unk4, int unk5)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, TouchAction unk0_arg, int unk1_arg, int unk2_arg, int unk3_arg, int unk4_arg, int unk5_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1266::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1267::func;
 	return execfunc(this, unk0, unk1, unk2, unk3, unk4, unk5);
 }
 
-namespace _func1267
+namespace _func1268
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17473,11 +17487,11 @@ namespace _func1267
 Location *StarMap::LoadGame(int fileHelper)
 {
 	typedef Location *__attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1267::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1268::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1268
+namespace _func1269
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -17487,11 +17501,11 @@ namespace _func1268
 void StarMap::RenderLeftInsetButton(float unk0, float unk1, bool unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, float unk0_arg, float unk1_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1268::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1269::func;
 	return execfunc(this, unk0, unk1, unk2);
 }
 
-namespace _func1269
+namespace _func1270
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17501,11 +17515,11 @@ namespace _func1269
 void StarMap::RenderDistressButtons()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1269::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1270::func;
 	return execfunc(this);
 }
 
-namespace _func1270
+namespace _func1271
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17515,11 +17529,11 @@ namespace _func1270
 void StarMap::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1270::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1271::func;
 	return execfunc(this);
 }
 
-namespace _func1271
+namespace _func1272
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -17529,11 +17543,11 @@ namespace _func1271
 void StarMap::DrawConnection(const Pointf &pos1, const Pointf &pos2, const GL_Color *color)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, const Pointf &pos1_arg, const Pointf &pos2_arg, const GL_Color *color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1271::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1272::func;
 	return execfunc(this, pos1, pos2, color);
 }
 
-namespace _func1272
+namespace _func1273
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17543,11 +17557,11 @@ namespace _func1272
 void StarMap::TurnIntoFleetLocation(Location *loc)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1272::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1273::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1273
+namespace _func1274
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17557,11 +17571,11 @@ namespace _func1273
 std::string StarMap::GetLocationText(const Location *loc)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, const Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1273::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1274::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1274
+namespace _func1275
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17571,11 +17585,11 @@ namespace _func1274
 void StarMap::SetupNoFuel(int seed, const std::string &forceEscape)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int seed_arg, const std::string &forceEscape_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1274::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1275::func;
 	return execfunc(this, seed, forceEscape);
 }
 
-namespace _func1275
+namespace _func1276
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17585,11 +17599,11 @@ namespace _func1275
 void StarMap::GenerateNebulas(const std::vector<std::string> &names)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, const std::vector<std::string> &names_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1275::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1276::func;
 	return execfunc(this, names);
 }
 
-namespace _func1276
+namespace _func1277
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17599,11 +17613,11 @@ namespace _func1276
 void StarMap::UpdateBoss()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1276::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1277::func;
 	return execfunc(this);
 }
 
-namespace _func1277
+namespace _func1278
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -17613,11 +17627,11 @@ namespace _func1277
 StatusEffect *StatusEffect::GetNebulaEffect()
 {
 	typedef StatusEffect *__attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1277::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1278::func;
 	return execfunc();
 }
 
-namespace _func1278
+namespace _func1279
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -17627,11 +17641,11 @@ namespace _func1278
 void Store::OnInit(ShipManager *shopper, Equipment *equip, int worldLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, ShipManager *shopper_arg, Equipment *equip_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1278::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1279::func;
 	return execfunc(this, shopper, equip, worldLevel);
 }
 
-namespace _func1279
+namespace _func1280
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17641,11 +17655,11 @@ namespace _func1279
 void Store::CreateStoreBoxes(int type, Equipment *equip)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, int type_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1279::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1280::func;
 	return execfunc(this, type, equip);
 }
 
-namespace _func1280
+namespace _func1281
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17655,11 +17669,11 @@ namespace _func1280
 bool Store::KeyDown(SDLKey key)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1280::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1281::func;
 	return execfunc(this, key);
 }
 
-namespace _func1281
+namespace _func1282
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17669,11 +17683,11 @@ namespace _func1281
 void Store::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1281::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1282::func;
 	return execfunc(this);
 }
 
-namespace _func1282
+namespace _func1283
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17683,11 +17697,11 @@ namespace _func1282
 void Store::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1282::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1283::func;
 	return execfunc(this);
 }
 
-namespace _func1283
+namespace _func1284
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17697,11 +17711,11 @@ namespace _func1283
 void Store::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1283::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1284::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1284
+namespace _func1285
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17711,11 +17725,11 @@ namespace _func1284
 void Store::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1284::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1285::func;
 	return execfunc(this);
 }
 
-namespace _func1285
+namespace _func1286
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17725,11 +17739,11 @@ namespace _func1285
 void Store::SaveStore(int file)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1285::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1286::func;
 	return execfunc(this, file);
 }
 
-namespace _func1286
+namespace _func1287
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17739,11 +17753,11 @@ namespace _func1286
 void Store::RelinkShip(ShipManager *ship, Equipment *equip)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, ShipManager *ship_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1286::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1287::func;
 	return execfunc(this, ship, equip);
 }
 
-namespace _func1287
+namespace _func1288
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17753,11 +17767,11 @@ namespace _func1287
 bool Store::HasType(int type)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1287::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1288::func;
 	return execfunc(this, type);
 }
 
-namespace _func1288
+namespace _func1289
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17767,11 +17781,11 @@ namespace _func1288
 void Store::Clear()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1288::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1289::func;
 	return execfunc(this);
 }
 
-namespace _func1289
+namespace _func1290
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff};
@@ -17781,11 +17795,11 @@ namespace _func1289
 void Store::InitHeading(int index, Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, int index_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1289::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1290::func;
 	return execfunc(this, index, pos);
 }
 
-namespace _func1290
+namespace _func1291
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -17795,11 +17809,11 @@ namespace _func1290
 void Store::DrawBuySellTabText()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1290::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1291::func;
 	return execfunc();
 }
 
-namespace _func1291
+namespace _func1292
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17809,11 +17823,11 @@ namespace _func1291
 void Store::MouseClick(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1291::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1292::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1292
+namespace _func1293
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17823,11 +17837,11 @@ namespace _func1292
 void Store::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1292::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1293::func;
 	return execfunc(this);
 }
 
-namespace _func1293
+namespace _func1294
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17837,11 +17851,11 @@ namespace _func1293
 void Store::SetPositions()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1293::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1294::func;
 	return execfunc(this);
 }
 
-namespace _func1294
+namespace _func1295
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17851,11 +17865,11 @@ namespace _func1294
 void Store::LoadStore(int file, int worldLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, int file_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1294::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1295::func;
 	return execfunc(this, file, worldLevel);
 }
 
-namespace _func1295
+namespace _func1296
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -17865,11 +17879,11 @@ namespace _func1295
 void Store::SetPosition(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1295::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1296::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1296
+namespace _func1297
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17879,11 +17893,11 @@ namespace _func1296
 void Store::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1296::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1297::func;
 	return execfunc(this);
 }
 
-namespace _func1297
+namespace _func1298
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17893,11 +17907,11 @@ namespace _func1297
 void StoreBox::MouseClick(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1297::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1298::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1298
+namespace _func1299
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17907,11 +17921,11 @@ namespace _func1298
 void StoreBox::Activate()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1298::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1299::func;
 	return execfunc(this);
 }
 
-namespace _func1299
+namespace _func1300
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17921,11 +17935,11 @@ namespace _func1299
 void StoreBox::InitBlueprint(Blueprint *bp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg, Blueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1299::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1300::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1300
+namespace _func1301
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -17935,11 +17949,11 @@ namespace _func1300
 void StoreBox::constructor(const std::string &buttonImage, ShipManager *shopper, Equipment *equip)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg, const std::string &buttonImage_arg, ShipManager *shopper_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1300::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1301::func;
 	return execfunc(this, buttonImage, shopper, equip);
 }
 
-namespace _func1301
+namespace _func1302
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17949,11 +17963,11 @@ namespace _func1301
 void StoreBox::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1301::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1302::func;
 	return execfunc(this);
 }
 
-namespace _func1302
+namespace _func1303
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -17963,11 +17977,11 @@ namespace _func1302
 void StoreBox::SetPosition(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1302::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1303::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1303
+namespace _func1304
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17977,11 +17991,11 @@ namespace _func1303
 void StoreBox::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1303::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1304::func;
 	return execfunc(this);
 }
 
-namespace _func1304
+namespace _func1305
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17991,11 +18005,11 @@ namespace _func1304
 void StoreBox::Purchase()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1304::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1305::func;
 	return execfunc(this);
 }
 
-namespace _func1305
+namespace _func1306
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -18005,11 +18019,11 @@ namespace _func1305
 void SuperShieldDrone::constructor(int iShipId, int selfId, DroneBlueprint *blueprint)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SuperShieldDrone *this_arg, int iShipId_arg, int selfId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1305::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1306::func;
 	return execfunc(this, iShipId, selfId, blueprint);
 }
 
-namespace _func1306
+namespace _func1307
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18019,11 +18033,11 @@ namespace _func1306
 void SuperShieldDrone::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SuperShieldDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1306::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1307::func;
 	return execfunc(this);
 }
 
-namespace _func1307
+namespace _func1308
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18033,11 +18047,11 @@ namespace _func1307
 void SystemBox::OnRender(bool ignoreStatus)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemBox *this_arg, bool ignoreStatus_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1307::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1308::func;
 	return execfunc(this, ignoreStatus);
 }
 
-namespace _func1308
+namespace _func1309
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -18047,11 +18061,11 @@ namespace _func1308
 void SystemBox::constructor(Point pos, ShipSystem *sys, bool playerUI)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, bool playerUI_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1308::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1309::func;
 	return execfunc(this, pos, sys, playerUI);
 }
 
-namespace _func1309
+namespace _func1310
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -18061,11 +18075,11 @@ namespace _func1309
 void SystemBox::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1309::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1310::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1310
+namespace _func1311
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18075,11 +18089,11 @@ namespace _func1310
 bool SystemBox::MouseClick(bool shift)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemBox *this_arg, bool shift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1310::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1311::func;
 	return execfunc(this, shift);
 }
 
-namespace _func1311
+namespace _func1312
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -18089,11 +18103,11 @@ namespace _func1311
 void SystemBox::KeyDown(SDLKey key, bool shift)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemBox *this_arg, SDLKey key_arg, bool shift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1311::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1312::func;
 	return execfunc(this, key, shift);
 }
 
-namespace _func1312
+namespace _func1313
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18103,11 +18117,11 @@ namespace _func1312
 void SystemControl::CreateSystemBoxes()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1312::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1313::func;
 	return execfunc(this);
 }
 
-namespace _func1313
+namespace _func1314
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18117,11 +18131,11 @@ namespace _func1313
 SystemBox *SystemControl::GetSystemBox(int systemId)
 {
 	typedef SystemBox *__attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemControl *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1313::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1314::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1314
+namespace _func1315
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18131,11 +18145,11 @@ namespace _func1314
 void SystemControl::RenderPowerBar()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1314::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1315::func;
 	return execfunc(this);
 }
 
-namespace _func1315
+namespace _func1316
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18145,25 +18159,25 @@ namespace _func1315
 SystemControl::PowerBars *SystemControl::GetPowerBars(int width, int height, int gap, bool useShieldGap)
 {
 	typedef SystemControl::PowerBars *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int width_arg, int height_arg, int gap_arg, bool useShieldGap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1315::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1316::func;
 	return execfunc(width, height, gap, useShieldGap);
 }
 
 Point *Global_SystemControl_weapon_position;
 
-namespace _var1316
+namespace _var1317
 {
     static VariableDefinition varObj("Global_SystemControl_weapon_position", "!a3(???????\?)8915????????e8????????8b55e08b45dc83ec088b7b0c8915????????8b5308a3(???????\?)", &Global_SystemControl_weapon_position);
 }
 
 Point *Global_SystemControl_drone_position;
 
-namespace _var1317
+namespace _var1318
 {
     static VariableDefinition varObj("Global_SystemControl_drone_position", "", &Global_SystemControl_drone_position);
 }
 
-namespace _func1318
+namespace _func1319
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -18173,11 +18187,11 @@ namespace _func1318
 void SystemCustomBox::constructor(Point pos, ShipSystem *sys, ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemCustomBox *this_arg, Point pos_arg, ShipSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1318::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1319::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func1319
+namespace _func1320
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18187,11 +18201,11 @@ namespace _func1319
 void SystemStoreBox::SetExtraData(int droneChoice)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, int droneChoice_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1319::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1320::func;
 	return execfunc(this, droneChoice);
 }
 
-namespace _func1320
+namespace _func1321
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -18201,11 +18215,11 @@ namespace _func1320
 void SystemStoreBox::constructor(ShipManager *shopper, Equipment *equip, int sys)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, ShipManager *shopper_arg, Equipment *equip_arg, int sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1320::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1321::func;
 	return execfunc(this, shopper, equip, sys);
 }
 
-namespace _func1321
+namespace _func1322
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18215,11 +18229,11 @@ namespace _func1321
 bool SystemStoreBox::CanHold()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1321::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1322::func;
 	return execfunc(this);
 }
 
-namespace _func1322
+namespace _func1323
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -18229,11 +18243,11 @@ namespace _func1322
 void SystemStoreBox::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1322::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1323::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1323
+namespace _func1324
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18241,20 +18255,6 @@ namespace _func1323
 }
 
 void SystemStoreBox::Activate()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1323::func;
-	return execfunc(this);
-}
-
-namespace _func1324
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SystemStoreBox::Purchase", typeid(void (SystemStoreBox::*)()), "578d7c240883e4f0ff77fc5589e557565389cb8d75d883ec4c", argdata, 1, 5, &func);
-}
-
-void SystemStoreBox::Purchase()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1324::func;
@@ -18265,17 +18265,31 @@ namespace _func1325
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("SystemStoreBox::Purchase", typeid(void (SystemStoreBox::*)()), "578d7c240883e4f0ff77fc5589e557565389cb8d75d883ec4c", argdata, 1, 5, &func);
+}
+
+void SystemStoreBox::Purchase()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1325::func;
+	return execfunc(this);
+}
+
+namespace _func1326
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("TabbedWindow::Close", typeid(void (TabbedWindow::*)()), "5589e5538b51408b412889cb83e4f08b0c908b01ff501089d9e8????????8b5dfcc9c3", argdata, 1, 5, &func);
 }
 
 void TabbedWindow::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TabbedWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1325::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1326::func;
 	return execfunc(this);
 }
 
-namespace _func1326
+namespace _func1327
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -18285,18 +18299,18 @@ namespace _func1326
 void TeleportBox::constructor(Point pos, TeleportSystem *sys)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportBox *this_arg, Point pos_arg, TeleportSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1326::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1327::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func1327
+namespace _func1328
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("TeleportSystem::__DO_NOT_HOOK", typeid(void (TeleportSystem::*)()), "8d????0483e4f0ff????5589e5535183ec408b15????????a1????????", argdata, 0, 4, &func);
 }
 
-namespace _func1328
+namespace _func1329
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18306,11 +18320,11 @@ namespace _func1328
 void TeleportSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1328::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1329::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func1329
+namespace _func1330
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18320,11 +18334,11 @@ namespace _func1329
 void TeleportSystem::OnRenderFloor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1329::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1330::func;
 	return execfunc(this);
 }
 
-namespace _func1330
+namespace _func1331
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18334,11 +18348,11 @@ namespace _func1330
 void TeleportSystem::constructor(int systemId, int roomId, int shipId, int startingPower)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int systemId_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1330::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1331::func;
 	return execfunc(this, systemId, roomId, shipId, startingPower);
 }
 
-namespace _func1331
+namespace _func1332
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18348,11 +18362,11 @@ namespace _func1331
 float TeleportSystem::GetChargedPercent()
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1331::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1332::func;
 	return execfunc(this);
 }
 
-namespace _func1332
+namespace _func1333
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18362,11 +18376,11 @@ namespace _func1332
 bool TeleportSystem::Charged()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1332::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1333::func;
 	return execfunc(this);
 }
 
-namespace _func1333
+namespace _func1334
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18376,11 +18390,11 @@ namespace _func1333
 void TeleportSystem::ClearCrewLocations()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1333::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1334::func;
 	return execfunc(this);
 }
 
-namespace _func1334
+namespace _func1335
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18390,11 +18404,11 @@ namespace _func1334
 void TeleportSystem::UpdateCrewLocation(int unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1334::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1335::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1335
+namespace _func1336
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18404,11 +18418,11 @@ namespace _func1335
 void TeleportSystem::SetArmed(int armed)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int armed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1335::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1336::func;
 	return execfunc(this, armed);
 }
 
-namespace _func1336
+namespace _func1337
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18418,20 +18432,6 @@ namespace _func1336
 void TeleportSystem::ForceReady()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1336::func;
-	return execfunc(this);
-}
-
-namespace _func1337
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("TeleportSystem::CanSend", typeid(bool (TeleportSystem::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b490c85c975??80bbc401000000", argdata, 1, 1, &func);
-}
-
-bool TeleportSystem::CanSend()
-{
-	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1337::func;
 	return execfunc(this);
 }
@@ -18440,10 +18440,10 @@ namespace _func1338
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("TeleportSystem::CanReceive", typeid(bool (TeleportSystem::*)()), ".5589e556538b750883e4f080b9c50100000075??8b410c85c074??8b0189cbff502c84c0", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("TeleportSystem::CanSend", typeid(bool (TeleportSystem::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b490c85c975??80bbc401000000", argdata, 1, 1, &func);
 }
 
-bool TeleportSystem::CanReceive()
+bool TeleportSystem::CanSend()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1338::func;
@@ -18454,12 +18454,12 @@ namespace _func1339
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("TeleportSystem::InitiateTeleport", typeid(void (TeleportSystem::*)()), ".578d7c240883e4f0ff77fc5589e5575389cb83ec30e8????????83e80131d283f80277??", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("TeleportSystem::CanReceive", typeid(bool (TeleportSystem::*)()), ".5589e556538b750883e4f080b9c50100000075??8b410c85c074??8b0189cbff502c84c0", argdata, 1, 1, &func);
 }
 
-void TeleportSystem::InitiateTeleport()
+bool TeleportSystem::CanReceive()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
+	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1339::func;
 	return execfunc(this);
 }
@@ -18468,10 +18468,10 @@ namespace _func1340
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("TeleportSystem::OnLoop", typeid(void (TeleportSystem::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb83ec4ce8????????8b0389d9", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("TeleportSystem::InitiateTeleport", typeid(void (TeleportSystem::*)()), ".578d7c240883e4f0ff77fc5589e5575389cb83ec30e8????????83e80131d283f80277??", argdata, 1, 5, &func);
 }
 
-void TeleportSystem::OnLoop()
+void TeleportSystem::InitiateTeleport()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1340::func;
@@ -18482,10 +18482,10 @@ namespace _func1341
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("TeleportSystem::Jump", typeid(void (TeleportSystem::*)()), ".5589e55389cb83e4f0e8????????c783c0010000000000008b5dfc", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("TeleportSystem::OnLoop", typeid(void (TeleportSystem::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb83ec4ce8????????8b0389d9", argdata, 1, 5, &func);
 }
 
-void TeleportSystem::Jump()
+void TeleportSystem::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1341::func;
@@ -18496,17 +18496,31 @@ namespace _func1342
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("TeleportSystem::Jump", typeid(void (TeleportSystem::*)()), ".5589e55389cb83e4f0e8????????c783c0010000000000008b5dfc", argdata, 1, 5, &func);
+}
+
+void TeleportSystem::Jump()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1342::func;
+	return execfunc(this);
+}
+
+namespace _func1343
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("TextButton::ResetPrimitives", typeid(void (TextButton::*)()), "5589e55756538d79548d594889ce83e4f083ec108b0383c304890424e8????????c743fc0000000039fb75??", argdata, 1, 5, &func);
 }
 
 void TextButton::ResetPrimitives()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1342::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1343::func;
 	return execfunc(this);
 }
 
-namespace _func1343
+namespace _func1344
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18516,18 +18530,18 @@ namespace _func1343
 int TextButton::GetIdealButtonWidth()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1343::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1344::func;
 	return execfunc(this);
 }
 
-namespace _func1344
+namespace _func1345
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("TextButton::__DO_NOT_HOOK", typeid(void (TextButton::*)()), ".83c30439f375??8d65f85b5e5dc204008d742600ffd08d65f85b", argdata, 0, 4, &func);
 }
 
-namespace _func1345
+namespace _func1346
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18537,11 +18551,11 @@ namespace _func1345
 void TextButton::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1345::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1346::func;
 	return execfunc(this);
 }
 
-namespace _func1346
+namespace _func1347
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x2ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18551,11 +18565,11 @@ namespace _func1346
 void TextButton::OnInit(Point pos, Point size, int cornerInset, TextString *buttonLabel, int font)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, Point pos_arg, Point size_arg, int cornerInset_arg, TextString *buttonLabel_arg, int font_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1346::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1347::func;
 	return execfunc(this, pos, size, cornerInset, buttonLabel, font);
 }
 
-namespace _func1347
+namespace _func1348
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18565,11 +18579,11 @@ namespace _func1347
 void TextButton::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1347::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1348::func;
 	return execfunc(this);
 }
 
-namespace _func1348
+namespace _func1349
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18579,11 +18593,11 @@ namespace _func1348
 void TextButton::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1348::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1349::func;
 	return execfunc(this);
 }
 
-namespace _func1349
+namespace _func1350
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18609,11 +18623,11 @@ FUNC_NAKED __int64 TextButton::GetSize_DO_NOT_USE_DIRECTLY()
 		"movl %%ebp, %%esp\n\t"
 		"popl %%ebp\n\t"
 		"ret\n\t"
-		 :: "m"(_func1349::func)
+		 :: "m"(_func1350::func)
 	);
 }
 
-namespace _func1350
+namespace _func1351
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18623,11 +18637,11 @@ namespace _func1350
 void TextButton::OnInitRect(Globals::Rect &rect, int cornerInset, TextString &buttonLabel, int font)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, Globals::Rect &rect_arg, int cornerInset_arg, TextString &buttonLabel_arg, int font_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1350::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1351::func;
 	return execfunc(this, rect, cornerInset, buttonLabel, font);
 }
 
-namespace _func1351
+namespace _func1352
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x1ff};
@@ -18637,11 +18651,11 @@ namespace _func1351
 void TextButton::SetBaseImage(const std::string &name, Point pos, int autoWidthMin)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, const std::string &name_arg, Point pos_arg, int autoWidthMin_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1351::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1352::func;
 	return execfunc(this, name, pos, autoWidthMin);
 }
 
-namespace _func1352
+namespace _func1353
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18651,11 +18665,11 @@ namespace _func1352
 void TextButton::SetAutoWidth(bool autoWidth, bool autoRightAlign, int margin, int min)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, bool autoWidth_arg, bool autoRightAlign_arg, int margin_arg, int min_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1352::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1353::func;
 	return execfunc(this, autoWidth, autoRightAlign, margin, min);
 }
 
-namespace _func1353
+namespace _func1354
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18665,11 +18679,11 @@ namespace _func1353
 void TextButton::UpdateAutoWidth()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1353::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1354::func;
 	return execfunc(this);
 }
 
-namespace _func1354
+namespace _func1355
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x4ff};
@@ -18677,20 +18691,6 @@ namespace _func1354
 }
 
 void TextButton::SetInactiveColor(GL_Color color)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1354::func;
-	return execfunc(this, color);
-}
-
-namespace _func1355
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x4ff};
-	static FunctionDefinition funcObj("TextButton::SetActiveColor", typeid(void (TextButton::*)(GL_Color )), ".5589e557565389cb83e4f083ec10807964000f85????????f30f1005????????c6416401f30f100d????????c741740000803ff30f1015????????", argdata, 2, 5, &func);
-}
-
-void TextButton::SetActiveColor(GL_Color color)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1355::func;
@@ -18701,10 +18701,10 @@ namespace _func1356
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x4ff};
-	static FunctionDefinition funcObj("TextButton::SetSelectedColor", typeid(void (TextButton::*)(GL_Color )), ".5589e557565389cb83e4f083ec10807964000f85????????f30f1005????????c6416401f30f100d????????c741740000803ff30f1015????????f30f5ec8c781840000000000803f", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("TextButton::SetActiveColor", typeid(void (TextButton::*)(GL_Color )), ".5589e557565389cb83e4f083ec10807964000f85????????f30f1005????????c6416401f30f100d????????c741740000803ff30f1015????????", argdata, 2, 5, &func);
 }
 
-void TextButton::SetSelectedColor(GL_Color color)
+void TextButton::SetActiveColor(GL_Color color)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1356::func;
@@ -18715,10 +18715,10 @@ namespace _func1357
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x4ff};
-	static FunctionDefinition funcObj("TextButton::SetTextColor", typeid(void (TextButton::*)(GL_Color )), ".807964000f85????????f30f1005????????c6416401f30f100d????????c741740000803ff30f1015????????f30f5ec8c781840000000000803ff30f101d????????c781940000000000803ff30f5ed0f30f114970f30f100d????????", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("TextButton::SetSelectedColor", typeid(void (TextButton::*)(GL_Color )), ".5589e557565389cb83e4f083ec10807964000f85????????f30f1005????????c6416401f30f100d????????c741740000803ff30f1015????????f30f5ec8c781840000000000803f", argdata, 2, 5, &func);
 }
 
-void TextButton::SetTextColor(GL_Color color)
+void TextButton::SetSelectedColor(GL_Color color)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1357::func;
@@ -18728,6 +18728,20 @@ void TextButton::SetTextColor(GL_Color color)
 namespace _func1358
 {
     static void *func = 0;
+	static short argdata[] = {0x101, 0x4ff};
+	static FunctionDefinition funcObj("TextButton::SetTextColor", typeid(void (TextButton::*)(GL_Color )), ".807964000f85????????f30f1005????????c6416401f30f100d????????c741740000803ff30f1015????????f30f5ec8c781840000000000803ff30f101d????????c781940000000000803ff30f5ed0f30f114970f30f100d????????", argdata, 2, 5, &func);
+}
+
+void TextButton::SetTextColor(GL_Color color)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1358::func;
+	return execfunc(this, color);
+}
+
+namespace _func1359
+{
+    static void *func = 0;
 	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("TextButton::InitPrimitives", typeid(void (TextButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cf81ec????????807964000f84????????8b4704c745c000000000c745c400000000c745c8000000008945b08b4708", argdata, 1, 5, &func);
 }
@@ -18735,11 +18749,11 @@ namespace _func1358
 void TextButton::InitPrimitives()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1358::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1359::func;
 	return execfunc(this);
 }
 
-namespace _func1359
+namespace _func1360
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -18749,11 +18763,11 @@ namespace _func1359
 void TextInput::constructor(int maxChars, TextInput::AllowedCharType allowedCharType, const std::string &prompt)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg, int maxChars_arg, TextInput::AllowedCharType allowedCharType_arg, const std::string &prompt_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1359::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1360::func;
 	return execfunc(this, maxChars, allowedCharType, prompt);
 }
 
-namespace _func1360
+namespace _func1361
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff};
@@ -18763,11 +18777,11 @@ namespace _func1360
 void TextInput::OnRender(int font, Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg, int font_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1360::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1361::func;
 	return execfunc(this, font, pos);
 }
 
-namespace _func1361
+namespace _func1362
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18777,11 +18791,11 @@ namespace _func1361
 void TextInput::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1361::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1362::func;
 	return execfunc(this);
 }
 
-namespace _func1362
+namespace _func1363
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18791,11 +18805,11 @@ namespace _func1362
 void TextInput::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1362::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1363::func;
 	return execfunc(this, event);
 }
 
-namespace _func1363
+namespace _func1364
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18805,11 +18819,11 @@ namespace _func1363
 bool TextInput::GetActive()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1363::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1364::func;
 	return execfunc(this);
 }
 
-namespace _func1364
+namespace _func1365
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18819,11 +18833,11 @@ namespace _func1364
 std::string TextInput::GetText()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1364::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1365::func;
 	return execfunc(this);
 }
 
-namespace _func1365
+namespace _func1366
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18833,11 +18847,11 @@ namespace _func1365
 void TextInput::Start()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1365::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1366::func;
 	return execfunc(this);
 }
 
-namespace _func1366
+namespace _func1367
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18847,11 +18861,11 @@ namespace _func1366
 void TextInput::Stop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1366::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1367::func;
 	return execfunc(this);
 }
 
-namespace _func1367
+namespace _func1368
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18861,11 +18875,11 @@ namespace _func1367
 int TextInput::SetText(const std::string &text)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1367::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1368::func;
 	return execfunc(this, text);
 }
 
-namespace _func1368
+namespace _func1369
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18875,11 +18889,11 @@ namespace _func1368
 void TextInput::OnTextInput(int asciiChar)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg, int asciiChar_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1368::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1369::func;
 	return execfunc(this, asciiChar);
 }
 
-namespace _func1369
+namespace _func1370
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -18889,11 +18903,11 @@ namespace _func1369
 std::string TextLibrary::GetText(const std::string &name, const std::string &lang)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextLibrary *this_arg, const std::string &name_arg, const std::string &lang_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1369::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1370::func;
 	return execfunc(this, name, lang);
 }
 
-namespace _func1370
+namespace _func1371
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18903,11 +18917,11 @@ namespace _func1370
 std::string TextString::GetText()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextString *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1370::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1371::func;
 	return execfunc(this);
 }
 
-namespace _func1371
+namespace _func1372
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18917,11 +18931,11 @@ namespace _func1371
 void TimerHelper::Start(int goal)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TimerHelper *this_arg, int goal_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1371::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1372::func;
 	return execfunc(this, goal);
 }
 
-namespace _func1372
+namespace _func1373
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18931,11 +18945,11 @@ namespace _func1372
 bool TimerHelper::Running()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1372::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1373::func;
 	return execfunc(this);
 }
 
-namespace _func1373
+namespace _func1374
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -18945,11 +18959,11 @@ namespace _func1373
 void TimerHelper::ResetMinMax(int min, int max)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TimerHelper *this_arg, int min_arg, int max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1373::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1374::func;
 	return execfunc(this, min, max);
 }
 
-namespace _func1374
+namespace _func1375
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18959,11 +18973,11 @@ namespace _func1374
 void TimerHelper::SetMaxTime(float max)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TimerHelper *this_arg, float max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1374::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1375::func;
 	return execfunc(this, max);
 }
 
-namespace _func1375
+namespace _func1376
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18971,20 +18985,6 @@ namespace _func1375
 }
 
 void TimerHelper::Stop()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1375::func;
-	return execfunc(this);
-}
-
-namespace _func1376
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("TimerHelper::Update", typeid(void (TimerHelper::*)()), ".8079110075??c389f68dbc27000000005589e55389cbb9????????83e4f0", argdata, 1, 5, &func);
-}
-
-void TimerHelper::Update()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1376::func;
@@ -18995,17 +18995,31 @@ namespace _func1377
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("TimerHelper::Update", typeid(void (TimerHelper::*)()), ".8079110075??c389f68dbc27000000005589e55389cbb9????????83e4f0", argdata, 1, 5, &func);
+}
+
+void TimerHelper::Update()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1377::func;
+	return execfunc(this);
+}
+
+namespace _func1378
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("TimerHelper::Done", typeid(bool (TimerHelper::*)()), ".0fb6411184c074??f30f1041080f2e410c76??5589e55756530fb6711083e4f0", argdata, 1, 1, &func);
 }
 
 bool TimerHelper::Done()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1377::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1378::func;
 	return execfunc(this);
 }
 
-namespace _func1378
+namespace _func1379
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19015,11 +19029,11 @@ namespace _func1378
 void TopScore::copy_constructor(const TopScore &other)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TopScore *this_arg, const TopScore &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1378::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1379::func;
 	return execfunc(this, other);
 }
 
-namespace _func1379
+namespace _func1380
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19029,11 +19043,11 @@ namespace _func1379
 void TutorialManager::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1379::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1380::func;
 	return execfunc(this);
 }
 
-namespace _func1380
+namespace _func1381
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19043,11 +19057,11 @@ namespace _func1380
 bool TutorialManager::Running()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1380::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1381::func;
 	return execfunc(this);
 }
 
-namespace _func1381
+namespace _func1382
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -19057,18 +19071,18 @@ namespace _func1381
 void TutorialManager::OnInit(ShipManager *ship, CommandGui *gui, CrewControl *crewControl, Upgrades *upgradesScreen, CombatControl *combatControl, SystemControl *sysControl, TabbedWindow *unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TutorialManager *this_arg, ShipManager *ship_arg, CommandGui *gui_arg, CrewControl *crewControl_arg, Upgrades *upgradesScreen_arg, CombatControl *combatControl_arg, SystemControl *sysControl_arg, TabbedWindow *unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1381::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1382::func;
 	return execfunc(this, ship, gui, crewControl, upgradesScreen, combatControl, sysControl, unk);
 }
 
 TutorialManager *Global_TutorialManager_Tutorial;
 
-namespace _var1382
+namespace _var1383
 {
     static VariableDefinition varObj("Global_TutorialManager_Tutorial", "!b9(???????\?)e8????????84c075??8b4b08", &Global_TutorialManager_Tutorial);
 }
 
-namespace _func1383
+namespace _func1384
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -19078,11 +19092,11 @@ namespace _func1383
 void UnlockArrow::constructor(Point pos, int unk1, int unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UnlockArrow *this_arg, Point pos_arg, int unk1_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1383::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1384::func;
 	return execfunc(this, pos, unk1, unk2);
 }
 
-namespace _func1384
+namespace _func1385
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19092,11 +19106,11 @@ namespace _func1384
 bool UnlockArrow::MouseMove(int x, int y)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(UnlockArrow *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1384::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1385::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1385
+namespace _func1386
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19106,11 +19120,11 @@ namespace _func1385
 void UnlockArrow::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UnlockArrow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1385::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1386::func;
 	return execfunc(this);
 }
 
-namespace _func1386
+namespace _func1387
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -19120,11 +19134,11 @@ namespace _func1386
 void UpgradeBox::constructorEmpty(Point pos, bool subsystem)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, Point pos_arg, bool subsystem_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1386::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1387::func;
 	return execfunc(this, pos, subsystem);
 }
 
-namespace _func1387
+namespace _func1388
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -19134,11 +19148,11 @@ namespace _func1387
 void UpgradeBox::constructorSystem(ShipManager *ship, ShipSystem *sys, Point pos, bool subsystem)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, ShipManager *ship_arg, ShipSystem *sys_arg, Point pos_arg, bool subsystem_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1387::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1388::func;
 	return execfunc(this, ship, sys, pos, subsystem);
 }
 
-namespace _func1388
+namespace _func1389
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19148,11 +19162,11 @@ namespace _func1388
 void UpgradeBox::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1388::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1389::func;
 	return execfunc(this);
 }
 
-namespace _func1389
+namespace _func1390
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19162,11 +19176,11 @@ namespace _func1389
 void UpgradeBox::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1389::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1390::func;
 	return execfunc(this);
 }
 
-namespace _func1390
+namespace _func1391
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19174,20 +19188,6 @@ namespace _func1390
 }
 
 void UpgradeBox::MouseMove(int mX, int mY)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1390::func;
-	return execfunc(this, mX, mY);
-}
-
-namespace _func1391
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("UpgradeBox::MouseClick", typeid(void (UpgradeBox::*)(int , int )), "8b1185d20f84????????8b4118807840000f84????????807841000f84????????8b42540341143b82a00100000f8d????????5783e8018d7c240883e4f0ff77fc5589e557", argdata, 3, 5, &func);
-}
-
-void UpgradeBox::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1391::func;
@@ -19198,10 +19198,10 @@ namespace _func1392
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("UpgradeBox::MouseRightClick", typeid(void (UpgradeBox::*)(int , int )), "8b1185d20f84????????8b4118807840000f84????????807841000f84????????8b411485c00f8e????????578d7c240883e4f0ff77fc5589e557", argdata, 3, 5, &func);
+	static FunctionDefinition funcObj("UpgradeBox::MouseClick", typeid(void (UpgradeBox::*)(int , int )), "8b1185d20f84????????8b4118807840000f84????????807841000f84????????8b42540341143b82a00100000f8d????????5783e8018d7c240883e4f0ff77fc5589e557", argdata, 3, 5, &func);
 }
 
-void UpgradeBox::MouseRightClick(int mX, int mY)
+void UpgradeBox::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1392::func;
@@ -19211,25 +19211,25 @@ void UpgradeBox::MouseRightClick(int mX, int mY)
 namespace _func1393
 {
     static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("UpgradeBox::Undo", typeid(void (UpgradeBox::*)()), "8b411485c07e??578d7c240883e4f0ff77fc5589e557565389cb83ec1c8d76008b1331f60342548b53088b8ac4000000", argdata, 1, 5, &func);
+	static short argdata[] = {0x101, 0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("UpgradeBox::MouseRightClick", typeid(void (UpgradeBox::*)(int , int )), "8b1185d20f84????????8b4118807840000f84????????807841000f84????????8b411485c00f8e????????578d7c240883e4f0ff77fc5589e557", argdata, 3, 5, &func);
 }
 
-void UpgradeBox::Undo()
+void UpgradeBox::MouseRightClick(int mX, int mY)
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1393::func;
-	return execfunc(this);
+	return execfunc(this, mX, mY);
 }
 
 namespace _func1394
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("UpgradeBox::Accept", typeid(void (UpgradeBox::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b0985c90f84????????8b4314890424e8????????8b0b83ec04", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("UpgradeBox::Undo", typeid(void (UpgradeBox::*)()), "8b411485c07e??578d7c240883e4f0ff77fc5589e557565389cb83ec1c8d76008b1331f60342548b53088b8ac4000000", argdata, 1, 5, &func);
 }
 
-void UpgradeBox::Accept()
+void UpgradeBox::Undo()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1394::func;
@@ -19239,6 +19239,20 @@ void UpgradeBox::Accept()
 namespace _func1395
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("UpgradeBox::Accept", typeid(void (UpgradeBox::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b0985c90f84????????8b4314890424e8????????8b0b83ec04", argdata, 1, 5, &func);
+}
+
+void UpgradeBox::Accept()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1395::func;
+	return execfunc(this);
+}
+
+namespace _func1396
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("Upgrades::OnInit", typeid(void (Upgrades::*)(ShipManager *)), "578d7c240883e4f0ff77fc5589e557565389cb8d75bc81ec????????8b07c64105018d7dd489412c8945888b4118894424048b41148d4dcc", argdata, 2, 5, &func);
 }
@@ -19246,11 +19260,11 @@ namespace _func1395
 void Upgrades::OnInit(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1395::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1396::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1396
+namespace _func1397
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19260,11 +19274,11 @@ namespace _func1396
 void Upgrades::ClearUpgradeBoxes()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1396::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1397::func;
 	return execfunc(this);
 }
 
-namespace _func1397
+namespace _func1398
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19274,11 +19288,11 @@ namespace _func1397
 void Upgrades::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1397::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1398::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1398
+namespace _func1399
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19288,11 +19302,11 @@ namespace _func1398
 void Upgrades::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1398::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1399::func;
 	return execfunc(this);
 }
 
-namespace _func1399
+namespace _func1400
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19302,11 +19316,11 @@ namespace _func1399
 void Upgrades::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1399::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1400::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1400
+namespace _func1401
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19316,11 +19330,11 @@ namespace _func1400
 void Upgrades::MouseRightClick(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1400::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1401::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1401
+namespace _func1402
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19328,20 +19342,6 @@ namespace _func1401
 }
 
 void Upgrades::OnRender()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1401::func;
-	return execfunc(this);
-}
-
-namespace _func1402
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("Upgrades::Close", typeid(void (Upgrades::*)()), "8079040075??c389f68dbc2700000000578d7c240883e4f0ff77fc5589e557565389cf31db8d75d883ec4c", argdata, 1, 5, &func);
-}
-
-void Upgrades::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1402::func;
@@ -19352,10 +19352,10 @@ namespace _func1403
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("Upgrades::ConfirmUpgrades", typeid(void (Upgrades::*)()), "578d7c240883e4f0ff77fc5589e557565331f68d7dd883ec4c8b51248b4120894dc489d129c1c1f902", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("Upgrades::Close", typeid(void (Upgrades::*)()), "8079040075??c389f68dbc2700000000578d7c240883e4f0ff77fc5589e557565389cf31db8d75d883ec4c", argdata, 1, 5, &func);
 }
 
-void Upgrades::ConfirmUpgrades()
+void Upgrades::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1403::func;
@@ -19366,12 +19366,12 @@ namespace _func1404
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("WarningMessage::Start", typeid(void (WarningMessage::*)()), "8079140075??578d7c240883e4f0ff77fc5589e5575389cb", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("Upgrades::ConfirmUpgrades", typeid(void (Upgrades::*)()), "578d7c240883e4f0ff77fc5589e557565331f68d7dd883ec4c8b51248b4120894dc489d129c1c1f902", argdata, 1, 5, &func);
 }
 
-void WarningMessage::Start()
+void Upgrades::ConfirmUpgrades()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1404::func;
 	return execfunc(this);
 }
@@ -19380,10 +19380,10 @@ namespace _func1405
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("WarningMessage::OnRender", typeid(void (WarningMessage::*)()), "807916000f85????????807914000f84????????578d7c240883e4f0ff77fc5589e55753", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("WarningMessage::Start", typeid(void (WarningMessage::*)()), "8079140075??578d7c240883e4f0ff77fc5589e5575389cb", argdata, 1, 5, &func);
 }
 
-void WarningMessage::OnRender()
+void WarningMessage::Start()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1405::func;
@@ -19393,6 +19393,20 @@ void WarningMessage::OnRender()
 namespace _func1406
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("WarningMessage::OnRender", typeid(void (WarningMessage::*)()), "807916000f85????????807914000f84????????578d7c240883e4f0ff77fc5589e55753", argdata, 1, 5, &func);
+}
+
+void WarningMessage::OnRender()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1406::func;
+	return execfunc(this);
+}
+
+namespace _func1407
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("WarningMessage::RenderWithAlpha", typeid(void (WarningMessage::*)(float )), "578d7c240883e4f0ff77fc5589e557565389cb81ec8c00000080792800f30f100f744d", argdata, 2, 5, &func);
 }
@@ -19400,11 +19414,11 @@ namespace _func1406
 void WarningMessage::RenderWithAlpha(float alpha)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1406::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1407::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func1407
+namespace _func1408
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19414,11 +19428,11 @@ namespace _func1407
 void WarningMessage::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1407::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1408::func;
 	return execfunc(this);
 }
 
-namespace _func1408
+namespace _func1409
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -19428,11 +19442,11 @@ namespace _func1408
 void WarningMessage::InitImage(const std::string &imageName, Point position, float time, bool flash)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &imageName_arg, Point position_arg, float time_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1408::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1409::func;
 	return execfunc(this, imageName, position, time, flash);
 }
 
-namespace _func1409
+namespace _func1410
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -19442,11 +19456,11 @@ namespace _func1409
 void WarningMessage::InitText(const TextString &text, Point position, float time, GL_Color textColor, bool centerText, bool flash)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg, Point position_arg, float time_arg, GL_Color textColor_arg, bool centerText_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1409::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1410::func;
 	return execfunc(this, text, position, time, textColor, centerText, flash);
 }
 
-namespace _func1410
+namespace _func1411
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19456,11 +19470,11 @@ namespace _func1410
 void WarningMessage::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1410::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1411::func;
 	return execfunc(this);
 }
 
-namespace _func1411
+namespace _func1412
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19470,11 +19484,11 @@ namespace _func1411
 void WarningMessage::SetImage(const std::string &imageName)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &imageName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1411::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1412::func;
 	return execfunc(this, imageName);
 }
 
-namespace _func1412
+namespace _func1413
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19484,11 +19498,11 @@ namespace _func1412
 void WarningMessage::SetText(const TextString &text)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1412::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1413::func;
 	return execfunc(this, text);
 }
 
-namespace _func1413
+namespace _func1414
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x4ff};
@@ -19498,11 +19512,11 @@ namespace _func1413
 void WarningMessage::SetText(const TextString &text, GL_Color textColor)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg, GL_Color textColor_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1413::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1414::func;
 	return execfunc(this, text, textColor);
 }
 
-namespace _func1414
+namespace _func1415
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -19512,11 +19526,11 @@ namespace _func1414
 void WarningMessage::SetPosition(Point position)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, Point position_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1414::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1415::func;
 	return execfunc(this, position);
 }
 
-namespace _func1415
+namespace _func1416
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19526,11 +19540,11 @@ namespace _func1415
 void WarningMessage::SetLoop(bool loop)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, bool loop_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1415::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1416::func;
 	return execfunc(this, loop);
 }
 
-namespace _func1416
+namespace _func1417
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19540,11 +19554,11 @@ namespace _func1416
 void WarningMessage::SetSound(const std::string &sound)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &sound_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1416::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1417::func;
 	return execfunc(this, sound);
 }
 
-namespace _func1417
+namespace _func1418
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19554,11 +19568,11 @@ namespace _func1417
 bool WeaponAnimation::StartFire()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1417::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1418::func;
 	return execfunc(this);
 }
 
-namespace _func1418
+namespace _func1419
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19568,11 +19582,11 @@ namespace _func1418
 void WeaponAnimation::SetFireTime(float time)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float time_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1418::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1419::func;
 	return execfunc(this, time);
 }
 
-namespace _func1419
+namespace _func1420
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19582,11 +19596,11 @@ namespace _func1419
 Pointf WeaponAnimation::GetSlide()
 {
 	typedef Pointf __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1419::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1420::func;
 	return execfunc(this);
 }
 
-namespace _func1420
+namespace _func1421
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19596,11 +19610,11 @@ namespace _func1420
 void WeaponAnimation::Update()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1420::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1421::func;
 	return execfunc(this);
 }
 
-namespace _func1421
+namespace _func1422
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19610,18 +19624,18 @@ namespace _func1421
 void WeaponAnimation::OnRender(float alpha)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1421::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1422::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func1422
+namespace _func1423
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("WeaponBlueprint::__DO_NOT_HOOK", typeid(void (WeaponBlueprint::*)()), "5589e55389cb83e4f083ec108b81c4000000c701????????85c074??890424e8????????8b83a00000008d93a8000000c703????????39d0", argdata, 0, 4, &func);
 }
 
-namespace _func1423
+namespace _func1424
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19631,11 +19645,11 @@ namespace _func1423
 void WeaponBlueprint::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1423::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1424::func;
 	return execfunc(this);
 }
 
-namespace _func1424
+namespace _func1425
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19645,11 +19659,11 @@ namespace _func1424
 void WeaponBlueprint::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1424::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1425::func;
 	return execfunc(this);
 }
 
-namespace _func1425
+namespace _func1426
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19659,11 +19673,11 @@ namespace _func1425
 std::string WeaponBlueprint::GetDescription(bool tooltip)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg, bool tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1425::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1426::func;
 	return execfunc(this, tooltip);
 }
 
-namespace _func1426
+namespace _func1427
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19673,11 +19687,11 @@ namespace _func1426
 void WeaponBlueprint::RenderIcon(float scale)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg, float scale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1426::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1427::func;
 	return execfunc(this, scale);
 }
 
-namespace _func1427
+namespace _func1428
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19687,11 +19701,11 @@ namespace _func1427
 Point WeaponBlueprint::GetDimensions()
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1427::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1428::func;
 	return execfunc(this);
 }
 
-namespace _func1428
+namespace _func1429
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19701,11 +19715,11 @@ namespace _func1428
 void WeaponBox::RenderBox(bool dragging, bool flashPowerBox)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponBox *this_arg, bool dragging_arg, bool flashPowerBox_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1428::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1429::func;
 	return execfunc(this, dragging, flashPowerBox);
 }
 
-namespace _func1429
+namespace _func1430
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19715,11 +19729,11 @@ namespace _func1429
 std::string WeaponBox::GenerateTooltip()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1429::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1430::func;
 	return execfunc(this);
 }
 
-namespace _func1430
+namespace _func1431
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -19729,11 +19743,11 @@ namespace _func1430
 void WeaponControl::Fire(std::vector<Pointf> &points, int target, bool autoFire)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, std::vector<Pointf> &points_arg, int target_arg, bool autoFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1430::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1431::func;
 	return execfunc(this, points, target, autoFire);
 }
 
-namespace _func1431
+namespace _func1432
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19743,11 +19757,11 @@ namespace _func1431
 void WeaponControl::OnRender(bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1431::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1432::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1432
+namespace _func1433
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -19757,11 +19771,11 @@ namespace _func1432
 bool WeaponControl::LButton(int x, int y, bool holdingShift)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, int x_arg, int y_arg, bool holdingShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1432::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1433::func;
 	return execfunc(this, x, y, holdingShift);
 }
 
-namespace _func1433
+namespace _func1434
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19771,11 +19785,11 @@ namespace _func1433
 void WeaponControl::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1433::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1434::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1434
+namespace _func1435
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19785,11 +19799,11 @@ namespace _func1434
 void WeaponControl::LinkShip(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1434::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1435::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1435
+namespace _func1436
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19799,11 +19813,11 @@ namespace _func1435
 void WeaponControl::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1435::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1436::func;
 	return execfunc(this);
 }
 
-namespace _func1436
+namespace _func1437
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19813,11 +19827,11 @@ namespace _func1436
 void WeaponControl::SetAutofiring(bool on, bool simple)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, bool on_arg, bool simple_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1436::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1437::func;
 	return execfunc(this, on, simple);
 }
 
-namespace _func1437
+namespace _func1438
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19827,11 +19841,11 @@ namespace _func1437
 bool WeaponControl::KeyDown(SDLKey key)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1437::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1438::func;
 	return execfunc(this, key);
 }
 
-namespace _func1438
+namespace _func1439
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19839,20 +19853,6 @@ namespace _func1438
 }
 
 void WeaponControl::RenderAiming()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1438::func;
-	return execfunc(this);
-}
-
-namespace _func1439
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("WeaponControl::RenderSelfAiming", typeid(void (WeaponControl::*)()), "5589e557565383e4f083ec308b41148b71108944242429f0c1f80285c0", argdata, 1, 5, &func);
-}
-
-void WeaponControl::RenderSelfAiming()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1439::func;
@@ -19863,10 +19863,10 @@ namespace _func1440
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("WeaponControl::OnLanguageChange", typeid(void (WeaponControl::*)()), "578d7c240883e4f0ff77fc5589e557565389cf8d75b48d5dd481ecac0000008b8188010000890424", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("WeaponControl::RenderSelfAiming", typeid(void (WeaponControl::*)()), "5589e557565383e4f083ec308b41148b71108944242429f0c1f80285c0", argdata, 1, 5, &func);
 }
 
-void WeaponControl::OnLanguageChange()
+void WeaponControl::RenderSelfAiming()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1440::func;
@@ -19876,6 +19876,20 @@ void WeaponControl::OnLanguageChange()
 namespace _func1441
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("WeaponControl::OnLanguageChange", typeid(void (WeaponControl::*)()), "578d7c240883e4f0ff77fc5589e557565389cf8d75b48d5dd481ecac0000008b8188010000890424", argdata, 1, 5, &func);
+}
+
+void WeaponControl::OnLanguageChange()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1441::func;
+	return execfunc(this);
+}
+
+namespace _func1442
+{
+    static void *func = 0;
 	static short argdata[] = {0x2ff, 0x2ff, 0x1ff};
 	static FunctionDefinition funcObj("WeaponControl::RenderBeamAiming", typeid(void (*)(Pointf , Pointf , bool )), "8d4c240483e4f0ff71fc5589e55756535189cb81ec880000008b018b7910f30f10410c", argdata, 3, 6, &func);
 }
@@ -19883,11 +19897,11 @@ namespace _func1441
 void WeaponControl::RenderBeamAiming(Pointf one, Pointf two, bool bAutoFire)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf one_arg, Pointf two_arg, bool bAutoFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1441::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1442::func;
 	return execfunc(one, two, bAutoFire);
 }
 
-namespace _func1442
+namespace _func1443
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19897,11 +19911,11 @@ namespace _func1442
 TextString WeaponControl::HolderLabel()
 {
 	typedef TextString __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1442::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1443::func;
 	return execfunc(this);
 }
 
-namespace _func1443
+namespace _func1444
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19911,18 +19925,18 @@ namespace _func1443
 SDLKey WeaponControl::ArmamentHotkey(unsigned int i)
 {
 	typedef SDLKey __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, unsigned int i_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1443::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1444::func;
 	return execfunc(this, i);
 }
 
-namespace _func1444
+namespace _func1445
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("WeaponStoreBox::__DO_NOT_HOOK", typeid(void (WeaponStoreBox::*)()), "c7442404000000008904248975d0e8????????8b55ccc7400c655f627583ec08c74010795f7765c7401461706f6e89d9c64018738945d08955d8c700????????c740046555492fc7400873746f72", argdata, 0, 4, &func);
 }
 
-namespace _func1445
+namespace _func1446
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -19932,11 +19946,11 @@ namespace _func1445
 void WeaponStoreBox::constructor(ShipManager *ship, Equipment *equip, const WeaponBlueprint *weaponBp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponStoreBox *this_arg, ShipManager *ship_arg, Equipment *equip_arg, const WeaponBlueprint *weaponBp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1445::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1446::func;
 	return execfunc(this, ship, equip, weaponBp);
 }
 
-namespace _func1446
+namespace _func1447
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19946,11 +19960,11 @@ namespace _func1446
 void WeaponSystem::RemoveWeapon(int slot)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1446::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1447::func;
 	return execfunc(this, slot);
 }
 
-namespace _func1447
+namespace _func1448
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19960,11 +19974,11 @@ namespace _func1447
 void WeaponSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1447::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1448::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func1448
+namespace _func1449
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19974,11 +19988,11 @@ namespace _func1448
 void WeaponSystem::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1448::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1449::func;
 	return execfunc(this);
 }
 
-namespace _func1449
+namespace _func1450
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -19988,11 +20002,11 @@ namespace _func1449
 void WeaponSystemBox::constructor(Point pos, ShipSystem *sys, WeaponControl *weapCtrl)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponSystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, WeaponControl *weapCtrl_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1449::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1450::func;
 	return execfunc(this, pos, sys, weapCtrl);
 }
 
-namespace _func1450
+namespace _func1451
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -20002,11 +20016,11 @@ namespace _func1450
 void WindowFrame::Draw(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WindowFrame *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1450::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1451::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1451
+namespace _func1452
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -20016,11 +20030,11 @@ namespace _func1451
 void WindowFrame::DrawMask(int unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WindowFrame *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1451::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1452::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1452
+namespace _func1453
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20030,11 +20044,11 @@ namespace _func1452
 void WindowFrame::constructor(int x, int y, int w, int h)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WindowFrame *this_arg, int x_arg, int y_arg, int w_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1452::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1453::func;
 	return execfunc(this, x, y, w, h);
 }
 
-namespace _func1453
+namespace _func1454
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20044,11 +20058,11 @@ namespace _func1453
 void WindowFrame::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WindowFrame *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1453::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1454::func;
 	return execfunc(this);
 }
 
-namespace _func1454
+namespace _func1455
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20058,11 +20072,11 @@ namespace _func1454
 void WorldManager::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1454::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1455::func;
 	return execfunc(this);
 }
 
-namespace _func1455
+namespace _func1456
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20072,11 +20086,11 @@ namespace _func1455
 int WorldManager::OnInit()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1455::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1456::func;
 	return execfunc(this);
 }
 
-namespace _func1456
+namespace _func1457
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -20086,11 +20100,11 @@ namespace _func1456
 CompleteShip *WorldManager::CreateShip(ShipEvent *shipEvent, bool boss)
 {
 	typedef CompleteShip *__attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, ShipEvent *shipEvent_arg, bool boss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1456::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1457::func;
 	return execfunc(this, shipEvent, boss);
 }
 
-namespace _func1457
+namespace _func1458
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -20100,11 +20114,11 @@ namespace _func1457
 void WorldManager::CreateLocation(Location *loc)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1457::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1458::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1458
+namespace _func1459
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20114,11 +20128,11 @@ namespace _func1458
 void WorldManager::ClearLocation()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1458::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1459::func;
 	return execfunc(this);
 }
 
-namespace _func1459
+namespace _func1460
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20128,11 +20142,11 @@ namespace _func1459
 void WorldManager::SaveGame()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1459::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1460::func;
 	return execfunc(this);
 }
 
-namespace _func1460
+namespace _func1461
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -20140,20 +20154,6 @@ namespace _func1460
 }
 
 void WorldManager::CreateChoiceBox(LocationEvent *event)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1460::func;
-	return execfunc(this, event);
-}
-
-namespace _func1461
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("WorldManager::CreateChoiceBox0", typeid(void (WorldManager::*)(LocationEvent *)), "578d7c240883e4f0ff77fc5589e557565389cb83ec1c8b018b378b48088b018b40443d????????752a0fb6819904000084c0751185f6742889342489d9e8????????83ec04", argdata, 2, 5, &func);
-}
-
-void WorldManager::CreateChoiceBox0(LocationEvent *event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1461::func;
@@ -20164,10 +20164,10 @@ namespace _func1462
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("WorldManager::UpdateLocation", typeid(void (WorldManager::*)(LocationEvent *)), "578d7c240883e4f0ff77fc5589e557565381ec????????8b3f898d70fbffff807f1c000f85????????8d85bcfbffff89ce898568fbffff8d85c4fbffff898564fbffff8d874406000089f1890424", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("WorldManager::CreateChoiceBox0", typeid(void (WorldManager::*)(LocationEvent *)), "578d7c240883e4f0ff77fc5589e557565389cb83ec1c8b018b378b48088b018b40443d????????752a0fb6819904000084c0751185f6742889342489d9e8????????83ec04", argdata, 2, 5, &func);
 }
 
-void WorldManager::UpdateLocation(LocationEvent *event)
+void WorldManager::CreateChoiceBox0(LocationEvent *event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1462::func;
@@ -20178,10 +20178,10 @@ namespace _func1463
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("WorldManager::UpdateLocation0", typeid(void (WorldManager::*)(LocationEvent *)), "578d7c240883e4f0ff77fc5589e557565389cb83ec1c8b018b378b48088b018b40443d????????75270fb6819904000084c0750d89342489d9e8????????83ec04", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("WorldManager::UpdateLocation", typeid(void (WorldManager::*)(LocationEvent *)), "578d7c240883e4f0ff77fc5589e557565381ec????????8b3f898d70fbffff807f1c000f85????????8d85bcfbffff89ce898568fbffff8d85c4fbffff898564fbffff8d874406000089f1890424", argdata, 2, 5, &func);
 }
 
-void WorldManager::UpdateLocation0(LocationEvent *event)
+void WorldManager::UpdateLocation(LocationEvent *event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1463::func;
@@ -20192,17 +20192,31 @@ namespace _func1464
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("WorldManager::UpdateLocation0", typeid(void (WorldManager::*)(LocationEvent *)), "578d7c240883e4f0ff77fc5589e557565389cb83ec1c8b018b378b48088b018b40443d????????75270fb6819904000084c0750d89342489d9e8????????83ec04", argdata, 2, 5, &func);
+}
+
+void WorldManager::UpdateLocation0(LocationEvent *event)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1464::func;
+	return execfunc(this, event);
+}
+
+namespace _func1465
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("WorldManager::ModifyResources", typeid(LocationEvent *(WorldManager::*)(LocationEvent *)), "578d7c240883e4f0ff77fc5589e557565389ce8d8d2cfeffff81ec????????8b078985d8fcffff", argdata, 2, 1, &func);
 }
 
 LocationEvent *WorldManager::ModifyResources(LocationEvent *event)
 {
 	typedef LocationEvent *__attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1464::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1465::func;
 	return execfunc(this, event);
 }
 
-namespace _func1465
+namespace _func1466
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -20212,11 +20226,11 @@ namespace _func1465
 void WorldManager::ModifyEnvironment(int envFlag, int envTarget)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, int envFlag_arg, int envTarget_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1465::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1466::func;
 	return execfunc(this, envFlag, envTarget);
 }
 
-namespace _func1466
+namespace _func1467
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -20226,11 +20240,11 @@ namespace _func1466
 void WorldManager::CheckStatusEffects(std::vector<StatusEffect> &vec)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, std::vector<StatusEffect> &vec_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1466::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1467::func;
 	return execfunc(this, vec);
 }
 
-namespace _func1467
+namespace _func1468
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x4ff, 0x1ff, 0x1ff};
@@ -20240,11 +20254,11 @@ namespace _func1467
 void WorldManager::ModifyStatusEffect(StatusEffect effect, ShipManager *target, int targetType)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, StatusEffect effect_arg, ShipManager *target_arg, int targetType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1467::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1468::func;
 	return execfunc(this, effect, target, targetType);
 }
 
-namespace _func1468
+namespace _func1469
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -20254,11 +20268,11 @@ namespace _func1468
 void WorldManager::StartGame(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1468::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1469::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1469
+namespace _func1470
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20268,11 +20282,11 @@ namespace _func1469
 void WorldManager::Restart()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1469::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1470::func;
 	return execfunc(this);
 }
 
-namespace _func1470
+namespace _func1471
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -20282,11 +20296,11 @@ namespace _func1470
 void WorldManager::LoadGame(const std::string &fileName)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1470::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1471::func;
 	return execfunc(this, fileName);
 }
 
-namespace _func1471
+namespace _func1472
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20294,20 +20308,6 @@ namespace _func1471
 }
 
 void WorldManager::OnLoop()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1471::func;
-	return execfunc(this);
-}
-
-namespace _func1472
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("WorldManager::PauseLoop", typeid(void (WorldManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec5c8b098b01ff500c83be3408000001", argdata, 1, 5, &func);
-}
-
-void WorldManager::PauseLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1472::func;
@@ -20318,10 +20318,10 @@ namespace _func1473
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("WorldManager::CreateNewGame", typeid(void (WorldManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce8d5dd88d7dd083ec3c8b018b480881c1????????e8????????8b068b5008895dd08b8aa4060000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("WorldManager::PauseLoop", typeid(void (WorldManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec5c8b098b01ff500c83be3408000001", argdata, 1, 5, &func);
 }
 
-void WorldManager::CreateNewGame()
+void WorldManager::PauseLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1473::func;
@@ -20332,17 +20332,31 @@ namespace _func1474
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("WorldManager::CreateNewGame", typeid(void (WorldManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce8d5dd88d7dd083ec3c8b018b480881c1????????e8????????8b068b5008895dd08b8aa4060000", argdata, 1, 5, &func);
+}
+
+void WorldManager::CreateNewGame()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1474::func;
+	return execfunc(this);
+}
+
+namespace _func1475
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("WorldManager::HostileEnvironment", typeid(bool (WorldManager::*)()), "5589e55389cb83c10883e4f0e8????????84c075??8b038b4808b8????????8b91f007000085d274??", argdata, 1, 1, &func);
 }
 
 bool WorldManager::HostileEnvironment()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1474::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1475::func;
 	return execfunc(this);
 }
 
-namespace _func1475
+namespace _func1476
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -20352,11 +20366,11 @@ namespace _func1475
 bool WorldManager::AddBoarders(BoardingEvent &boardingEvent)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, BoardingEvent &boardingEvent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1475::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1476::func;
 	return execfunc(this, boardingEvent);
 }
 
-namespace _func1476
+namespace _func1477
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -20366,11 +20380,11 @@ namespace _func1476
 void WorldManager::CreateStore(LocationEvent *event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1476::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1477::func;
 	return execfunc(this, event);
 }
 
-namespace _func1477
+namespace _func1478
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -20380,11 +20394,11 @@ namespace _func1477
 bool WorldManager::CheckRequirements(LocationEvent *event, bool hidden)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg, bool hidden_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1477::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1478::func;
 	return execfunc(this, event, hidden);
 }
 
-namespace _func1478
+namespace _func1479
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20394,11 +20408,11 @@ namespace _func1478
 Pointf freetype::easy_measurePrintLines(int fontSize, float x, float y, int line_length, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1478::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1479::func;
 	return execfunc(fontSize, x, y, line_length, text);
 }
 
-namespace _func1479
+namespace _func1480
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20408,11 +20422,11 @@ namespace _func1479
 int freetype::easy_measureWidth(int fontSize, const std::string &text)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1479::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1480::func;
 	return execfunc(fontSize, text);
 }
 
-namespace _func1480
+namespace _func1481
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20422,11 +20436,11 @@ namespace _func1480
 Pointf freetype::easy_print(int fontSize, float x, float y, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1480::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1481::func;
 	return execfunc(fontSize, x, y, text);
 }
 
-namespace _func1481
+namespace _func1482
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20436,11 +20450,11 @@ namespace _func1481
 Pointf freetype::easy_printRightAlign(int fontSize, float x, float y, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1481::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1482::func;
 	return execfunc(fontSize, x, y, text);
 }
 
-namespace _func1482
+namespace _func1483
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20450,11 +20464,11 @@ namespace _func1482
 Pointf freetype::easy_printNewlinesCentered(int fontSize, float x, float y, int line_length, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1482::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1483::func;
 	return execfunc(fontSize, x, y, line_length, text);
 }
 
-namespace _func1483
+namespace _func1484
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20464,11 +20478,11 @@ namespace _func1483
 Pointf freetype::easy_printAutoNewlines(int fontSize, float x, float y, int line_length, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1483::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1484::func;
 	return execfunc(fontSize, x, y, line_length, text);
 }
 
-namespace _func1484
+namespace _func1485
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20478,11 +20492,11 @@ namespace _func1484
 Pointf freetype::easy_printCenter(int fontSize, float x, float y, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1484::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1485::func;
 	return execfunc(fontSize, x, y, text);
 }
 
-namespace _func1485
+namespace _func1486
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20492,11 +20506,11 @@ namespace _func1485
 void freetype::easy_printAutoShrink(int fontId, float x, float y, int maxWidth, bool centered, const std::string &text)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontId_arg, float x_arg, float y_arg, int maxWidth_arg, bool centered_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1485::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1486::func;
 	return execfunc(fontId, x, y, maxWidth, centered, text);
 }
 
-namespace _func1486
+namespace _func1487
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20506,11 +20520,11 @@ namespace _func1486
 void freetype::font_data::init(const void *buffer, int bufferSize, unsigned int h, bool glow)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(freetype::font_data *this_arg, const void *buffer_arg, int bufferSize_arg, unsigned int h_arg, bool glow_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1486::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1487::func;
 	return execfunc(this, buffer, bufferSize, h, glow);
 }
 
-namespace _func1487
+namespace _func1488
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20520,11 +20534,11 @@ namespace _func1487
 void freetype::font_data::init_bitmap(const void *buffer, int bufferSize, int size, int h)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(freetype::font_data *this_arg, const void *buffer_arg, int bufferSize_arg, int size_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1487::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1488::func;
 	return execfunc(this, buffer, bufferSize, size, h);
 }
 
-namespace _func1488
+namespace _func1489
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20534,11 +20548,11 @@ namespace _func1488
 void freetype::font_data::clean()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(freetype::font_data *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1488::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1489::func;
 	return execfunc(this);
 }
 
-namespace _func1489
+namespace _func1490
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20548,11 +20562,11 @@ namespace _func1489
 float __stdcall font_baseline(int font_id, float size)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(int font_id_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1489::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1490::func;
 	return execfunc(font_id, size);
 }
 
-namespace _func1490
+namespace _func1491
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20562,13 +20576,13 @@ namespace _func1490
 float __stdcall font_height(int font_id, float size)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(int font_id_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1490::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1491::func;
 	return execfunc(font_id, size);
 }
 
 float *Global_freetype_sil_freetype_outline;
 
-namespace _var1491
+namespace _var1492
 {
     static VariableDefinition varObj("Global_freetype_sil_freetype_outline", "!89108b559cc705(???????\?)000000408950048b55a0", &Global_freetype_sil_freetype_outline);
 }

--- a/FTLGameWin32.h
+++ b/FTLGameWin32.h
@@ -556,6 +556,7 @@ struct AchievementTracker
 	LIBZHL_API void LoadAchievementDescriptions();
 	LIBZHL_API void LoadProfile(int file, int version);
 	LIBZHL_API void OnLanguageChange();
+	LIBZHL_API void OnLoop();
 	LIBZHL_API void ResetFlags();
 	LIBZHL_API void SaveProfile(int file);
 	LIBZHL_API void SetAchievement(const std::string &achievement, bool noPopup, bool sendToServer);

--- a/Mod Files/data/hyperspace.xml
+++ b/Mod Files/data/hyperspace.xml
@@ -464,7 +464,7 @@ Omit score_main_right_2b when you don't care about matching a pattern outside an
 	<achievement name="ACH_ID">
 		<name id="text_id">text</name>
 		<description id="text_id">text</name>
-		<header id="text_id">text</name>
+		<header id="text_id">text</name> (if set, will play the ship unlock sound unless <sound> is specified)
 		<secretName id="text_id">text</name>
 		<secretDescription id="text_id">text</name>
 		<icon>image_name</icon> (name of image file in achievements folder, without extension)
@@ -472,6 +472,7 @@ Omit score_main_right_2b when you don't care about matching a pattern outside an
 		<variable name="varname" amount="100"/> (name of variable or meta-variable to track, optional)
 		<hidden/> (don't show achievement on stats if locked)
 		<multiDifficulty>true</multiDifficulty> (if true display the achieved difficulty, if false then don't)
+		<sound>sound_id</sound> (replace the achievement sound with a custom sound)
 	</achievement>
 	<page>
 		<section id="text_id" text="text" secretId="text_id" secretText="text" hidden="false">

--- a/libzhlgen/test/functions/ELF_amd64/1.6.13/AchievementTracker.zhl
+++ b/libzhlgen/test/functions/ELF_amd64/1.6.13/AchievementTracker.zhl
@@ -30,6 +30,8 @@ cleanup __amd64 void AchievementTracker::OnLanguageChange(AchievementTracker *th
 cleanup __amd64 void AchievementTracker::SetTooltip(AchievementTracker *this, CAchievement *ach);
 "53488b77584889fb488d7f48":
 cleanup __amd64 void AchievementTracker::ResetFlags(AchievementTracker *this);
+"415455534889fb4883ec20488b":
+cleanup __amd64 void AchievementTracker::OnLoop(AchievementTracker *this);
 
 
 "!488d742420bf(???????\?)e8????????488b5424208b44240c":

--- a/libzhlgen/test/functions/ELF_x86/1.6.13/AchievementTracker.zhl
+++ b/libzhlgen/test/functions/ELF_x86/1.6.13/AchievementTracker.zhl
@@ -28,6 +28,8 @@ cleanup __cdecl void AchievementTracker::OnLanguageChange(AchievementTracker *th
 cleanup __cdecl void AchievementTracker::SetTooltip(AchievementTracker *this, CAchievement *ach);
 "565383ec148b7424208b462c894424048d4624890424":
 cleanup __cdecl void AchievementTracker::ResetFlags(AchievementTracker *this);
+"554889e5415741564154534883ec204989fc":
+cleanup __cdecl void AchievementTracker::OnLoop(AchievementTracker *this);
 
 
 "!e8????????89742404c70424(???????\?)e8????????8b44242c8d50f4":

--- a/libzhlgen/test/functions/win32/1.6.9/AchievementTracker.zhl
+++ b/libzhlgen/test/functions/win32/1.6.9/AchievementTracker.zhl
@@ -28,6 +28,8 @@ __thiscall void AchievementTracker::OnLanguageChange(AchievementTracker *this);
 __thiscall void AchievementTracker::SetTooltip(AchievementTracker *this, CAchievement *ach);
 "578d41248d7c240883e4f0ff77fc5589e557565389cf83ec2c8b712c8945e485f6":
 __thiscall void AchievementTracker::ResetFlags(AchievementTracker *this);
+"578d7c????83e4f0ff????5589e557565389cb83ec4c8b013b":
+__thiscall void AchievementTracker::OnLoop(AchievementTracker *this);
 
 
 "!b9(???????\?)e8????????c744240c00000000":


### PR DESCRIPTION
Required adding `AchievementTracker::OnLoop()` sig.
Untested on linux.

Adds the `<sound>sound_id</sound>` tag to the `<achievements>` xml, allowing for custom sounds.
Also somewhat fixes the issue of `<header>` replacing the achievements sound by the ship unlock sound when uneeded. #350 
