### PR TITLE
Halt non-hostile enemy's artillery firing

### DIFF
--- a/ArtillerySystem.cpp
+++ b/ArtillerySystem.cpp
@@ -227,7 +227,7 @@ HOOK_METHOD(WeaponControl, SetAutofiring, (bool on, bool simple) -> void)
     }
 }
 
-// Prevent non-hostile enemy's artillery from firing when the system power is provided by energy crews (i.g. zoltans)
+// Prevents neutral enemy's artillery from firing when the system is powered by energy crews (i.g. zoltans)
 static bool g_haltArtilleryFire = false;
 HOOK_METHOD(ArtillerySystem, OnLoop, () -> void)
 {

--- a/ArtillerySystem.cpp
+++ b/ArtillerySystem.cpp
@@ -226,3 +226,21 @@ HOOK_METHOD(WeaponControl, SetAutofiring, (bool on, bool simple) -> void)
         }
     }
 }
+
+// Prevent non-hostile enemy's artillery from firing when the system power is provided by energy crews (i.g. zoltans)
+static bool g_haltArtilleryFire = false;
+HOOK_METHOD(ArtillerySystem, OnLoop, () -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> ArtillerySystem::OnLoop -> Begin (ArtillerySystem.cpp)\n")
+    if (projectileFactory->targetId == 1 || !G_->GetShipManager(1) || G_->GetShipManager(1)->_targetable.hostile) return super();
+
+    g_haltArtilleryFire = true;
+    super();
+    g_haltArtilleryFire = false;
+}
+HOOK_METHOD(ProjectileFactory, ReadyToFire, () -> bool)
+{
+    LOG_HOOK("HOOK_METHOD -> ProjectileFactory::ReadyToFire -> Begin (ArtillerySystem.cpp)\n")
+    if (g_haltArtilleryFire) return false;
+    return super();
+}


### PR DESCRIPTION
Fix https://discord.com/channels/604415384979898464/1370779098905051146

This pr prevents non-hostile enemy's artillery from firing when the system is powered by energy crews (i.g. zoltans).

For testing, you can use MV ship `MU_FED_ASSAULT` and the command would look like `LOAD MU_FED_ASSAULT 8`. Make sure the enemy artillery is powered by zoltan crew and run command `LUA Hyperspace.ships.enemy._targetable.hostile=false` to make the enemy neutral. Now the artillery still can be charged, but never be able to fire.