### PR TITLE
Display enum name when getting lua error

### DIFF
--- a/Misc.cpp
+++ b/Misc.cpp
@@ -712,6 +712,8 @@ int LuaLibScript::l_on_render_event(lua_State* lua)
     return 0;
 }
 
+static_assert(sizeof(RenderEventNames) / sizeof(RenderEventNames[0]) - 1 == RenderEvents::UNKNOWN_MAX, "You need to update RenderEventNames with a change of RenderEvents.");
+
 // Pre callback calls from highest priority to lowest priority, can return chain to stop the loop, returns index of last callback called plus 1.
 // If pre-empt is signalled then returns a negative index.
 // Absolute value of the pre_callbacks return is passed to the post_callbacks method.
@@ -735,7 +737,7 @@ int LuaLibScript::call_on_render_event_pre_callbacks(RenderEvents::Identifiers i
             lua_pushvalue(this->m_Lua, -1-nArg);
         }
         if(lua_pcall(this->m_Lua, nArg, 1, 0) != 0) {
-            hs_log_file("Failed to call the before callback for RenderEvent %u!\n %s\n", id, lua_tostring(this->m_Lua, -1)); // TODO: Maybe map RenderEvents to a readable string also?
+            hs_log_file("Failed to call the before callback for RenderEvent %s!\n %s\n", RenderEventNames[id], lua_tostring(this->m_Lua, -1)); // TODO: Maybe map RenderEvents to a readable string also?
             lua_pop(this->m_Lua, 1);
             continue;
         }
@@ -778,7 +780,7 @@ void LuaLibScript::call_on_render_event_post_callbacks(RenderEvents::Identifiers
             lua_pushvalue(this->m_Lua, -1-nArg);
         }
         if(lua_pcall(this->m_Lua, nArg, 0, 0) != 0) {
-            hs_log_file("Failed to call the after callback for RenderEvent %u!\n %s\n", id, lua_tostring(this->m_Lua, -1)); // TODO: Maybe map RenderEvents to a readable string also?
+            hs_log_file("Failed to call the after callback for RenderEvent %s!\n %s\n", RenderEventNames[id], lua_tostring(this->m_Lua, -1)); // TODO: Maybe map RenderEvents to a readable string also?
             lua_pop(this->m_Lua, 1);
             continue;
         }
@@ -824,6 +826,8 @@ int LuaLibScript::l_on_internal_event(lua_State* lua)
     return 0;
 }
 
+static_assert(sizeof(InternalEventNames) / sizeof(InternalEventNames[0]) - 1 == InternalEvents::UNKNOWN_MAX, "You need to update InternalEventNames with a change of InternalEvents.");
+
 // TODO: This might need to be a varargs in the future to allow calling with the arguments from the hook & also passing that infromation via the enum so we can check at registration time above if the function has the correct number of arguments and if the correct number were passed here.
 int LuaLibScript::call_on_internal_event_callbacks(InternalEvents::Identifiers id, int nArg, int nRet)
 {
@@ -844,7 +848,7 @@ int LuaLibScript::call_on_internal_event_callbacks(InternalEvents::Identifiers i
             lua_pushvalue(this->m_Lua, -1-nArg);
         }
         if(lua_pcall(this->m_Lua, nArg, nRet, 0) != 0) {
-            hs_log_file("Failed to call the callback for InternalEvent %u!\n %s\n", id, lua_tostring(this->m_Lua, -1)); // Also TODO: Maybe map RenderEvents to a readable string also?
+            hs_log_file("Failed to call the callback for InternalEvent %s!\n %s\n", InternalEventNames[id], lua_tostring(this->m_Lua, -1)); // Also TODO: Maybe map RenderEvents to a readable string also?
             lua_pop(this->m_Lua, 1);
             continue;
         }
@@ -889,7 +893,7 @@ bool LuaLibScript::call_on_internal_chain_event_callbacks(InternalEvents::Identi
         }
         if(lua_pcall(this->m_Lua, nArg, nRet+1, 0) != 0) {
             // if the pcall fails then we just continue
-            hs_log_file("Failed to call the callback for InternalEvent %u!\n %s\n", id, lua_tostring(this->m_Lua, -1)); // Also TODO: Maybe map RenderEvents to a readable string also?
+            hs_log_file("Failed to call the callback for InternalEvent %s!\n %s\n", InternalEventNames[id], lua_tostring(this->m_Lua, -1)); // Also TODO: Maybe map RenderEvents to a readable string also?
             lua_pop(this->m_Lua, 1);
             continue;
         }

--- a/lua/InternalEvents.h
+++ b/lua/InternalEvents.h
@@ -11,6 +11,7 @@
 */
 struct InternalEvents
 {
+    // DO NOT FORGET TO UPDATE InternalEventNames as well
     enum Identifiers {
         UNKNOWN, // Must always be first, used to check for bounds of enum input value
 
@@ -173,6 +174,77 @@ struct InternalEvents
 
         UNKNOWN_MAX // Must always be last, used to check for bounds of enum input value
     };
+};
+
+// You update InternalEvents and not this with a code change and YOU_WILL_BE_FIRED
+constexpr const char* InternalEventNames[] = {
+    "UNKNOWN",
+    "ON_TICK",
+    "MAIN_MENU",
+    "GET_RUN_SEED",
+    "ON_KEY_DOWN",
+    "ON_KEY_UP",
+    "ON_MOUSE_MOVE",
+    "ON_MOUSE_L_BUTTON_DOWN",
+    "ON_MOUSE_L_BUTTON_UP",
+    "ON_MOUSE_R_BUTTON_DOWN",
+    "ON_MOUSE_R_BUTTON_UP",
+    "ON_MOUSE_M_BUTTON_DOWN",
+    "GUI_MOUSE_MOVE",
+    "CREW_LOOP",
+    "CREW_CLONE",
+    "SHIP_LOOP",
+    "HAS_EQUIPMENT",
+    "HAS_AUGMENTATION",
+    "GET_AUGMENTATION_VALUE",
+    "GET_DODGE_FACTOR",
+    "SET_BONUS_POWER",
+    "SELECT_ARMAMENT_PRE",
+    "SELECT_ARMAMENT_POST",
+    "PROJECTILE_INITIALIZE",
+    "PROJECTILE_FIRE",
+    "PROJECTILE_PRE",
+    "PROJECTILE_POST",
+    "PROJECTILE_UPDATE_PRE",
+    "PROJECTILE_UPDATE_POST",
+    "WEAPON_STATBOX",
+    "WEAPON_DESCBOX",
+    "WEAPON_RENDERBOX",
+    "DRONE_FIRE",
+    "DRONE_COLLISION",
+    "PROJECTILE_COLLISION",
+    "SHIELD_COLLISION_PRE",
+    "SHIELD_COLLISION",
+    "DAMAGE_AREA",
+    "DAMAGE_AREA_HIT",
+    "DAMAGE_BEAM",
+    "DAMAGE_SYSTEM",
+    "SYSTEM_ADD_DAMAGE",
+    "ACTIVATE_POWER",
+    "PREPARE_POWER",
+    "CANCEL_POWER",
+    "POWER_ON_UPDATE",
+    "POWER_RESOURCE_ON_UPDATE",
+    "POWER_ENABLE_INIT",
+    "POWER_RESOURCE_ENABLE_INIT",
+    "POWER_REQ",
+    "POWER_READY",
+    "POWER_TOOLTIP",
+    "GENERATOR_CREATE_SHIP",
+    "GENERATOR_CREATE_SHIP_POST",
+    "PRE_CREATE_CHOICEBOX",
+    "POST_CREATE_CHOICEBOX",
+    "JUMP_ARRIVE",
+    "JUMP_LEAVE",
+    "ON_WAIT",
+    "CONSTRUCT_CREWMEMBER",
+    "CONSTRUCT_SPACEDRONE",
+    "CONSTRUCT_PROJECTILE_FACTORY",
+    "CONSTRUCT_PROJECTILE",
+    "CONSTRUCT_ROOM",
+    "CONSTRUCT_SHIP_MANAGER",
+    "CONSTRUCT_SHIP_SYSTEM",
+    "UNKNOWN_MAX",
 };
 
 // TODO: Maybe we store an array using the Identifiers as the index and store the additional call data in there? Like number of arguments etc...?

--- a/lua/RenderEvents.h
+++ b/lua/RenderEvents.h
@@ -3,6 +3,7 @@
 
 struct RenderEvents
 {
+    // DO NOT FORGET TO UPDATE RenderEventNames as well
     enum Identifiers {
         UNKNOWN, // Must always be first, used to check for bounds of enum input value
 
@@ -66,5 +67,30 @@ struct RenderEvents
         UNKNOWN_MAX // Must always be last, used to check for bounds of enum input value
     };
 };
+
+// You update RenderEvents and not this with a code change and YOU_WILL_BE_FIRED
+constexpr const char* RenderEventNames[] = {
+    "UNKNOWN",
+    "MAIN_MENU",
+    "GUI_CONTAINER",
+    "LAYER_BACKGROUND",
+    "LAYER_FOREGROUND",
+    "LAYER_ASTEROIDS",
+    "LAYER_PLAYER",
+    "SHIP",
+    "SHIP_MANAGER",
+    "SHIP_JUMP",
+    "SHIP_HULL",
+    "SHIP_ENGINES",
+    "SHIP_FLOOR",
+    "SHIP_BREACHES",
+    "SHIP_SPARKS",
+    "CREW_MEMBER_HEALTH",
+    "LAYER_FRONT",
+    "FTL_BUTTON",
+    "SPACE_STATUS",
+    "MOUSE_CONTROL",
+    "UNKNOWN_MAX",
+}
 
 #endif // RENDEREVENTS_H

--- a/lua/modules/defines.i
+++ b/lua/modules/defines.i
@@ -8,6 +8,9 @@
 %nodefaultctor RenderEvents;
 %nodefaultdtor RenderEvents;
 
+%ignore InternalEventNames;
+%ignore RenderEventNames;
+
 %{
 #include "InternalEvents.h"
 #include "RenderEvents.h"


### PR DESCRIPTION
for #395

This pr takes new enum item of InternalEvents from custom clone bay pr into account beforehand. So auto build error due to assert is intentional.