### PR TITLE
Fix warning lights position

### DIFF
--- a/CustomShips.h
+++ b/CustomShips.h
@@ -6,6 +6,8 @@ extern bool g_enemyPreigniterFix;
 
 extern bool g_artilleryGibMountFix;
 
+extern bool g_warningLightPositionFix;
+
 extern bool g_hideHullDuringExplosion;
 
 extern bool revisitingShip;

--- a/Mod Files/data/hyperspace.xml
+++ b/Mod Files/data/hyperspace.xml
@@ -283,6 +283,11 @@ When the fix is enabled, the range will be unlimited against enemy combat drones
 
 <artilleryGibMountFix enabled="false"/>
 
+<!--  Moves red flashing lights (which appear when there is fire or breach in the room) to an appropriate position so that they no longer stick to doors or leave from walls.
+-->
+
+<warningLightPositionFix enabled="false"/>
+
 <!--  Prevents hull image from being drawn over gibs during a ship explosion.
 -->
 

--- a/Resources.cpp
+++ b/Resources.cpp
@@ -426,6 +426,12 @@ void Global::InitializeResources(ResourceControl *resources)
                 g_artilleryGibMountFix = EventsParser::ParseBoolean(enabled);
             }
 
+            if (strcmp(node->name(), "warningLightPositionFix") == 0)
+            {
+                auto enabled = node->first_attribute("enabled")->value();
+                g_warningLightPositionFix = EventsParser::ParseBoolean(enabled);
+            }
+
             if (strcmp(node->name(), "hideHullDuringExplosion") == 0)
             {
                 auto enabled = node->first_attribute("enabled")->value();


### PR DESCRIPTION
Fix issue #323 

This pr adds an algorithm to relocate warning lights so that they no longer stick to doors or leave from walls.

Example 1 Before
![image](https://github.com/user-attachments/assets/c2f03649-9fed-484e-b91b-c041006f6c82)
Example 1 After
![image](https://github.com/user-attachments/assets/8931986a-a574-44ad-bc09-aa6a6a76968d)

Example 2 Before
![image](https://github.com/user-attachments/assets/e8163b84-c62f-4e07-8b7f-07b0c11f5597)
Example 2 After
![image](https://github.com/user-attachments/assets/0c877be3-33e4-4ff8-be09-37c616b88103)
