### PR TITLE
Fix off-by-one error in level retrieval logic for customSys

### DIFF
--- a/CustomSystems.cpp
+++ b/CustomSystems.cpp
@@ -84,7 +84,7 @@ CustomMindSystem::MindLevel& CustomMindSystem::GetLevel(MindSystem* sys)
 {
     bool hacked = sys->iHackEffect >= 2 && sys->bUnderAttack;
     int power = hacked ? sys->healthState.first : sys->GetEffectivePower();
-    return (power > 0 && power < levels.size()) ? levels[power - 1] : defaultLevel;
+    return (power > 0 && power - 1 < levels.size()) ? levels[power - 1] : defaultLevel;
 }
 
 // TODO, get the real value for those
@@ -141,7 +141,7 @@ void CustomCloneSystem::ParseSystemNode(rapidxml::xml_node<char>* node)
 
 CustomCloneSystem::CloneLevel& CustomCloneSystem::GetLevel(int power)
 {
-    return (power > 0 && power < levels.size()) ? levels[power - 1] : defaultLevel;
+    return (power > 0 && power - 1 < levels.size()) ? levels[power - 1] : defaultLevel;
 }
 
 CustomCloneSystem::CloneLevel& CustomCloneSystem::GetLevel(CloneSystem* sys, bool passive)
@@ -156,7 +156,7 @@ CustomCloneSystem::CloneLevel& CustomCloneSystem::GetLevel(CloneSystem* sys, boo
         bool hacked = sys->iHackEffect >= 2 && sys->bUnderAttack;
         power = hacked ? sys->healthState.first : sys->GetEffectivePower();
     }
-    return (power > 0 && power < levels.size()) ? levels[power - 1] : defaultLevel;
+    return (power > 0 && power - 1 < levels.size()) ? levels[power - 1] : defaultLevel;
 }
 
 HOOK_STATIC(ShipSystem, NameToSystemId, (std::string& name) -> int)


### PR DESCRIPTION
Valid index at the limit of the vector would be wrongfully considered out of bound and fetch the default instead.