### PR TITLE
fix event tooltip bug

### DIFF
--- a/EventTooltip.cpp
+++ b/EventTooltip.cpp
@@ -66,3 +66,12 @@ HOOK_METHOD(ChoiceBox, OnRender, () -> void)
         CSurface::GL_PopMatrix();
     }
 }
+
+HOOK_METHOD(ShipBuilder, Open, () -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> ShipBuilder::Open -> Begin (EventTooltip.cpp)\n")
+    // fix a bug where the infoBox keeps showing when returning to the hangar with the infoBox showing
+
+    super();
+    ::infoBox->Clear();
+}


### PR DESCRIPTION
This pr fixes a bug where the infoBox keeps showing when returning to the hangar with the infoBox showing.

You can replicate the bug by returning the hanger while hovering a choice where the description tooltip appears at the right side of the choiceBox.
![image](https://github.com/user-attachments/assets/51fe1af3-fc01-450e-9d9b-5ac485d7d0a7)
![image](https://github.com/user-attachments/assets/171c7a64-5abe-4667-a5b8-bcb0e0eb96ca)
