### PR TITLE
shieldWithoutSystem tag

### DIFF
--- a/CustomOptions.h
+++ b/CustomOptions.h
@@ -83,6 +83,8 @@ public:
     
     Setting<bool> oxygenWithoutSystem;
 
+    Setting<bool> shieldWithoutSystem;
+
     Setting<bool> droneSaveStations;
 
     Setting<bool> droneSelectHotkeys;

--- a/CustomSystems.cpp
+++ b/CustomSystems.cpp
@@ -302,9 +302,9 @@ HOOK_METHOD(ShipSystem, constructor, (int systemId, int roomId, int shipId, int 
     }
 }
 
-HOOK_METHOD(ShipManager, CreateSystems, () -> int)
+HOOK_METHOD_PRIORITY(ShipManager, CreateSystems, 9999, () -> int)
 {
-    LOG_HOOK("HOOK_METHOD -> ShipManager::CreateSystems -> Begin (CustomSystems.cpp)\n")
+    LOG_HOOK("HOOK_METHOD_PRIORITY -> ShipManager::CreateSystems -> Begin (CustomSystems.cpp)\n")
     if (myBlueprint.systemInfo.find(0) != myBlueprint.systemInfo.end())
     {
         auto shieldInfo = myBlueprint.systemInfo[0];
@@ -316,7 +316,16 @@ HOOK_METHOD(ShipManager, CreateSystems, () -> int)
     }
     else
     {
-        shieldSystem = nullptr;
+        if (CustomOptionsManager::GetInstance()->shieldWithoutSystem.currentValue)
+        {
+            auto sys = new Shields(-1, iShipId, 0, myBlueprint.shieldFile);
+            shieldSystem = sys;
+            sys->SetBaseEllipse(ship.GetBaseEllipse());
+        }
+        else
+        {
+            shieldSystem = nullptr;
+        }
     }
 
     systemKey.clear();

--- a/Mod Files/data/hyperspace.xml
+++ b/Mod Files/data/hyperspace.xml
@@ -109,6 +109,8 @@ See data/names.xml and data/text-<langcode>.xml files in the vanilla data for re
 
 <oxygenWithoutSystem enabled="false"/> <!-- If enabled, the game will allow oxygen to function without a system -->
 
+<shieldWithoutSystem enabled="false"/> <!-- If enabled, the game will allow supershields to function without a shield declared in the shipBlueprint -->
+
 <droneSelectHotkeys enabled="false"/> <!--If enabled, controllable crew drones will be selected when their hotkey is pressed.-->
 
 <droneSaveStations enabled="false"/> <!--If enabled, controllable crew drones will be able to save their current stations alongside the rest of the crew, and will return to these stations when requested.-->

--- a/Resources.cpp
+++ b/Resources.cpp
@@ -588,6 +588,13 @@ void Global::InitializeResources(ResourceControl *resources)
                 customOptions->oxygenWithoutSystem.defaultValue = EventsParser::ParseBoolean(enabled);
                 customOptions->oxygenWithoutSystem.currentValue = EventsParser::ParseBoolean(enabled);
             }
+
+            if (strcmp(node->name(), "shieldWithoutSystem") == 0)
+            {
+                auto enabled = node->first_attribute("enabled")->value();
+                customOptions->shieldWithoutSystem.defaultValue = EventsParser::ParseBoolean(enabled);
+                customOptions->shieldWithoutSystem.currentValue = EventsParser::ParseBoolean(enabled);
+            }
             
             if (strcmp(node->name(), "altLockedMiniships") == 0)
             {


### PR DESCRIPTION
This PR addresses issue #571. The `shieldWithoutSystem` tag allows supershield mechanics to function properly even without a `shield` tag  in the `shipBlueprint`