### PR TITLE
expose CustomAugmentManager::GetShipAugments

### DIFF
--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -85,6 +85,13 @@ namespace std {
         bool empty() const;
         void clear();
         %extend {
+            std::vector<K> keys() {
+                std::vector<K> keys;
+                keys.reserve(self->size());
+                for (std::unordered_map< K, T, H, E >::iterator i = self->begin(); i != self->end(); ++i)
+                    keys.push_back(i->first);
+                return keys;
+            }
             const T& get(const K& key) throw (std::out_of_range) {
                 std::unordered_map< K, T, H, E >::iterator i = self->find(key);
                 if (i != self->end())
@@ -2067,6 +2074,7 @@ We can expose them once the root cause is identified and the crash is fixed.
 %rename("%s") CustomAugmentManager;
 %rename("%s") CustomAugmentManager::GetInstance;
 %rename("%s") CustomAugmentManager::GetAugmentDefinition;
+%rename("%s") CustomAugmentManager::GetShipAugments;
 
 %nodefaultctor AugmentFunction;
 %nodefaultdtor AugmentFunction;

--- a/wiki/Lua-Hyperspace-Module.md
+++ b/wiki/Lua-Hyperspace-Module.md
@@ -2843,7 +2843,8 @@ Accessed via `Hyperspace.CustomAugmentManager.GetInstance()`
 
 ### Methods
 - `static` [`CustomAugmentManager*`](#CustomAugmentManager) `.GetInstance()`
-- [`AugmentDefinition*`](#AugmentDefinition) `CustomAugmentManager::GetAugmentDefinition(const std::string &name)`
+- [`AugmentDefinition*`](#AugmentDefinition) `:GetAugmentDefinition(const std::string &name)`
+- `std::unordered_map<std::string, int>` `:GetShipAugments(int iShipId)`
 
 ## AugmentFunction
 


### PR DESCRIPTION
Also added a `keys` method for `unordered_map`. The script I used to test this:
```lua
script.on_internal_event(Defines.InternalEvents.ON_KEY_DOWN, function(key)
    if key == 96 then
        local augs = Hyperspace.CustomAugmentManager.GetInstance():GetShipAugments(0)
        for key in vter(augs:keys()) do
            print(key, augs[key])
        end
    end
end)
```
Prints all augments and the amount when pressing the tilde key.