### PR TITLE
Fix bug with engineless player ships

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,8 @@ target_compile_options(
 
     # Explicit C++11 mode
     -std=c++11
+    # No warning for this == nullptr (can be removed once ShipSystem::GetPowerCap workaround is replaced)
+    -fno-delete-null-pointer-checks
 
     # Warn everything
     # TODO: Check if it's meaningful (original .cbp defined it)

--- a/CustomSystems.cpp
+++ b/CustomSystems.cpp
@@ -1994,9 +1994,9 @@ HOOK_METHOD(FTLButton, GetPilotTooltip, () -> std::string)
 
 HOOK_METHOD(ShipSystem, GetPowerCap, () -> int)
 {
-    LOG_HOOK("HOOK_METHOD -> ShipSystem::GetPowerCap -> Begin (CustomSystems.cpp)\n")
-    volatile ShipSystem* thisPtr = this;
-    if (thisPtr == nullptr) return 0;
+    LOG_HOOK("HOOK_METHOD -> ShipSystem::GetPowerCap -> Begin (CustomSystems.cpp)\n")  
+    //This necessitates building under -fno-delete-null-pointer-checks  
+    if (this == nullptr) return 0;
     else return super();
 }
 

--- a/CustomSystems.cpp
+++ b/CustomSystems.cpp
@@ -1747,8 +1747,7 @@ HOOK_METHOD(ShipManager, OnLoop, () -> void)
 
 void ShipManager::RemoveSystem(int iSystemId)
 {
-    bool playerEngines = iSystemId == SYS_ENGINES && iShipId == 0;
-    if (HasSystem(iSystemId) && iSystemId != SYS_REACTOR && iSystemId != SYS_INVALID && !playerEngines) //TODO: Possibly fix bug with engineless player ships?
+    if (HasSystem(iSystemId) && iSystemId != SYS_REACTOR && iSystemId != SYS_INVALID)
     {
         //Remove base ShipSystem
         ShipSystem* removeSys = GetSystem(iSystemId);
@@ -1988,6 +1987,17 @@ HOOK_METHOD(FTLButton, GetPilotTooltip, () -> std::string)
     if (!ship->HasSystem(SYS_PILOT)) return "";
 
     return super(); // nullptr check for pilot system isn't performed in the base function, which results in segfault.
+}
+
+//Quick fix for engineless player ships crashing when entering combat.
+//This can be removed when rewriting WorldManager::OnLoop, as that function calls this on a null ShipSystem*
+
+HOOK_METHOD(ShipSystem, GetPowerCap, () -> int)
+{
+    LOG_HOOK("HOOK_METHOD -> ShipSystem::GetPowerCap -> Begin (CustomSystems.cpp)\n")
+    volatile ShipSystem* thisPtr = this;
+    if (thisPtr == nullptr) return 0;
+    else return super();
 }
 
 //The original game code uses the starting ShipBlueprint when loading the game, and adds all starting systems by default.

--- a/FTL_HyperspaceGCC.cbp
+++ b/FTL_HyperspaceGCC.cbp
@@ -260,6 +260,8 @@
 				<Compiler>
 					<Add option="-m32" />
 					<Add option="-O3" />
+					<!--No warning for this == nullptr (can be removed once ShipSystem::GetPowerCap workaround is replaced)-->
+					<Add option="-fno-delete-null-pointer-checks" />
 					<Add option="-Wall" />
 					<Add option="-msse -msse2 -mfpmath=sse -std=c++11 -target i686-pc-windows-gnu -stdlib=libstdc++" />
 					<Add option="-Werror=narrowing" />
@@ -439,6 +441,8 @@
 					<Add option="-fPIC" />
 					<Add option="-m32" />
 					<Add option="-O3" />
+					<!--No warning for this == nullptr (can be removed once ShipSystem::GetPowerCap workaround is replaced)-->
+					<Add option="-fno-delete-null-pointer-checks" />
 					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-msse" />
@@ -485,6 +489,8 @@
 					<Add option="-fPIC" />
 					<Add option="-m32" />
 					<Add option="-O3" />
+					<!--No warning for this == nullptr (can be removed once ShipSystem::GetPowerCap workaround is replaced)-->
+					<Add option="-fno-delete-null-pointer-checks" />
 					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-msse" />
@@ -670,6 +676,8 @@
 					<Add option="-fPIC" />
 					<Add option="-m64" />
 					<Add option="-O3" />
+					<!--No warning for this == nullptr (can be removed once ShipSystem::GetPowerCap workaround is replaced)-->
+					<Add option="-fno-delete-null-pointer-checks" />
 					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-msse" />
@@ -716,6 +724,8 @@
 					<Add option="-fPIC" />
 					<Add option="-m64" />
 					<Add option="-O3" />
+					<!--No warning for this == nullptr (can be removed once ShipSystem::GetPowerCap workaround is replaced)-->
+					<Add option="-fno-delete-null-pointer-checks" />
 					<Add option="-Wall" />
 					<Add option="-std=c++11" />
 					<Add option="-msse" />

--- a/Mod Files/data/hyperspace.xml
+++ b/Mod Files/data/hyperspace.xml
@@ -1492,7 +1492,6 @@ Syntax ->
 
 	<!--
 	Define exclusive systems here. Each system can only be part of one exclusivity group, and if it is defined in multiple groups it will only register as being part of the last group.
-	Some systems do not work as exclusive systems. These are the same systems that cannot be removed using the removeSystem event tag.
 	<exclusivityGroup>
 		<clonebay/>
 		<medbay/>
@@ -2357,7 +2356,6 @@ Syntax ->
 		                                                                                          a "removed" message. Hidden augments can be removed by giving the name "HIDDEN AUG_ID", replacing AUG_ID with the normal
 		                                                                                          augment's id.
 		<removeSystem player="true">systemName</removeSystem>									Removes a system from the player ship. If player attribute is false, removes the system from the enemy ship instead, if present. Applies to the player ship if no attribute is provided.
-																								NOTE: The engine system cannot be removed from the player ship at present, as this causes a crash.
 		<variable name="varname" op="set" val="0" min="0" max="0" var="_var_req_"/>             Sets or changes a custom variable. Operation can be "set", "add", "mul", "div", "min", or "max".
 		                                                                                          Value can either be a fixed value (using val) or a random value (using min and max).
 		                                                                                          The "var" attribute lets you apply a variable or equipment req to another variable, instead of a constant.


### PR DESCRIPTION
This needs to be tested on release builds for all platforms as it relies on a comparison of `this` to `nullptr`. The volatile variable should prevent this from being optimized out and does so successfully on windows builds but should be checked just in case.