### PR TITLE
Exposing BreachSpecificHull

### DIFF
--- a/FTLGameELF32.cpp
+++ b/FTLGameELF32.cpp
@@ -12526,12 +12526,12 @@ namespace _func913
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("Ship::BreachSpecificHull", typeid(void (Ship::*)(int , int )), "5589e557565383ec4c8b450c8b7d10", argdata, 3, 6, &func);
+	static FunctionDefinition funcObj("Ship::BreachSpecificHull", typeid(bool (Ship::*)(int , int )), "5589e557565383ec4c8b450c8b7d10", argdata, 3, 2, &func);
 }
 
-void Ship::BreachSpecificHull(int grid_x, int grid_y)
+bool Ship::BreachSpecificHull(int grid_x, int grid_y)
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int grid_x_arg, int grid_y_arg);
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int grid_x_arg, int grid_y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func913::func;
 	return execfunc(this, grid_x, grid_y);
 }

--- a/FTLGameELF32.h
+++ b/FTLGameELF32.h
@@ -6739,7 +6739,7 @@ struct Ship : ShipObject
 	};
 	
 	LIBZHL_API void BreachRandomHull(int roomId);
-	LIBZHL_API void BreachSpecificHull(int grid_x, int grid_y);
+	LIBZHL_API bool BreachSpecificHull(int grid_x, int grid_y);
 	LIBZHL_API bool DestroyedDone();
 	LIBZHL_API int EmptySlots(int roomId);
 	LIBZHL_API bool FullRoom(int roomId, bool intruder);

--- a/FTLGameELF64.cpp
+++ b/FTLGameELF64.cpp
@@ -11423,12 +11423,12 @@ void Ship::OnRenderBreaches()
 namespace _func895
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Ship::BreachSpecificHull", typeid(void (Ship::*)(int , int )), ".41564989fe4155415455534883ec30", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Ship::BreachSpecificHull", typeid(bool (Ship::*)(int , int )), ".41564989fe4155415455534883ec30", nullptr, 0, 0, &func);
 }
 
-void Ship::BreachSpecificHull(int grid_x, int grid_y)
+bool Ship::BreachSpecificHull(int grid_x, int grid_y)
 {
-	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, int grid_x_arg, int grid_y_arg);
+	typedef bool (*custom_arg_funcptr_t)(Ship *this_arg, int grid_x_arg, int grid_y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func895::func;
 	return execfunc(this, grid_x, grid_y);
 }

--- a/FTLGameELF64.h
+++ b/FTLGameELF64.h
@@ -6762,7 +6762,7 @@ struct Ship : ShipObject
 	};
 	
 	LIBZHL_API void BreachRandomHull(int roomId);
-	LIBZHL_API void BreachSpecificHull(int grid_x, int grid_y);
+	LIBZHL_API bool BreachSpecificHull(int grid_x, int grid_y);
 	LIBZHL_API bool DestroyedDone();
 	LIBZHL_API int EmptySlots(int roomId);
 	LIBZHL_API bool FullRoom(int roomId, bool intruder);

--- a/FTLGameWin32.cpp
+++ b/FTLGameWin32.cpp
@@ -12498,12 +12498,12 @@ namespace _func907
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("Ship::BreachSpecificHull", typeid(void (Ship::*)(int , int )), "578d7c240883e4f0ff77fc5589e557565331db89ce83ec4c8b078b51208945c48b47048945c08b4124", argdata, 3, 5, &func);
+	static FunctionDefinition funcObj("Ship::BreachSpecificHull", typeid(bool (Ship::*)(int , int )), "578d7c240883e4f0ff77fc5589e557565331db89ce83ec4c8b078b51208945c48b47048945c08b4124", argdata, 3, 1, &func);
 }
 
-void Ship::BreachSpecificHull(int grid_x, int grid_y)
+bool Ship::BreachSpecificHull(int grid_x, int grid_y)
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int grid_x_arg, int grid_y_arg);
+	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int grid_x_arg, int grid_y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func907::func;
 	return execfunc(this, grid_x, grid_y);
 }

--- a/FTLGameWin32.h
+++ b/FTLGameWin32.h
@@ -6765,7 +6765,7 @@ struct Ship : ShipObject
 	};
 	
 	LIBZHL_API void BreachRandomHull(int roomId);
-	LIBZHL_API void BreachSpecificHull(int grid_x, int grid_y);
+	LIBZHL_API bool BreachSpecificHull(int grid_x, int grid_y);
 	LIBZHL_API bool DestroyedDone();
 	LIBZHL_API int EmptySlots(int roomId);
 	LIBZHL_API bool FullRoom(int roomId, bool intruder);

--- a/libzhlgen/test/functions/ELF_amd64/1.6.13/Ship.zhl
+++ b/libzhlgen/test/functions/ELF_amd64/1.6.13/Ship.zhl
@@ -15,7 +15,7 @@ cleanup __amd64 void Ship::OnRenderSparks(Ship *this);
 ".41544531e45531ed53488b57404889fb":
 cleanup __amd64 void Ship::OnRenderBreaches(Ship *this);
 ".41564989fe4155415455534883ec30":
-cleanup __amd64 void Ship::BreachSpecificHull(Ship *this, int grid_x, int grid_y);
+cleanup __amd64 bool Ship::BreachSpecificHull(Ship *this, int grid_x, int grid_y);
 "!.41544189cc5589d5538b7f08":
 cleanup __amd64 int Ship::GetSelectedRoomId(Ship *this, int x, int y, bool unk);
 ".415431c94189f4554889fd53488b5710":

--- a/libzhlgen/test/functions/ELF_x86/1.6.13/Ship.zhl
+++ b/libzhlgen/test/functions/ELF_x86/1.6.13/Ship.zhl
@@ -39,7 +39,7 @@ cleanup __cdecl void Ship::BreachRandomHull(Ship *this, int roomId);
 "5589e557565383ec5c8b5510":
 cleanup __cdecl int Ship::GetAvailableRoom(Ship *this, int preferred, bool intruder);
 "5589e557565383ec4c8b450c8b7d10":
-cleanup __cdecl void Ship::BreachSpecificHull(Ship *this, int grid_x, int grid_y);
+cleanup __cdecl bool Ship::BreachSpecificHull(Ship *this, int grid_x, int grid_y);
 "57565383ec208b7c24348b5c24308b4c2438":
 cleanup __cdecl std::vector<Repairable*> Ship::GetHullBreaches(Ship *this, bool onlyDamaged);
 

--- a/libzhlgen/test/functions/win32/1.6.9/Ship.zhl
+++ b/libzhlgen/test/functions/win32/1.6.9/Ship.zhl
@@ -37,7 +37,7 @@ __thiscall void Ship::OnLoop(Ship *this, std::vector<float>& oxygenLevels);
 "578d7c240883e4f0ff77fc5589e557565383ec5c8b51208b41248b3fc745c400000000c745c800000000c745cc0000000029d0":
 __thiscall void Ship::BreachRandomHull(Ship *this, int roomId);
 "578d7c240883e4f0ff77fc5589e557565331db89ce83ec4c8b078b51208945c48b47048945c08b4124":
-__thiscall void Ship::BreachSpecificHull(Ship *this, int grid_x, int grid_y);
+__thiscall bool Ship::BreachSpecificHull(Ship *this, int grid_x, int grid_y);
 "578d7c240883e4f0ff77fc5589e557565389cb83ec4c8b0789c68945c08b470483feff8845b8":
 __thiscall int Ship::GetAvailableRoom(Ship *this, int preferred, bool intruder);
 "5589e557565383e4f083ec300fb6450c8b7d08c70100000000c7410400000000c7410800000000894c242c":

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -1886,6 +1886,7 @@ playerVariableType playerVariables;
 %rename("%s") Ship::DoorState::level;
 */
 %rename("%s") Ship::BreachRandomHull;
+%rename("%s") Ship::BreachSpecificHull;
 %rename("%s") Ship::EmptySlots;
 %rename("%s") Ship::FullRoom;
 %rename("%s") Ship::GetAvailableRoomSlot;

--- a/wiki/Lua-Hyperspace-Module.md
+++ b/wiki/Lua-Hyperspace-Module.md
@@ -512,6 +512,8 @@ Accessed via `ShipManager`'s `.extend` field
 
 -  `bool :BreachRandomHull(int roomId)`
    -  Breaches a random tile in the room with `roomId` as its id. This can select an already breached tile, in which case nothing will happen.
+-  `bool :BreachSpecificHull(int grid_x, int grid_y)`
+   -  Breaches a tile at the specified grid coordinates.
 -  `int :EmptySlots(int roomId)`
    -  Returns the number of tiles within the room (Equivalent to the area of the room). I think this marks all tiles in the room as empty, so you can use this to fit more crew than you should in a given room.
 -  `bool :FullRoom(int roomId, bool intruder)`


### PR DESCRIPTION
Allows for player to accurately breach specific tiles. The zhl was giving back a void instead of a bool for this method, so I updated it, shouldn't affect anything.

For testing you can use this to breach at the mouse position
```lua
script.on_internal_event(Defines.InternalEvents.ON_MOUSE_L_BUTTON_DOWN, function(x, y)
    local nx = Hyperspace.Mouse.position.x - Hyperspace.App.gui.shipPosition.x
    local ny = Hyperspace.Mouse.position.y - Hyperspace.App.gui.shipPosition.y

    Hyperspace.ships.player.ship:BreachSpecificHull(nx/35, ny/35)
    return Defines.Chain.CONTINUE
end)
```

fix #408 