### PR TITLE
No crash on invalid medical replacement

### DIFF
--- a/CustomSystems.cpp
+++ b/CustomSystems.cpp
@@ -797,6 +797,8 @@ HOOK_METHOD(ShipManager, AddSystem, (int systemId) -> int)
 {
     LOG_HOOK("HOOK_METHOD -> ShipManager::AddSystem -> Begin (CustomSystems.cpp)\n")
     
+    if (myBlueprint.systemInfo.find(systemId) == myBlueprint.systemInfo.end()) return 0;
+
     int removedSystemPower = 0;
     int replacedSystem = SystemWillReplace(systemId);
     if (replacedSystem != SYS_INVALID)


### PR DESCRIPTION
This PR address issue #585 by preventing certain invalid system additions from causing crashes.