### PR TITLE
Fix multiple over capacity item duplication

### DIFF
--- a/CustomAugments.cpp
+++ b/CustomAugments.cpp
@@ -4,6 +4,7 @@
 #include "Global.h"
 #include "ShipManager_Extend.h"
 #include "CustomEvents.h"
+#include "Equipment_Extend.h"
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
 
@@ -534,7 +535,7 @@ HOOK_METHOD(Equipment, MouseClick, (int mX, int mY) -> void)
     if (draggingEquipBox != -1)
     {
         auto box = vEquipmentBoxes[draggingEquipBox];
-        if (box->CanHoldAugment() && box->slot != 4)
+        if (box->CanHoldAugment() && box->slot != -2)
         {
             if (box->item.augment && customAug->IsAugment(box->item.augment->name))
             {
@@ -564,7 +565,7 @@ HOOK_METHOD(EquipmentBox, OnRender, (bool isEmpty) -> void)
 
         if (item.augment && customAug->IsAugment(item.augment->name) && customAug->GetAugmentDefinition(item.augment->name)->locked && augLockTexture)
         {
-            float xPos = slot == 4 ? location.x - 36.f : location.x - 24.f;
+            float xPos = slot == -2 ? location.x - 36.f : location.x - 24.f;
 
             G_->GetResources()->RenderImage(augLockTexture, xPos, location.y + 7.f, 0.f, COLOR_WHITE, 1.f, false);
         }
@@ -575,11 +576,11 @@ HOOK_METHOD(Equipment, OnLoop, () -> void)
 {
     LOG_HOOK("HOOK_METHOD -> Equipment::OnLoop -> Begin (CustomAugments.cpp)\n")
     super();
+    CustomEquipment *customEquip = EQ_EX(this)->customEquipment;
     CustomAugmentManager* customAug = CustomAugmentManager::GetInstance();
 
-    EquipmentBox *firstSlot;
-    EquipmentBox *fullSlot;
-    bool swapSlots = false;
+    EquipmentBox *firstSlot = nullptr;
+    EquipmentBox *fullSlot = nullptr;
 
     for (auto i : vEquipmentBoxes)
     {
@@ -594,16 +595,17 @@ HOOK_METHOD(Equipment, OnLoop, () -> void)
             {
                 i->bBlocked = true;
 
-                if (i->slot == 4)
+                if (i->slot == -2)
                 {
                     fullSlot = i;
-                    swapSlots = true;
                 }
             }
         }
     }
 
-    if (swapSlots)
+    if (!firstSlot) return;
+
+    if (fullSlot)
     {
         EquipmentBoxItem item1 = fullSlot->item;
         EquipmentBoxItem item2 = firstSlot->item;
@@ -611,6 +613,22 @@ HOOK_METHOD(Equipment, OnLoop, () -> void)
         firstSlot->RemoveItem();
         fullSlot->AddItem(item2);
         firstSlot->AddItem(item1);
+        customEquip->UpdateOverCapacityItems();
+        return;
+    }
+
+    // Search over capacity items for locked augments to force swap
+    for (auto &i : customEquip->overCapacityItems)
+    {
+        if (i.first.augment && customAug->IsAugment(i.first.augment->name) && customAug->GetAugmentDefinition(i.first.augment->name)->locked)
+        {
+            EquipmentBoxItem item1 = i.first;
+            EquipmentBoxItem item2 = firstSlot->item;
+            firstSlot->RemoveItem();
+            i.first = item2;
+            firstSlot->AddItem(item1);
+            return;
+        }
     }
 }
 

--- a/CustomEquipment.cpp
+++ b/CustomEquipment.cpp
@@ -384,10 +384,10 @@ void CustomEquipment::OnInit(ShipManager *ship)
         orig->vEquipmentBoxes.push_back(box);
     }
 
-    orig->overcapacityBox = new EquipmentBox(Point(0, 0), 4);
+    orig->overcapacityBox = new EquipmentBox(Point(0, 0), -2); // in vanilla, slot is 4
     orig->vEquipmentBoxes.push_back(orig->overcapacityBox);
 
-    orig->overAugBox = new AugmentEquipBox(Point(0, 0), nullptr, 4);
+    orig->overAugBox = new AugmentEquipBox(Point(0, 0), nullptr, -2); // in vanilla, slot is 4
     orig->vEquipmentBoxes.push_back(orig->overAugBox);
 
     orig->SetPosition(orig->position);
@@ -907,7 +907,7 @@ void CustomEquipment::OnLoop()
     int newAugNumber = CustomShipSelect::GetInstance()->GetDefinition(orig->shipManager->myBlueprint.blueprintName).augSlots;
     if (orig->shipManager->HasAugmentation("AUGMENT_SLOT")) newAugNumber += static_cast<int>(orig->shipManager->GetAugmentationValue("AUGMENT_SLOT"));
     if (newAugNumber < 0) newAugNumber = 0;
-    
+
     if (augNumber != newAugNumber)
     {
         if (newAugNumber > augNumber)
@@ -1078,6 +1078,20 @@ void CustomEquipment::AddOverCapacityItem(const EquipmentBoxItem &item)
     currentOverCapacityPage = 0;
 }
 
+void CustomEquipment::UpdateOverCapacityItems()
+{
+    if (overCapacityItems.empty()) return;
+
+    if (orig->bOverCapacity)
+    {
+        overCapacityItems[currentOverCapacityPage].first = orig->overcapacityBox->item;
+    }
+    else if (orig->bOverAugCapacity)
+    {
+        overCapacityItems[currentOverCapacityPage].first = orig->overAugBox->item;
+    }
+}
+
 
 HOOK_METHOD_PRIORITY(Equipment, OnInit, 9999, (ShipManager *ship) -> void)
 {
@@ -1134,23 +1148,7 @@ HOOK_METHOD(Equipment, MouseUp, (int mX, int mY) -> void)
 
     CustomEquipment *custom = EQ_EX(this)->customEquipment;
     // updates over capacity item when player swaps item in over capacity box.
-    if (!custom->overCapacityItems.empty())
-    {
-        if (bOverCapacity)
-        {
-            if (overcapacityBox->item != custom->overCapacityItems[custom->currentOverCapacityPage].first)
-            {
-                custom->overCapacityItems[custom->currentOverCapacityPage].first = overcapacityBox->item;
-            }
-        }
-        else if (bOverAugCapacity)
-        {
-            if (overAugBox->item != custom->overCapacityItems[custom->currentOverCapacityPage].first)
-            {
-                custom->overCapacityItems[custom->currentOverCapacityPage].first = overAugBox->item;
-            }
-        }
-    }
+    custom->UpdateOverCapacityItems();
 }
 
 

--- a/CustomEvents.cpp
+++ b/CustomEvents.cpp
@@ -12,6 +12,7 @@
 #include "CustomScoreKeeper.h"
 #include "CustomBackgroundObject.h"
 #include "EventButtons.h"
+#include "Equipment_Extend.h"
 #include <algorithm>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
@@ -3125,8 +3126,9 @@ HOOK_METHOD_PRIORITY(ShipManager, RemoveItem, 9999, (const std::string& name) ->
 
     if (!removedItem && g_checkCargo)
     {
-        Equipment equip = G_->GetWorld()->commandGui->equipScreen;
-        auto boxes = equip.vEquipmentBoxes;
+        Equipment *equip = &(G_->GetWorld()->commandGui->equipScreen);
+        CustomEquipment *custom = EQ_EX(equip)->customEquipment;
+        auto boxes = equip->vEquipmentBoxes;
 
         for (auto const& box: boxes)
         {
@@ -3141,6 +3143,7 @@ HOOK_METHOD_PRIORITY(ShipManager, RemoveItem, 9999, (const std::string& name) ->
                     if (cargoItem->name == name)
                     {
                         box->RemoveItem();
+                        custom->UpdateOverCapacityItems();
                         return;
                     }
                 }

--- a/Equipment_Extend.h
+++ b/Equipment_Extend.h
@@ -13,6 +13,7 @@ public:
 
     void OnScrollWheel(float direction);
     void AddOverCapacityItem(const EquipmentBoxItem &item);
+    void UpdateOverCapacityItems();
 
     CustomEquipment(Equipment *equipment)
     {
@@ -33,7 +34,7 @@ public:
     int currentAugPage = 0;
     int currentCargoPage = 0;
     int currentOverCapacityPage = 0;
-    
+
 private:
     Equipment *orig = nullptr;
 


### PR DESCRIPTION
To replicate the bug, you can assemble the gatling when the barrel or base is in a multiple over capacity box. You will see the completed gatling in your cargo and the part remaining in the over box.