### PR TITLE
Prevent the scrolling tooltip from overlapping the point of the cursor

### DIFF
--- a/RedesignedTooltips.cpp
+++ b/RedesignedTooltips.cpp
@@ -1356,7 +1356,7 @@ HOOK_METHOD_PRIORITY(MouseControl, RenderTooltip, 9999, (Point tooltipPoint, boo
         }
         if (1260.f < position.x + rect_w)
         {
-            if (rect_h > 620.f) // prevent the scrolling tooltip overlapping the point of the cursor
+            if (rect_h > 620.f) // prevent the scrolling tooltip from overlapping the point of the cursor
             {
                 tooltipPoint.x -= rect_w + 31.f;
             }

--- a/RedesignedTooltips.cpp
+++ b/RedesignedTooltips.cpp
@@ -1356,7 +1356,14 @@ HOOK_METHOD_PRIORITY(MouseControl, RenderTooltip, 9999, (Point tooltipPoint, boo
         }
         if (1260.f < position.x + rect_w)
         {
-            tooltipPoint.x -= position.x + rect_w - 1240.f;
+            if (rect_h > 620.f) // prevent the scrolling tooltip overlapping the point of the cursor
+            {
+                tooltipPoint.x -= rect_w + 31.f;
+            }
+            else
+            {
+                tooltipPoint.x -= position.x + rect_w - 1240.f;
+            }
         }
     }
 

--- a/RedesignedTooltips.cpp
+++ b/RedesignedTooltips.cpp
@@ -1356,7 +1356,7 @@ HOOK_METHOD_PRIORITY(MouseControl, RenderTooltip, 9999, (Point tooltipPoint, boo
         }
         if (1260.f < position.x + rect_w)
         {
-            if (rect_h > 620.f) // prevent the scrolling tooltip from overlapping the point of the cursor
+            if (tooltipPoint.y <= position.y && position.y <= tooltipPoint.y + rect_h) // prevent the tooltip from overlapping the point of the cursor
             {
                 tooltipPoint.x -= rect_w + 31.f;
             }


### PR DESCRIPTION
Fixed an issue where the scrolling tooltip obstructs vision of the crew itself, which makes it difficult to aim crewkill weapons on top of the crew

Before, 
![image](https://github.com/user-attachments/assets/08f72840-4dc2-40c1-9990-eee8814af8cc)

After:
![image](https://github.com/user-attachments/assets/4044d702-33e9-4c3f-a345-040ebadb520f)
