### PR TITLE
Ability tooltip bugfix

### DIFF
--- a/CustomCrew.cpp
+++ b/CustomCrew.cpp
@@ -4628,7 +4628,7 @@ HOOK_METHOD_PRIORITY(CrewBox, OnRender, 1000, () -> void)
             skillNumber++;
         }
 
-        if (!sTooltip.empty())
+        if (!sTooltip.empty() && !G_->GetCApp()->gui->choiceBoxOpen)
         {
             Point tooltipPosition = Point(box.x + box.w + 95, box.y);
             auto mouse = G_->GetMouseControl();


### PR DESCRIPTION
This PR addresses issue #522 and prevents ability tooltips from displaying while the event box is open.