### PR TITLE
Fix incorrect task blockage

### DIFF
--- a/CustomCrew.cpp
+++ b/CustomCrew.cpp
@@ -5380,6 +5380,33 @@ HOOK_METHOD(CrewAI, PrioritizeTask, (CrewTask task, int crewId) -> int)
     return super(task, crewId);
 }
 
+//Prevent impossible tasks from blocking manning
+HOOK_METHOD(CrewMember, SetCurrentSystem, (ShipSystem* system) -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> CrewMember::SetCurrentSystem -> Begin (CustomCrew.cpp)\n")
+    
+    if (system == nullptr) return super(system);
+    else
+    {
+        bool oldOccupied = system->bOccupied;
+        bool oldOnFire = system->bOnFire;
+        int oldHealth = system->healthState.first;
+
+        if (!CanRepair())
+        {
+            system->bOnFire = false;
+            system->healthState.first = system->healthState.second;
+        }
+        if (!CanFight()) system->bOccupied = false;
+
+        super(system);
+
+        system->bOccupied = oldOccupied;
+        system->bOnFire = oldOnFire;
+        system->healthState.first = oldHealth;
+    }
+}
+
 HOOK_METHOD(CrewMember, GetSavedPosition, () -> Slot)
 {
     LOG_HOOK("HOOK_METHOD -> CrewMember::GetSavedPosition -> Begin (CustomCrew.cpp)\n")

--- a/FTLGameWin32.cpp
+++ b/FTLGameWin32.cpp
@@ -6016,7 +6016,7 @@ namespace _func431
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("CrewMember::SetCurrentSystem", typeid(void (CrewMember::*)(ShipSystem *)), ".578d7c240883e4f0ff77fc", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("CrewMember::SetCurrentSystem", typeid(void (CrewMember::*)(ShipSystem *)), ".578d7c240883e4f0ff77fc5589e557565389cb83ec1c", argdata, 2, 5, &func);
 }
 
 void CrewMember::SetCurrentSystem(ShipSystem *sys)

--- a/libzhlgen/test/functions/win32/1.6.9/CrewMember.zhl
+++ b/libzhlgen/test/functions/win32/1.6.9/CrewMember.zhl
@@ -31,7 +31,7 @@ __thiscall void CrewMember::destructor(CrewMember *this);
 __thiscall void CrewMember::Cleanup(CrewMember *this);
 ".578d7c240883e4f0ff77fc5589f889e557565389cf83ec2c8b30893424e8????????d95de48b45e4893424":
 __thiscall void CrewMember::LoadState(CrewMember *this, int fileHelper);
-".578d7c240883e4f0ff77fc":
+".578d7c240883e4f0ff77fc5589e557565389cb83ec1c":
 __thiscall void CrewMember::SetCurrentSystem(CrewMember *this, ShipSystem *sys);
 ".83797c0b0f94c0":
 __thiscall bool CrewMember::IsManningArtillery(CrewMember *this);


### PR DESCRIPTION
## Bugfix
Crew no longer stop manning a system in order to perform a task that is impossible for them.
Examples of this bug include:
- Ceasing to man when a system is damaged but the crew cannot repair.
- Ceasing to man when a room is occupied by boarders but the crew cannot fight.
- Ceasing to man when a system is on fire but the crew cannot repair.
## ZHL Changes
The signature for `CrewMember::SetCurrentSystem` was incorrect on windows and matched `CrystalAlien::LoadState` previously. This may need to be corrected on other platforms as well.