### PR TITLE
fix for when systemPowerScaling is omitted in a statBoost definition with systemPowerDependency.

### DIFF
--- a/Mod Files/data/hyperspace.xml
+++ b/Mod Files/data/hyperspace.xml
@@ -1552,6 +1552,7 @@ systemPowerDependency: determines the systems that affect the power of this stat
 systemPowerScaling: determines how the boost is affected by the total power bars within the systems in systemPowerDependency.
   noSys and hackedSys are values used for if the system isn't there and if the system is being hacked, respectively.
   The other tag names don't matter; the first value is used when the system is offline, and the second onwards determines the power at each given bar of power (with any amount of power over the max using the last number).
+  If this tag is omitted, then it will default to a value of 0 when the system is unpowered, hacked, or nonpresent, and a value of 1 otherwise.
 deathEffect: When the statBoost name is "deathEffect", specifies the deathEffect to replace or be added to the crewmember's normal deathEffect.
 powerEffect: When the statBoost name is "powerEffect", adds a new powerEffect.
   If boost type is SET then all the crew's existing powerEffects are removed and the new effect is added (or no power if none is specified).

--- a/StatBoost.cpp
+++ b/StatBoost.cpp
@@ -2247,7 +2247,7 @@ float CrewMember_Extend::CalculateStat(CrewStat stat, const CrewDefinition* def,
             {
                 // Calculate power scaling
                 int numPower = 0;
-                float sysPowerScaling = statBoost.def->powerScalingNoSys;
+                float sysPowerScaling = statBoost.def->systemPowerScaling.empty() ? 1.f : statBoost.def->powerScalingNoSys;
                 bool systemExists = false;
 
                 int statBoostSourceShipId;

--- a/StatBoost.cpp
+++ b/StatBoost.cpp
@@ -2779,7 +2779,7 @@ float CrewMember_Extend::CalculatePowerScaling(const StatBoost& statBoost)
     {
         // Calculate power scaling
         int numPower = 0;
-        float sysPowerScaling = statBoost.def->powerScalingNoSys;
+        float sysPowerScaling = statBoost.def->systemPowerScaling.empty() ? 1.f : statBoost.def->powerScalingNoSys;
         bool systemExists = false;
         for (auto system : statBoost.def->systemPowerScaling)
         {
@@ -2817,7 +2817,8 @@ float CrewMember_Extend::CalculatePowerScaling(const StatBoost& statBoost)
         }
         if (systemExists)
         {
-            sysPowerScaling = statBoost.def->powerScaling.at(numPower < statBoost.def->powerScaling.size() ? numPower : statBoost.def->powerScaling.size()-1);
+            if (!statBoost.def->powerScaling.empty()) sysPowerScaling = statBoost.def->powerScaling.at(numPower < statBoost.def->powerScaling.size() ? numPower : statBoost.def->powerScaling.size()-1);
+            else sysPowerScaling = numPower > 0 ? 1.f : 0.f;
         }
         return sysPowerScaling;
     };

--- a/StatBoost.cpp
+++ b/StatBoost.cpp
@@ -2296,7 +2296,8 @@ float CrewMember_Extend::CalculateStat(CrewStat stat, const CrewDefinition* def,
                 }
                 if (systemExists)
                 {
-                    sysPowerScaling = statBoost.def->powerScaling.at(numPower < statBoost.def->powerScaling.size() ? numPower : statBoost.def->powerScaling.size()-1);
+                    if (!statBoost.def->powerScaling.empty()) sysPowerScaling = statBoost.def->powerScaling.at(numPower < statBoost.def->powerScaling.size() ? numPower : statBoost.def->powerScaling.size()-1);
+                    else sysPowerScaling = numPower > 0 ? 1.f : 0.f;
                 }
 
                 // Apply effect

--- a/StatBoost.h
+++ b/StatBoost.h
@@ -178,8 +178,8 @@ struct StatBoostDefinition
     ExplosionDefinition* deathEffectChange;
 
     std::vector<float> powerScaling = std::vector<float>();
-    float powerScalingNoSys = 0.0;
-    float powerScalingHackedSys = 0.0;
+    float powerScalingNoSys = 0.f;
+    float powerScalingHackedSys = 0.f;
     std::vector<int> systemPowerScaling;
 
     std::vector<std::pair<CrewExtraCondition,bool>> extraConditions = std::vector<std::pair<CrewExtraCondition,bool>>();

--- a/StatBoost.h
+++ b/StatBoost.h
@@ -178,8 +178,8 @@ struct StatBoostDefinition
     ExplosionDefinition* deathEffectChange;
 
     std::vector<float> powerScaling = std::vector<float>();
-    float powerScalingNoSys = 1.0;
-    float powerScalingHackedSys = 1.0;
+    float powerScalingNoSys = 0.0;
+    float powerScalingHackedSys = 0.0;
     std::vector<int> systemPowerScaling;
 
     std::vector<std::pair<CrewExtraCondition,bool>> extraConditions = std::vector<std::pair<CrewExtraCondition,bool>>();


### PR DESCRIPTION
## Bugfix
Previously, an omitted `systemPowerScaling` tag in a `statBoost` that had a `systemPowerDependency` tag would result in a crash when that system was present on the ship. This PR implements default behavior for `statBoost`s of this type.

## Backward Compatibility
This PR changes the default values of `powerScalingNoSys` and `powerScalingHackedSys` in `StatBoostDefinition`. Previously, the only case in which these values are used would be if  `systemPowerScaling` was omitted, which would lead to a crash.

