### PR TITLE
lowercase command parity for sys all

### DIFF
--- a/CommandConsole.cpp
+++ b/CommandConsole.cpp
@@ -146,7 +146,7 @@ bool CommandConsole::RunCommand(CommandGui *commandGui, const std::string& cmd)
         std::string luaCode = boost::trim_copy(command.substr(4));
         Global::GetInstance()->getLuaContext()->runLuaString(luaCode);
     }
-    if (command == "SYS ALL")
+    if (boost::to_upper_copy(command) == "SYS ALL")
     {
         ShipManager *ship = commandGui->shipComplete->shipManager;
         


### PR DESCRIPTION
When adding specific systems, `sys systemName` and `SYS systemName` were both functional, but `sys all` does not work unless capitalized. 