### PR TITLE
Fix linux various crashes

### DIFF
--- a/CustomCrew.cpp
+++ b/CustomCrew.cpp
@@ -2408,7 +2408,7 @@ bool CrewMember_Extend::IsInvulnerable()
     // Determine if this crewmember has any temporary effect that makes them invulnerable
     for (ActivatedPower *power : crewPowers)
     {
-        if (power->temporaryPowerActive && power->def->tempPower.invulnerable)
+        if (power && power->temporaryPowerActive && power->def->tempPower.invulnerable)
         {
             return true;
         }

--- a/StatBoost.cpp
+++ b/StatBoost.cpp
@@ -1806,7 +1806,7 @@ int CrewMember_Extend::CalculateMaxHealth(const CrewDefinition* def)
     _destination = def->_statName; \
     for (ActivatedPower *power : crewPowers) \
     { \
-        if (power->temporaryPowerActive && power->def->tempPower._statName.enabled) \
+        if (power && power->temporaryPowerActive && power->def->tempPower._statName.enabled) \
         { \
             _destination = power->def->tempPower._statName.value; \
             break; \


### PR DESCRIPTION
Most HS dev being based on windows did not properly test past feature on linux, as such too many crash case are now present stopping the player from being able to complete a run.

In this PR we will collect all stack trace and issues, speculate on their cause and fix them.

Some prior linux crashes reported:
https://github.com/FTL-Hyperspace/FTL-Hyperspace/issues/393
https://github.com/FTL-Hyperspace/FTL-Hyperspace/issues/288