### PR TITLE
Add overloads for hs_log_file

### DIFF
--- a/Global.cpp
+++ b/Global.cpp
@@ -46,6 +46,32 @@ void hs_log_file(const char *str...)
     va_end(va);
 }
 
+void hs_log_file(const std::string &str)
+{
+    FILE* log = G_->logFile;
+    if (log != nullptr)
+    {
+        fputs(str.c_str(), log);
+        fflush(G_->logFile);
+    }
+}
+
+void hs_log_file(bool val)
+{
+    if (val) hs_log_file("true");
+    else hs_log_file("false");
+}
+
+void hs_log_file(int val) {hs_log_file(std::to_string(val));}
+void hs_log_file(unsigned int val) {hs_log_file(std::to_string(val));}
+void hs_log_file(long val) {hs_log_file(std::to_string(val));}
+void hs_log_file(unsigned long val) {hs_log_file(std::to_string(val));}
+void hs_log_file(long long val) {hs_log_file(std::to_string(val));}
+void hs_log_file(unsigned long long val) {hs_log_file(std::to_string(val));}
+void hs_log_file(float val) {hs_log_file(std::to_string(val));}
+void hs_log_file(double val) {hs_log_file(std::to_string(val));}
+void hs_log_file(long double val) {hs_log_file(std::to_string(val));}
+
 void ftl_log(const char *str...)
 {
     va_list va;

--- a/Global.cpp
+++ b/Global.cpp
@@ -56,8 +56,6 @@ void hs_log_file(const std::string &str)
     }
 }
 
-
-
 void ftl_log(const char *str...)
 {
     va_list va;

--- a/Global.cpp
+++ b/Global.cpp
@@ -56,21 +56,7 @@ void hs_log_file(const std::string &str)
     }
 }
 
-void hs_log_file(bool val)
-{
-    if (val) hs_log_file("true");
-    else hs_log_file("false");
-}
 
-void hs_log_file(int val) {hs_log_file(std::to_string(val));}
-void hs_log_file(unsigned int val) {hs_log_file(std::to_string(val));}
-void hs_log_file(long val) {hs_log_file(std::to_string(val));}
-void hs_log_file(unsigned long val) {hs_log_file(std::to_string(val));}
-void hs_log_file(long long val) {hs_log_file(std::to_string(val));}
-void hs_log_file(unsigned long long val) {hs_log_file(std::to_string(val));}
-void hs_log_file(float val) {hs_log_file(std::to_string(val));}
-void hs_log_file(double val) {hs_log_file(std::to_string(val));}
-void hs_log_file(long double val) {hs_log_file(std::to_string(val));}
 
 void ftl_log(const char *str...)
 {

--- a/Global.h
+++ b/Global.h
@@ -91,16 +91,6 @@ private:
 
 void hs_log_file(const char *str...);
 void hs_log_file(const std::string &str);
-void hs_log_file(bool val);
-void hs_log_file(int val);
-void hs_log_file(unsigned int val);
-void hs_log_file(long val);
-void hs_log_file(unsigned long val);
-void hs_log_file(long long val);
-void hs_log_file(unsigned long long val);
-void hs_log_file(float val);
-void hs_log_file(double val);
-void hs_log_file(long double val);
 void ftl_log(const char *str...);
 void ErrorMessage(const std::string &msg);
 void ErrorMessage(const char *msg);

--- a/Global.h
+++ b/Global.h
@@ -90,6 +90,17 @@ private:
 };
 
 void hs_log_file(const char *str...);
+void hs_log_file(const std::string &str);
+void hs_log_file(bool val);
+void hs_log_file(int val);
+void hs_log_file(unsigned int val);
+void hs_log_file(long val);
+void hs_log_file(unsigned long val);
+void hs_log_file(long long val);
+void hs_log_file(unsigned long long val);
+void hs_log_file(float val);
+void hs_log_file(double val);
+void hs_log_file(long double val);
 void ftl_log(const char *str...);
 void ErrorMessage(const std::string &msg);
 void ErrorMessage(const char *msg);


### PR DESCRIPTION
I often use hs_log_file as printing values, though it can only handle *char. So this pr add basic overloads for hs_log_file so that it can help me a lot for HS development.

Add overloads for following types:
- std::string
- bool
- int
- unsigned int
- long
- unsigned long
- long long
- unsigned long long
- float
- double
- long double