### PR TITLE
Bomb bugfix

### DIFF
--- a/CustomWeapons.cpp
+++ b/CustomWeapons.cpp
@@ -275,6 +275,10 @@ HOOK_METHOD(ProjectileFactory, NumTargetsRequired, () -> int)
             return 1;
         }
     }
+    else if (blueprint->type == 3 && targetId == iShipId) //self-targetting bomb
+    {
+        return 1;
+    }
 
     int ret = super();
 
@@ -288,6 +292,19 @@ HOOK_METHOD(ProjectileFactory, NumTargetsRequired, () -> int)
     }
 
     return ret;
+}
+
+//Reverse inlining of NumTargetsRequired
+HOOK_METHOD_PRIORITY(ProjectileFactory, ClearAiming, 9999, () -> void)
+{
+    LOG_HOOK("HOOK_METHOD_PRIORITY -> ProjectileFactory::ClearAiming -> Begin (CustomWeapons.cpp)\n")
+    
+    if (targets.size() > 0 && targets.size() >= NumTargetsRequired())
+    {
+        fireWhenReady = false;
+        targets.clear();
+        lastTargets.clear();
+    }
 }
 
 // Pinpoint targeting

--- a/CustomWeapons.cpp
+++ b/CustomWeapons.cpp
@@ -277,7 +277,7 @@ HOOK_METHOD(ProjectileFactory, NumTargetsRequired, () -> int)
     }
     else if (blueprint->type == 3 && targetId == iShipId) //self-targetting bomb
     {
-        return 1;
+        return 1; // fix for self-targeting bomb with multiple shots being unable to change the target
     }
 
     int ret = super();
@@ -299,12 +299,11 @@ HOOK_METHOD_PRIORITY(ProjectileFactory, ClearAiming, 9999, () -> void)
 {
     LOG_HOOK("HOOK_METHOD_PRIORITY -> ProjectileFactory::ClearAiming -> Begin (CustomWeapons.cpp)\n")
     
-    if (targets.size() > 0 && targets.size() >= NumTargetsRequired())
-    {
-        fireWhenReady = false;
-        targets.clear();
-        lastTargets.clear();
-    }
+    if (targets.size() > 0 && targets.size() < NumTargetsRequired()) return;
+
+    fireWhenReady = false;
+    targets.clear();
+    lastTargets.clear();
 }
 
 // Pinpoint targeting


### PR DESCRIPTION
## Overview
This PR fixes a bug in which after targeting the player ship with a bomb weapon that fires multiple shots, the player would not be able to choose a new target without depowering the weapon or firing a shot.
## Changes
- Small modification to `ProjectileFactory::NumTargetsRequired` to handle this specific case.
- Rewrite of `ProjectileFactory::ClearAiming` to reverse inlining of `ProjectileFactory::NumTargetsRequired`.