### PR TITLE
Added Editorconfig configuration to stop forgetting newline at end of file.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# 4 space indentation
+[*.{cpp,h,c,hpp,i}]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 # 4 space indentation
 [*.{cpp,h,c,hpp,i}]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ See [Building Windows](../../wiki/Building-on-Windows)
 ## Linux
 See [Building Linux](BUILDING.LINUX.md)
 
+# Contributing
+Please set up editorconfig in your editor.
+See [editorconfig.org](https://editorconfig.org/) for more information on if your editor requires a plugin.
+
 # Licenses
 Please see [LICENSE.md](LICENSE.md) for license details & other open source licenses in use by libraries.
 


### PR DESCRIPTION
Please set up your editors to use editorconfig if required!

Not sure if enforcing LF ending style will be an issue for those checking out on Windows CRLF style-commit LF; we can always tweak that one back if it's an issue.


- Sets newline at end of file
- Sets trim_trailing_whitespace for all files.
- Sets SPACE tab mode (`i/cpp/h/hpp/c` files only)
- Sets tabstop to `4` spaces (`i/cpp/h/hpp/c` files only)
- Sets default line ending to Unix-style `LF` for new files.