### PR TITLE
Exposed bPaused to Lua scripting, updated documentation

### DIFF
--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -580,9 +580,9 @@ playerVariableType playerVariables;
 %rename("%s") CommandGui::outOfFuel;
 %immutable CommandGui::outOfFuel;
 %rename("%s") CommandGui::bPaused;
-%immutable CommandGui::bPaused;
+// %immutable CommandGui::bPaused;
 %rename("%s") CommandGui::bAutoPaused;
-%immutable CommandGui::bAutoPaused;
+%immutable CommandGui::bAutoPaused; // potentially find a way to try ESC pausing, currently does nothing
 %rename("%s") CommandGui::menu_pause;
 %immutable CommandGui::menu_pause;
 %rename("%s") CommandGui::event_pause;

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -580,7 +580,6 @@ playerVariableType playerVariables;
 %rename("%s") CommandGui::outOfFuel;
 %immutable CommandGui::outOfFuel;
 %rename("%s") CommandGui::bPaused;
-// %immutable CommandGui::bPaused;
 %rename("%s") CommandGui::bAutoPaused;
 %immutable CommandGui::bAutoPaused; // potentially find a way to try ESC pausing, currently does nothing
 %rename("%s") CommandGui::menu_pause;

--- a/wiki/Lua-Hyperspace-Module.md
+++ b/wiki/Lua-Hyperspace-Module.md
@@ -2198,8 +2198,8 @@ local _, canMove = crew.extend:CalculateStat(Hyperspace.CrewStat.CAN_MOVE)
 - `bool` `.outOfFuel`
    - **Read-only**
 - `bool` `.bPaused`
-   - **Read-only**
    - Only true for spacebar pauses, NOT event pauses or ESC menu pauses.
+   - Modifying this variable during event pauses and ESC menu pauses does not unfreeze the game; it will only change whether or not the game remains paused when the event or ESC menu closes.
 - `bool` `.bAutoPaused`
    - **Read-only**
    - Maybe true for event pauses and ESC menu pauses? Not sure.


### PR DESCRIPTION
The variable `bPaused`, part of `CApp`, is now exposed to Lua scripting. See the documentation for further details.