### PR TITLE
Controllable artillery bugfixes

### DIFF
--- a/CustomWeapons.cpp
+++ b/CustomWeapons.cpp
@@ -1004,7 +1004,8 @@ HOOK_METHOD_PRIORITY(ProjectileFactory, Update, 9999, () -> void)
                         Pointf offset(r * cos(theta), r * sin(theta));
                         Pointf flakTarget = target + offset;
                         currTargets.push_back(flakTarget);
-                        if (isArtillery) break;
+                        bool manualAiming = iShipId == 0 && (CustomOptionsManager::GetInstance()->targetableArtillery.currentValue || HasAugmentation("ARTILLERY_ORDER"));
+                        if (isArtillery && !manualAiming) break;
                     }
                 }  
             }

--- a/FTLGameELF32.h
+++ b/FTLGameELF32.h
@@ -1205,6 +1205,8 @@ struct ArtilleryBox : CooldownSystemBox
 	{
 		this->constructor(pos, sys);
 	}
+	
+	int _HS_GetHeightModifier();
 
 	LIBZHL_API void OnRender(bool ignoreStatus);
 	LIBZHL_API void constructor(Point pos, ArtillerySystem *sys);

--- a/FTLGameELF64.h
+++ b/FTLGameELF64.h
@@ -1207,6 +1207,8 @@ struct ArtilleryBox : CooldownSystemBox
 		this->constructor(pos, sys);
 	}
 
+	int _HS_GetHeightModifier();
+
 	LIBZHL_API void OnRender(bool ignoreStatus);
 	LIBZHL_API void constructor(Point pos, ArtillerySystem *sys);
 	

--- a/FTLGameWin32.h
+++ b/FTLGameWin32.h
@@ -1198,6 +1198,8 @@ struct ArtilleryBox : CooldownSystemBox
 		this->constructor(pos, sys);
 	}
 
+	int _HS_GetHeightModifier();
+
 	LIBZHL_API void OnRender(bool ignoreStatus);
 	LIBZHL_API void constructor(Point pos, ArtillerySystem *sys);
 	

--- a/libzhlgen/test/functions/ELF_amd64/1.6.13/ArtilleryBox.zhl
+++ b/libzhlgen/test/functions/ELF_amd64/1.6.13/ArtilleryBox.zhl
@@ -10,4 +10,6 @@ struct ArtilleryBox
 	{
 		this->constructor(pos, sys);
 	}
+
+	int _HS_GetHeightModifier();
 }};

--- a/libzhlgen/test/functions/ELF_x86/1.6.13/ArtilleryBox.zhl
+++ b/libzhlgen/test/functions/ELF_x86/1.6.13/ArtilleryBox.zhl
@@ -10,4 +10,6 @@ struct ArtilleryBox
 	{
 		this->constructor(pos, sys);
 	}
+	
+	int _HS_GetHeightModifier();
 }};

--- a/libzhlgen/test/functions/win32/1.6.9/ArtilleryBox.zhl
+++ b/libzhlgen/test/functions/win32/1.6.9/ArtilleryBox.zhl
@@ -10,4 +10,6 @@ struct ArtilleryBox
 	{
 		this->constructor(pos, sys);
 	}
+
+	int _HS_GetHeightModifier();
 }};


### PR DESCRIPTION
## Bugfixes
This PR addresses some bugs with aimable artilleries:
- Targeting button now renders underneath status icons when position is dynamic (fire/sabotage/etc).
- BURST artilleries now function properly when targeted manually.
## ZHL Changes
- Added new `ArtilleryBox::_HS_GetHeightModifier` method.
- Modify vtable of `ArtilleryBox` to use this function. This should be tested on all platforms to ensure proper function.