### PR TITLE
expose custom ship unlock

### DIFF
--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -459,6 +459,7 @@ playerVariableType playerVariables;
 %rename("%s") CustomEventsParser;
 %rename("%s") CustomEventsParser::GetInstance;
 %rename("%s") CustomEventsParser::LoadEvent;
+%rename("%s") CustomEventsParser::GetCustomEvent;
 %luacode {
     print "Hyperspace SWIG Lua loaded"
     _G["mods"] = {}
@@ -651,6 +652,11 @@ playerVariableType playerVariables;
 %rename("%s") LocationEvent::unlockShip;
 %rename("%s") LocationEvent::unlockShipText;
 %rename("%s") LocationEvent::secretSector;
+
+%nodefaultctor CustomEvent;
+%nodefaultdtor CustomEvent;
+%rename("%s") CustomEvent;
+%rename("%s") CustomEvent::unlockShip;
 
 %rename("%s") FocusWindow;
 %rename("%s") FocusWindow::bOpen;

--- a/wiki/Lua-Hyperspace-Module.md
+++ b/wiki/Lua-Hyperspace-Module.md
@@ -3415,6 +3415,13 @@ Accessed via `Hyperspace.CustomEventsParser.GetInstance()`
 
 - `void :LoadEvent(WorldManager *world, EventLoadList *eventList, int seed, CustomEvent *parentEvent = nullptr)`
 - `void :LoadEvent(WorldManager *world, std::string eventName, bool ignoreUnique, int seed, CustomEvent *parentEvent = nullptr)`
+- [`CustomEvent*`](#CustomEvent) `CustomEventsParser::GetCustomEvent(std::string eventName)`
+- [`CustomEvent*`](#CustomEvent) `CustomEventsParser::GetCustomEvent(Location *loc)`
+
+## CustomEvent
+
+### Fields
+- `std::string` `unlockShip`
 
 ## MainMenu
 


### PR DESCRIPTION
`CustomEvent::unlockShip` can now be accessed from Lua, specifically the `PRE_CREATE_CHOICEBOX` and `POST_CREATE_CHOICEBOX` events.
```lua
Hyperspace.CustomEventsParser.GetInstance():GetCustomEvent(event.eventName)
```