### PR TITLE
Prevent GetAugmentDefinition from causing crash when called from lua with invalid augment name 

### DIFF
--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -2075,7 +2075,18 @@ We can expose them once the root cause is identified and the crash is fixed.
 %rename("%s") CustomAugmentManager::GetInstance;
 %rename("%s") CustomAugmentManager::GetAugmentDefinition;
 %rename("%s") CustomAugmentManager::GetShipAugments;
-
+%rename("%s") CustomAugmentManager::IsAugment;
+%extend CustomAugmentManager {
+    AugmentDefinition* GetAugmentDefinition(const std::string& name) throw (std::string)
+    {
+        if (!$self->IsAugment(name))
+        {
+            std::string error = "No definition found for augment: " + name;
+            throw error;
+        }
+        return $self->GetAugmentDefinition(name);
+    }
+}
 %nodefaultctor AugmentFunction;
 %nodefaultdtor AugmentFunction;
 %rename("%s") AugmentFunction;


### PR DESCRIPTION
This PR builds on and addresses some issues in PR #547.