### PR TITLE
bounds checking and exception macro tweaks

### DIFF
--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -1843,6 +1843,16 @@ We can expose them once the root cause is identified and the crash is fixed.
         }
         $self->ModifyRoomOxygen(roomId, amount);
     }
+    //EmptyOxygen allows an out-of-bounds write in vanilla code
+    void EmptyOxygen(int roomId) throw (std::invalid_argument)
+    {
+        if (roomId < 0 || roomId >= $self->oxygenLevels.size())
+        {
+            std::string error = (boost::format("Invalid roomId: %i") % roomId).str();
+            throw std::invalid_argument(error);
+        }
+        $self->EmptyOxygen(roomId);
+    }
 }
 
 %rename("%s") OxygenSystem::max_oxygen;

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -31,11 +31,18 @@
 #include "CustomDamage.h"
 %}
 
-//Current exception macro offers a trace to the wrong level
+//Some exception levels are empty, this grabs the first non-empty level
 %{
     #define SWIG_exception(a, b)\
     {\
-        luaL_where(L, 2);\
+        int errorLevel = 0;\
+        size_t len = 0;\
+        do {\
+            luaL_where(L, errorLevel++);\
+            lua_tolstring(L, -1, &len);\
+            if (len == 0) lua_pop(L, 1);\
+            else break;\
+        } while (true);\
         lua_pushfstring(L,"%s:%s",#a,b);\
         lua_concat(L, 2);\
         SWIG_fail;\
@@ -1693,7 +1700,14 @@ We can expose them once the root cause is identified and the crash is fixed.
 
 %nodefaultctor ShipManager_Extend;
 %rename("%s") ShipManager_Extend;
-//Potential fix for fireSpreader indexing issue
+
+%{
+    static bool Fire_Coordinates_Valid(ShipManager* shipManager, int x, int y)
+    {
+        return (x >= 0 && x < shipManager->fireSpreader.grid.size() && y >= 0 && y < shipManager->fireSpreader.grid[x].size());
+    }
+%}
+
 %rename("%s") ShipManager::GetFireAtPoint;
 %rename("%s") ShipManager::GetFire;
 %extend ShipManager {
@@ -1702,33 +1716,52 @@ We can expose them once the root cause is identified and the crash is fixed.
     //Possible Methods
 
     //Get fire at spacial coordinates
-    Fire& GetFireAtPoint(float x, float y)
+    Fire& GetFireAtPoint(float x, float y) throw (std::invalid_argument)
     {
         Point fireCoordinates = ShipGraph::TranslateToGrid(x, y);
+        if (!Fire_Coordinates_Valid($self, fireCoordinates.x, fireCoordinates.y))
+        {
+            std::string error = (boost::format("Invalid fire coordinates: (%f, %f)") % x % y).str();
+            throw std::invalid_argument(error);
+        }
         return $self->fireSpreader.grid[fireCoordinates.x][fireCoordinates.y];
     }
 
     //Get fire at spacial coordintes (Point form)
-    Fire& GetFireAtPoint(Point p)
+    Fire& GetFireAtPoint(Point p) throw (std::invalid_argument)
     {
         Point fireCoordinates = ShipGraph::TranslateToGrid(p.x, p.y);
+        if (!Fire_Coordinates_Valid($self, fireCoordinates.x, fireCoordinates.y))
+        {
+            std::string error = (boost::format("Invalid fire coordinates: Point(%i, %i)") % p.x % p.y).str();
+            throw std::invalid_argument(error);
+        }
         return $self->fireSpreader.grid[fireCoordinates.x][fireCoordinates.y];
     }
 
     //Get fire at spacial coordinates (Pointf form)
-    Fire& GetFireAtPoint(Pointf p)
+    Fire& GetFireAtPoint(Pointf p) throw (std::invalid_argument)
     {
         Point fireCoordinates = ShipGraph::TranslateToGrid(p.x, p.y);
+        if (!Fire_Coordinates_Valid($self, fireCoordinates.x, fireCoordinates.y))
+        {
+            std::string error = (boost::format("Invalid fire coordinates: Pointf(%f, %f)") % p.x % p.y).str();
+            throw std::invalid_argument(error);
+        }
         return $self->fireSpreader.grid[fireCoordinates.x][fireCoordinates.y];
     }
 
     //Indexing function, grid coordinates
-    Fire& GetFire(int x, int y)
+    Fire& GetFire(int x, int y) throw (std::invalid_argument)
     {
+        if (!Fire_Coordinates_Valid($self, x, y))
+        {
+            std::string error = (boost::format("Invalid fire coordinates: (%i, %i)") % x % y).str();
+            throw std::invalid_argument(error);
+        }
         return $self->fireSpreader.grid[x][y];
     }
 }
-
 
 %rename("%s") Spreader_Fire;
 %rename("%s") Spreader_Fire::count;
@@ -1799,6 +1832,19 @@ We can expose them once the root cause is identified and the crash is fixed.
 %rename("%s") OxygenSystem::EmptyOxygen;
 %rename("%s") OxygenSystem::GetRefillSpeed;
 %rename("%s") OxygenSystem::ModifyRoomOxygen;
+%extend OxygenSystem {
+    //ModifyRoomOxygen allows an out-of-bounds write in vanilla code
+    void ModifyRoomOxygen(int roomId, float amount) throw (std::invalid_argument)
+    {
+        if (roomId < 0 || roomId >= $self->oxygenLevels.size())
+        {
+            std::string error = (boost::format("Invalid roomId: %i") % roomId).str();
+            throw std::invalid_argument(error);
+        }
+        $self->ModifyRoomOxygen(roomId, amount);
+    }
+}
+
 %rename("%s") OxygenSystem::max_oxygen;
 %rename("%s") OxygenSystem::oxygenLevels;
 %rename("%s") OxygenSystem::fTotalOxygen;


### PR DESCRIPTION
## Feature
This PR adds bounds checking for the following functions as wrapped in SWIG:
- `OxygenSystem::ModifyRoomOxygen`
- `ShipManager::GetFire`
- `ShipManager::GetFireAtPoint`
Additionally, the `SWIG_exception` macro is tweaked to show the proper control level when exceptions are translated to lua errors.