### PR TITLE
Fix custom systems Linux crash

### DIFF
--- a/CustomShipGenerator.cpp
+++ b/CustomShipGenerator.cpp
@@ -345,9 +345,7 @@ int CustomShipGenerator::InitShip(ShipManager *ship, ShipBlueprint &bp, int leve
 
 std::vector<int> CustomShipGenerator::GenerateSystemMaxes(ShipBlueprint &bp, int level)
 {
-    std::vector<int> systemMaxes = std::vector<int>();
-    systemMaxes.reserve(21);
-    systemMaxes.resize(21, 0);
+    std::vector<int> systemMaxes = std::vector<int>(CustomUserSystems::GetLastSystemId() + 1, 0);
 
     for (auto sysInfo : bp.systemInfo)
     {


### PR DESCRIPTION
The crash was caused by `CustomShipGenerator::GenerateSystemMaxes` allocating only 21 slots  in the `systemMaxes` vector. The proceeding out-of-bounds write then corrupted the heap and caused the crash on a later free (on glibc 2.40).

Fixed with the help of @ranhai613.