### PR TITLE
Fix upgrade rendering for reduced reactor cap

### DIFF
--- a/CustomReactor.cpp
+++ b/CustomReactor.cpp
@@ -72,7 +72,7 @@ HOOK_METHOD(ReactorButton, OnRightClick, ()->void)
     }
 }
 
-HOOK_METHOD(ReactorButton, OnRender, ()->void)
+HOOK_METHOD_PRIORITY(ReactorButton, OnRender, 9999, ()->void)
 {
     LOG_HOOK("HOOK_METHOD -> ReactorButton::OnRender -> Begin (CustomReactor.cpp)\n")
     const CustomShipDefinition &def = CustomShipSelect::GetInstance()->GetDefinition(ship->myBlueprint.blueprintName);
@@ -121,6 +121,7 @@ HOOK_METHOD(ReactorButton, OnRender, ()->void)
     while(displayMaxLevel > 25){
         displayMaxLevel -= 5;
     }
+    int displayMaxCol = (displayMaxLevel > 20) ? 5 : ceil(displayMaxLevel / 5);
 
     //reactor upgrade boxes rendering
     GL_Color currentColour = (bActive && bHover) ? hoverColour : dirtyWhite;
@@ -130,7 +131,7 @@ HOOK_METHOD(ReactorButton, OnRender, ()->void)
             GL_Color colour;
             if(currentBar <= displayReactorLevel) colour = fullColour;
             else if (currentBar <= displayTempLevel) colour = COLOR_YELLOW;
-            else if((tempLevel > (maxLevel - 4)) && (currentBar > displayMaxLevel)) continue;
+            else if (currentBar > displayMaxLevel) continue;
             else colour = emptyColour;
             CSurface::GL_DrawRect(baseX + 30 + col * 44, baseY + 74 - row * 13, 32, -8, colour);
         }
@@ -143,7 +144,7 @@ HOOK_METHOD(ReactorButton, OnRender, ()->void)
         }
 
         //prices over the coloumns
-        std::string price = std::to_string(currentCost);
+        std::string price = col >= displayMaxCol ? "--" : std::to_string(currentCost);
         CSurface::GL_SetColor(currentColour);
         freetype::easy_printRightAlign(5, baseX + 47 + col * 44, baseY + 2, price);
     }

--- a/CustomReactor.cpp
+++ b/CustomReactor.cpp
@@ -72,7 +72,7 @@ HOOK_METHOD(ReactorButton, OnRightClick, ()->void)
     }
 }
 
-HOOK_METHOD_PRIORITY(ReactorButton, OnRender, 9999, ()->void)
+HOOK_METHOD(ReactorButton, OnRender, ()->void)
 {
     LOG_HOOK("HOOK_METHOD -> ReactorButton::OnRender -> Begin (CustomReactor.cpp)\n")
     const CustomShipDefinition &def = CustomShipSelect::GetInstance()->GetDefinition(ship->myBlueprint.blueprintName);


### PR DESCRIPTION
Fix issue #398 
change the original conditon
`else if((tempLevel > (maxLevel - 4)) && (currentBar > displayMaxLevel)) continue;`
to
`else if (currentBar > displayMaxLevel) continue;`

Not sure what `(tempLevel > (maxLevel - 4))` is intended, only laszlogasd who wrote this would know.

And make columns that have no upgrade rectangles due to low max power display `--` at the price display instead of increased value form previous price.

~~Also, this hook seems never call super inside and intend to rewrite vanilla function. So I replace HOOK_METHOD with HOOK_METHOD_PRIORITY with priority 9999. This is what rewriting should be.~~
Reverted to HOOK_METHOD