### PR TITLE
New tag to make store no longer dissapear due to hazard

### DIFF
--- a/CustomOptions.h
+++ b/CustomOptions.h
@@ -90,6 +90,8 @@ public:
     Setting<bool> cloakRenderFix;
 
     Setting<bool> enhancedCloneUI;
+
+    Setting<bool> permanentStore;
     
     Defaults defaults;
 

--- a/Misc.cpp
+++ b/Misc.cpp
@@ -617,6 +617,22 @@ HOOK_METHOD(Door, LoadState, (int fd) -> void)
     lockedDown.LoadState(fd);
 }
 
+int overrideSetActiveButton = 0;
+HOOK_METHOD(CommandGui, OnLoop, () -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> CommandGui::OnLoop -> Begin (Misc.cpp)\n")
+    if (CustomOptionsManager::GetInstance()->permanentStore.currentValue && storeScreens.windows[0] && !(enemyShip && enemyShip->shipManager && enemyShip->shipManager->hostile_ship)) overrideSetActiveButton = 2;
+    super();
+    overrideSetActiveButton = 0;
+}
+
+HOOK_METHOD(GenericButton, SetActive, (bool active) -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> GenericButton::SetActive -> Begin (Misc.cpp)\n")
+    if (overrideSetActiveButton-- == 1) active = true;
+    super(active);
+}
+
 // Everything from here onward was originally in the lua folder and needed
 // to be moved in order to compile properly on Linux.
 

--- a/Mod Files/data/hyperspace.xml
+++ b/Mod Files/data/hyperspace.xml
@@ -409,6 +409,10 @@ If the chance attribute is set to 1 or above, every time the main menu is loaded
 
 <enhancedCloneUI enabled="false"/>
 
+<!--Store button remains if an hazard is present and no hostile ship.-->
+
+<permanentStore enabled="false"/>
+
 <!-- Insert newline between each crew description in a tooltip when mouse over a tile where multiple crews are fighting -->
   
 <insertNewlineForMultipleCrewTooltips enabled="false"/>

--- a/Resources.cpp
+++ b/Resources.cpp
@@ -620,6 +620,13 @@ void Global::InitializeResources(ResourceControl *resources)
                 customOptions->enhancedCloneUI.defaultValue = EventsParser::ParseBoolean(enabled);
                 customOptions->enhancedCloneUI.currentValue = EventsParser::ParseBoolean(enabled);
             }
+
+            if (strcmp(node->name(), "permanentStore") == 0)
+            {
+                auto enabled = node->first_attribute("enabled")->value();
+                customOptions->permanentStore.defaultValue = EventsParser::ParseBoolean(enabled);
+                customOptions->permanentStore.currentValue = EventsParser::ParseBoolean(enabled);
+            }
             
             if (strcmp(node->name(), "insertNewlineForMultipleCrewTooltips") == 0)
             {


### PR DESCRIPTION
Adds the permanentStore tag that ensure the store button remains during an hazard.

fix #540 