### PR TITLE
Expose ShipRepairDrone members and fix inheritence

### DIFF
--- a/FTLGameELF32.h
+++ b/FTLGameELF32.h
@@ -7328,8 +7328,10 @@ struct ShipRepair
 {
 };
 
-struct ShipRepairDrone
+struct ShipRepairDrone : CombatDrone
 {
+	CachedImage repairBeam;
+	std::vector<float> repairBeams;
 };
 
 struct SlugAlien

--- a/FTLGameELF64.h
+++ b/FTLGameELF64.h
@@ -7351,8 +7351,10 @@ struct ShipRepair
 {
 };
 
-struct ShipRepairDrone
+struct ShipRepairDrone : CombatDrone
 {
+	CachedImage repairBeam;
+	std::vector<float> repairBeams;
 };
 
 struct SlugAlien

--- a/FTLGameWin32.h
+++ b/FTLGameWin32.h
@@ -7351,8 +7351,10 @@ struct ShipRepair
 {
 };
 
-struct ShipRepairDrone
+struct ShipRepairDrone : CombatDrone
 {
+	CachedImage repairBeam;
+	std::vector<float> repairBeams;
 };
 
 struct SlugAlien

--- a/libzhlgen/test/functions/ELF_amd64/FTLGameStripped.h
+++ b/libzhlgen/test/functions/ELF_amd64/FTLGameStripped.h
@@ -4885,7 +4885,12 @@ struct TutorialManager
 };
 
 /* 159 */
-struct ShipRepairDrone;
+struct ShipRepairDrone
+{
+    CombatDrone _base;
+    CachedImage repairBeam;
+    std::vector<float> repairBeams;
+};
 
 /* 161 */
 struct CombatDrone

--- a/libzhlgen/test/functions/ELF_x86/FTLGameStripped.ELF32.h
+++ b/libzhlgen/test/functions/ELF_x86/FTLGameStripped.ELF32.h
@@ -4874,7 +4874,12 @@ struct TutorialManager
 };
 
 /* 159 */
-struct ShipRepairDrone;
+struct ShipRepairDrone
+{
+    CombatDrone _base;
+    CachedImage repairBeam;
+    std::vector<float> repairBeams;
+};
 
 /* 161 */
 struct CombatDrone

--- a/libzhlgen/test/functions/win32/FTLGameStripped.h
+++ b/libzhlgen/test/functions/win32/FTLGameStripped.h
@@ -4879,7 +4879,12 @@ struct TutorialManager
 };
 
 /* 159 */
-struct ShipRepairDrone;
+struct ShipRepairDrone
+{
+    CombatDrone _base;
+    CachedImage repairBeam;
+    std::vector<float> repairBeams;
+};
 
 /* 161 */
 struct CombatDrone

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -3517,6 +3517,8 @@ We can expose them once the root cause is identified and the crash is fixed.
 %rename("%s") BoarderPodDrone::diedInSpace;
 
 %rename("%s") ShipRepairDrone;
+%rename("%s") ShipRepairDrone::repairBeam;
+%rename("%s") ShipRepairDrone::repairBeams;
 
 %rename("%s") HackingDrone;
 

--- a/wiki/Lua-Hyperspace-Module.md
+++ b/wiki/Lua-Hyperspace-Module.md
@@ -1325,6 +1325,14 @@ No methods are exposed currently.
 - [`CachedImage`](#CachedImage) `.drone_image_glow`
 - `float` `.glowAnimation`
 
+## ShipRepairDrone
+
+**Extends [`CombatDrone`](#CombatDrone)**
+
+### Fields
+- [`CachedImage`](#CachedImage) `.repairBeam`
+- `std::vector<float>` `.repairBeams`
+
 ## DroneBlueprint
 
 **Extends [`Blueprint`](#blueprint)**


### PR DESCRIPTION
This PR adds exposures for `ShipRepairDrone` members as well as exposing it as a derived class of `CombatDrone`.