### PR TITLE
Fix multi overcapacity duplicate bug

### DIFF
--- a/CustomEquipment.cpp
+++ b/CustomEquipment.cpp
@@ -1015,6 +1015,32 @@ HOOK_METHOD(Equipment, Open, () -> void)
     custom->currentOverCapacityPage = 0;
 }
 
+HOOK_METHOD(Equipment, MouseUp, (int mX, int mY) -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> Equipment::MouseUp -> Begin (CustomEquipment.cpp)\n")
+    super(mX, mY);
+    
+    CustomEquipment *custom = EQ_EX(this)->customEquipment;
+    // updates over capacity item when player swaps item in over capacity box.
+    if (!custom->overCapacityItems.empty())
+    {
+        if (bOverCapacity)
+        {
+            if (overcapacityBox->item != custom->overCapacityItems[custom->currentOverCapacityPage].first)
+            {
+                custom->overCapacityItems[custom->currentOverCapacityPage].first = overcapacityBox->item;
+            }
+        }
+        else if (bOverAugCapacity)
+        {
+            if (overAugBox->item != custom->overCapacityItems[custom->currentOverCapacityPage].first)
+            {
+                custom->overCapacityItems[custom->currentOverCapacityPage].first = overAugBox->item;
+            }
+        }
+    }
+}
+
 
 // unused rewrite
 /*

--- a/FTLGameELF32.h
+++ b/FTLGameELF32.h
@@ -1708,6 +1708,15 @@ struct Drone;
 
 struct EquipmentBoxItem
 {
+	friend bool operator==(const EquipmentBoxItem &a, const EquipmentBoxItem &b)
+	{
+		return a.pWeapon == b.pWeapon && a.pDrone == b.pDrone && a.augment == b.augment && a.pCrew == b.pCrew;
+	}
+	friend bool operator!=(const EquipmentBoxItem &a, const EquipmentBoxItem &b)
+	{
+		return a.pWeapon != b.pWeapon || a.pDrone != b.pDrone || a.augment != b.augment || a.pCrew != b.pCrew;
+	}
+
 	ProjectileFactory *pWeapon;
 	Drone *pDrone;
 	CrewMember *pCrew;

--- a/FTLGameELF64.h
+++ b/FTLGameELF64.h
@@ -1716,6 +1716,15 @@ struct Drone;
 
 struct EquipmentBoxItem
 {
+	friend bool operator==(const EquipmentBoxItem &a, const EquipmentBoxItem &b)
+	{
+		return a.pWeapon == b.pWeapon && a.pDrone == b.pDrone && a.augment == b.augment && a.pCrew == b.pCrew;
+	}
+	friend bool operator!=(const EquipmentBoxItem &a, const EquipmentBoxItem &b)
+	{
+		return a.pWeapon != b.pWeapon || a.pDrone != b.pDrone || a.augment != b.augment || a.pCrew != b.pCrew;
+	}
+
 	ProjectileFactory *pWeapon;
 	Drone *pDrone;
 	CrewMember *pCrew;

--- a/FTLGameWin32.h
+++ b/FTLGameWin32.h
@@ -1700,6 +1700,15 @@ struct Drone;
 
 struct EquipmentBoxItem
 {
+	friend bool operator==(const EquipmentBoxItem &a, const EquipmentBoxItem &b)
+	{
+		return a.pWeapon == b.pWeapon && a.pDrone == b.pDrone && a.augment == b.augment && a.pCrew == b.pCrew;
+	}
+	friend bool operator!=(const EquipmentBoxItem &a, const EquipmentBoxItem &b)
+	{
+		return a.pWeapon != b.pWeapon || a.pDrone != b.pDrone || a.augment != b.augment || a.pCrew != b.pCrew;
+	}
+
 	ProjectileFactory *pWeapon;
 	Drone *pDrone;
 	CrewMember *pCrew;

--- a/libzhlgen/test/functions/ELF_amd64/1.6.13/EquipmentBoxItem.zhl
+++ b/libzhlgen/test/functions/ELF_amd64/1.6.13/EquipmentBoxItem.zhl
@@ -1,0 +1,11 @@
+struct EquipmentBoxItem
+{{
+	friend bool operator==(const EquipmentBoxItem &a, const EquipmentBoxItem &b)
+	{
+		return a.pWeapon == b.pWeapon && a.pDrone == b.pDrone && a.augment == b.augment && a.pCrew == b.pCrew;
+	}
+	friend bool operator!=(const EquipmentBoxItem &a, const EquipmentBoxItem &b)
+	{
+		return a.pWeapon != b.pWeapon || a.pDrone != b.pDrone || a.augment != b.augment || a.pCrew != b.pCrew;
+	}
+}};

--- a/libzhlgen/test/functions/ELF_x86/1.6.13/EquipmentBoxItem.zhl
+++ b/libzhlgen/test/functions/ELF_x86/1.6.13/EquipmentBoxItem.zhl
@@ -1,0 +1,11 @@
+struct EquipmentBoxItem
+{{
+	friend bool operator==(const EquipmentBoxItem &a, const EquipmentBoxItem &b)
+	{
+		return a.pWeapon == b.pWeapon && a.pDrone == b.pDrone && a.augment == b.augment && a.pCrew == b.pCrew;
+	}
+	friend bool operator!=(const EquipmentBoxItem &a, const EquipmentBoxItem &b)
+	{
+		return a.pWeapon != b.pWeapon || a.pDrone != b.pDrone || a.augment != b.augment || a.pCrew != b.pCrew;
+	}
+}};

--- a/libzhlgen/test/functions/win32/1.6.9/EquipmentBoxItem.zhl
+++ b/libzhlgen/test/functions/win32/1.6.9/EquipmentBoxItem.zhl
@@ -1,0 +1,11 @@
+struct EquipmentBoxItem
+{{
+	friend bool operator==(const EquipmentBoxItem &a, const EquipmentBoxItem &b)
+	{
+		return a.pWeapon == b.pWeapon && a.pDrone == b.pDrone && a.augment == b.augment && a.pCrew == b.pCrew;
+	}
+	friend bool operator!=(const EquipmentBoxItem &a, const EquipmentBoxItem &b)
+	{
+		return a.pWeapon != b.pWeapon || a.pDrone != b.pDrone || a.augment != b.augment || a.pCrew != b.pCrew;
+	}
+}};


### PR DESCRIPTION
To replicate this bug in MV (make sure multipleOverCapacity is enabled):
1. Fill your cargo fully.
2. Go to event `QUEST_GATLING_BASE` and dig up Jackson Newman.
3. Before starting fighting against elite fed, swap over capacitied Gatling Base with any item in your cargo.
4. Destroy elit fed.
5. You have duplicated Gatling Base in over capacity box and your cargo