### PR TITLE
Fixed a tpyo in hyperspace.i (MouseControl::selling)

### DIFF
--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -1038,7 +1038,7 @@ playerVariableType playerVariables;
 %rename("%s") MouseControl::animateDoor;
 %rename("%s") MouseControl::validPointer;
 %rename("%s") MouseControl::invalidPointer;
-%rename("%s") MouseControl::cselling;
+%rename("%s") MouseControl::selling;
 %rename("%s") MouseControl::openDoor;
 %rename("%s") MouseControl::tooltip;
 %rename("%s") MouseControl::tooltipTimer;


### PR DESCRIPTION
In FTLGameWin32.h on line 6367 the field is listed as `GL_Texture *selling;`.

I tried grepping for cselling through the repository, and its only occurrence is in hyperspace.i.

Edit: on wiki the field is already listed as `.selling`