### PR TITLE
Save/Load fixes

### DIFF
--- a/CustomEvents.cpp
+++ b/CustomEvents.cpp
@@ -5124,7 +5124,9 @@ HOOK_METHOD(StarMap, SaveGame, (int file) -> void)
 HOOK_METHOD(StarMap, LoadGame, (int file) -> Location*)
 {
     LOG_HOOK("HOOK_METHOD -> StarMap::LoadGame -> Begin (CustomEvents.cpp)\n")
-    sectorChange = FileHelper::readString(file);
+    std::string sectorName = FileHelper::readString(file);
+    sectorChange = sectorName;
+    forceSectorChoice = sectorName;
     Location* ret = super(file);
     sectorChange = "";
     return ret;

--- a/CustomStore.cpp
+++ b/CustomStore.cpp
@@ -1566,23 +1566,25 @@ void StoreComplete::LoadStore(int file, int worldLevel)
 
                     CustomStoreBox* box = new CustomStoreBox();
 
+                    ShipManager* ship = G_->GetShipManager(0);
+
                     switch (sec.category)
                     {
                     case CategoryType::WEAPONS:
 
-                        box->orig = new WeaponStoreBox(nullptr, nullptr, G_->GetBlueprints()->GetWeaponBlueprint(blueprintName));
+                        box->orig = new WeaponStoreBox(ship, nullptr, G_->GetBlueprints()->GetWeaponBlueprint(blueprintName));
                         break;
                     case CategoryType::DRONES:
-                        box->orig = new DroneStoreBox(nullptr, nullptr, G_->GetBlueprints()->GetDroneBlueprint(blueprintName));
+                        box->orig = new DroneStoreBox(ship, nullptr, G_->GetBlueprints()->GetDroneBlueprint(blueprintName));
                         break;
                     case CategoryType::AUGMENTS:
-                        box->orig = new AugmentStoreBox(nullptr, G_->GetBlueprints()->GetAugmentBlueprint(blueprintName));
+                        box->orig = new AugmentStoreBox(ship, G_->GetBlueprints()->GetAugmentBlueprint(blueprintName));
                         break;
                     case CategoryType::CREW:
-                        box->orig = new CrewStoreBox(nullptr, worldLevel, blueprintName);
+                        box->orig = new CrewStoreBox(ship, worldLevel, blueprintName);
                         break;
                     case CategoryType::SYSTEMS:
-                        box->orig = new SystemStoreBox(nullptr, nullptr, ShipSystem::NameToSystemId(blueprintName));
+                        box->orig = new SystemStoreBox(ship, nullptr, ShipSystem::NameToSystemId(blueprintName));
                         break;
                     }
 


### PR DESCRIPTION
## Changes

### `CustomEvents.cpp`
This PR should fix the issue in #498 by ensuring the correct sector is generated on load even when changed via console. I haven't had the chance to test the exact issue with `priorityEvents` but this fixes some unrelated strangeness with the SECTOR command and corrects the return of `CustomEventsParser::GetCurrentCustomSector`.

### `CustomStore.cpp`
When saving and loading with a custom store open, the game would crash because of a nullptr value of `shopper` in the `SystemStoreBox::constructor` hook. This fixes that issue by linking the player ship.
