### PR TITLE
Proper lua errors for out-of-bounds vector access

### DIFF
--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -31,6 +31,24 @@
 #include "CustomDamage.h"
 %}
 
+//Current exception macro offers a trace to the wrong level
+%{
+    #define SWIG_exception(a, b)\
+    {\
+        luaL_where(L, 2);\
+        lua_pushfstring(L,"%s:%s",#a,b);\
+        lua_concat(L, 2);\
+        SWIG_fail;\
+    }\
+%}
+//Change typemap for unsigned numeric types to throw a proper lua error when provided a negative value
+%typemap(in, checkfn="lua_isnumber") unsigned int, unsigned short, unsigned long, unsigned char
+%{
+    if (lua_tonumber(L, $input) < 0) SWIG_exception(SWIG_ValueError, "number must not be negative");
+    $1 = ($type) lua_tonumber(L, $input);
+%}
+
+
 //This macro defines a wrapper class for any exposed arrays of TYPE with length SIZE
 %define %array_wrapper(TYPE, NAME, SIZE)
 


### PR DESCRIPTION
This should also hopefully take care of some other cases where a proper error position is not provided.