### PR TITLE
Remove ship box from UI with instant escape events

### DIFF
--- a/CustomEvents.cpp
+++ b/CustomEvents.cpp
@@ -4179,6 +4179,7 @@ void RecallBoarders(int direction, bool force, bool effects)
     }
 }
 
+static bool forcedEscape = false;
 void CustomCreateLocation(WorldManager* world, LocationEvent* event, CustomEvent* customEvent)
 {
     for (auto& alias : customEvent->eventAlias)
@@ -4324,6 +4325,7 @@ void CustomCreateLocation(WorldManager* world, LocationEvent* event, CustomEvent
         {
             enemyShip->shipAI.escaping = true;
             enemyShip->shipManager->JumpLeave();
+            if (!enemyShip->shipManager->_targetable.hostile) forcedEscape = true;
         }
     }
 
@@ -4474,6 +4476,17 @@ void CustomCreateLocation(WorldManager* world, LocationEvent* event, CustomEvent
                 eventQueue.clear();
             }
         }
+    }
+}
+
+HOOK_METHOD(WorldManager, OnLoop, () -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> WorldManager::OnLoop -> Begin (CustomEvents.cpp)\n")
+    super();
+    if (forcedEscape && playerShip->enemyShip != nullptr && playerShip->enemyShip->shipManager->jumpAnimation.done)
+    {
+        forcedEscape = false;
+        commandGui->ClearLocation();
     }
 }
 

--- a/FTLGameELF32.cpp
+++ b/FTLGameELF32.cpp
@@ -4181,18 +4181,32 @@ void CommandGui::LButtonUp(int mX, int mY, bool shiftHeld)
 namespace _func300
 {
     static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("CompleteShip::DO_NOT_HOOK", typeid(void (CompleteShip::*)()), "!8b48fc8d59ff8958fc89c8e9????????8b48fc8d59ff8958fc89c8eb??6690", argdata, 0, 4, &func);
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CommandGui::ClearLocation", typeid(void (CommandGui::*)()), "5383ec188b5c????8b83b41200008b40088b887c010000", argdata, 1, 6, &func);
+}
+
+void CommandGui::ClearLocation()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func300::func;
+	return execfunc(this);
 }
 
 namespace _func301
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("CompleteShip::DO_NOT_HOOK2", typeid(void (CompleteShip::*)()), "!.8b48fc8d59ff8958fc89c8e9????????8b48fc8d59ff8958fc89c8eb??6690", argdata, 0, 4, &func);
+	static FunctionDefinition funcObj("CompleteShip::DO_NOT_HOOK", typeid(void (CompleteShip::*)()), "!8b48fc8d59ff8958fc89c8e9????????8b48fc8d59ff8958fc89c8eb??6690", argdata, 0, 4, &func);
 }
 
 namespace _func302
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("CompleteShip::DO_NOT_HOOK2", typeid(void (CompleteShip::*)()), "!.8b48fc8d59ff8958fc89c8e9????????8b48fc8d59ff8958fc89c8eb??6690", argdata, 0, 4, &func);
+}
+
+namespace _func303
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4202,11 +4216,11 @@ namespace _func302
 void CompleteShip::PauseLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func302::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func303::func;
 	return execfunc(this);
 }
 
-namespace _func303
+namespace _func304
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4216,11 +4230,11 @@ namespace _func303
 void CompleteShip::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func303::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func304::func;
 	return execfunc(this);
 }
 
-namespace _func304
+namespace _func305
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4230,11 +4244,11 @@ namespace _func304
 void CompleteShip::constructor(SpaceManager *space, bool unk, int unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, SpaceManager *space_arg, bool unk_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func304::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func305::func;
 	return execfunc(this, space, unk, unk2);
 }
 
-namespace _func305
+namespace _func306
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4244,11 +4258,11 @@ namespace _func305
 void CompleteShip::SetShip(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func305::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func306::func;
 	return execfunc(this, ship);
 }
 
-namespace _func306
+namespace _func307
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4258,11 +4272,11 @@ namespace _func306
 void CompleteShip::OnInit(const ShipBlueprint *blueprint, int unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, const ShipBlueprint *blueprint_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func306::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func307::func;
 	return execfunc(this, blueprint, unk);
 }
 
-namespace _func307
+namespace _func308
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4272,11 +4286,11 @@ namespace _func307
 void CompleteShip::AddBoarders(int amount, const std::string &race, bool unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int amount_arg, const std::string &race_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func307::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func308::func;
 	return execfunc(this, amount, race, unk2);
 }
 
-namespace _func308
+namespace _func309
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4286,11 +4300,11 @@ namespace _func308
 CrewMember *CompleteShip::AddCrewMember(const CrewBlueprint *blueprint, bool hostile)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, const CrewBlueprint *blueprint_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func308::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func309::func;
 	return execfunc(this, blueprint, hostile);
 }
 
-namespace _func309
+namespace _func310
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4300,11 +4314,11 @@ namespace _func309
 CrewMember *CompleteShip::AddCrewMember1(const std::string &race, const std::string &name, bool hostile)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, const std::string &race_arg, const std::string &name_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func309::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func310::func;
 	return execfunc(this, race, name, hostile);
 }
 
-namespace _func310
+namespace _func311
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4314,11 +4328,11 @@ namespace _func310
 Drone *CompleteShip::AddDrone(const DroneBlueprint *blueprint, int unk)
 {
 	typedef Drone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, const DroneBlueprint *blueprint_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func310::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func311::func;
 	return execfunc(this, blueprint, unk);
 }
 
-namespace _func311
+namespace _func312
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4328,11 +4342,11 @@ namespace _func311
 CrewMember *CompleteShip::AddCrewMember2(CrewMember *member, int unk)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, CrewMember *member_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func311::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func312::func;
 	return execfunc(this, member, unk);
 }
 
-namespace _func312
+namespace _func313
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4342,11 +4356,11 @@ namespace _func312
 void CompleteShip::SaveState(int unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func312::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func313::func;
 	return execfunc(this, unk);
 }
 
-namespace _func313
+namespace _func314
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4356,11 +4370,11 @@ namespace _func313
 void CompleteShip::LoadState(int unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func313::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func314::func;
 	return execfunc(this, unk);
 }
 
-namespace _func314
+namespace _func315
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4370,11 +4384,11 @@ namespace _func314
 void CompleteShip::InitiateTeleport(int targetRoom, int command)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int targetRoom_arg, int command_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func314::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func315::func;
 	return execfunc(this, targetRoom, command);
 }
 
-namespace _func315
+namespace _func316
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4384,11 +4398,11 @@ namespace _func315
 void CompleteShip::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func315::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func316::func;
 	return execfunc(this);
 }
 
-namespace _func316
+namespace _func317
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4398,11 +4412,11 @@ namespace _func316
 std::vector<CrewMember*> CompleteShip::GetTeleportingParty()
 {
 	typedef std::vector<CrewMember*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func316::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func317::func;
 	return execfunc(this);
 }
 
-namespace _func317
+namespace _func318
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4412,11 +4426,11 @@ namespace _func317
 void CompleteShip::KillRandomCrew()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func317::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func318::func;
 	return execfunc(this);
 }
 
-namespace _func318
+namespace _func319
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4426,11 +4440,11 @@ namespace _func318
 int CompleteShip::CountCrew(bool boarders)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, bool boarders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func318::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func319::func;
 	return execfunc(this, boarders);
 }
 
-namespace _func319
+namespace _func320
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4440,11 +4454,11 @@ namespace _func319
 void CompleteShip::Jump()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func319::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func320::func;
 	return execfunc(this);
 }
 
-namespace _func320
+namespace _func321
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4454,11 +4468,11 @@ namespace _func320
 void CompleteShip::SetEnemyShip(CompleteShip *other)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, CompleteShip *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func320::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func321::func;
 	return execfunc(this, other);
 }
 
-namespace _func321
+namespace _func322
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4468,11 +4482,11 @@ namespace _func321
 bool CompleteShip::DeadCrew()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func321::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func322::func;
 	return execfunc(this);
 }
 
-namespace _func322
+namespace _func323
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4482,11 +4496,11 @@ namespace _func322
 std::vector<CrewMember*> CompleteShip::TeleportCrew(int roomId, bool intruders)
 {
 	typedef std::vector<CrewMember*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int roomId_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func322::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func323::func;
 	return execfunc(this, roomId, intruders);
 }
 
-namespace _func323
+namespace _func324
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4496,11 +4510,11 @@ namespace _func323
 void CompleteShip::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func323::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func324::func;
 	return execfunc(this);
 }
 
-namespace _func324
+namespace _func325
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4510,11 +4524,11 @@ namespace _func324
 void CompleteShip::OnRenderSpace()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func324::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func325::func;
 	return execfunc(this);
 }
 
-namespace _func325
+namespace _func326
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4524,11 +4538,11 @@ namespace _func325
 void CompleteShip::OnRenderShip(bool unk1, bool unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, bool unk1_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func325::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func326::func;
 	return execfunc(this, unk1, unk2);
 }
 
-namespace _func326
+namespace _func327
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4538,11 +4552,11 @@ namespace _func326
 void ConfirmWindow::SetText(const TextString &text_, int minWidth, bool autoCenter, const TextString &yesText_, const TextString &noText_)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, const TextString &text__arg, int minWidth_arg, bool autoCenter_arg, const TextString &yesText__arg, const TextString &noText__arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func326::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func327::func;
 	return execfunc(this, text_, minWidth, autoCenter, yesText_, noText_);
 }
 
-namespace _func327
+namespace _func328
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4552,11 +4566,11 @@ namespace _func327
 void ConfirmWindow::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func327::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func328::func;
 	return execfunc(this);
 }
 
-namespace _func328
+namespace _func329
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -4566,11 +4580,11 @@ namespace _func328
 void ConfirmWindow::SetPosition(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func328::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func329::func;
 	return execfunc(this, pos);
 }
 
-namespace _func329
+namespace _func330
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4580,11 +4594,11 @@ namespace _func329
 void ConfirmWindow::Open()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func329::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func330::func;
 	return execfunc(this);
 }
 
-namespace _func330
+namespace _func331
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4594,11 +4608,11 @@ namespace _func330
 void ConfirmWindow::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func330::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func331::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func331
+namespace _func332
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4608,11 +4622,11 @@ namespace _func331
 void ConfirmWindow::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func331::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func332::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func332
+namespace _func333
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4620,20 +4634,6 @@ namespace _func332
 }
 
 void ConfirmWindow::constructor()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func332::func;
-	return execfunc(this);
-}
-
-namespace _func333
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ConfirmWindow::Close", typeid(void (ConfirmWindow::*)()), "5383ec188b5c24208b4348890424", argdata, 1, 6, &func);
-}
-
-void ConfirmWindow::Close()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func333::func;
@@ -4644,12 +4644,12 @@ namespace _func334
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ControlButton::OnRender", typeid(void (ControlButton::*)()), "5589e557565383ec6c8b5d08f30f102d????????", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ConfirmWindow::Close", typeid(void (ConfirmWindow::*)()), "5383ec188b5c24208b4348890424", argdata, 1, 6, &func);
 }
 
-void ControlButton::OnRender()
+void ConfirmWindow::Close()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ControlButton *this_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func334::func;
 	return execfunc(this);
 }
@@ -4658,12 +4658,12 @@ namespace _func335
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ControlsScreen::OnInit", typeid(void (ControlsScreen::*)()), "5589e557565381ecbc0000008b45088b80cc040000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ControlButton::OnRender", typeid(void (ControlButton::*)()), "5589e557565383ec6c8b5d08f30f102d????????", argdata, 1, 6, &func);
 }
 
-void ControlsScreen::OnInit()
+void ControlButton::OnRender()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ControlButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func335::func;
 	return execfunc(this);
 }
@@ -4672,10 +4672,10 @@ namespace _func336
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ControlsScreen::OnLoop", typeid(void (ControlsScreen::*)()), "5589e557565331db83ec4c8b45088b4d08", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ControlsScreen::OnInit", typeid(void (ControlsScreen::*)()), "5589e557565381ecbc0000008b45088b80cc040000", argdata, 1, 6, &func);
 }
 
-void ControlsScreen::OnLoop()
+void ControlsScreen::OnInit()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func336::func;
@@ -4686,10 +4686,10 @@ namespace _func337
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ControlsScreen::OnRender", typeid(void (ControlsScreen::*)()), "5589e557565381ec7c0100008b7508", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ControlsScreen::OnLoop", typeid(void (ControlsScreen::*)()), "5589e557565331db83ec4c8b45088b4d08", argdata, 1, 6, &func);
 }
 
-void ControlsScreen::OnRender()
+void ControlsScreen::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func337::func;
@@ -4699,6 +4699,20 @@ void ControlsScreen::OnRender()
 namespace _func338
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ControlsScreen::OnRender", typeid(void (ControlsScreen::*)()), "5589e557565381ec7c0100008b7508", argdata, 1, 6, &func);
+}
+
+void ControlsScreen::OnRender()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func338::func;
+	return execfunc(this);
+}
+
+namespace _func339
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CooldownSystemBox::constructor", typeid(void (CooldownSystemBox::*)(Point , ShipSystem *, bool )), "5557565381ec1c0100008bac24300100008b9c24340100008bb424380100008b84243c0100008bbc2440010000", argdata, 4, 6, &func);
 }
@@ -4706,11 +4720,11 @@ namespace _func338
 void CooldownSystemBox::constructor(Point pos, ShipSystem *sys, bool roundDown)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CooldownSystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, bool roundDown_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func338::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func339::func;
 	return execfunc(this, pos, sys, roundDown);
 }
 
-namespace _func339
+namespace _func340
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4720,11 +4734,11 @@ namespace _func339
 void CooldownSystemBox::OnRender(bool ignoreStatus)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CooldownSystemBox *this_arg, bool ignoreStatus_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func339::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func340::func;
 	return execfunc(this, ignoreStatus);
 }
 
-namespace _func340
+namespace _func341
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4734,11 +4748,11 @@ namespace _func340
 void CreditScreen::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CreditScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func340::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func341::func;
 	return execfunc(this);
 }
 
-namespace _func341
+namespace _func342
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4748,11 +4762,11 @@ namespace _func341
 void CreditScreen::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CreditScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func341::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func342::func;
 	return execfunc(this);
 }
 
-namespace _func342
+namespace _func343
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -4762,11 +4776,11 @@ namespace _func342
 void CreditScreen::Start(const std::string &shipName, const std::vector<std::string> &crewNames)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CreditScreen *this_arg, const std::string &shipName_arg, const std::vector<std::string> &crewNames_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func342::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func343::func;
 	return execfunc(this, shipName, crewNames);
 }
 
-namespace _func343
+namespace _func344
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4776,11 +4790,11 @@ namespace _func343
 bool CreditScreen::Done()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CreditScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func343::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func344::func;
 	return execfunc(this);
 }
 
-namespace _func344
+namespace _func345
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4790,11 +4804,11 @@ namespace _func344
 void CrewAI::UpdateDrones()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func344::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func345::func;
 	return execfunc(this);
 }
 
-namespace _func345
+namespace _func346
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4804,11 +4818,11 @@ namespace _func345
 void CrewAI::AssignCrewmembers()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func345::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func346::func;
 	return execfunc(this);
 }
 
-namespace _func346
+namespace _func347
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x3ff, 0x1ff};
@@ -4818,11 +4832,11 @@ namespace _func346
 int CrewAI::PrioritizeTask(CrewTask task, int crewId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg, CrewTask task_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func346::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func347::func;
 	return execfunc(this, task, crewId);
 }
 
-namespace _func347
+namespace _func348
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4832,11 +4846,11 @@ namespace _func347
 void CrewAI::UpdateIntruders()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func347::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func348::func;
 	return execfunc(this);
 }
 
-namespace _func348
+namespace _func349
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4846,11 +4860,11 @@ namespace _func348
 int CrewAI::PrioritizeIntruderRoom(CrewMember *crew, int roomId, int target)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg, CrewMember *crew_arg, int roomId_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func348::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func349::func;
 	return execfunc(this, crew, roomId, target);
 }
 
-namespace _func349
+namespace _func350
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4860,11 +4874,11 @@ namespace _func349
 void CrewAI::UpdateCrewMember(int crewId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func349::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func350::func;
 	return execfunc(this, crewId);
 }
 
-namespace _func350
+namespace _func351
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -4872,20 +4886,6 @@ namespace _func350
 }
 
 void CrewAI::CheckForHealing()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func350::func;
-	return execfunc(this);
-}
-
-namespace _func351
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewAI::OnLoop", typeid(void (CrewAI::*)()), "5589e557565383ec4c8b5d088b0389442404", argdata, 1, 6, &func);
-}
-
-void CrewAI::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func351::func;
@@ -4896,10 +4896,10 @@ namespace _func352
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewAI::CheckForProblems", typeid(void (CrewAI::*)()), "5589e557565383ec7c8b7d088b07c6470801", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewAI::OnLoop", typeid(void (CrewAI::*)()), "5589e557565383ec4c8b5d088b0389442404", argdata, 1, 6, &func);
 }
 
-void CrewAI::CheckForProblems()
+void CrewAI::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func352::func;
@@ -4909,6 +4909,20 @@ void CrewAI::CheckForProblems()
 namespace _func353
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CrewAI::CheckForProblems", typeid(void (CrewAI::*)()), "5589e557565383ec7c8b7d088b07c6470801", argdata, 1, 6, &func);
+}
+
+void CrewAI::CheckForProblems()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func353::func;
+	return execfunc(this);
+}
+
+namespace _func354
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CrewAI::DangerRating", typeid(int (CrewAI::*)(int , int )), "5589e557565383ec5c8b75088b4d108b5d0c", argdata, 3, 2, &func);
 }
@@ -4916,11 +4930,11 @@ namespace _func353
 int CrewAI::DangerRating(int roomId, int crewId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAI *this_arg, int roomId_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func353::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func354::func;
 	return execfunc(this, roomId, crewId);
 }
 
-namespace _func354
+namespace _func355
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -4930,11 +4944,11 @@ namespace _func354
 void CrewAnimation::constructor(int shipId, const std::string &race, Pointf unk, bool hostile)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, int shipId_arg, const std::string &race_arg, Pointf unk_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func354::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func355::func;
 	return execfunc(this, shipId, race, unk, hostile);
 }
 
-namespace _func355
+namespace _func356
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4944,25 +4958,25 @@ namespace _func355
 std::string CrewAnimation::GetDeathSound()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func355::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func356::func;
 	return execfunc(this);
-}
-
-namespace _func356
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("DO_NOT_HOOK_MANTISANIMATIONSHOOTINGSOUND", typeid(void (*)()), "5557565381ec0c010000803d????????00", argdata, 0, 4, &func);
 }
 
 namespace _func357
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("DO_NOT_HOOK_ROCKANIMATIONSHOOTINGSOUND", typeid(void (*)()), ".5557565381ec0c010000803d????????00", argdata, 0, 4, &func);
+	static FunctionDefinition funcObj("DO_NOT_HOOK_MANTISANIMATIONSHOOTINGSOUND", typeid(void (*)()), "5557565381ec0c010000803d????????00", argdata, 0, 4, &func);
 }
 
 namespace _func358
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("DO_NOT_HOOK_ROCKANIMATIONSHOOTINGSOUND", typeid(void (*)()), ".5557565381ec0c010000803d????????00", argdata, 0, 4, &func);
+}
+
+namespace _func359
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -4972,11 +4986,11 @@ namespace _func358
 std::string CrewAnimation::GetShootingSound()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func358::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func359::func;
 	return execfunc(this);
 }
 
-namespace _func359
+namespace _func360
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4986,11 +5000,11 @@ namespace _func359
 void CrewAnimation::OnRender(float scale, int selectedState, bool outlineOnly)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, float scale_arg, int selectedState_arg, bool outlineOnly_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func359::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func360::func;
 	return execfunc(this, scale, selectedState, outlineOnly);
 }
 
-namespace _func360
+namespace _func361
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5000,11 +5014,11 @@ namespace _func360
 void CrewAnimation::OnRenderProps()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func360::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func361::func;
 	return execfunc(this);
 }
 
-namespace _func361
+namespace _func362
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -5014,11 +5028,11 @@ namespace _func361
 void CrewAnimation::OnInit(const std::string &name, Pointf position, bool enemy)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, const std::string &name_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func361::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func362::func;
 	return execfunc(this, name, position, enemy);
 }
 
-namespace _func362
+namespace _func363
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5028,11 +5042,11 @@ namespace _func362
 void CrewAnimation::SetupStrips()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func362::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func363::func;
 	return execfunc(this);
 }
 
-namespace _func363
+namespace _func364
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5042,11 +5056,11 @@ namespace _func363
 void CrewAnimation::OnUpdate(Pointf position, bool moving, bool fighting, bool repairing, bool dying, bool onFire)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, Pointf position_arg, bool moving_arg, bool fighting_arg, bool repairing_arg, bool dying_arg, bool onFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func363::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func364::func;
 	return execfunc(this, position, moving, fighting, repairing, dying, onFire);
 }
 
-namespace _func364
+namespace _func365
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5056,11 +5070,11 @@ namespace _func364
 void CrewAnimation::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func364::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func365::func;
 	return execfunc(this);
 }
 
-namespace _func365
+namespace _func366
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5070,11 +5084,11 @@ namespace _func365
 bool CrewAnimation::FireShot()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func365::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func366::func;
 	return execfunc(this);
 }
 
-namespace _func366
+namespace _func367
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5084,11 +5098,11 @@ namespace _func366
 int CrewAnimation::GetFiringFrame()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func366::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func367::func;
 	return execfunc(this);
 }
 
-namespace _func367
+namespace _func368
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5098,11 +5112,11 @@ namespace _func367
 void CrewAnimation::RenderIcon(bool border)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, bool border_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func367::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func368::func;
 	return execfunc(this, border);
 }
 
-namespace _func368
+namespace _func369
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5112,11 +5126,11 @@ namespace _func368
 void CrewAnimation::OnUpdateEffects()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func368::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func369::func;
 	return execfunc(this);
 }
 
-namespace _func369
+namespace _func370
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5126,11 +5140,11 @@ namespace _func369
 void CrewBlueprint::RandomSkills(int worldLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func369::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func370::func;
 	return execfunc(this, worldLevel);
 }
 
-namespace _func370
+namespace _func371
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5140,11 +5154,11 @@ namespace _func370
 void CrewBlueprint::RenderSkill(int x, int y, int length, int height, int skill)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int x_arg, int y_arg, int length_arg, int height_arg, int skill_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func370::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func371::func;
 	return execfunc(this, x, y, length, height, skill);
 }
 
-namespace _func371
+namespace _func372
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5154,11 +5168,11 @@ namespace _func371
 void CrewBlueprint::RenderIcon(float opacity)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, float opacity_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func371::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func372::func;
 	return execfunc(this, opacity);
 }
 
-namespace _func372
+namespace _func373
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5168,11 +5182,11 @@ namespace _func372
 void CrewBlueprint::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func372::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func373::func;
 	return execfunc(this);
 }
 
-namespace _func373
+namespace _func374
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5182,11 +5196,11 @@ namespace _func373
 std::string CrewBlueprint::GetNameShort()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func373::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func374::func;
 	return execfunc(this);
 }
 
-namespace _func374
+namespace _func375
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -5196,11 +5210,11 @@ namespace _func374
 GL_Color CrewBlueprint::GetCurrentSkillColor(int skill)
 {
 	typedef GL_Color __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int skill_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func374::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func375::func;
 	return execfunc(this, skill);
 }
 
-namespace _func375
+namespace _func376
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -5210,11 +5224,11 @@ namespace _func375
 void CrewBox::constructor(Point pos, CrewMember *crew, int number)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg, Point pos_arg, CrewMember *crew_arg, int number_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func375::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func376::func;
 	return execfunc(this, pos, crew, number);
 }
 
-namespace _func376
+namespace _func377
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5224,11 +5238,11 @@ namespace _func376
 void CrewBox::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func376::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func377::func;
 	return execfunc(this);
 }
 
-namespace _func377
+namespace _func378
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -5238,11 +5252,11 @@ namespace _func377
 CrewMember *CrewBox::GetSelected(int mouseX, int mouseY)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg, int mouseX_arg, int mouseY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func377::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func378::func;
 	return execfunc(this, mouseX, mouseY);
 }
 
-namespace _func378
+namespace _func379
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5252,11 +5266,11 @@ namespace _func378
 void CrewBox::OnLoop(bool selected)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg, bool selected_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func378::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func379::func;
 	return execfunc(this, selected);
 }
 
-namespace _func379
+namespace _func380
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5264,20 +5278,6 @@ namespace _func379
 }
 
 void CrewBox::OnRenderSkillLevel()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func379::func;
-	return execfunc(this);
-}
-
-namespace _func380
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewBox::destructor", typeid(void (CrewBox::*)()), "5557565383ec2c8b7424408b8628010000890424", argdata, 1, 6, &func);
-}
-
-void CrewBox::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func380::func;
@@ -5288,12 +5288,12 @@ namespace _func381
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewBox::MouseClick", typeid(bool (CrewBox::*)()), "83ec1c8b5424200fb64268", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CrewBox::destructor", typeid(void (CrewBox::*)()), "5557565383ec2c8b7424408b8628010000890424", argdata, 1, 6, &func);
 }
 
-bool CrewBox::MouseClick()
+void CrewBox::destructor()
 {
-	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func381::func;
 	return execfunc(this);
 }
@@ -5302,12 +5302,12 @@ namespace _func382
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewBox::RenderIcon", typeid(void (CrewBox::*)()), "565383ec348b5c24408b4320", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewBox::MouseClick", typeid(bool (CrewBox::*)()), "83ec1c8b5424200fb64268", argdata, 1, 2, &func);
 }
 
-void CrewBox::RenderIcon()
+bool CrewBox::MouseClick()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func382::func;
 	return execfunc(this);
 }
@@ -5316,10 +5316,10 @@ namespace _func383
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewBox::RenderLabels", typeid(void (CrewBox::*)()), "5589e557565383ec5c8b75088d5dd4", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewBox::RenderIcon", typeid(void (CrewBox::*)()), "565383ec348b5c24408b4320", argdata, 1, 6, &func);
 }
 
-void CrewBox::RenderLabels()
+void CrewBox::RenderIcon()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func383::func;
@@ -5330,10 +5330,10 @@ namespace _func384
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewBox::RenderCloneDying", typeid(void (CrewBox::*)()), "83ec3c8b44244080b80801000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewBox::RenderLabels", typeid(void (CrewBox::*)()), "5589e557565383ec5c8b75088d5dd4", argdata, 1, 6, &func);
 }
 
-void CrewBox::RenderCloneDying()
+void CrewBox::RenderLabels()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func384::func;
@@ -5344,12 +5344,12 @@ namespace _func385
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewControl::OnRender", typeid(void (CrewControl::*)()), "5589e557565381ec8c0000008b5d088b4b3c8b4340", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewBox::RenderCloneDying", typeid(void (CrewBox::*)()), "83ec3c8b44244080b80801000000", argdata, 1, 6, &func);
 }
 
-void CrewControl::OnRender()
+void CrewBox::RenderCloneDying()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func385::func;
 	return execfunc(this);
 }
@@ -5358,10 +5358,10 @@ namespace _func386
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewControl::OnLoop", typeid(void (CrewControl::*)()), "5589e557565383ec4c8b5d088db388000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewControl::OnRender", typeid(void (CrewControl::*)()), "5589e557565381ec8c0000008b5d088b4b3c8b4340", argdata, 1, 6, &func);
 }
 
-void CrewControl::OnLoop()
+void CrewControl::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func386::func;
@@ -5372,10 +5372,10 @@ namespace _func387
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewControl::UpdateCrewBoxes", typeid(void (CrewControl::*)()), "5557565383ec4c8b5c24608d442430", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewControl::OnLoop", typeid(void (CrewControl::*)()), "5589e557565383ec4c8b5d088db388000000", argdata, 1, 6, &func);
 }
 
-void CrewControl::UpdateCrewBoxes()
+void CrewControl::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func387::func;
@@ -5385,6 +5385,20 @@ void CrewControl::UpdateCrewBoxes()
 namespace _func388
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CrewControl::UpdateCrewBoxes", typeid(void (CrewControl::*)()), "5557565383ec4c8b5c24608d442430", argdata, 1, 6, &func);
+}
+
+void CrewControl::UpdateCrewBoxes()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func388::func;
+	return execfunc(this);
+}
+
+namespace _func389
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CrewControl::LinkShip", typeid(void (CrewControl::*)(ShipManager *)), "5383ec188b5c24208b4424248903891c24", argdata, 2, 6, &func);
 }
@@ -5392,11 +5406,11 @@ namespace _func388
 void CrewControl::LinkShip(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func388::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func389::func;
 	return execfunc(this, ship);
 }
 
-namespace _func389
+namespace _func390
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5406,11 +5420,11 @@ namespace _func389
 void CrewControl::MouseMove(int mX, int mY, int wX, int wY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, int wX_arg, int wY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func389::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func390::func;
 	return execfunc(this, mX, mY, wX, wY);
 }
 
-namespace _func390
+namespace _func391
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5420,11 +5434,11 @@ namespace _func390
 void CrewControl::LButton(int mX, int mY, int wX, int wY, bool shiftHeld)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, int wX_arg, int wY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func390::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func391::func;
 	return execfunc(this, mX, mY, wX, wY, shiftHeld);
 }
 
-namespace _func391
+namespace _func392
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5434,11 +5448,11 @@ namespace _func391
 void CrewControl::ClearDeadCrew(std::vector<CrewMember*> *crew)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg, std::vector<CrewMember*> *crew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func391::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func392::func;
 	return execfunc(this, crew);
 }
 
-namespace _func392
+namespace _func393
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5448,11 +5462,11 @@ namespace _func392
 void CrewControl::ClearCrewBoxes()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func392::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func393::func;
 	return execfunc(this);
 }
 
-namespace _func393
+namespace _func394
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -5462,11 +5476,11 @@ namespace _func393
 void CrewControl::SelectPotentialCrew(CrewMember *crew, bool allowTeleportLeaving)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg, CrewMember *crew_arg, bool allowTeleportLeaving_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func393::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func394::func;
 	return execfunc(this, crew, allowTeleportLeaving);
 }
 
-namespace _func394
+namespace _func395
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5476,11 +5490,11 @@ namespace _func394
 void CrewControl::KeyDown(SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func394::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func395::func;
 	return execfunc(this, key);
 }
 
-namespace _func395
+namespace _func396
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5490,11 +5504,11 @@ namespace _func395
 void CrewControl::RButton(int mX, int mY, bool shiftHeld)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func395::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func396::func;
 	return execfunc(this, mX, mY, shiftHeld);
 }
 
-namespace _func396
+namespace _func397
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5504,11 +5518,11 @@ namespace _func396
 void CrewControl::SelectCrew(bool keep_current)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewControl *this_arg, bool keep_current_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func396::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func397::func;
 	return execfunc(this, keep_current);
 }
 
-namespace _func397
+namespace _func398
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5518,11 +5532,11 @@ namespace _func397
 void CrewCustomizeBox::CheckContents()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewCustomizeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func397::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func398::func;
 	return execfunc(this);
 }
 
-namespace _func398
+namespace _func399
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -5532,11 +5546,11 @@ namespace _func398
 void CrewCustomizeBox::constructor(Point location, ShipManager *shipManager, int slot)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewCustomizeBox *this_arg, Point location_arg, ShipManager *shipManager_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func398::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func399::func;
 	return execfunc(this, location, shipManager, slot);
 }
 
-namespace _func399
+namespace _func400
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5546,11 +5560,11 @@ namespace _func399
 void CrewDrone::constructor(const std::string &type, const std::string &name, int shipId, const DroneBlueprint *blueprint, CrewAnimation *anim)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewDrone *this_arg, const std::string &type_arg, const std::string &name_arg, int shipId_arg, const DroneBlueprint *blueprint_arg, CrewAnimation *anim_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func399::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func400::func;
 	return execfunc(this, type, name, shipId, blueprint, anim);
 }
 
-namespace _func400
+namespace _func401
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5560,11 +5574,11 @@ namespace _func400
 void CrewDrone::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func400::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func401::func;
 	return execfunc(this);
 }
 
-namespace _func401
+namespace _func402
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5574,11 +5588,11 @@ namespace _func401
 bool CrewDrone::ProvidesVision()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func401::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func402::func;
 	return execfunc(this);
 }
 
-namespace _func402
+namespace _func403
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5588,11 +5602,11 @@ namespace _func402
 void CrewDrone::SetCurrentShip(int shipId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewDrone *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func402::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func403::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func403
+namespace _func404
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5602,11 +5616,11 @@ namespace _func403
 void CrewDrone::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func403::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func404::func;
 	return execfunc(this);
 }
 
-namespace _func404
+namespace _func405
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5616,11 +5630,11 @@ namespace _func404
 void CrewEquipBox::RemoveItem()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func404::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func405::func;
 	return execfunc(this);
 }
 
-namespace _func405
+namespace _func406
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -5630,11 +5644,11 @@ namespace _func405
 void CrewEquipBox::constructor(Point pos, ShipManager *ship, int slot)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, Point pos_arg, ShipManager *ship_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func405::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func406::func;
 	return execfunc(this, pos, ship, slot);
 }
 
-namespace _func406
+namespace _func407
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5644,11 +5658,11 @@ namespace _func406
 bool CrewEquipBox::GetConfirmDelete()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func406::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func407::func;
 	return execfunc(this);
 }
 
-namespace _func407
+namespace _func408
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -5658,11 +5672,11 @@ namespace _func407
 void CrewEquipBox::RenderLabels(bool dragging, bool isNew)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, bool dragging_arg, bool isNew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func407::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func408::func;
 	return execfunc(this, dragging, isNew);
 }
 
-namespace _func408
+namespace _func409
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5672,11 +5686,11 @@ namespace _func408
 void CrewEquipBox::OnRender(bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func408::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func409::func;
 	return execfunc(this, unk);
 }
 
-namespace _func409
+namespace _func410
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5686,11 +5700,11 @@ namespace _func409
 void CrewEquipBox::OnTextInput(SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func409::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func410::func;
 	return execfunc(this, key);
 }
 
-namespace _func410
+namespace _func411
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5700,11 +5714,11 @@ namespace _func410
 void CrewEquipBox::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func410::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func411::func;
 	return execfunc(this, event);
 }
 
-namespace _func411
+namespace _func412
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5714,11 +5728,11 @@ namespace _func411
 void CrewEquipBox::MouseClick()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func411::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func412::func;
 	return execfunc(this);
 }
 
-namespace _func412
+namespace _func413
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5728,11 +5742,11 @@ namespace _func412
 void CrewEquipBox::CloseRename()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func412::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func413::func;
 	return execfunc(this);
 }
 
-namespace _func413
+namespace _func414
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5742,11 +5756,11 @@ namespace _func413
 void CrewManifest::OnInit(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func413::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func414::func;
 	return execfunc(this, ship);
 }
 
-namespace _func414
+namespace _func415
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5754,20 +5768,6 @@ namespace _func414
 }
 
 void CrewManifest::OnRender()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func414::func;
-	return execfunc(this);
-}
-
-namespace _func415
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewManifest::Update", typeid(void (CrewManifest::*)()), "565383ec448b7424508d442420", argdata, 1, 6, &func);
-}
-
-void CrewManifest::Update()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func415::func;
@@ -5778,10 +5778,10 @@ namespace _func416
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewManifest::constructor", typeid(void (CrewManifest::*)()), "5557565381ec8c0000008bbc24a00000008d5c24708d7424688d6c2458", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewManifest::Update", typeid(void (CrewManifest::*)()), "565383ec448b7424508d442420", argdata, 1, 6, &func);
 }
 
-void CrewManifest::constructor()
+void CrewManifest::Update()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func416::func;
@@ -5791,25 +5791,25 @@ void CrewManifest::constructor()
 namespace _func417
 {
     static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CrewManifest::OnKeyDown", typeid(void (CrewManifest::*)(SDLKey )), ".57565331db83ec108b7c24208b7424248b57708b477429d0c1f80285c0", argdata, 2, 6, &func);
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CrewManifest::constructor", typeid(void (CrewManifest::*)()), "5557565381ec8c0000008bbc24a00000008d5c24708d7424688d6c2458", argdata, 1, 6, &func);
 }
 
-void CrewManifest::OnKeyDown(SDLKey key)
+void CrewManifest::constructor()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func417::func;
-	return execfunc(this, key);
+	return execfunc(this);
 }
 
 namespace _func418
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CrewManifest::OnKeyUp", typeid(void (CrewManifest::*)(SDLKey )), ".57565331db83ec108b7c24208b7424248b57708b477429d0c1f80285c0", argdata, 2, 6, &func);
+	static FunctionDefinition funcObj("CrewManifest::OnKeyDown", typeid(void (CrewManifest::*)(SDLKey )), ".57565331db83ec108b7c24208b7424248b57708b477429d0c1f80285c0", argdata, 2, 6, &func);
 }
 
-void CrewManifest::OnKeyUp(SDLKey key)
+void CrewManifest::OnKeyDown(SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func418::func;
@@ -5820,10 +5820,10 @@ namespace _func419
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CrewManifest::OnTextInput", typeid(void (CrewManifest::*)(SDLKey )), ".57565331db83ec108b7c24208b7424248b57708b477429d0c1f80285c0", argdata, 2, 6, &func);
+	static FunctionDefinition funcObj("CrewManifest::OnKeyUp", typeid(void (CrewManifest::*)(SDLKey )), ".57565331db83ec108b7c24208b7424248b57708b477429d0c1f80285c0", argdata, 2, 6, &func);
 }
 
-void CrewManifest::OnTextInput(SDLKey key)
+void CrewManifest::OnKeyUp(SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func419::func;
@@ -5834,17 +5834,31 @@ namespace _func420
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("CrewManifest::OnTextInput", typeid(void (CrewManifest::*)(SDLKey )), ".57565331db83ec108b7c24208b7424248b57708b477429d0c1f80285c0", argdata, 2, 6, &func);
+}
+
+void CrewManifest::OnTextInput(SDLKey key)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func420::func;
+	return execfunc(this, key);
+}
+
+namespace _func421
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CrewManifest::OnTextEvent", typeid(void (CrewManifest::*)(CEvent::TextEvent )), ".57565331db83ec108b7c24208b7424248b57708b477429d0c1f80285c0", argdata, 2, 6, &func);
 }
 
 void CrewManifest::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func420::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func421::func;
 	return execfunc(this, event);
 }
 
-namespace _func421
+namespace _func422
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5854,11 +5868,11 @@ namespace _func421
 void CrewManifest::Close()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func421::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func422::func;
 	return execfunc(this);
 }
 
-namespace _func422
+namespace _func423
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5868,11 +5882,11 @@ namespace _func422
 void CrewManifest::Open()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func422::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func423::func;
 	return execfunc(this);
 }
 
-namespace _func423
+namespace _func424
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -5882,11 +5896,11 @@ namespace _func423
 void CrewManifest::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func423::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func424::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func424
+namespace _func425
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -5896,11 +5910,11 @@ namespace _func424
 void CrewManifest::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func424::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func425::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func425
+namespace _func426
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5910,11 +5924,11 @@ namespace _func425
 void CrewMember::OnRender(bool outlineOnly)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool outlineOnly_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func425::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func426::func;
 	return execfunc(this, outlineOnly);
 }
 
-namespace _func426
+namespace _func427
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5924,11 +5938,11 @@ namespace _func426
 Damage CrewMember::GetRoomDamage()
 {
 	typedef Damage __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func426::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func427::func;
 	return execfunc(this);
 }
 
-namespace _func427
+namespace _func428
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -5938,11 +5952,11 @@ namespace _func427
 void CrewMember::StartRepair(Repairable *toRepair)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Repairable *toRepair_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func427::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func428::func;
 	return execfunc(this, toRepair);
 }
 
-namespace _func428
+namespace _func429
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -5950,20 +5964,6 @@ namespace _func428
 }
 
 void CrewMember::UpdateRepair()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func428::func;
-	return execfunc(this);
-}
-
-namespace _func429
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::UpdateMovement", typeid(void (CrewMember::*)()), "5589e5565383ec408b5d088b839c00000083783806", argdata, 1, 6, &func);
-}
-
-void CrewMember::UpdateMovement()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func429::func;
@@ -5974,10 +5974,10 @@ namespace _func430
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::OnLoop", typeid(void (CrewMember::*)()), "5589e557565381ec8c0000008b5d0880bbac01000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewMember::UpdateMovement", typeid(void (CrewMember::*)()), "5589e5565383ec408b5d088b839c00000083783806", argdata, 1, 6, &func);
 }
 
-void CrewMember::OnLoop()
+void CrewMember::UpdateMovement()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func430::func;
@@ -5987,6 +5987,20 @@ void CrewMember::OnLoop()
 namespace _func431
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CrewMember::OnLoop", typeid(void (CrewMember::*)()), "5589e557565381ec8c0000008b5d0880bbac01000000", argdata, 1, 6, &func);
+}
+
+void CrewMember::OnLoop()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func431::func;
+	return execfunc(this);
+}
+
+namespace _func432
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CrewMember::GetTooltip", typeid(std::string (CrewMember::*)()), "5589e557565381ec8c0000008b45088d5dd8895c2408", argdata, 2, 18, &func);
 }
@@ -5994,11 +6008,11 @@ namespace _func431
 std::string CrewMember::GetTooltip()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func431::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func432::func;
 	return execfunc(this);
 }
 
-namespace _func432
+namespace _func433
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -6008,11 +6022,11 @@ namespace _func432
 std::string CrewMember::GetSkillTooltip(int skillId, int skillLevel, std::pair<int, int> progress, bool infoScreen)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(int skillId_arg, int skillLevel_arg, std::pair<int, int> progress_arg, bool infoScreen_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func432::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func433::func;
 	return execfunc(skillId, skillLevel, progress, infoScreen);
 }
 
-namespace _func433
+namespace _func434
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6022,11 +6036,11 @@ namespace _func433
 void CrewMember::SetSex(bool male)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool male_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func433::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func434::func;
 	return execfunc(this, male);
 }
 
-namespace _func434
+namespace _func435
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6036,11 +6050,11 @@ namespace _func434
 void CrewMember::CycleColorLayer(int unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func434::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func435::func;
 	return execfunc(this, unk);
 }
 
-namespace _func435
+namespace _func436
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -6050,11 +6064,11 @@ namespace _func435
 void CrewMember::constructor(CrewBlueprint &blueprint, int shipId, bool intruder, CrewAnimation *animation)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewBlueprint &blueprint_arg, int shipId_arg, bool intruder_arg, CrewAnimation *animation_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func435::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func436::func;
 	return execfunc(this, blueprint, shipId, intruder, animation);
 }
 
-namespace _func436
+namespace _func437
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6062,20 +6076,6 @@ namespace _func436
 }
 
 bool CrewMember::Functional()
-{
-	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func436::func;
-	return execfunc(this);
-}
-
-namespace _func437
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::CountForVictory", typeid(bool (CrewMember::*)()), "5383ec188b5c24208b03891c24ff9088000000", argdata, 1, 2, &func);
-}
-
-bool CrewMember::CountForVictory()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func437::func;
@@ -6086,10 +6086,10 @@ namespace _func438
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::CanSabotage", typeid(bool (CrewMember::*)()), "8b4424040fb68098000000", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CrewMember::CountForVictory", typeid(bool (CrewMember::*)()), "5383ec188b5c24208b03891c24ff9088000000", argdata, 1, 2, &func);
 }
 
-bool CrewMember::CanSabotage()
+bool CrewMember::CountForVictory()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func438::func;
@@ -6100,10 +6100,10 @@ namespace _func439
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::CanMan", typeid(bool (CrewMember::*)()), "8b54240431c080ba9800000000", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CrewMember::CanSabotage", typeid(bool (CrewMember::*)()), "8b4424040fb68098000000", argdata, 1, 2, &func);
 }
 
-bool CrewMember::CanMan()
+bool CrewMember::CanSabotage()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func439::func;
@@ -6114,10 +6114,10 @@ namespace _func440
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::CanRepair", typeid(bool (CrewMember::*)()), "5383ec188b5c242080bb9800000000", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CrewMember::CanMan", typeid(bool (CrewMember::*)()), "8b54240431c080ba9800000000", argdata, 1, 2, &func);
 }
 
-bool CrewMember::CanRepair()
+bool CrewMember::CanMan()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func440::func;
@@ -6128,10 +6128,10 @@ namespace _func441
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::GetControllable", typeid(bool (CrewMember::*)()), "5331c083ec188b5c24208b530485d2", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CrewMember::CanRepair", typeid(bool (CrewMember::*)()), "5383ec188b5c242080bb9800000000", argdata, 1, 2, &func);
 }
 
-bool CrewMember::GetControllable()
+bool CrewMember::CanRepair()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func441::func;
@@ -6142,10 +6142,10 @@ namespace _func442
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::CanHeal", typeid(bool (CrewMember::*)()), "5383ec188b5c2420f30f1043280f2e432c", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CrewMember::GetControllable", typeid(bool (CrewMember::*)()), "5331c083ec188b5c24208b530485d2", argdata, 1, 2, &func);
 }
 
-bool CrewMember::CanHeal()
+bool CrewMember::GetControllable()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func442::func;
@@ -6156,17 +6156,31 @@ namespace _func443
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CrewMember::CanHeal", typeid(bool (CrewMember::*)()), "5383ec188b5c2420f30f1043280f2e432c", argdata, 1, 2, &func);
+}
+
+bool CrewMember::CanHeal()
+{
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func443::func;
+	return execfunc(this);
+}
+
+namespace _func444
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("CrewMember::Jump", typeid(void (CrewMember::*)()), "!8b4424048b908803000083420c018b108b82cc000000", argdata, 1, 6, &func);
 }
 
 void CrewMember::Jump()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func443::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func444::func;
 	return execfunc(this);
 }
 
-namespace _func444
+namespace _func445
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6176,11 +6190,11 @@ namespace _func444
 bool CrewMember::GetIntruder()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func444::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func445::func;
 	return execfunc(this);
 }
 
-namespace _func445
+namespace _func446
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6190,11 +6204,11 @@ namespace _func445
 void CrewMember::SetOutOfGame()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func445::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func446::func;
 	return execfunc(this);
 }
 
-namespace _func446
+namespace _func447
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6204,11 +6218,11 @@ namespace _func446
 float CrewMember::PositionShift()
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func446::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func447::func;
 	return execfunc(this);
 }
 
-namespace _func447
+namespace _func448
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6218,11 +6232,11 @@ namespace _func447
 void CrewMember::SaveState(int fileHelper)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func447::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func448::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func448
+namespace _func449
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6232,11 +6246,11 @@ namespace _func448
 bool CrewMember::CanTeleport()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func448::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func449::func;
 	return execfunc(this);
 }
 
-namespace _func449
+namespace _func450
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6246,11 +6260,11 @@ namespace _func449
 void CrewMember::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func449::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func450::func;
 	return execfunc(this);
 }
 
-namespace _func450
+namespace _func451
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6260,11 +6274,11 @@ namespace _func450
 void CrewMember::Cleanup()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func450::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func451::func;
 	return execfunc(this);
 }
 
-namespace _func451
+namespace _func452
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6274,11 +6288,11 @@ namespace _func451
 void CrewMember::LoadState(int fileHelper)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func451::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func452::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func452
+namespace _func453
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6288,11 +6302,11 @@ namespace _func452
 void CrewMember::SetCurrentSystem(ShipSystem *sys)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, ShipSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func452::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func453::func;
 	return execfunc(this, sys);
 }
 
-namespace _func453
+namespace _func454
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6302,11 +6316,11 @@ namespace _func453
 bool CrewMember::IsManningArtillery()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func453::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func454::func;
 	return execfunc(this);
 }
 
-namespace _func454
+namespace _func455
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6316,11 +6330,11 @@ namespace _func454
 void CrewMember::IncreaseSkill(int skillId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func454::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func455::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func455
+namespace _func456
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6330,11 +6344,11 @@ namespace _func455
 void CrewMember::CheckSkills()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func455::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func456::func;
 	return execfunc(this);
 }
 
-namespace _func456
+namespace _func457
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6344,11 +6358,11 @@ namespace _func456
 void CrewMember::MasterSkill(int skillId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func456::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func457::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func457
+namespace _func458
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6358,11 +6372,11 @@ namespace _func457
 int CrewMember::GetSkillFromSystem(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func457::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func458::func;
 	return execfunc(systemId);
 }
 
-namespace _func458
+namespace _func459
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6372,11 +6386,11 @@ namespace _func458
 void CrewMember::SetResisted(bool resisted)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool resisted_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func458::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func459::func;
 	return execfunc(this, resisted);
 }
 
-namespace _func459
+namespace _func460
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6386,11 +6400,11 @@ namespace _func459
 bool CrewMember::GetResisted()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func459::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func460::func;
 	return execfunc(this);
 }
 
-namespace _func460
+namespace _func461
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -6400,11 +6414,11 @@ namespace _func460
 void CrewMember::SetSkillProgress(int skillId, int skillLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg, int skillLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func460::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func461::func;
 	return execfunc(this, skillId, skillLevel);
 }
 
-namespace _func461
+namespace _func462
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6414,11 +6428,11 @@ namespace _func461
 int CrewMember::GetSkillLevel(int skillId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func461::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func462::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func462
+namespace _func463
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -6428,11 +6442,11 @@ namespace _func462
 std::pair<int, int> CrewMember::GetSkillProgress(int skillId)
 {
 	typedef std::pair<int, int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func462::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func463::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func463
+namespace _func464
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6442,11 +6456,11 @@ namespace _func463
 float CrewMember::GetSkillModifier(int skillId)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func463::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func464::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func464
+namespace _func465
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6456,11 +6470,11 @@ namespace _func464
 bool CrewMember::BadAtCombat()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func464::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func465::func;
 	return execfunc(this);
 }
 
-namespace _func465
+namespace _func466
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6470,11 +6484,11 @@ namespace _func465
 void CrewMember::EmptySlot()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func465::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func466::func;
 	return execfunc(this);
 }
 
-namespace _func466
+namespace _func467
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6484,11 +6498,11 @@ namespace _func466
 bool CrewMember::NeedsSlot()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func466::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func467::func;
 	return execfunc(this);
 }
 
-namespace _func467
+namespace _func468
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6498,11 +6512,11 @@ namespace _func467
 bool CrewMember::DirectModifyHealth(float health)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func467::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func468::func;
 	return execfunc(this, health);
 }
 
-namespace _func468
+namespace _func469
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6512,11 +6526,11 @@ namespace _func468
 void CrewMember::ModifyHealth(float health)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func468::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func469::func;
 	return execfunc(this, health);
 }
 
-namespace _func469
+namespace _func470
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6526,11 +6540,11 @@ namespace _func469
 bool CrewMember::ApplyDamage(float damage)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func469::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func470::func;
 	return execfunc(this, damage);
 }
 
-namespace _func470
+namespace _func471
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6538,20 +6552,6 @@ namespace _func470
 }
 
 bool CrewMember::RepairingSystem()
-{
-	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func470::func;
-	return execfunc(this);
-}
-
-namespace _func471
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::Sabotaging", typeid(bool (CrewMember::*)()), "5383ec188b5c24208b436885c074??8b10", argdata, 1, 2, &func);
-}
-
-bool CrewMember::Sabotaging()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func471::func;
@@ -6562,10 +6562,10 @@ namespace _func472
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::RepairingFire", typeid(bool (CrewMember::*)()), "8b54240431c08b4a6885c9", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CrewMember::Sabotaging", typeid(bool (CrewMember::*)()), "5383ec188b5c24208b436885c074??8b10", argdata, 1, 2, &func);
 }
 
-bool CrewMember::RepairingFire()
+bool CrewMember::Sabotaging()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func472::func;
@@ -6575,6 +6575,20 @@ bool CrewMember::RepairingFire()
 namespace _func473
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CrewMember::RepairingFire", typeid(bool (CrewMember::*)()), "8b54240431c08b4a6885c9", argdata, 1, 2, &func);
+}
+
+bool CrewMember::RepairingFire()
+{
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func473::func;
+	return execfunc(this);
+}
+
+namespace _func474
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CrewMember::SelectSabotageTarget", typeid(Pointf (CrewMember::*)()), "5589e557565383ec2c8b750c8b5d088b4668", argdata, 2, 18, &func);
 }
@@ -6582,11 +6596,11 @@ namespace _func473
 Pointf CrewMember::SelectSabotageTarget()
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func473::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func474::func;
 	return execfunc(this);
 }
 
-namespace _func474
+namespace _func475
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6596,11 +6610,11 @@ namespace _func474
 void CrewMember::SavePosition()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func474::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func475::func;
 	return execfunc(this);
 }
 
-namespace _func475
+namespace _func476
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6610,11 +6624,11 @@ namespace _func475
 void CrewMember::ClearPosition()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func475::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func476::func;
 	return execfunc(this);
 }
 
-namespace _func476
+namespace _func477
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6624,11 +6638,11 @@ namespace _func476
 Slot CrewMember::GetSavedPosition()
 {
 	typedef Slot __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func476::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func477::func;
 	return execfunc(this);
 }
 
-namespace _func477
+namespace _func478
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff};
@@ -6638,11 +6652,11 @@ namespace _func477
 void CrewMember::SetSavePosition(Slot position)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Slot position_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func477::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func478::func;
 	return execfunc(this, position);
 }
 
-namespace _func478
+namespace _func479
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6652,11 +6666,11 @@ namespace _func478
 void CrewMember::StopRepairing()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func478::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func479::func;
 	return execfunc(this);
 }
 
-namespace _func479
+namespace _func480
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6666,11 +6680,11 @@ namespace _func479
 bool CrewMember::Repairing()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func479::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func480::func;
 	return execfunc(this);
 }
 
-namespace _func480
+namespace _func481
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6680,11 +6694,11 @@ namespace _func480
 void CrewMember::SetFrozen(bool frozen)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool frozen_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func480::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func481::func;
 	return execfunc(this, frozen);
 }
 
-namespace _func481
+namespace _func482
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6694,11 +6708,11 @@ namespace _func481
 void CrewMember::SetFrozenLocation(bool frozenLocation)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool frozenLocation_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func481::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func482::func;
 	return execfunc(this, frozenLocation);
 }
 
-namespace _func482
+namespace _func483
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x3ff};
@@ -6708,11 +6722,11 @@ namespace _func482
 void CrewMember::SetTask(CrewTask task)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewTask task_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func482::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func483::func;
 	return execfunc(this, task);
 }
 
-namespace _func483
+namespace _func484
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -6722,11 +6736,11 @@ namespace _func483
 Slot CrewMember::FindSlot(int roomId, int slotId, bool closeEnough)
 {
 	typedef Slot __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg, int slotId_arg, bool closeEnough_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func483::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func484::func;
 	return execfunc(this, roomId, slotId, closeEnough);
 }
 
-namespace _func484
+namespace _func485
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6736,11 +6750,11 @@ namespace _func484
 bool CrewMember::CheckRoomPath(int roomId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func484::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func485::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func485
+namespace _func486
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -6750,11 +6764,11 @@ namespace _func485
 void CrewMember::SetPosition(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func485::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func486::func;
 	return execfunc(this, pos);
 }
 
-namespace _func486
+namespace _func487
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6764,11 +6778,11 @@ namespace _func486
 void CrewMember::ClearTask()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func486::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func487::func;
 	return execfunc(this);
 }
 
-namespace _func487
+namespace _func488
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6778,11 +6792,11 @@ namespace _func487
 void CrewMember::ClearPath()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func487::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func488::func;
 	return execfunc(this);
 }
 
-namespace _func488
+namespace _func489
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6792,11 +6806,11 @@ namespace _func488
 void CrewMember::SetRoom(int roomId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func488::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func489::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func489
+namespace _func490
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6806,11 +6820,11 @@ namespace _func489
 bool CrewMember::IsBusy()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func489::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func490::func;
 	return execfunc(this);
 }
 
-namespace _func490
+namespace _func491
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6820,20 +6834,6 @@ namespace _func490
 bool CrewMember::OnInit()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func490::func;
-	return execfunc(this);
-}
-
-namespace _func491
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CrewMember::GetFinalGoal", typeid(Point (CrewMember::*)()), "83ec1c8b542424f30f1005????????", argdata, 2, 18, &func);
-}
-
-Point CrewMember::GetFinalGoal()
-{
-	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func491::func;
 	return execfunc(this);
 }
@@ -6842,10 +6842,10 @@ namespace _func492
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("CrewMember::GetNextGoal", typeid(Point (CrewMember::*)()), "57565383ec108b7424248b5c2420f30f10461c", argdata, 2, 18, &func);
+	static FunctionDefinition funcObj("CrewMember::GetFinalGoal", typeid(Point (CrewMember::*)()), "83ec1c8b542424f30f1005????????", argdata, 2, 18, &func);
 }
 
-Point CrewMember::GetNextGoal()
+Point CrewMember::GetFinalGoal()
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func492::func;
@@ -6856,17 +6856,31 @@ namespace _func493
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("CrewMember::GetNextGoal", typeid(Point (CrewMember::*)()), "57565383ec108b7424248b5c2420f30f10461c", argdata, 2, 18, &func);
+}
+
+Point CrewMember::GetNextGoal()
+{
+	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func493::func;
+	return execfunc(this);
+}
+
+namespace _func494
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CrewMember::CloseDoorBehind", typeid(void (CrewMember::*)(Door *)), "8b5424088b442404895064", argdata, 2, 6, &func);
 }
 
 void CrewMember::CloseDoorBehind(Door *door)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Door *door_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func493::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func494::func;
 	return execfunc(this, door);
 }
 
-namespace _func494
+namespace _func495
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6876,11 +6890,11 @@ namespace _func494
 float CrewMember::GetMoveSpeed()
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func494::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func495::func;
 	return execfunc(this);
 }
 
-namespace _func495
+namespace _func496
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6890,11 +6904,11 @@ namespace _func495
 void CrewMember::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func495::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func496::func;
 	return execfunc(this);
 }
 
-namespace _func496
+namespace _func497
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6904,11 +6918,11 @@ namespace _func496
 void CrewMember::SetDamageBoost(float damageBoost)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float damageBoost_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func496::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func497::func;
 	return execfunc(this, damageBoost);
 }
 
-namespace _func497
+namespace _func498
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6918,11 +6932,11 @@ namespace _func497
 void CrewMember::SetHealthBoost(int healthBoost)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int healthBoost_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func497::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func498::func;
 	return execfunc(this, healthBoost);
 }
 
-namespace _func498
+namespace _func499
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6932,11 +6946,11 @@ namespace _func498
 void CrewMember::InitializeSkills()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func498::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func499::func;
 	return execfunc(this);
 }
 
-namespace _func499
+namespace _func500
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6946,11 +6960,11 @@ namespace _func499
 void CrewMember::SetCloneReady(bool cloneReady)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool cloneReady_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func499::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func500::func;
 	return execfunc(this, cloneReady);
 }
 
-namespace _func500
+namespace _func501
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -6960,11 +6974,11 @@ namespace _func500
 void CrewMember::Kill(bool noClone)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool noClone_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func500::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func501::func;
 	return execfunc(this, noClone);
 }
 
-namespace _func501
+namespace _func502
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6974,11 +6988,11 @@ namespace _func501
 bool CrewMember::NeedFrozenLocation()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func501::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func502::func;
 	return execfunc(this);
 }
 
-namespace _func502
+namespace _func503
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6988,11 +7002,11 @@ namespace _func502
 void CrewMember::CheckForTeleport()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func502::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func503::func;
 	return execfunc(this);
 }
 
-namespace _func503
+namespace _func504
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7002,11 +7016,11 @@ namespace _func503
 void CrewMember::SetCurrentShip(int shipId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func503::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func504::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func504
+namespace _func505
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7016,11 +7030,11 @@ namespace _func504
 void CrewMember::CheckFighting()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func504::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func505::func;
 	return execfunc(this);
 }
 
-namespace _func505
+namespace _func506
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7030,11 +7044,11 @@ namespace _func505
 void CrewMember::SetDeathNumber(int deathNum)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int deathNum_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func505::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func506::func;
 	return execfunc(this, deathNum);
 }
 
-namespace _func506
+namespace _func507
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7044,11 +7058,11 @@ namespace _func506
 void CrewMember::ForceMindControl(bool force)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func506::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func507::func;
 	return execfunc(this, force);
 }
 
-namespace _func507
+namespace _func508
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -7058,11 +7072,11 @@ namespace _func507
 void CrewMember::RenderSkillUpAnimation(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func507::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func508::func;
 	return execfunc(this, pos);
 }
 
-namespace _func508
+namespace _func509
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7070,20 +7084,6 @@ namespace _func508
 }
 
 void CrewMember::Clone()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func508::func;
-	return execfunc(this);
-}
-
-namespace _func509
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::UpdateHealth", typeid(void (CrewMember::*)()), "565383ec448b5c24508b83b0010000", argdata, 1, 6, &func);
-}
-
-void CrewMember::UpdateHealth()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func509::func;
@@ -7094,10 +7094,10 @@ namespace _func510
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::OnRenderPath", typeid(void (CrewMember::*)()), "5383ec288b5c24308b4b0485c9", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("CrewMember::UpdateHealth", typeid(void (CrewMember::*)()), "565383ec448b5c24508b83b0010000", argdata, 1, 6, &func);
 }
 
-void CrewMember::OnRenderPath()
+void CrewMember::UpdateHealth()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func510::func;
@@ -7107,6 +7107,20 @@ void CrewMember::OnRenderPath()
 namespace _func511
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CrewMember::OnRenderPath", typeid(void (CrewMember::*)()), "5383ec288b5c24308b4b0485c9", argdata, 1, 6, &func);
+}
+
+void CrewMember::OnRenderPath()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func511::func;
+	return execfunc(this);
+}
+
+namespace _func512
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CrewMember::SetPath", typeid(bool (CrewMember::*)(Path *)), "5557565383ec3c8b742454f30f1005????????", argdata, 2, 2, &func);
 }
@@ -7114,11 +7128,11 @@ namespace _func511
 bool CrewMember::SetPath(Path *path)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Path *path_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func511::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func512::func;
 	return execfunc(this, path);
 }
 
-namespace _func512
+namespace _func513
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7128,11 +7142,11 @@ namespace _func512
 void CrewMember::SetRoomPath(int slotId, int roomId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int slotId_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func512::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func513::func;
 	return execfunc(this, slotId, roomId);
 }
 
-namespace _func513
+namespace _func514
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7142,20 +7156,6 @@ namespace _func513
 Point CrewMember::GetLocation()
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func513::func;
-	return execfunc(this);
-}
-
-namespace _func514
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::AtGoal", typeid(bool (CrewMember::*)()), "8b442404f30f1015????????f30f100d????????f30f105818", argdata, 1, 2, &func);
-}
-
-bool CrewMember::AtGoal()
-{
-	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func514::func;
 	return execfunc(this);
 }
@@ -7164,10 +7164,10 @@ namespace _func515
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("CrewMember::AtFinalGoal", typeid(bool (CrewMember::*)()), ".8b442404f30f1015????????f30f2a8890000000f30f104008", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("CrewMember::AtGoal", typeid(bool (CrewMember::*)()), "8b442404f30f1015????????f30f100d????????f30f105818", argdata, 1, 2, &func);
 }
 
-bool CrewMember::AtFinalGoal()
+bool CrewMember::AtGoal()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func515::func;
@@ -7178,17 +7178,31 @@ namespace _func516
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("CrewMember::AtFinalGoal", typeid(bool (CrewMember::*)()), ".8b442404f30f1015????????f30f2a8890000000f30f104008", argdata, 1, 2, &func);
+}
+
+bool CrewMember::AtFinalGoal()
+{
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func516::func;
+	return execfunc(this);
+}
+
+namespace _func517
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("CrewMember::OnRenderHealth", typeid(void (CrewMember::*)()), "5589e557565381ecac0000008b7d0880bfac01000000", argdata, 1, 6, &func);
 }
 
 void CrewMember::OnRenderHealth()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func516::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func517::func;
 	return execfunc(this);
 }
 
-namespace _func517
+namespace _func518
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7198,11 +7212,11 @@ namespace _func517
 int CrewMember::GetIntegerHealth()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func517::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func518::func;
 	return execfunc(this);
 }
 
-namespace _func518
+namespace _func519
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7212,11 +7226,11 @@ namespace _func518
 int CrewMember::GetRepairingId()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func518::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func519::func;
 	return execfunc(this);
 }
 
-namespace _func519
+namespace _func520
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -7226,11 +7240,11 @@ namespace _func519
 bool CrewMember::WithinRect(int x, int y, int w, int h)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int x_arg, int y_arg, int w_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func519::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func520::func;
 	return execfunc(this, x, y, w, h);
 }
 
-namespace _func520
+namespace _func521
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7240,11 +7254,11 @@ namespace _func520
 std::string CrewMember::GetLongName()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func520::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func521::func;
 	return execfunc(this);
 }
 
-namespace _func521
+namespace _func522
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7254,11 +7268,11 @@ namespace _func521
 void CrewMember::SetName(TextString *name, bool force)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, TextString *name_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func521::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func522::func;
 	return execfunc(this, name, force);
 }
 
-namespace _func522
+namespace _func523
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7268,11 +7282,11 @@ namespace _func522
 std::string CrewMember::GetName()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func522::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func523::func;
 	return execfunc(this);
 }
 
-namespace _func523
+namespace _func524
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7282,11 +7296,11 @@ namespace _func523
 void CrewMember::SetCurrentTarget(CrewTarget *target, bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewTarget *target_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func523::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func524::func;
 	return execfunc(this, target, unk);
 }
 
-namespace _func524
+namespace _func525
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7296,11 +7310,11 @@ namespace _func524
 bool CrewMember::GetNewGoal()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func524::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func525::func;
 	return execfunc(this);
 }
 
-namespace _func525
+namespace _func526
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -7310,11 +7324,11 @@ namespace _func525
 bool CrewMember::MoveToRoom(int roomId, int slotId, bool forceMove)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg, int slotId_arg, bool forceMove_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func525::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func526::func;
 	return execfunc(this, roomId, slotId, forceMove);
 }
 
-namespace _func526
+namespace _func527
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7324,11 +7338,11 @@ namespace _func526
 void CrewMember::SetMindControl(bool controlled)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool controlled_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func526::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func527::func;
 	return execfunc(this, controlled);
 }
 
-namespace _func527
+namespace _func528
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7338,11 +7352,11 @@ namespace _func527
 bool CrewMember::RestorePosition()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func527::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func528::func;
 	return execfunc(this);
 }
 
-namespace _func528
+namespace _func529
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7352,11 +7366,11 @@ namespace _func528
 bool CrewMember::ContainsPoint(int x, int y)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func528::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func529::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func529
+namespace _func530
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7366,11 +7380,11 @@ namespace _func529
 void CrewMember::SetMedbay(float health)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func529::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func530::func;
 	return execfunc(this, health);
 }
 
-namespace _func530
+namespace _func531
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7380,11 +7394,11 @@ namespace _func530
 void CrewMember::StartTeleport()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func530::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func531::func;
 	return execfunc(this);
 }
 
-namespace _func531
+namespace _func532
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7394,11 +7408,11 @@ namespace _func531
 void CrewMember::StartTeleportArrive()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func531::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func532::func;
 	return execfunc(this);
 }
 
-namespace _func532
+namespace _func533
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7408,11 +7422,11 @@ namespace _func532
 bool CrewMember::InsideRoom(int roomId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func532::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func533::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func533
+namespace _func534
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7422,11 +7436,11 @@ namespace _func533
 std::string CrewMember::GetUniqueRepairing()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func533::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func534::func;
 	return execfunc(this);
 }
 
-namespace _func534
+namespace _func535
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7436,11 +7450,11 @@ namespace _func534
 void CrewMemberFactory::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func534::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func535::func;
 	return execfunc(this);
 }
 
-namespace _func535
+namespace _func536
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7450,11 +7464,11 @@ namespace _func535
 void CrewMemberFactory::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func535::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func536::func;
 	return execfunc(this);
 }
 
-namespace _func536
+namespace _func537
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7464,11 +7478,11 @@ namespace _func536
 int CrewMemberFactory::CountCloneReadyCrew(bool player)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, bool player_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func536::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func537::func;
 	return execfunc(this, player);
 }
 
-namespace _func537
+namespace _func538
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7478,11 +7492,11 @@ namespace _func537
 void CrewMemberFactory::GetCrewPortraitList(std::vector<CrewMember*> *vec, int teamId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> *vec_arg, int teamId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func537::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func538::func;
 	return execfunc(this, vec, teamId);
 }
 
-namespace _func538
+namespace _func539
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -7492,11 +7506,11 @@ namespace _func538
 void CrewMemberFactory::GetCrewList(std::vector<CrewMember*> *vec, int unk, bool unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> *vec_arg, int unk_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func538::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func539::func;
 	return execfunc(this, vec, unk, unk2);
 }
 
-namespace _func539
+namespace _func540
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7506,11 +7520,11 @@ namespace _func539
 int CrewMemberFactory::GetPlayerCrewCount()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func539::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func540::func;
 	return execfunc(this);
 }
 
-namespace _func540
+namespace _func541
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7520,11 +7534,11 @@ namespace _func540
 int CrewMemberFactory::GetEnemyCloneCount()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func540::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func541::func;
 	return execfunc(this);
 }
 
-namespace _func541
+namespace _func542
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7534,11 +7548,11 @@ namespace _func541
 int CrewMemberFactory::GetCrewCount(bool enemy)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func541::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func542::func;
 	return execfunc(this, enemy);
 }
 
-namespace _func542
+namespace _func543
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7548,11 +7562,11 @@ namespace _func542
 int CrewMemberFactory::GetEnemyCrewCount()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func542::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func543::func;
 	return execfunc(this);
 }
 
-namespace _func543
+namespace _func544
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7562,11 +7576,11 @@ namespace _func543
 bool CrewMemberFactory::IsRace(const std::string &species)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &species_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func543::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func544::func;
 	return execfunc(species);
 }
 
-namespace _func544
+namespace _func545
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7576,11 +7590,11 @@ namespace _func544
 BoarderDrone *CrewMemberFactory::CreateBoarderDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef BoarderDrone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func544::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func545::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func545
+namespace _func546
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7590,11 +7604,11 @@ namespace _func545
 BattleDrone *CrewMemberFactory::CreateBattleDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef BattleDrone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func545::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func546::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func546
+namespace _func547
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7604,11 +7618,11 @@ namespace _func546
 void CrewMemberFactory::GetCloneReadyList(std::vector<CrewMember*> &vec, bool player)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> &vec_arg, bool player_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func546::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func547::func;
 	return execfunc(this, vec, player);
 }
 
-namespace _func547
+namespace _func548
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7618,11 +7632,11 @@ namespace _func547
 RepairDrone *CrewMemberFactory::CreateRepairDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef RepairDrone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func547::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func548::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func548
+namespace _func549
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7632,11 +7646,11 @@ namespace _func548
 std::pair<std::string, bool> CrewMemberFactory::GetRandomFriendlyName(const std::string &race)
 {
 	typedef std::pair<std::string, bool> __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, const std::string &race_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func548::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func549::func;
 	return execfunc(this, race);
 }
 
-namespace _func549
+namespace _func550
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7646,11 +7660,11 @@ namespace _func549
 std::vector<std::string> CrewMemberFactory::GetCrewNames()
 {
 	typedef std::vector<std::string> __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func549::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func550::func;
 	return execfunc(this);
 }
 
-namespace _func550
+namespace _func551
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7660,11 +7674,11 @@ namespace _func550
 void CrewMemberFactory::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func550::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func551::func;
 	return execfunc(this);
 }
 
-namespace _func551
+namespace _func552
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7674,11 +7688,11 @@ namespace _func551
 void CrewMemberFactory::RemoveExcessCrew()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func551::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func552::func;
 	return execfunc(this);
 }
 
-namespace _func552
+namespace _func553
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -7688,18 +7702,18 @@ namespace _func552
 CrewMember *CrewMemberFactory::CreateCrewMember(CrewBlueprint *bp, int shipId, bool intruder)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, CrewBlueprint *bp_arg, int shipId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func552::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func553::func;
 	return execfunc(this, bp, shipId, intruder);
 }
 
 CrewMemberFactory *Global_CrewMemberFactory_Factory;
 
-namespace _var553
+namespace _var554
 {
     static VariableDefinition varObj("Global_CrewMemberFactory_Factory", "!c70424(???????\?)e8????????29c6", &Global_CrewMemberFactory_Factory);
 }
 
-namespace _func554
+namespace _func555
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7709,11 +7723,11 @@ namespace _func554
 bool CrewStoreBox::CanHold()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func554::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func555::func;
 	return execfunc(this);
 }
 
-namespace _func555
+namespace _func556
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -7723,11 +7737,11 @@ namespace _func555
 void CrewStoreBox::constructor(ShipManager *ship, int worldLevel, const std::string &type)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewStoreBox *this_arg, ShipManager *ship_arg, int worldLevel_arg, const std::string &type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func555::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func556::func;
 	return execfunc(this, ship, worldLevel, type);
 }
 
-namespace _func556
+namespace _func557
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7737,11 +7751,11 @@ namespace _func556
 void CrewStoreBox::Purchase()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func556::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func557::func;
 	return execfunc(this);
 }
 
-namespace _func557
+namespace _func558
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -7751,11 +7765,11 @@ namespace _func557
 void CrewStoreBox::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(CrewStoreBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func557::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func558::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func558
+namespace _func559
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -7765,11 +7779,11 @@ namespace _func558
 void DamageMessage::constructor(float length, Pointf pos, DamageMessage::MessageType type)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DamageMessage *this_arg, float length_arg, Pointf pos_arg, DamageMessage::MessageType type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func558::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func559::func;
 	return execfunc(this, length, pos, type);
 }
 
-namespace _func559
+namespace _func560
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -7779,11 +7793,11 @@ namespace _func559
 void DamageMessage::constructor2(float length, int amount, Pointf pos, bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DamageMessage *this_arg, float length_arg, int amount_arg, Pointf pos_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func559::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func560::func;
 	return execfunc(this, length, amount, pos, unk);
 }
 
-namespace _func560
+namespace _func561
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7793,11 +7807,11 @@ namespace _func560
 bool DefenseDrone::ValidTargetObject(Targetable *target)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func560::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func561::func;
 	return execfunc(this, target);
 }
 
-namespace _func561
+namespace _func562
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7807,11 +7821,11 @@ namespace _func561
 void DefenseDrone::PickTarget()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func561::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func562::func;
 	return execfunc(this);
 }
 
-namespace _func562
+namespace _func563
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7821,11 +7835,11 @@ namespace _func562
 void DefenseDrone::SetWeaponTarget(Targetable *target)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func562::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func563::func;
 	return execfunc(this, target);
 }
 
-namespace _func563
+namespace _func564
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7835,11 +7849,11 @@ namespace _func563
 std::string DefenseDrone::GetTooltip()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func563::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func564::func;
 	return execfunc(this);
 }
 
-namespace _func564
+namespace _func565
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7849,11 +7863,11 @@ namespace _func564
 void DefenseDrone::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func564::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func565::func;
 	return execfunc(this);
 }
 
-namespace _func565
+namespace _func566
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7863,11 +7877,11 @@ namespace _func565
 Description &Description::copy_assign_2(Description &other)
 {
 	typedef Description &__attribute__((cdecl)) (*custom_arg_funcptr_t)(Description *this_arg, Description &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func565::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func566::func;
 	return execfunc(this, other);
 }
 
-namespace _func566
+namespace _func567
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7877,11 +7891,11 @@ namespace _func566
 Description &Description::copy_assign_1(const Description &other)
 {
 	typedef Description &__attribute__((cdecl)) (*custom_arg_funcptr_t)(Description *this_arg, const Description &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func566::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func567::func;
 	return execfunc(this, other);
 }
 
-namespace _func567
+namespace _func568
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7891,11 +7905,11 @@ namespace _func567
 void Description::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Description *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func567::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func568::func;
 	return execfunc(this);
 }
 
-namespace _func568
+namespace _func569
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7905,11 +7919,11 @@ namespace _func568
 Point Door::GetPosition()
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func568::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func569::func;
 	return execfunc(this);
 }
 
-namespace _func569
+namespace _func570
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7919,11 +7933,11 @@ namespace _func569
 bool Door::ApplyDamage(float amount)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Door *this_arg, float amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func569::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func570::func;
 	return execfunc(this, amount);
 }
 
-namespace _func570
+namespace _func571
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7933,11 +7947,11 @@ namespace _func570
 void Door::SaveState(int fd)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Door *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func570::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func571::func;
 	return execfunc(this, fd);
 }
 
-namespace _func571
+namespace _func572
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7947,11 +7961,11 @@ namespace _func571
 void Door::LoadState(int fd)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Door *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func571::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func572::func;
 	return execfunc(this, fd);
 }
 
-namespace _func572
+namespace _func573
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7961,11 +7975,11 @@ namespace _func572
 void Door::FakeOpen()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func572::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func573::func;
 	return execfunc(this);
 }
 
-namespace _func573
+namespace _func574
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7975,11 +7989,11 @@ namespace _func573
 void Door::FakeClose()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func573::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func574::func;
 	return execfunc(this);
 }
 
-namespace _func574
+namespace _func575
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -7989,11 +8003,11 @@ namespace _func574
 bool Door::IsSealed(int shipId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Door *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func574::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func575::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func575
+namespace _func576
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8003,11 +8017,11 @@ namespace _func575
 void Door::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func575::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func576::func;
 	return execfunc(this);
 }
 
-namespace _func576
+namespace _func577
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -8017,11 +8031,11 @@ namespace _func576
 void DoorBox::constructor(Point pos, ShipSystem *sys, ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DoorBox *this_arg, Point pos_arg, ShipSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func576::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func577::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func577
+namespace _func578
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8031,18 +8045,18 @@ namespace _func577
 void DroneBlueprint::RenderIcon(float scale)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneBlueprint *this_arg, float scale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func577::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func578::func;
 	return execfunc(this, scale);
 }
 
-namespace _func578
+namespace _func579
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("DroneControl::DO_NOT_HOOK", typeid(void (DroneControl::*)()), "!565383ec148b4424208b5c24248b7424288b400c890424", argdata, 0, 4, &func);
 }
 
-namespace _func579
+namespace _func580
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8052,11 +8066,11 @@ namespace _func579
 TextString DroneControl::HolderLabel()
 {
 	typedef TextString __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func579::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func580::func;
 	return execfunc(this);
 }
 
-namespace _func580
+namespace _func581
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8066,11 +8080,11 @@ namespace _func580
 SDLKey DroneControl::ArmamentHotkey(unsigned int i)
 {
 	typedef SDLKey __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneControl *this_arg, unsigned int i_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func580::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func581::func;
 	return execfunc(this, i);
 }
 
-namespace _func581
+namespace _func582
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8080,11 +8094,11 @@ namespace _func581
 void DroneControl::SelectArmament(unsigned int i)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneControl *this_arg, unsigned int i_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func581::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func582::func;
 	return execfunc(this, i);
 }
 
-namespace _func582
+namespace _func583
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8094,11 +8108,11 @@ namespace _func582
 void DroneControl::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func582::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func583::func;
 	return execfunc(this);
 }
 
-namespace _func583
+namespace _func584
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8108,11 +8122,11 @@ namespace _func583
 void DroneStoreBox::constructor(ShipManager *ship, Equipment *equip, const DroneBlueprint *bp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneStoreBox *this_arg, ShipManager *ship_arg, Equipment *equip_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func583::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func584::func;
 	return execfunc(this, ship, equip, bp);
 }
 
-namespace _func584
+namespace _func585
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8122,11 +8136,11 @@ namespace _func584
 Drone *DroneSystem::RemoveDrone(int slot)
 {
 	typedef Drone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneSystem *this_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func584::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func585::func;
 	return execfunc(this, slot);
 }
 
-namespace _func585
+namespace _func586
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8136,11 +8150,11 @@ namespace _func585
 void DroneSystem::Jump()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func585::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func586::func;
 	return execfunc(this);
 }
 
-namespace _func586
+namespace _func587
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8150,11 +8164,11 @@ namespace _func586
 void DroneSystem::UpdateBonusPower()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func586::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func587::func;
 	return execfunc(this);
 }
 
-namespace _func587
+namespace _func588
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8164,11 +8178,11 @@ namespace _func587
 void DroneSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func587::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func588::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func588
+namespace _func589
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8178,11 +8192,11 @@ namespace _func588
 void DroneSystem::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func588::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func589::func;
 	return execfunc(this);
 }
 
-namespace _func589
+namespace _func590
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102, 0x101};
@@ -8192,11 +8206,11 @@ namespace _func589
 bool DroneSystem::DePowerDrone(Drone *drone, bool unk)
 {
 	typedef bool __attribute__((regparm(3))) (*custom_arg_funcptr_t)(DroneSystem *this_arg, Drone *drone_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func589::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func590::func;
 	return execfunc(this, drone, unk);
 }
 
-namespace _func590
+namespace _func591
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8206,11 +8220,11 @@ namespace _func590
 int DroneSystem::StringToDrone(std::string &name)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func590::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func591::func;
 	return execfunc(name);
 }
 
-namespace _func591
+namespace _func592
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8220,11 +8234,11 @@ namespace _func591
 void DropBox::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DropBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func591::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func592::func;
 	return execfunc(this);
 }
 
-namespace _func592
+namespace _func593
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8234,11 +8248,11 @@ namespace _func592
 int DropBox::GetHeight()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(DropBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func592::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func593::func;
 	return execfunc(this);
 }
 
-namespace _func593
+namespace _func594
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8248,11 +8262,11 @@ namespace _func593
 bool DropBox::Contains(int x, int y)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(DropBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func593::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func594::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func594
+namespace _func595
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8262,11 +8276,11 @@ namespace _func594
 int DropBox::GetBodySpaceOffset()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(DropBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func594::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func595::func;
 	return execfunc(this);
 }
 
-namespace _func595
+namespace _func596
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8276,11 +8290,11 @@ namespace _func595
 void DropBox::OnInit(Point p, bool isSellBox_, TextString *titleText_, TextString *bodyText_, int bodySpace_, TextString *lowerText_)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DropBox *this_arg, Point p_arg, bool isSellBox__arg, TextString *titleText__arg, TextString *bodyText__arg, int bodySpace__arg, TextString *lowerText__arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func595::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func596::func;
 	return execfunc(this, p, isSellBox_, titleText_, bodyText_, bodySpace_, lowerText_);
 }
 
-namespace _func596
+namespace _func597
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8290,11 +8304,11 @@ namespace _func596
 void EnergyAlien::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EnergyAlien *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func596::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func597::func;
 	return execfunc(this);
 }
 
-namespace _func597
+namespace _func598
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8304,11 +8318,11 @@ namespace _func597
 Damage EnergyAlien::GetRoomDamage()
 {
 	typedef Damage __attribute__((cdecl)) (*custom_arg_funcptr_t)(EnergyAlien *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func597::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func598::func;
 	return execfunc(this);
 }
 
-namespace _func598
+namespace _func599
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8318,11 +8332,11 @@ namespace _func598
 void Equipment::Open()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func598::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func599::func;
 	return execfunc(this);
 }
 
-namespace _func599
+namespace _func600
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8332,11 +8346,11 @@ namespace _func599
 void Equipment::Close()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func599::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func600::func;
 	return execfunc(this);
 }
 
-namespace _func600
+namespace _func601
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8346,11 +8360,11 @@ namespace _func600
 void Equipment::OnInit(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func600::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func601::func;
 	return execfunc(this, ship);
 }
 
-namespace _func601
+namespace _func602
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8360,11 +8374,11 @@ namespace _func601
 void Equipment::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func601::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func602::func;
 	return execfunc(this);
 }
 
-namespace _func602
+namespace _func603
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8374,11 +8388,11 @@ namespace _func602
 void Equipment::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func602::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func603::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func603
+namespace _func604
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8388,11 +8402,11 @@ namespace _func603
 void Equipment::MouseUp(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func603::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func604::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func604
+namespace _func605
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8402,11 +8416,11 @@ namespace _func604
 void Equipment::AddWeapon(WeaponBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, WeaponBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func604::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func605::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func605
+namespace _func606
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8416,11 +8430,11 @@ namespace _func605
 void Equipment::AddDrone(DroneBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, DroneBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func605::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func606::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func606
+namespace _func607
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8430,11 +8444,11 @@ namespace _func606
 void Equipment::AddAugment(AugmentBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, AugmentBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func606::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func607::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func607
+namespace _func608
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8444,11 +8458,11 @@ namespace _func607
 void Equipment::AddToCargo(const std::string &name)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func607::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func608::func;
 	return execfunc(this, name);
 }
 
-namespace _func608
+namespace _func609
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8458,11 +8472,11 @@ namespace _func608
 std::vector<std::string> Equipment::GetCargoHold()
 {
 	typedef std::vector<std::string> __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func608::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func609::func;
 	return execfunc(this);
 }
 
-namespace _func609
+namespace _func610
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8472,11 +8486,11 @@ namespace _func609
 bool Equipment::IsCompletelyFull(int type)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func609::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func610::func;
 	return execfunc(this, type);
 }
 
-namespace _func610
+namespace _func611
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8486,11 +8500,11 @@ namespace _func610
 void Equipment::Jump()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func610::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func611::func;
 	return execfunc(this);
 }
 
-namespace _func611
+namespace _func612
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8500,11 +8514,11 @@ namespace _func611
 void Equipment::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func611::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func612::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func612
+namespace _func613
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8514,11 +8528,11 @@ namespace _func612
 void Equipment::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func612::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func613::func;
 	return execfunc(this);
 }
 
-namespace _func613
+namespace _func614
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -8528,11 +8542,11 @@ namespace _func613
 void Equipment::SetPosition(Point p)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg, Point p_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func613::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func614::func;
 	return execfunc(this, p);
 }
 
-namespace _func614
+namespace _func615
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8542,11 +8556,11 @@ namespace _func614
 void Equipment::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func614::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func615::func;
 	return execfunc(this);
 }
 
-namespace _func615
+namespace _func616
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8556,11 +8570,11 @@ namespace _func615
 void Equipment::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func615::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func616::func;
 	return execfunc(this);
 }
 
-namespace _func616
+namespace _func617
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -8570,11 +8584,11 @@ namespace _func616
 void EquipmentBox::SetPosition(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func616::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func617::func;
 	return execfunc(this, pos);
 }
 
-namespace _func617
+namespace _func618
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8584,11 +8598,11 @@ namespace _func617
 void EquipmentBox::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func617::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func618::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func618
+namespace _func619
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8598,11 +8612,11 @@ namespace _func618
 void EquipmentBox::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func618::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func619::func;
 	return execfunc(this);
 }
 
-namespace _func619
+namespace _func620
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff};
@@ -8612,11 +8626,11 @@ namespace _func619
 void EquipmentBox::AddItem(EquipmentBoxItem item)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, EquipmentBoxItem item_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func619::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func620::func;
 	return execfunc(this, item);
 }
 
-namespace _func620
+namespace _func621
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8626,11 +8640,11 @@ namespace _func620
 bool EquipmentBox::CanHoldWeapon()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func620::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func621::func;
 	return execfunc(this);
 }
 
-namespace _func621
+namespace _func622
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8640,11 +8654,11 @@ namespace _func621
 bool EquipmentBox::CanHoldDrone()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func621::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func622::func;
 	return execfunc(this);
 }
 
-namespace _func622
+namespace _func623
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8654,11 +8668,11 @@ namespace _func622
 int EquipmentBox::GetType(bool forcedEmpty)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool forcedEmpty_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func622::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func623::func;
 	return execfunc(this, forcedEmpty);
 }
 
-namespace _func623
+namespace _func624
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8668,11 +8682,11 @@ namespace _func623
 void EquipmentBox::OnRender(bool isEmpty)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool isEmpty_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func623::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func624::func;
 	return execfunc(this, isEmpty);
 }
 
-namespace _func624
+namespace _func625
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8682,11 +8696,11 @@ namespace _func624
 void EquipmentBox::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func624::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func625::func;
 	return execfunc(this);
 }
 
-namespace _func625
+namespace _func626
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8696,11 +8710,11 @@ namespace _func625
 void EquipmentBox::UpdateBoxImage(bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func625::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func626::func;
 	return execfunc(this, unk);
 }
 
-namespace _func626
+namespace _func627
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8710,11 +8724,11 @@ namespace _func626
 void EquipmentBox::RenderLabels(bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func626::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func627::func;
 	return execfunc(this, unk);
 }
 
-namespace _func627
+namespace _func628
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
@@ -8724,11 +8738,11 @@ namespace _func627
 void EquipmentBox::constructor(Point pos, int slot)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, Point pos_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func627::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func628::func;
 	return execfunc(this, pos, slot);
 }
 
-namespace _func628
+namespace _func629
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8738,11 +8752,11 @@ namespace _func628
 int EquipmentBox::GetItemValue()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func628::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func629::func;
 	return execfunc(this);
 }
 
-namespace _func629
+namespace _func630
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8752,11 +8766,11 @@ namespace _func629
 void EquipmentBox::SetBlueprint(InfoBox *infoBox, bool detailedBox)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, InfoBox *infoBox_arg, bool detailedBox_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func629::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func630::func;
 	return execfunc(this, infoBox, detailedBox);
 }
 
-namespace _func630
+namespace _func631
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8766,11 +8780,11 @@ namespace _func630
 Blueprint *EquipmentBox::GetBlueprint()
 {
 	typedef Blueprint *__attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func630::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func631::func;
 	return execfunc(this);
 }
 
-namespace _func631
+namespace _func632
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8780,11 +8794,11 @@ namespace _func631
 void EquipmentBox::RenderIcon()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func631::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func632::func;
 	return execfunc(this);
 }
 
-namespace _func632
+namespace _func633
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8794,11 +8808,11 @@ namespace _func632
 void EquipmentBox::ForceHitBox(Globals::Rect *newBox)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, Globals::Rect *newBox_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func632::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func633::func;
 	return execfunc(this, newBox);
 }
 
-namespace _func633
+namespace _func634
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8808,11 +8822,11 @@ namespace _func633
 LocationEvent *EventGenerator::GetBaseEvent(const std::string &name, int worldLevel, bool ignoreUnique, int seed)
 {
 	typedef LocationEvent *__attribute__((cdecl)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg, int worldLevel_arg, bool ignoreUnique_arg, int seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func633::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func634::func;
 	return execfunc(this, name, worldLevel, ignoreUnique, seed);
 }
 
-namespace _func634
+namespace _func635
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8822,11 +8836,11 @@ namespace _func634
 LocationEvent *EventGenerator::CreateEvent(const std::string &name, int worldLevel, bool ignoreUnique)
 {
 	typedef LocationEvent *__attribute__((cdecl)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg, int worldLevel_arg, bool ignoreUnique_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func634::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func635::func;
 	return execfunc(this, name, worldLevel, ignoreUnique);
 }
 
-namespace _func635
+namespace _func636
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8836,11 +8850,11 @@ namespace _func635
 SectorDescription EventGenerator::GetSpecificSector(const std::string &name)
 {
 	typedef SectorDescription __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func635::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func636::func;
 	return execfunc(this, name);
 }
 
-namespace _func636
+namespace _func637
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8850,11 +8864,11 @@ namespace _func636
 std::string EventGenerator::GetImageFromList(const std::string &listName)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &listName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func636::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func637::func;
 	return execfunc(this, listName);
 }
 
-namespace _func637
+namespace _func638
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8864,11 +8878,11 @@ namespace _func637
 SectorDescription EventGenerator::GetSectorDescription(const std::string &type, int level)
 {
 	typedef SectorDescription __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &type_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func637::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func638::func;
 	return execfunc(this, type, level);
 }
 
-namespace _func638
+namespace _func639
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8878,11 +8892,11 @@ namespace _func638
 ShipEvent EventGenerator::GetShipEvent(const std::string &event)
 {
 	typedef ShipEvent __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func638::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func639::func;
 	return execfunc(this, event);
 }
 
-namespace _func639
+namespace _func640
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8892,18 +8906,18 @@ namespace _func639
 void EventGenerator::Clear()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventGenerator *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func639::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func640::func;
 	return execfunc(this);
 }
 
 EventGenerator *Global_EventGenerator_Generator;
 
-namespace _var640
+namespace _var641
 {
     static VariableDefinition varObj("Global_EventGenerator_Generator", "!c74424080000000089742404c70424(???????\?)e8????????8b54242c8d4af4", &Global_EventGenerator_Generator);
 }
 
-namespace _func641
+namespace _func642
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8913,11 +8927,11 @@ namespace _func641
 void EventSystem::AddEvent(int id)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventSystem *this_arg, int id_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func641::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func642::func;
 	return execfunc(this, id);
 }
 
-namespace _func642
+namespace _func643
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -8927,18 +8941,18 @@ namespace _func642
 bool EventSystem::PollEvent(int id)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventSystem *this_arg, int id_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func642::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func643::func;
 	return execfunc(this, id);
 }
 
 EventSystem *Global_EventSystem_EventManager;
 
-namespace _var643
+namespace _var644
 {
     static VariableDefinition varObj("Global_EventSystem_EventManager", "!c74424040c000000c70424(???????\?)e8????????31c0", &Global_EventSystem_EventManager);
 }
 
-namespace _func644
+namespace _func645
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8948,11 +8962,11 @@ namespace _func644
 RandomAmount EventsParser::PullMinMax(rapidxml::xml_node<char> *node, const std::string &name)
 {
 	typedef RandomAmount __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func644::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func645::func;
 	return execfunc(this, node, name);
 }
 
-namespace _func645
+namespace _func646
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8962,11 +8976,11 @@ namespace _func645
 std::string EventsParser::ProcessEvent(rapidxml::xml_node<char> *node, const std::string &eventName)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &eventName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func645::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func646::func;
 	return execfunc(this, node, eventName);
 }
 
-namespace _func646
+namespace _func647
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -8976,11 +8990,11 @@ namespace _func646
 ShipTemplate EventsParser::ProcessShipEvent(rapidxml::xml_node<char> *node)
 {
 	typedef ShipTemplate __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func646::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func647::func;
 	return execfunc(this, node);
 }
 
-namespace _func647
+namespace _func648
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8990,11 +9004,11 @@ namespace _func647
 ResourcesTemplate EventsParser::ProcessModifyItem(ResourcesTemplate &resources, rapidxml::xml_node<char> *node, const std::string &unk)
 {
 	typedef ResourcesTemplate __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg, ResourcesTemplate &resources_arg, rapidxml::xml_node<char> *node_arg, const std::string &unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func647::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func648::func;
 	return execfunc(this, resources, node, unk);
 }
 
-namespace _func648
+namespace _func649
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9004,11 +9018,11 @@ namespace _func648
 void EventsParser::AddAllEvents()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func648::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func649::func;
 	return execfunc(this);
 }
 
-namespace _func649
+namespace _func650
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9018,11 +9032,11 @@ namespace _func649
 void EventsParser::AddEvents(EventGenerator &generator, char *file, const std::string &fileName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg, EventGenerator &generator_arg, char *file_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func649::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func650::func;
 	return execfunc(this, generator, file, fileName);
 }
 
-namespace _func650
+namespace _func651
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9032,11 +9046,11 @@ namespace _func650
 std::vector<std::string> EventsParser::ProcessEventList(rapidxml::xml_node<char> *node, const std::string &listName)
 {
 	typedef std::vector<std::string> __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &listName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func650::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func651::func;
 	return execfunc(this, node, listName);
 }
 
-namespace _func651
+namespace _func652
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9046,11 +9060,11 @@ namespace _func651
 void EventsParser::ProcessChoice(EventTemplate *event, rapidxml::xml_node<char> *node, std::string &eventName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg, EventTemplate *event_arg, rapidxml::xml_node<char> *node_arg, std::string &eventName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func651::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func652::func;
 	return execfunc(this, event, node, eventName);
 }
 
-namespace _func652
+namespace _func653
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9060,18 +9074,18 @@ namespace _func652
 void EventsParser::ProcessBaseNode(rapidxml::xml_node<char> *node, EventGenerator &generator)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, EventGenerator &generator_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func652::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func653::func;
 	return execfunc(this, node, generator);
 }
 
 EventsParser *Global_EventsParser_Parser;
 
-namespace _var653
+namespace _var654
 {
     static VariableDefinition varObj("Global_EventsParser_Parser", "!c70424(???????\?)89442408898554ffffff", &Global_EventsParser_Parser);
 }
 
-namespace _func654
+namespace _func655
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x2ff};
@@ -9081,11 +9095,11 @@ namespace _func654
 void ExplosionAnimation::OnInit(rapidxml::xml_node<char> *node, const std::string &name, Point glowOffset)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &name_arg, Point glowOffset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func654::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func655::func;
 	return execfunc(this, node, name, glowOffset);
 }
 
-namespace _func655
+namespace _func656
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x7ff, 0x1ff};
@@ -9095,11 +9109,11 @@ namespace _func655
 void ExplosionAnimation::OnRender(Globals::Rect *shipRect, ImageDesc shipImage, GL_Primitive *shipImagePrimitive)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg, Globals::Rect *shipRect_arg, ImageDesc shipImage_arg, GL_Primitive *shipImagePrimitive_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func655::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func656::func;
 	return execfunc(this, shipRect, shipImage, shipImagePrimitive);
 }
 
-namespace _func656
+namespace _func657
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9109,11 +9123,11 @@ namespace _func656
 void ExplosionAnimation::LoadGibs()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func656::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func657::func;
 	return execfunc(this);
 }
 
-namespace _func657
+namespace _func658
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9123,11 +9137,11 @@ namespace _func657
 std::string FTLButton::GetPilotTooltip()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(FTLButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func657::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func658::func;
 	return execfunc(this);
 }
 
-namespace _func658
+namespace _func659
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9137,11 +9151,11 @@ namespace _func658
 void FTLButton::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(FTLButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func658::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func659::func;
 	return execfunc(this);
 }
 
-namespace _func659
+namespace _func660
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9151,11 +9165,11 @@ namespace _func659
 void FTLButton::MouseMove(int mX, int mY, bool silent)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(FTLButton *this_arg, int mX_arg, int mY_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func659::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func660::func;
 	return execfunc(this, mX, mY, silent);
 }
 
-namespace _func660
+namespace _func661
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9165,11 +9179,11 @@ namespace _func660
 void FileHelper::deleteFile(const std::string &fileName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func660::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func661::func;
 	return execfunc(fileName);
 }
 
-namespace _func661
+namespace _func662
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9177,20 +9191,6 @@ namespace _func661
 }
 
 std::string FileHelper::getResourceFile()
-{
-	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func661::func;
-	return execfunc();
-}
-
-namespace _func662
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("FileHelper::getUserFolder", typeid(std::string (*)()), "5383ec288b5c2430e8????????", argdata, 1, 18, &func);
-}
-
-std::string FileHelper::getUserFolder()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func662::func;
@@ -9201,10 +9201,10 @@ namespace _func663
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("FileHelper::getSaveFile", typeid(std::string (*)()), "57565383ec208b5c24308d74241ce8????????", argdata, 1, 18, &func);
+	static FunctionDefinition funcObj("FileHelper::getUserFolder", typeid(std::string (*)()), "5383ec288b5c2430e8????????", argdata, 1, 18, &func);
 }
 
-std::string FileHelper::getSaveFile()
+std::string FileHelper::getUserFolder()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func663::func;
@@ -9214,6 +9214,20 @@ std::string FileHelper::getSaveFile()
 namespace _func664
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("FileHelper::getSaveFile", typeid(std::string (*)()), "57565383ec208b5c24308d74241ce8????????", argdata, 1, 18, &func);
+}
+
+std::string FileHelper::getSaveFile()
+{
+	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func664::func;
+	return execfunc();
+}
+
+namespace _func665
+{
+    static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("FileHelper::initFileHelper", typeid(void (*)()), "565383ec34c605????????018d5c241f", argdata, 0, 6, &func);
 }
@@ -9221,11 +9235,11 @@ namespace _func664
 void FileHelper::initFileHelper()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func664::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func665::func;
 	return execfunc();
 }
 
-namespace _func665
+namespace _func666
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9235,11 +9249,11 @@ namespace _func665
 bool FileHelper::fileExists(const std::string &fileName)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func665::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func666::func;
 	return execfunc(fileName);
 }
 
-namespace _func666
+namespace _func667
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9249,11 +9263,11 @@ namespace _func666
 void FileHelper::renameFile(const std::string &fileName, const std::string &newName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg, const std::string &newName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func666::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func667::func;
 	return execfunc(fileName, newName);
 }
 
-namespace _func667
+namespace _func668
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9263,11 +9277,11 @@ namespace _func667
 int FileHelper::createBinaryFile(const std::string &fileName)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func667::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func668::func;
 	return execfunc(fileName);
 }
 
-namespace _func668
+namespace _func669
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -9277,20 +9291,6 @@ namespace _func668
 bool FileHelper::saveFileExists()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func668::func;
-	return execfunc();
-}
-
-namespace _func669
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::readSaveFile", typeid(int (*)()), ".5557565383ec3c8d442420894424088d442410", argdata, 0, 2, &func);
-}
-
-int FileHelper::readSaveFile()
-{
-	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func669::func;
 	return execfunc();
 }
@@ -9299,10 +9299,10 @@ namespace _func670
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::readStatsFile", typeid(int (*)()), ".5557565383ec3c8d442420894424088d442410", argdata, 0, 2, &func);
+	static FunctionDefinition funcObj("FileHelper::readSaveFile", typeid(int (*)()), ".5557565383ec3c8d442420894424088d442410", argdata, 0, 2, &func);
 }
 
-int FileHelper::readStatsFile()
+int FileHelper::readSaveFile()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func670::func;
@@ -9313,10 +9313,10 @@ namespace _func671
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::createSaveFile", typeid(int (*)()), ".a1????????a3????????b8????????", argdata, 0, 2, &func);
+	static FunctionDefinition funcObj("FileHelper::readStatsFile", typeid(int (*)()), ".5557565383ec3c8d442420894424088d442410", argdata, 0, 2, &func);
 }
 
-int FileHelper::createSaveFile()
+int FileHelper::readStatsFile()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func671::func;
@@ -9327,10 +9327,10 @@ namespace _func672
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::createStatsFile", typeid(int (*)()), ".a1????????a3????????b8????????", argdata, 0, 2, &func);
+	static FunctionDefinition funcObj("FileHelper::createSaveFile", typeid(int (*)()), ".a1????????a3????????b8????????", argdata, 0, 2, &func);
 }
 
-int FileHelper::createStatsFile()
+int FileHelper::createSaveFile()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func672::func;
@@ -9341,12 +9341,12 @@ namespace _func673
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::deleteSaveFile", typeid(void (*)()), "5383ec18c70424????????e8????????89c3", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("FileHelper::createStatsFile", typeid(int (*)()), ".a1????????a3????????b8????????", argdata, 0, 2, &func);
 }
 
-void FileHelper::deleteSaveFile()
+int FileHelper::createStatsFile()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func673::func;
 	return execfunc();
 }
@@ -9355,10 +9355,10 @@ namespace _func674
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::deleteAllSaveFiles", typeid(void (*)()), "5557565383ec2ce8????????8d74241c8d7c241b", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("FileHelper::deleteSaveFile", typeid(void (*)()), "5383ec18c70424????????e8????????89c3", argdata, 0, 6, &func);
 }
 
-void FileHelper::deleteAllSaveFiles()
+void FileHelper::deleteSaveFile()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func674::func;
@@ -9368,6 +9368,20 @@ void FileHelper::deleteAllSaveFiles()
 namespace _func675
 {
     static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("FileHelper::deleteAllSaveFiles", typeid(void (*)()), "5557565383ec2ce8????????8d74241c8d7c241b", argdata, 0, 6, &func);
+}
+
+void FileHelper::deleteAllSaveFiles()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func675::func;
+	return execfunc();
+}
+
+namespace _func676
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("FileHelper::getPosition", typeid(int (*)(int )), ".a1????????c3", argdata, 1, 2, &func);
 }
@@ -9375,11 +9389,11 @@ namespace _func675
 int FileHelper::getPosition(int file)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func675::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func676::func;
 	return execfunc(file);
 }
 
-namespace _func676
+namespace _func677
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9389,11 +9403,11 @@ namespace _func676
 int FileHelper::readBinaryFile(const std::string &fileName)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func676::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func677::func;
 	return execfunc(fileName);
 }
 
-namespace _func677
+namespace _func678
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9403,11 +9417,11 @@ namespace _func677
 bool FileHelper::writeFloat(int file, float data)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, float data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func677::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func678::func;
 	return execfunc(file, data);
 }
 
-namespace _func678
+namespace _func679
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9417,11 +9431,11 @@ namespace _func678
 bool FileHelper::writeInt(int file, int data)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, int data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func678::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func679::func;
 	return execfunc(file, data);
 }
 
-namespace _func679
+namespace _func680
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9431,11 +9445,11 @@ namespace _func679
 bool FileHelper::writeData(int file, void *data, int len)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, void *data_arg, int len_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func679::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func680::func;
 	return execfunc(file, data, len);
 }
 
-namespace _func680
+namespace _func681
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9445,11 +9459,11 @@ namespace _func680
 bool FileHelper::writeString(int file, const std::string &data)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, const std::string &data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func680::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func681::func;
 	return execfunc(file, data);
 }
 
-namespace _func681
+namespace _func682
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9459,11 +9473,11 @@ namespace _func681
 void FileHelper::closeBinaryFile(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func681::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func682::func;
 	return execfunc(file);
 }
 
-namespace _func682
+namespace _func683
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9473,11 +9487,11 @@ namespace _func682
 std::string FileHelper::readString(int file)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func682::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func683::func;
 	return execfunc(file);
 }
 
-namespace _func683
+namespace _func684
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9487,11 +9501,11 @@ namespace _func683
 float FileHelper::readFloat(int file)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func683::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func684::func;
 	return execfunc(file);
 }
 
-namespace _func684
+namespace _func685
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9501,11 +9515,11 @@ namespace _func684
 int FileHelper::readInteger(int file)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func684::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func685::func;
 	return execfunc(file);
 }
 
-namespace _func685
+namespace _func686
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9515,11 +9529,11 @@ namespace _func685
 bool FileHelper::seekPosition(int file, int pos)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, int pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func685::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func686::func;
 	return execfunc(file, pos);
 }
 
-namespace _func686
+namespace _func687
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9529,11 +9543,11 @@ namespace _func686
 char *FileHelper::readBuffer(int file, int len, bool nullTerminate)
 {
 	typedef char *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, int len_arg, bool nullTerminate_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func686::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func687::func;
 	return execfunc(file, len, nullTerminate);
 }
 
-namespace _func687
+namespace _func688
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9543,11 +9557,11 @@ namespace _func687
 void FileHelper::readData(int file, void *data, int len)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, void *data_arg, int len_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func687::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func688::func;
 	return execfunc(file, data, len);
 }
 
-namespace _func688
+namespace _func689
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9557,11 +9571,11 @@ namespace _func688
 void Fire::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Fire *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func688::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func689::func;
 	return execfunc(this);
 }
 
-namespace _func689
+namespace _func690
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9571,11 +9585,11 @@ namespace _func689
 void Fire::UpdateDeathTimer(int connectedFires)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Fire *this_arg, int connectedFires_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func689::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func690::func;
 	return execfunc(this, connectedFires);
 }
 
-namespace _func690
+namespace _func691
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9585,11 +9599,11 @@ namespace _func690
 void Fire::UpdateStartTimer(int doorLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Fire *this_arg, int doorLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func690::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func691::func;
 	return execfunc(this, doorLevel);
 }
 
-namespace _func691
+namespace _func692
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -9599,11 +9613,11 @@ namespace _func691
 void FocusWindow::SetPosition(Point p)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(FocusWindow *this_arg, Point p_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func691::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func692::func;
 	return execfunc(this, p);
 }
 
-namespace _func692
+namespace _func693
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9613,11 +9627,11 @@ namespace _func692
 void FocusWindow::Close()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(FocusWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func692::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func693::func;
 	return execfunc(this);
 }
 
-namespace _func693
+namespace _func694
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9627,11 +9641,11 @@ namespace _func693
 void FocusWindow::Open()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(FocusWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func693::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func694::func;
 	return execfunc(this);
 }
 
-namespace _func694
+namespace _func695
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9641,11 +9655,11 @@ namespace _func694
 void FocusWindow::MouseClick(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(FocusWindow *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func694::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func695::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func695
+namespace _func696
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9655,11 +9669,11 @@ namespace _func695
 void FocusWindow::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(FocusWindow *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func695::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func696::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func696
+namespace _func697
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9669,11 +9683,11 @@ namespace _func696
 void FocusWindow::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(FocusWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func696::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func697::func;
 	return execfunc(this);
 }
 
-namespace _func697
+namespace _func698
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9683,11 +9697,11 @@ namespace _func697
 void GameOver::OpenText(const std::string &text)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GameOver *this_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func697::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func698::func;
 	return execfunc(this, text);
 }
 
-namespace _func698
+namespace _func699
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9697,11 +9711,11 @@ namespace _func698
 void GameOver::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GameOver *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func698::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func699::func;
 	return execfunc(this);
 }
 
-namespace _func699
+namespace _func700
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9711,11 +9725,11 @@ namespace _func699
 void GameOver::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GameOver *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func699::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func700::func;
 	return execfunc(this);
 }
 
-namespace _func700
+namespace _func701
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -9725,11 +9739,11 @@ namespace _func700
 void GenericButton::SetLocation(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GenericButton *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func700::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func701::func;
 	return execfunc(this, pos);
 }
 
-namespace _func701
+namespace _func702
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9739,11 +9753,11 @@ namespace _func701
 void GenericButton::SetActive(bool active)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GenericButton *this_arg, bool active_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func701::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func702::func;
 	return execfunc(this, active);
 }
 
-namespace _func702
+namespace _func703
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9753,18 +9767,18 @@ namespace _func702
 void GenericButton::MouseMove(int x, int y, bool silent)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GenericButton *this_arg, int x_arg, int y_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func702::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func703::func;
 	return execfunc(this, x, y, silent);
 }
 
-namespace _func703
+namespace _func704
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("GenericButton::__DO_NOT_HOOK", typeid(void (GenericButton::*)()), "f3c36690669066906690669066906690", argdata, 0, 4, &func);
 }
 
-namespace _func704
+namespace _func705
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9772,20 +9786,6 @@ namespace _func704
 }
 
 void GenericButton::OnClick()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GenericButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func704::func;
-	return execfunc(this);
-}
-
-namespace _func705
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("GenericButton::OnRightClick", typeid(void (GenericButton::*)()), ".f3c36690669066906690669066906690", argdata, 1, 6, &func);
-}
-
-void GenericButton::OnRightClick()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GenericButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func705::func;
@@ -9796,10 +9796,10 @@ namespace _func706
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("GenericButton::ResetPrimitives", typeid(void (GenericButton::*)()), ".f3c36690669066906690669066906690", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("GenericButton::OnRightClick", typeid(void (GenericButton::*)()), ".f3c36690669066906690669066906690", argdata, 1, 6, &func);
 }
 
-void GenericButton::ResetPrimitives()
+void GenericButton::OnRightClick()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GenericButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func706::func;
@@ -9809,6 +9809,20 @@ void GenericButton::ResetPrimitives()
 namespace _func707
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("GenericButton::ResetPrimitives", typeid(void (GenericButton::*)()), ".f3c36690669066906690669066906690", argdata, 1, 6, &func);
+}
+
+void GenericButton::ResetPrimitives()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(GenericButton *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func707::func;
+	return execfunc(this);
+}
+
+namespace _func708
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("font_text_width", typeid(float (*)(freetype::font_data &, const char *, float )), "5557565383ec4c8b4c24608b6c246485c9", argdata, 3, 2, &func);
 }
@@ -9816,11 +9830,11 @@ namespace _func707
 float __stdcall font_text_width(freetype::font_data &fontData, const char *str, float size)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(freetype::font_data &fontData_arg, const char *str_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func707::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func708::func;
 	return execfunc(fontData, str, size);
 }
 
-namespace _func708
+namespace _func709
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -9830,11 +9844,11 @@ namespace _func708
 int __stdcall random32()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func708::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func709::func;
 	return execfunc();
 }
 
-namespace _func709
+namespace _func710
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9844,11 +9858,11 @@ namespace _func709
 void __stdcall srandom32(unsigned int seed)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(unsigned int seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func709::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func710::func;
 	return execfunc(seed);
 }
 
-namespace _func710
+namespace _func711
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9858,11 +9872,11 @@ namespace _func710
 float __stdcall getSkillBonus(int skill, int level)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(int skill_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func710::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func711::func;
 	return execfunc(skill, level);
 }
 
-namespace _func711
+namespace _func712
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9872,11 +9886,11 @@ namespace _func711
 void __stdcall GenerateReward(ResourceEvent &ref, RewardDesc &reward, int worldLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceEvent &ref_arg, RewardDesc &reward_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func711::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func712::func;
 	return execfunc(ref, reward, worldLevel);
 }
 
-namespace _func712
+namespace _func713
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9886,11 +9900,11 @@ namespace _func712
 void __stdcall GetValue(ResourceEvent &ref, const std::string &type, int level, int worldLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceEvent &ref_arg, const std::string &type_arg, int level_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func712::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func713::func;
 	return execfunc(ref, type, level, worldLevel);
 }
 
-namespace _func713
+namespace _func714
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9900,11 +9914,11 @@ namespace _func713
 void __stdcall sys_graphics_set_window_title(char *title)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(char *title_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func713::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func714::func;
 	return execfunc(title);
 }
 
-namespace _func714
+namespace _func715
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9914,11 +9928,11 @@ namespace _func714
 void __stdcall graphics_clear(float r, float g, float b, float a, float depth, unsigned int stencil)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(float r_arg, float g_arg, float b_arg, float a_arg, float depth_arg, unsigned int stencil_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func714::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func715::func;
 	return execfunc(r, g, b, a, depth, stencil);
 }
 
-namespace _func715
+namespace _func716
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x2ff};
@@ -9928,11 +9942,11 @@ namespace _func715
 Pointf Globals::GetNextPoint(Pointf current, float mag_speed, Pointf dest)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf current_arg, float mag_speed_arg, Pointf dest_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func715::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func716::func;
 	return execfunc(current, mag_speed, dest);
 }
 
-namespace _func716
+namespace _func717
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -9942,11 +9956,11 @@ namespace _func716
 int Globals::GetNextSpaceId()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func716::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func717::func;
 	return execfunc();
 }
 
-namespace _func717
+namespace _func718
 {
     static void *func = 0;
 	static short argdata[] = {0x2ff, 0x2ff, 0x1ff};
@@ -9956,11 +9970,11 @@ namespace _func717
 float Globals::AimAhead(Pointf delta, Pointf vr, float muzzleV)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf delta_arg, Pointf vr_arg, float muzzleV_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func717::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func718::func;
 	return execfunc(delta, vr, muzzleV);
 }
 
-namespace _func718
+namespace _func719
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -9970,39 +9984,39 @@ namespace _func718
 Pointf Globals::GetNextPoint(Pointf current, float mag_speed, float heading)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf current_arg, float mag_speed_arg, float heading_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func718::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func719::func;
 	return execfunc(current, mag_speed, heading);
 }
 
 TextLibrary *Global_Globals_Library;
 
-namespace _var719
+namespace _var720
 {
     static VariableDefinition varObj("Global_Globals_Library", "!c744240c????????895c2408c7442404(???????\?)893c24", &Global_Globals_Library);
 }
 
 int *Globals_GetNextSpaceId_id;
 
-namespace _var720
+namespace _var721
 {
     static VariableDefinition varObj("Globals_GetNextSpaceId_id", "!8b15(???????\?)b8650000008d4a0185d20f45c1", &Globals_GetNextSpaceId_id);
 }
 
 bool *Globals_RNG;
 
-namespace _var721
+namespace _var722
 {
     static VariableDefinition varObj("Globals_RNG", "!803d(???????\?)00c787800000003c000000c78784000000c8000000", &Globals_RNG);
 }
 
 FILE *ftl_log_logfile;
 
-namespace _var722
+namespace _var723
 {
     static VariableDefinition varObj("ftl_log_logfile", "!8974240c895c2408c744240401000000890424e8????????a1(???????\?)890424", &ftl_log_logfile);
 }
 
-namespace _func723
+namespace _func724
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -10012,11 +10026,11 @@ namespace _func723
 void HackBox::constructor(Point pos, HackingSystem *sys, ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(HackBox *this_arg, Point pos_arg, HackingSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func723::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func724::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func724
+namespace _func725
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10026,11 +10040,11 @@ namespace _func724
 void HackingDrone::SetMovementTarget(Targetable *target)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(HackingDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func724::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func725::func;
 	return execfunc(this, target);
 }
 
-namespace _func725
+namespace _func726
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -10040,11 +10054,11 @@ namespace _func725
 CollisionResponse HackingDrone::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((cdecl)) (*custom_arg_funcptr_t)(HackingDrone *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func725::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func726::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func726
+namespace _func727
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10054,20 +10068,6 @@ namespace _func726
 void HackingDrone::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(HackingDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func726::func;
-	return execfunc(this);
-}
-
-namespace _func727
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("HackingSystem::BlowHackingDrone", typeid(void (HackingSystem::*)()), "83ec1c8b44242080b8b001000000", argdata, 1, 6, &func);
-}
-
-void HackingSystem::BlowHackingDrone()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(HackingSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func727::func;
 	return execfunc(this);
 }
@@ -10076,10 +10076,10 @@ namespace _func728
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("HackingSystem::OnLoop", typeid(void (HackingSystem::*)()), "57565383ec308b5c2440891c24e8????????80bbbc01000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("HackingSystem::BlowHackingDrone", typeid(void (HackingSystem::*)()), "83ec1c8b44242080b8b001000000", argdata, 1, 6, &func);
 }
 
-void HackingSystem::OnLoop()
+void HackingSystem::BlowHackingDrone()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(HackingSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func728::func;
@@ -10090,17 +10090,31 @@ namespace _func729
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("HackingSystem::OnLoop", typeid(void (HackingSystem::*)()), "57565383ec308b5c2440891c24e8????????80bbbc01000000", argdata, 1, 6, &func);
+}
+
+void HackingSystem::OnLoop()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(HackingSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func729::func;
+	return execfunc(this);
+}
+
+namespace _func730
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("HackingSystem::SoundLoop", typeid(bool (HackingSystem::*)()), "5383ec??8b5c????80bb980100000075??83c4??31c05b", argdata, 1, 2, &func);
 }
 
 bool HackingSystem::SoundLoop()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(HackingSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func729::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func730::func;
 	return execfunc(this);
 }
 
-namespace _func730
+namespace _func731
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10110,11 +10124,11 @@ namespace _func730
 void InfoBox::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func730::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func731::func;
 	return execfunc(this);
 }
 
-namespace _func731
+namespace _func732
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10124,11 +10138,11 @@ namespace _func731
 void InfoBox::Clear()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func731::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func732::func;
 	return execfunc(this);
 }
 
-namespace _func732
+namespace _func733
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10138,11 +10152,11 @@ namespace _func732
 void InfoBox::SetDescription(Description *desc, int width, int height, InfoBox::ExpandDir dir)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, Description *desc_arg, int width_arg, int height_arg, InfoBox::ExpandDir dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func732::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func733::func;
 	return execfunc(this, desc, width, height, dir);
 }
 
-namespace _func733
+namespace _func734
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10152,11 +10166,11 @@ namespace _func733
 void InfoBox::SetText(const std::string &title, const std::string &text, int width, int height, InfoBox::ExpandDir dir)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const std::string &title_arg, const std::string &text_arg, int width_arg, int height_arg, InfoBox::ExpandDir dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func733::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func734::func;
 	return execfunc(this, title, text, width, height, dir);
 }
 
-namespace _func734
+namespace _func735
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10166,11 +10180,11 @@ namespace _func734
 void InfoBox::SetBlueprintWeapon(const WeaponBlueprint *bp, int status, bool hasWeaponSystem, int yShift)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const WeaponBlueprint *bp_arg, int status_arg, bool hasWeaponSystem_arg, int yShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func734::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func735::func;
 	return execfunc(this, bp, status, hasWeaponSystem, yShift);
 }
 
-namespace _func735
+namespace _func736
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10180,11 +10194,11 @@ namespace _func735
 void InfoBox::SetBlueprintDrone(const DroneBlueprint *bp, int status, bool hasDroneSystem, int yShift)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const DroneBlueprint *bp_arg, int status_arg, bool hasDroneSystem_arg, int yShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func735::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func736::func;
 	return execfunc(this, bp, status, hasDroneSystem, yShift);
 }
 
-namespace _func736
+namespace _func737
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10194,11 +10208,11 @@ namespace _func736
 void InfoBox::SetBlueprint(const ItemBlueprint *bp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const ItemBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func736::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func737::func;
 	return execfunc(this, bp);
 }
 
-namespace _func737
+namespace _func738
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10208,11 +10222,11 @@ namespace _func737
 void InfoBox::SetBlueprintCrew(const CrewBlueprint *bp, int yShift, bool detailedCrew)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const CrewBlueprint *bp_arg, int yShift_arg, bool detailedCrew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func737::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func738::func;
 	return execfunc(this, bp, yShift, detailedCrew);
 }
 
-namespace _func738
+namespace _func739
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10222,11 +10236,11 @@ namespace _func738
 void InfoBox::SetBlueprintAugment(const AugmentBlueprint *bp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const AugmentBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func738::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func739::func;
 	return execfunc(this, bp);
 }
 
-namespace _func739
+namespace _func740
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10236,11 +10250,11 @@ namespace _func739
 bool InfoBox::IsEmpty()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func739::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func740::func;
 	return execfunc(this);
 }
 
-namespace _func740
+namespace _func741
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10250,11 +10264,11 @@ namespace _func740
 int InfoBox::CalcBoxHeight()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func740::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func741::func;
 	return execfunc(this);
 }
 
-namespace _func741
+namespace _func742
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10264,11 +10278,11 @@ namespace _func741
 void InfoBox::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func741::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func742::func;
 	return execfunc(this);
 }
 
-namespace _func742
+namespace _func743
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10278,11 +10292,11 @@ namespace _func742
 void InfoBox::SetSystemId(int systemId, int maxPower, int currentLevel, int upgrade, int yShift, int forceSystemWidth)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, int systemId_arg, int maxPower_arg, int currentLevel_arg, int upgrade_arg, int yShift_arg, int forceSystemWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func742::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func743::func;
 	return execfunc(this, systemId, maxPower, currentLevel, upgrade, yShift, forceSystemWidth);
 }
 
-namespace _func743
+namespace _func744
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10292,25 +10306,25 @@ namespace _func743
 void InfoBox::SetSystem(ShipSystem *system, int upgrade, int yShift, int forceSystemWidth)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InfoBox *this_arg, ShipSystem *system_arg, int upgrade_arg, int yShift_arg, int forceSystemWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func743::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func744::func;
 	return execfunc(this, system, upgrade, yShift, forceSystemWidth);
 }
 
 GL_Color *Global_InfoBox_detailsBarOn;
 
-namespace _var744
+namespace _var745
 {
     static VariableDefinition varObj("Global_InfoBox_detailsBarOn", "!b8(???????\?)89fa84d2ba(???????\?)", &Global_InfoBox_detailsBarOn);
 }
 
 GL_Color *Global_InfoBox_detailsBarOff;
 
-namespace _var745
+namespace _var746
 {
     static VariableDefinition varObj("Global_InfoBox_detailsBarOff", "", &Global_InfoBox_detailsBarOff);
 }
 
-namespace _func746
+namespace _func747
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10320,11 +10334,11 @@ namespace _func746
 void InputBox::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InputBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func746::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func747::func;
 	return execfunc(this);
 }
 
-namespace _func747
+namespace _func748
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10334,11 +10348,11 @@ namespace _func747
 void InputBox::TextInput(int ch)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InputBox *this_arg, int ch_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func747::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func748::func;
 	return execfunc(this, ch);
 }
 
-namespace _func748
+namespace _func749
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10348,11 +10362,11 @@ namespace _func748
 void InputBox::TextEvent(CEvent::TextEvent event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InputBox *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func748::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func749::func;
 	return execfunc(this, event);
 }
 
-namespace _func749
+namespace _func750
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10362,11 +10376,11 @@ namespace _func749
 void InputBox::StartInput()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(InputBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func749::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func750::func;
 	return execfunc(this);
 }
 
-namespace _func750
+namespace _func751
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10376,11 +10390,11 @@ namespace _func750
 Damage IonDrone::GetRoomDamage()
 {
 	typedef Damage __attribute__((cdecl)) (*custom_arg_funcptr_t)(IonDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func750::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func751::func;
 	return execfunc(this);
 }
 
-namespace _func751
+namespace _func752
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -10390,11 +10404,11 @@ namespace _func751
 void IonDrone::constructor(int iShipId, DroneBlueprint *blueprint)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(IonDrone *this_arg, int iShipId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func751::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func752::func;
 	return execfunc(this, iShipId, blueprint);
 }
 
-namespace _func752
+namespace _func753
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -10404,11 +10418,11 @@ namespace _func752
 void IonDroneAnimation::constructor(int iShipId, Pointf position, bool enemy)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(IonDroneAnimation *this_arg, int iShipId_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func752::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func753::func;
 	return execfunc(this, iShipId, position, enemy);
 }
 
-namespace _func753
+namespace _func754
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10418,11 +10432,11 @@ namespace _func753
 void IonDroneAnimation::UpdateShooting()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(IonDroneAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func753::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func754::func;
 	return execfunc(this);
 }
 
-namespace _func754
+namespace _func755
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -10432,18 +10446,18 @@ namespace _func754
 void ItemStoreBox::constructor(ShipManager *ship, const std::string &resourceName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ItemStoreBox *this_arg, ShipManager *ship_arg, const std::string &resourceName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func754::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func755::func;
 	return execfunc(this, ship, resourceName);
 }
 
 std::vector<std::string> *Global_OptionsScreen_languageList;
 
-namespace _var755
+namespace _var756
 {
     static VariableDefinition varObj("Global_OptionsScreen_languageList", "!8d348500000000a1(???????\?)", &Global_OptionsScreen_languageList);
 }
 
-namespace _func756
+namespace _func757
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10453,11 +10467,11 @@ namespace _func756
 void LanguageChooser::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(LanguageChooser *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func756::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func757::func;
 	return execfunc(this);
 }
 
-namespace _func757
+namespace _func758
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10467,11 +10481,11 @@ namespace _func757
 void LaserBlast::OnUpdate()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(LaserBlast *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func757::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func758::func;
 	return execfunc(this);
 }
 
-namespace _func758
+namespace _func759
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10481,25 +10495,25 @@ namespace _func758
 void LaserBlast::OnInit()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(LaserBlast *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func758::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func759::func;
 	return execfunc(this);
 }
 
 void **VTable_LaserBlast;
 
-namespace _var759
+namespace _var760
 {
     static VariableDefinition varObj("VTable_LaserBlast", "!e8????????8b8d3cfffffff30f108538ffffff8b4174394170c701(???????\?)c74104(???????\?)", &VTable_LaserBlast);
 }
 
 void **VTable_Targetable_LaserBlast;
 
-namespace _var760
+namespace _var761
 {
     static VariableDefinition varObj("VTable_Targetable_LaserBlast", "", &VTable_Targetable_LaserBlast);
 }
 
-namespace _func761
+namespace _func762
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10509,11 +10523,11 @@ namespace _func761
 void LocationEvent::ClearEvent(bool force)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(LocationEvent *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func761::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func762::func;
 	return execfunc(this, force);
 }
 
-namespace _func762
+namespace _func763
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10523,11 +10537,11 @@ namespace _func762
 void LocationEvent::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(LocationEvent *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func762::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func763::func;
 	return execfunc(this);
 }
 
-namespace _func763
+namespace _func764
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10537,11 +10551,11 @@ namespace _func763
 void LockdownShard::Update()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(LockdownShard *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func763::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func764::func;
 	return execfunc(this);
 }
 
-namespace _func764
+namespace _func765
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10551,11 +10565,11 @@ namespace _func764
 void MainMenu::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func764::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func765::func;
 	return execfunc(this);
 }
 
-namespace _func765
+namespace _func766
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10565,11 +10579,11 @@ namespace _func765
 bool MainMenu::Open()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func765::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func766::func;
 	return execfunc(this);
 }
 
-namespace _func766
+namespace _func767
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -10579,11 +10593,11 @@ namespace _func766
 void MainMenu::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MainMenu *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func766::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func767::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func767
+namespace _func768
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10593,11 +10607,11 @@ namespace _func767
 void MainMenu::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func767::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func768::func;
 	return execfunc(this);
 }
 
-namespace _func768
+namespace _func769
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -10607,11 +10621,11 @@ namespace _func768
 void MainMenu::MouseClick(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MainMenu *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func768::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func769::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func769
+namespace _func770
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10621,18 +10635,18 @@ namespace _func769
 void MainMenu::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func769::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func770::func;
 	return execfunc(this);
 }
 
-namespace _func770
+namespace _func771
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("MantisAnimation::__DO_NOT_HOOK", typeid(void (MantisAnimation::*)()), "565383ec148b7424208b5c2424893424895c2404e8????????f30f108640050000", argdata, 0, 4, &func);
 }
 
-namespace _func771
+namespace _func772
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10642,18 +10656,18 @@ namespace _func771
 std::string MantisAnimation::GetShootingSound()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func771::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func772::func;
 	return execfunc(this);
 }
 
-namespace _func772
+namespace _func773
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("MantisAnimation::__DO_NOT_HOOK2", typeid(void (MantisAnimation::*)()), "8b44240431d280b8d108000000", argdata, 0, 4, &func);
 }
 
-namespace _func773
+namespace _func774
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10663,18 +10677,18 @@ namespace _func773
 std::string MantisAnimation::GetDeathSound()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func773::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func774::func;
 	return execfunc(this);
 }
 
-namespace _func774
+namespace _func775
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("MantisAnimation::__DO_NOT_HOOK3", typeid(void (MantisAnimation::*)()), "31c080bb9f0900000075??c6839f0900000183c418b8010000005b", argdata, 0, 4, &func);
 }
 
-namespace _func775
+namespace _func776
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10684,20 +10698,6 @@ namespace _func775
 bool MantisAnimation::FireShot()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func775::func;
-	return execfunc(this);
-}
-
-namespace _func776
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("MenuScreen::OnLanguageChange", typeid(void (MenuScreen::*)()), "5589e557565381ec9c0000008b75088b561c", argdata, 1, 6, &func);
-}
-
-void MenuScreen::OnLanguageChange()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func776::func;
 	return execfunc(this);
 }
@@ -10706,10 +10706,10 @@ namespace _func777
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("MenuScreen::OnRender", typeid(void (MenuScreen::*)()), ".5589e557565381ecbc0000008b5d0880bb5c02000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("MenuScreen::OnLanguageChange", typeid(void (MenuScreen::*)()), "5589e557565381ec9c0000008b75088b561c", argdata, 1, 6, &func);
 }
 
-void MenuScreen::OnRender()
+void MenuScreen::OnLanguageChange()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func777::func;
@@ -10720,10 +10720,10 @@ namespace _func778
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("MenuScreen::Open", typeid(void (MenuScreen::*)()), ".5589e557565383ec4c8b7d088d75d88d", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("MenuScreen::OnRender", typeid(void (MenuScreen::*)()), ".5589e557565381ecbc0000008b5d0880bb5c02000000", argdata, 1, 6, &func);
 }
 
-void MenuScreen::Open()
+void MenuScreen::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func778::func;
@@ -10734,10 +10734,10 @@ namespace _func779
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("MenuScreen::constructor", typeid(void (MenuScreen::*)()), ".5557565381ec0c0100008b9c24200100008db424a8000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("MenuScreen::Open", typeid(void (MenuScreen::*)()), ".5589e557565383ec4c8b7d088d75d88d", argdata, 1, 6, &func);
 }
 
-void MenuScreen::constructor()
+void MenuScreen::Open()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func779::func;
@@ -10747,6 +10747,20 @@ void MenuScreen::constructor()
 namespace _func780
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("MenuScreen::constructor", typeid(void (MenuScreen::*)()), ".5557565381ec0c0100008b9c24200100008db424a8000000", argdata, 1, 6, &func);
+}
+
+void MenuScreen::constructor()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func780::func;
+	return execfunc(this);
+}
+
+namespace _func781
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
 	static FunctionDefinition funcObj("MindBox::constructor", typeid(void (MindBox::*)(Point , MindSystem *)), "5557565383ec7c8b9c24900000008d7c243c", argdata, 3, 6, &func);
 }
@@ -10754,11 +10768,11 @@ namespace _func780
 void MindBox::constructor(Point pos, MindSystem *sys)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MindBox *this_arg, Point pos_arg, MindSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func780::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func781::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func781
+namespace _func782
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10768,11 +10782,11 @@ namespace _func781
 void MindSystem::ReleaseCrew()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MindSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func781::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func782::func;
 	return execfunc(this);
 }
 
-namespace _func782
+namespace _func783
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10782,11 +10796,11 @@ namespace _func782
 void MindSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MindSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func782::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func783::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func783
+namespace _func784
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10796,11 +10810,11 @@ namespace _func783
 void MindSystem::SetArmed(int armed)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MindSystem *this_arg, int armed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func783::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func784::func;
 	return execfunc(this, armed);
 }
 
-namespace _func784
+namespace _func785
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10810,11 +10824,11 @@ namespace _func784
 void MindSystem::InitiateMindControl()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MindSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func784::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func785::func;
 	return execfunc(this);
 }
 
-namespace _func785
+namespace _func786
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10824,11 +10838,11 @@ namespace _func785
 void MindSystem::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MindSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func785::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func786::func;
 	return execfunc(this);
 }
 
-namespace _func786
+namespace _func787
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -10838,11 +10852,11 @@ namespace _func786
 void Missile::constructor(Pointf _position, int _ownerId, int _targetId, Pointf _target, float _heading)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Missile *this_arg, Pointf _position_arg, int _ownerId_arg, int _targetId_arg, Pointf _target_arg, float _heading_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func786::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func787::func;
 	return execfunc(this, _position, _ownerId, _targetId, _target, _heading);
 }
 
-namespace _func787
+namespace _func788
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10852,11 +10866,11 @@ namespace _func787
 void MouseControl::SetTooltip(const std::string &tooltip)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func787::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func788::func;
 	return execfunc(this, tooltip);
 }
 
-namespace _func788
+namespace _func789
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -10866,11 +10880,11 @@ namespace _func788
 void MouseControl::SetTooltipTitle(const std::string &tooltip)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func788::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func789::func;
 	return execfunc(this, tooltip);
 }
 
-namespace _func789
+namespace _func790
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -10880,11 +10894,11 @@ namespace _func789
 Point MouseControl::MeasureTooltip(int unk)
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func789::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func790::func;
 	return execfunc(this, unk);
 }
 
-namespace _func790
+namespace _func791
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -10894,11 +10908,11 @@ namespace _func790
 void MouseControl::QueueStaticTooltip(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func790::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func791::func;
 	return execfunc(this, pos);
 }
 
-namespace _func791
+namespace _func792
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
@@ -10908,11 +10922,11 @@ namespace _func791
 void MouseControl::RenderTooltip(Point tooltipPoint, bool staticPos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg, Point tooltipPoint_arg, bool staticPos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func791::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func792::func;
 	return execfunc(this, tooltipPoint, staticPos);
 }
 
-namespace _func792
+namespace _func793
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -10920,20 +10934,6 @@ namespace _func792
 }
 
 void MouseControl::OnLoop()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func792::func;
-	return execfunc(this);
-}
-
-namespace _func793
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("MouseControl::InstantTooltip", typeid(void (MouseControl::*)()), "8b442404c680d400000001", argdata, 1, 6, &func);
-}
-
-void MouseControl::InstantTooltip()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func793::func;
@@ -10944,10 +10944,10 @@ namespace _func794
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("MouseControl::ResetArmed", typeid(void (MouseControl::*)()), ".8b442404c7401000000000c7401400000000c7401800000000c780e000000000000000c7402000000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("MouseControl::InstantTooltip", typeid(void (MouseControl::*)()), "8b442404c680d400000001", argdata, 1, 6, &func);
 }
 
-void MouseControl::ResetArmed()
+void MouseControl::InstantTooltip()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func794::func;
@@ -10958,10 +10958,10 @@ namespace _func795
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("MouseControl::OnRender", typeid(void (MouseControl::*)()), "5557565381ec3c0100008b9c245001000080bbc900000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("MouseControl::ResetArmed", typeid(void (MouseControl::*)()), ".8b442404c7401000000000c7401400000000c7401800000000c780e000000000000000c7402000000000", argdata, 1, 6, &func);
 }
 
-void MouseControl::OnRender()
+void MouseControl::ResetArmed()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func795::func;
@@ -10972,10 +10972,10 @@ namespace _func796
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("MouseControl::Reset", typeid(void (MouseControl::*)()), ".5383ec288b5c24308d83c0000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("MouseControl::OnRender", typeid(void (MouseControl::*)()), "5557565381ec3c0100008b9c245001000080bbc900000000", argdata, 1, 6, &func);
 }
 
-void MouseControl::Reset()
+void MouseControl::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func796::func;
@@ -10985,6 +10985,20 @@ void MouseControl::Reset()
 namespace _func797
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("MouseControl::Reset", typeid(void (MouseControl::*)()), ".5383ec288b5c24308d83c0000000", argdata, 1, 6, &func);
+}
+
+void MouseControl::Reset()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func797::func;
+	return execfunc(this);
+}
+
+namespace _func798
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("MouseControl::SetDoor", typeid(void (MouseControl::*)(int )), "565383ec148b5c24248b74242083fb01", argdata, 2, 6, &func);
 }
@@ -10992,11 +11006,11 @@ namespace _func797
 void MouseControl::SetDoor(int state)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg, int state_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func797::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func798::func;
 	return execfunc(this, state);
 }
 
-namespace _func798
+namespace _func799
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11006,11 +11020,11 @@ namespace _func798
 void MouseControl::SetValid(bool valid, bool newValid)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg, bool valid_arg, bool newValid_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func798::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func799::func;
 	return execfunc(this, valid, newValid);
 }
 
-namespace _func799
+namespace _func800
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11020,18 +11034,18 @@ namespace _func799
 void MouseControl::LoadTooltip(const std::string &tooltipName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltipName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func799::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func800::func;
 	return execfunc(this, tooltipName);
 }
 
 MouseControl *Global_MouseControl_Mouse;
 
-namespace _var800
+namespace _var801
 {
     static VariableDefinition varObj("Global_MouseControl_Mouse", "!e8????????e8????????884305c70424(???????\?)", &Global_MouseControl_Mouse);
 }
 
-namespace _func801
+namespace _func802
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11041,11 +11055,11 @@ namespace _func801
 void OptionsScreen::Open(bool mainMenu)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OptionsScreen *this_arg, bool mainMenu_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func801::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func802::func;
 	return execfunc(this, mainMenu);
 }
 
-namespace _func802
+namespace _func803
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11055,11 +11069,11 @@ namespace _func802
 void OptionsScreen::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OptionsScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func802::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func803::func;
 	return execfunc(this);
 }
 
-namespace _func803
+namespace _func804
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11069,18 +11083,18 @@ namespace _func803
 void OptionsScreen::OnInit()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OptionsScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func803::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func804::func;
 	return execfunc(this);
 }
 
 void **VTable_OuterHull;
 
-namespace _var804
+namespace _var805
 {
     static VariableDefinition varObj("VTable_OuterHull", "!8b8d44ffffff8d4168c701(???????\?)", &VTable_OuterHull);
 }
 
-namespace _func805
+namespace _func806
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11090,11 +11104,11 @@ namespace _func805
 void OuterHull::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OuterHull *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func805::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func806::func;
 	return execfunc(this);
 }
 
-namespace _func806
+namespace _func807
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -11104,11 +11118,11 @@ namespace _func806
 void OxygenSystem::UpdateBreach(int roomId, int count, bool silent)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, int count_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func806::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func807::func;
 	return execfunc(this, roomId, count, silent);
 }
 
-namespace _func807
+namespace _func808
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11118,11 +11132,11 @@ namespace _func807
 void OxygenSystem::UpdateAirlock(int roomId, int count)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, int count_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func807::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func808::func;
 	return execfunc(this, roomId, count);
 }
 
-namespace _func808
+namespace _func809
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11132,11 +11146,11 @@ namespace _func808
 void OxygenSystem::EmptyOxygen(int roomId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func808::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func809::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func809
+namespace _func810
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11146,11 +11160,11 @@ namespace _func809
 void OxygenSystem::ModifyRoomOxygen(int roomId, float value)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, float value_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func809::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func810::func;
 	return execfunc(this, roomId, value);
 }
 
-namespace _func810
+namespace _func811
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -11160,11 +11174,11 @@ namespace _func810
 void OxygenSystem::ComputeAirLoss(int roomId, float base_loss, bool silent)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, float base_loss_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func810::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func811::func;
 	return execfunc(this, roomId, base_loss, silent);
 }
 
-namespace _func811
+namespace _func812
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11174,11 +11188,11 @@ namespace _func811
 float OxygenSystem::GetRefillSpeed()
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func811::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func812::func;
 	return execfunc(this);
 }
 
-namespace _func812
+namespace _func813
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -11188,11 +11202,11 @@ namespace _func812
 void OxygenSystem::constructor(int numRooms, int roomId, int shipId, int startingPower)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int numRooms_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func812::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func813::func;
 	return execfunc(this, numRooms, roomId, shipId, startingPower);
 }
 
-namespace _func813
+namespace _func814
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11202,11 +11216,11 @@ namespace _func813
 void OxygenSystem::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func813::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func814::func;
 	return execfunc(this);
 }
 
-namespace _func814
+namespace _func815
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11216,11 +11230,11 @@ namespace _func814
 void PDSFire::OnUpdate()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(PDSFire *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func814::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func815::func;
 	return execfunc(this);
 }
 
-namespace _func815
+namespace _func816
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11230,11 +11244,11 @@ namespace _func815
 void PDSFire::CollisionCheck(Collideable *other)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(PDSFire *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func815::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func816::func;
 	return execfunc(this, other);
 }
 
-namespace _func816
+namespace _func817
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x2ff};
@@ -11244,11 +11258,11 @@ namespace _func816
 void PDSFire::constructor(Point pos, int destinationSpace, Pointf destination)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(PDSFire *this_arg, Point pos_arg, int destinationSpace_arg, Pointf destination_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func816::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func817::func;
 	return execfunc(this, pos, destinationSpace, destination);
 }
 
-namespace _func817
+namespace _func818
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -11258,11 +11272,11 @@ namespace _func817
 int Point::RelativeDistance(Point other)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Point *this_arg, Point other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func817::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func818::func;
 	return execfunc(this, other);
 }
 
-namespace _func818
+namespace _func819
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -11272,11 +11286,11 @@ namespace _func818
 int Point::Distance(Point other)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Point *this_arg, Point other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func818::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func819::func;
 	return execfunc(this, other);
 }
 
-namespace _func819
+namespace _func820
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11286,11 +11300,11 @@ namespace _func819
 void Pointf::constructor(float x, float y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf *this_arg, float x_arg, float y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func819::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func820::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func820
+namespace _func821
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -11300,11 +11314,11 @@ namespace _func820
 float Pointf::RelativeDistance(Pointf other)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf *this_arg, Pointf other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func820::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func821::func;
 	return execfunc(this, other);
 }
 
-namespace _func821
+namespace _func822
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11314,18 +11328,18 @@ namespace _func821
 Pointf Pointf::Normalize()
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func821::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func822::func;
 	return execfunc(this);
 }
 
-namespace _func822
+namespace _func823
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("PowerManager::DO_NOT_HOOK", typeid(void (PowerManager::*)()), "807c????018b54????", argdata, 0, 4, &func);
 }
 
-namespace _func823
+namespace _func824
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11335,11 +11349,11 @@ namespace _func823
 void PowerManager::SetHacked(bool val)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(PowerManager *this_arg, bool val_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func823::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func824::func;
 	return execfunc(this, val);
 }
 
-namespace _func824
+namespace _func825
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -11349,11 +11363,11 @@ namespace _func824
 void PowerManager::RestartAll()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func824::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func825::func;
 	return execfunc();
 }
 
-namespace _func825
+namespace _func826
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11363,11 +11377,11 @@ namespace _func825
 PowerManager *PowerManager::GetPowerManager(int iShipId)
 {
 	typedef PowerManager *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int iShipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func825::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func826::func;
 	return execfunc(iShipId);
 }
 
-namespace _func826
+namespace _func827
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11377,11 +11391,11 @@ namespace _func826
 bool Projectile::ValidTarget()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func826::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func827::func;
 	return execfunc(this);
 }
 
-namespace _func827
+namespace _func828
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11391,11 +11405,11 @@ namespace _func827
 int Projectile::ForceRenderLayer()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func827::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func828::func;
 	return execfunc(this);
 }
 
-namespace _func828
+namespace _func829
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -11405,11 +11419,11 @@ namespace _func828
 CollisionResponse Projectile::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func828::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func829::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func829
+namespace _func830
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11419,11 +11433,11 @@ namespace _func829
 void Projectile::OnUpdate()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func829::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func830::func;
 	return execfunc(this);
 }
 
-namespace _func830
+namespace _func831
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11433,11 +11447,11 @@ namespace _func830
 void Projectile::CollisionCheck(Collideable *other)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func830::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func831::func;
 	return execfunc(this, other);
 }
 
-namespace _func831
+namespace _func832
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff, 0x2ff};
@@ -11447,11 +11461,11 @@ namespace _func831
 void Projectile::constructor(Pointf position, int ownerId, int targetId, Pointf target)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *this_arg, Pointf position_arg, int ownerId_arg, int targetId_arg, Pointf target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func831::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func832::func;
 	return execfunc(this, position, ownerId, targetId, target);
 }
 
-namespace _func832
+namespace _func833
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11461,11 +11475,11 @@ namespace _func832
 void Projectile::Initialize(const WeaponBlueprint &bp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *this_arg, const WeaponBlueprint &bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func832::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func833::func;
 	return execfunc(this, bp);
 }
 
-namespace _func833
+namespace _func834
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11475,11 +11489,11 @@ namespace _func833
 Pointf Projectile::RandomSidePoint(int side)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int side_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func833::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func834::func;
 	return execfunc(side);
 }
 
-namespace _func834
+namespace _func835
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11489,11 +11503,11 @@ namespace _func834
 void Projectile::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func834::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func835::func;
 	return execfunc(this);
 }
 
-namespace _func835
+namespace _func836
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11503,11 +11517,11 @@ namespace _func835
 void ProjectileFactory::constructor(const WeaponBlueprint *bp, int shipId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, const WeaponBlueprint *bp_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func835::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func836::func;
 	return execfunc(this, bp, shipId);
 }
 
-namespace _func836
+namespace _func837
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11517,11 +11531,11 @@ namespace _func836
 void ProjectileFactory::SelectChargeGoal()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func836::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func837::func;
 	return execfunc(this);
 }
 
-namespace _func837
+namespace _func838
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11531,11 +11545,11 @@ namespace _func837
 bool ProjectileFactory::IsChargedGoal()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func837::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func838::func;
 	return execfunc(this);
 }
 
-namespace _func838
+namespace _func839
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11545,11 +11559,11 @@ namespace _func838
 void ProjectileFactory::SetHacked(int hacked)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, int hacked_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func838::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func839::func;
 	return execfunc(this, hacked);
 }
 
-namespace _func839
+namespace _func840
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11559,11 +11573,11 @@ namespace _func839
 void ProjectileFactory::SetCurrentShip(Targetable *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, Targetable *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func839::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func840::func;
 	return execfunc(this, ship);
 }
 
-namespace _func840
+namespace _func841
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11573,11 +11587,11 @@ namespace _func840
 void ProjectileFactory::SetCooldownModifier(float mod)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float mod_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func840::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func841::func;
 	return execfunc(this, mod);
 }
 
-namespace _func841
+namespace _func842
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11587,11 +11601,11 @@ namespace _func841
 void ProjectileFactory::ForceCoolup()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func841::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func842::func;
 	return execfunc(this);
 }
 
-namespace _func842
+namespace _func843
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11601,11 +11615,11 @@ namespace _func842
 void ProjectileFactory::RenderChargeBar(float unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func842::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func843::func;
 	return execfunc(this, unk);
 }
 
-namespace _func843
+namespace _func844
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11615,11 +11629,11 @@ namespace _func843
 int ProjectileFactory::StringToWeapon(const std::string &str)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &str_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func843::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func844::func;
 	return execfunc(str);
 }
 
-namespace _func844
+namespace _func845
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11629,11 +11643,11 @@ namespace _func844
 bool Projectile::QueuedShots()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func844::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func845::func;
 	return execfunc(this);
 }
 
-namespace _func845
+namespace _func846
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11643,11 +11657,11 @@ namespace _func845
 void ProjectileFactory::Fire(std::vector<Pointf> &points, int target)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, std::vector<Pointf> &points_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func845::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func846::func;
 	return execfunc(this, points, target);
 }
 
-namespace _func846
+namespace _func847
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11657,11 +11671,11 @@ namespace _func846
 void ProjectileFactory::LoadState(int fd)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func846::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func847::func;
 	return execfunc(this, fd);
 }
 
-namespace _func847
+namespace _func848
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11669,20 +11683,6 @@ namespace _func847
 }
 
 bool ProjectileFactory::FireNextShot()
-{
-	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func847::func;
-	return execfunc(this);
-}
-
-namespace _func848
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ProjectileFactory::ReadyToFire", typeid(bool (ProjectileFactory::*)()), ".8b54????31c08b8ab004000085c97e??80baba0000000074??8b421c", argdata, 1, 2, &func);
-}
-
-bool ProjectileFactory::ReadyToFire()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func848::func;
@@ -11693,17 +11693,31 @@ namespace _func849
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ProjectileFactory::ReadyToFire", typeid(bool (ProjectileFactory::*)()), ".8b54????31c08b8ab004000085c97e??80baba0000000074??8b421c", argdata, 1, 2, &func);
+}
+
+bool ProjectileFactory::ReadyToFire()
+{
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func849::func;
+	return execfunc(this);
+}
+
+namespace _func850
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("ProjectileFactory::SpendMissiles", typeid(int (ProjectileFactory::*)()), "57565383ec308b5c24408b839804000085c0", argdata, 1, 2, &func);
 }
 
 int ProjectileFactory::SpendMissiles()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func849::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func850::func;
 	return execfunc(this);
 }
 
-namespace _func850
+namespace _func851
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -11713,11 +11727,11 @@ namespace _func850
 void ProjectileFactory::OnRender(float alpha, bool forceVisual)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float alpha_arg, bool forceVisual_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func850::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func851::func;
 	return execfunc(this, alpha, forceVisual);
 }
 
-namespace _func851
+namespace _func852
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11725,20 +11739,6 @@ namespace _func851
 }
 
 void ProjectileFactory::ClearAiming()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func851::func;
-	return execfunc(this);
-}
-
-namespace _func852
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ProjectileFactory::ClearProjectiles", typeid(void (ProjectileFactory::*)()), ".8b4424048b9084040000899088040000", argdata, 1, 6, &func);
-}
-
-void ProjectileFactory::ClearProjectiles()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func852::func;
@@ -11749,17 +11749,31 @@ namespace _func853
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ProjectileFactory::ClearProjectiles", typeid(void (ProjectileFactory::*)()), ".8b4424048b9084040000899088040000", argdata, 1, 6, &func);
+}
+
+void ProjectileFactory::ClearProjectiles()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func853::func;
+	return execfunc(this);
+}
+
+namespace _func854
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("ProjectileFactory::NumTargetsRequired", typeid(int (ProjectileFactory::*)()), "8b5424048b421c83b8fc00000001", argdata, 1, 2, &func);
 }
 
 int ProjectileFactory::NumTargetsRequired()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func853::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func854::func;
 	return execfunc(this);
 }
 
-namespace _func854
+namespace _func855
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11769,11 +11783,11 @@ namespace _func854
 void ProjectileFactory::Update()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func854::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func855::func;
 	return execfunc(this);
 }
 
-namespace _func855
+namespace _func856
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11783,11 +11797,11 @@ namespace _func855
 Projectile *ProjectileFactory::GetProjectile()
 {
 	typedef Projectile *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func855::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func856::func;
 	return execfunc(this);
 }
 
-namespace _func856
+namespace _func857
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11797,11 +11811,11 @@ namespace _func856
 void ProjectileFactory::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func856::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func857::func;
 	return execfunc(this);
 }
 
-namespace _func857
+namespace _func858
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11811,11 +11825,11 @@ namespace _func857
 void ProjectileFactory::SaveProjectile(Projectile *p, int fd)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *p_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func857::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func858::func;
 	return execfunc(p, fd);
 }
 
-namespace _func858
+namespace _func859
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11825,11 +11839,11 @@ namespace _func858
 Projectile *ProjectileFactory::LoadProjectile(int fd)
 {
 	typedef Projectile *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func858::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func859::func;
 	return execfunc(fd);
 }
 
-namespace _func859
+namespace _func860
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11839,11 +11853,11 @@ namespace _func859
 void ProjectileFactory::SaveState(int fd)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func859::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func860::func;
 	return execfunc(this, fd);
 }
 
-namespace _func860
+namespace _func861
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11853,11 +11867,11 @@ namespace _func860
 void ProjectileFactory::SetAutoFire(bool autoFire)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, bool autoFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func860::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func861::func;
 	return execfunc(this, autoFire);
 }
 
-namespace _func861
+namespace _func862
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11865,20 +11879,6 @@ namespace _func861
 }
 
 void ReactorButton::Accept()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func861::func;
-	return execfunc(this);
-}
-
-namespace _func862
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ReactorButton::OnClick", typeid(void (ReactorButton::*)()), "5589e557565383ec3c8b5d088d75d08b4370", argdata, 1, 6, &func);
-}
-
-void ReactorButton::OnClick()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func862::func;
@@ -11889,10 +11889,10 @@ namespace _func863
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ReactorButton::OnRightClick", typeid(void (ReactorButton::*)()), "5589e557565383ec3c8b5d088d75d08b436c", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ReactorButton::OnClick", typeid(void (ReactorButton::*)()), "5589e557565383ec3c8b5d088d75d08b4370", argdata, 1, 6, &func);
 }
 
-void ReactorButton::OnRightClick()
+void ReactorButton::OnClick()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func863::func;
@@ -11903,24 +11903,38 @@ namespace _func864
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ReactorButton::OnRender", typeid(void (ReactorButton::*)()), "5589e557565381ec0c0300008b4508890424", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ReactorButton::OnRightClick", typeid(void (ReactorButton::*)()), "5589e557565383ec3c8b5d088d75d08b436c", argdata, 1, 6, &func);
 }
 
-void ReactorButton::OnRender()
+void ReactorButton::OnRightClick()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func864::func;
 	return execfunc(this);
 }
 
+namespace _func865
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ReactorButton::OnRender", typeid(void (ReactorButton::*)()), "5589e557565381ec0c0300008b4508890424", argdata, 1, 6, &func);
+}
+
+void ReactorButton::OnRender()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func865::func;
+	return execfunc(this);
+}
+
 void **VTable_RepairAnimation;
 
-namespace _var865
+namespace _var866
 {
     static VariableDefinition varObj("VTable_RepairAnimation", "!0f85150100008d44242889442418c706(???????\?)", &VTable_RepairAnimation);
 }
 
-namespace _func866
+namespace _func867
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -11930,11 +11944,11 @@ namespace _func866
 void RepairStoreBox::constructor(ShipManager *ship, bool repairAll, int price)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(RepairStoreBox *this_arg, ShipManager *ship_arg, bool repairAll_arg, int price_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func866::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func867::func;
 	return execfunc(this, ship, repairAll, price);
 }
 
-namespace _func867
+namespace _func868
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11944,11 +11958,11 @@ namespace _func867
 void ResourceControl::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func867::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func868::func;
 	return execfunc(this);
 }
 
-namespace _func868
+namespace _func869
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -11958,11 +11972,11 @@ namespace _func868
 GL_Primitive *ResourceControl::CreateImagePrimitive(GL_Texture *tex, int unk1, int unk2, int unk3, GL_Color color, float alpha, bool mirror)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg, int unk1_arg, int unk2_arg, int unk3_arg, GL_Color color_arg, float alpha_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func868::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func869::func;
 	return execfunc(this, tex, unk1, unk2, unk3, color, alpha, mirror);
 }
 
-namespace _func869
+namespace _func870
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11972,11 +11986,11 @@ namespace _func869
 void ResourceControl::OnInit(int imageSwappingMode)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, int imageSwappingMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func869::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func870::func;
 	return execfunc(this, imageSwappingMode);
 }
 
-namespace _func870
+namespace _func871
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11986,11 +12000,11 @@ namespace _func870
 char *ResourceControl::LoadFile(const std::string &fileName)
 {
 	typedef char *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func870::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func871::func;
 	return execfunc(this, fileName);
 }
 
-namespace _func871
+namespace _func872
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -12000,11 +12014,11 @@ namespace _func871
 char *ResourceControl::LoadFromResourceFile(const std::string &fileName, std::size_t &fileSize, const std::string *unused_resourceFile)
 {
 	typedef char *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &fileName_arg, std::size_t &fileSize_arg, const std::string *unused_resourceFile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func871::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func872::func;
 	return execfunc(this, fileName, fileSize, unused_resourceFile);
 }
 
-namespace _func872
+namespace _func873
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12014,11 +12028,11 @@ namespace _func872
 GL_Texture *ResourceControl::GetImageId(const std::string &dir)
 {
 	typedef GL_Texture *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func872::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func873::func;
 	return execfunc(this, dir);
 }
 
-namespace _func873
+namespace _func874
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -12028,11 +12042,11 @@ namespace _func873
 int ResourceControl::RenderImage(GL_Texture *tex, int x, int y, int rotation, GL_Color color, float opacity, bool mirror)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float opacity_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func873::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func874::func;
 	return execfunc(this, tex, x, y, rotation, color, opacity, mirror);
 }
 
-namespace _func874
+namespace _func875
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -12042,11 +12056,11 @@ namespace _func874
 int ResourceControl::RenderImageString(std::string &tex, int x, int y, int rotation, GL_Color color, float opacity, bool mirror)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, std::string &tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float opacity_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func874::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func875::func;
 	return execfunc(this, tex, x, y, rotation, color, opacity, mirror);
 }
 
-namespace _func875
+namespace _func876
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -12056,11 +12070,11 @@ namespace _func875
 GL_Primitive *ResourceControl::CreateImagePrimitiveString(const std::string &tex, int x, int y, int rotation, GL_Color color, float alpha, bool mirror)
 {
 	typedef GL_Primitive *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float alpha_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func875::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func876::func;
 	return execfunc(this, tex, x, y, rotation, color, alpha, mirror);
 }
 
-namespace _func876
+namespace _func877
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12070,11 +12084,11 @@ namespace _func876
 freetype::font_data &ResourceControl::GetFontData(int size, bool ignoreLanguage)
 {
 	typedef freetype::font_data &__attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, int size_arg, bool ignoreLanguage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func876::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func877::func;
 	return execfunc(this, size, ignoreLanguage);
 }
 
-namespace _func877
+namespace _func878
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12084,11 +12098,11 @@ namespace _func877
 ImageDesc ResourceControl::GetImageData(GL_Texture *tex)
 {
 	typedef ImageDesc __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func877::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func878::func;
 	return execfunc(this, tex);
 }
 
-namespace _func878
+namespace _func879
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12098,11 +12112,11 @@ namespace _func878
 bool ResourceControl::ImageExists(const std::string &name)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func878::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func879::func;
 	return execfunc(this, name);
 }
 
-namespace _func879
+namespace _func880
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12112,11 +12126,11 @@ namespace _func879
 bool ResourceControl::PreloadResources(bool unk)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func879::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func880::func;
 	return execfunc(this, unk);
 }
 
-namespace _func880
+namespace _func881
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12126,18 +12140,18 @@ namespace _func880
 void ResourceControl::RenderLoadingBar(float initialProgress, float finalProgress)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, float initialProgress_arg, float finalProgress_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func880::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func881::func;
 	return execfunc(this, initialProgress, finalProgress);
 }
 
 ResourceControl *Global_ResourceControl_GlobalResources;
 
-namespace _var881
+namespace _var882
 {
     static VariableDefinition varObj("Global_ResourceControl_GlobalResources", "!8b45e0890424e8????????c70424(???????\?)", &Global_ResourceControl_GlobalResources);
 }
 
-namespace _func882
+namespace _func883
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -12147,18 +12161,18 @@ namespace _func882
 void RockAnimation::constructor(const std::string &subRace, int iShipId, Pointf position, bool enemy)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(RockAnimation *this_arg, const std::string &subRace_arg, int iShipId_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func882::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func883::func;
 	return execfunc(this, subRace, iShipId, position, enemy);
 }
 
-namespace _func883
+namespace _func884
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK", typeid(void (RockAnimation::*)()), "5557565381ec0c010000803d????????000f85????????e8????????89c7", argdata, 0, 4, &func);
 }
 
-namespace _func884
+namespace _func885
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12168,25 +12182,25 @@ namespace _func884
 std::string RockAnimation::GetShootingSound()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(RockAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func884::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func885::func;
 	return execfunc(this);
-}
-
-namespace _func885
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK2", typeid(void (RockAnimation::*)()), "5383ec288b5c24308d44241f89442408c7442404????????891c24e8????????83c42889d85b", argdata, 0, 4, &func);
 }
 
 namespace _func886
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK3", typeid(void (RockAnimation::*)()), ".5383ec288b5c24308d44241f89442408c7442404????????891c24e8????????83c42889d85b", argdata, 0, 4, &func);
+	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK2", typeid(void (RockAnimation::*)()), "5383ec288b5c24308d44241f89442408c7442404????????891c24e8????????83c42889d85b", argdata, 0, 4, &func);
 }
 
 namespace _func887
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK3", typeid(void (RockAnimation::*)()), ".5383ec288b5c24308d44241f89442408c7442404????????891c24e8????????83c42889d85b", argdata, 0, 4, &func);
+}
+
+namespace _func888
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12196,11 +12210,11 @@ namespace _func887
 std::string RockAnimation::GetDeathSound()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(RockAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func887::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func888::func;
 	return execfunc(this);
 }
 
-namespace _func888
+namespace _func889
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12210,11 +12224,11 @@ namespace _func888
 int Room::GetEmptySlots(bool intruder)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func888::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func889::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func889
+namespace _func890
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12224,11 +12238,11 @@ namespace _func889
 bool Room::Full(bool intruder)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func889::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func890::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func890
+namespace _func891
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12238,18 +12252,18 @@ namespace _func890
 int Room::GetEmptySlot(bool intruder)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func890::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func891::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func891
+namespace _func892
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("Room::DO_NOT_HOOK", typeid(void (Room::*)()), ".56538b5c240c0fb64424148b4c2410", argdata, 0, 4, &func);
 }
 
-namespace _func892
+namespace _func893
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12259,11 +12273,11 @@ namespace _func892
 void Room::FillSlot(int slot, bool intruder)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Room *this_arg, int slot_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func892::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func893::func;
 	return execfunc(this, slot, intruder);
 }
 
-namespace _func893
+namespace _func894
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -12273,11 +12287,11 @@ namespace _func893
 void Room::constructor(int iShipId, int x, int y, int w, int h, int roomId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Room *this_arg, int iShipId_arg, int x_arg, int y_arg, int w_arg, int h_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func893::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func894::func;
 	return execfunc(this, iShipId, x, y, w, h, roomId);
 }
 
-namespace _func894
+namespace _func895
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12287,11 +12301,11 @@ namespace _func894
 void Room::OnRenderFloor(float alpha, bool experimental)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Room *this_arg, float alpha_arg, bool experimental_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func894::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func895::func;
 	return execfunc(this, alpha, experimental);
 }
 
-namespace _func895
+namespace _func896
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12301,11 +12315,11 @@ namespace _func895
 void Room::OnRenderWalls(float alpha)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Room *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func895::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func896::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func896
+namespace _func897
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12315,11 +12329,11 @@ namespace _func896
 void Room::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Room *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func896::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func897::func;
 	return execfunc(this);
 }
 
-namespace _func897
+namespace _func898
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12329,11 +12343,11 @@ namespace _func897
 bool ScoreKeeper::GetShipUnlocked(int shipId, int shipVariant)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int shipId_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func897::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func898::func;
 	return execfunc(this, shipId, shipVariant);
 }
 
-namespace _func898
+namespace _func899
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12343,11 +12357,11 @@ namespace _func898
 std::string ScoreKeeper::GetShipBlueprint(int index)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int index_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func898::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func899::func;
 	return execfunc(this, index);
 }
 
-namespace _func899
+namespace _func900
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12357,11 +12371,11 @@ namespace _func899
 void ScoreKeeper::OnInit()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func899::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func900::func;
 	return execfunc(this);
 }
 
-namespace _func900
+namespace _func901
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12371,11 +12385,11 @@ namespace _func900
 void ScoreKeeper::Save(bool newHighScore)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool newHighScore_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func900::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func901::func;
 	return execfunc(this, newHighScore);
 }
 
-namespace _func901
+namespace _func902
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12385,11 +12399,11 @@ namespace _func901
 void ScoreKeeper::OnRender(bool lastPlaythrough)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool lastPlaythrough_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func901::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func902::func;
 	return execfunc(this, lastPlaythrough);
 }
 
-namespace _func902
+namespace _func903
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
@@ -12399,11 +12413,11 @@ namespace _func902
 void ScoreKeeper::UnlockShip(int shipType, int shipVariant, bool save, bool hidePopup)
 {
 	typedef void __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int shipType_arg, int shipVariant_arg, bool save_arg, bool hidePopup_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func902::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func903::func;
 	return execfunc(this, shipType, shipVariant, save, hidePopup);
 }
 
-namespace _func903
+namespace _func904
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12413,11 +12427,11 @@ namespace _func903
 void ScoreKeeper::SetVictory(bool victory)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool victory_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func903::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func904::func;
 	return execfunc(this, victory);
 }
 
-namespace _func904
+namespace _func905
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12427,11 +12441,11 @@ namespace _func904
 void ScoreKeeper::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func904::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func905::func;
 	return execfunc(this);
 }
 
-namespace _func905
+namespace _func906
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12441,11 +12455,11 @@ namespace _func905
 std::pair<int, int> ScoreKeeper::GetShipId(const std::string &blueprintName)
 {
 	typedef std::pair<int, int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, const std::string &blueprintName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func905::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func906::func;
 	return execfunc(this, blueprintName);
 }
 
-namespace _func906
+namespace _func907
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12455,11 +12469,11 @@ namespace _func906
 void ScoreKeeper::LoadVersionFour(int file, int version)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int file_arg, int version_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func906::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func907::func;
 	return execfunc(this, file, version);
 }
 
-namespace _func907
+namespace _func908
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12469,11 +12483,11 @@ namespace _func907
 void ScoreKeeper::WipeProfile(bool permanent)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool permanent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func907::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func908::func;
 	return execfunc(this, permanent);
 }
 
-namespace _func908
+namespace _func909
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12483,11 +12497,11 @@ namespace _func908
 void ScoreKeeper::MouseClick(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func908::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func909::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func909
+namespace _func910
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12497,11 +12511,11 @@ namespace _func909
 void ScoreKeeper::SetupTopShip(int variant)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int variant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func909::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func910::func;
 	return execfunc(this, variant);
 }
 
-namespace _func910
+namespace _func911
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12511,11 +12525,11 @@ namespace _func910
 void ScoreKeeper::CheckTypes()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func910::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func911::func;
 	return execfunc(this);
 }
 
-namespace _func911
+namespace _func912
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102, 0x101};
@@ -12525,11 +12539,11 @@ namespace _func911
 void ScoreKeeper::AddTopScoreType(TopScore &topScore, int type)
 {
 	typedef void __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, TopScore &topScore_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func911::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func912::func;
 	return execfunc(this, topScore, type);
 }
 
-namespace _func912
+namespace _func913
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12539,11 +12553,11 @@ namespace _func912
 int ScoreKeeper::AddTopScoreList(TopScore &score, std::vector<TopScore> &topScoreList)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, TopScore &score_arg, std::vector<TopScore> &topScoreList_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func912::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func913::func;
 	return execfunc(this, score, topScoreList);
 }
 
-namespace _func913
+namespace _func914
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -12553,11 +12567,11 @@ namespace _func913
 void ScoreKeeper::RenderTopScores(const std::vector<TopScore> &topScoreList, Point position, int newHighScore)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, const std::vector<TopScore> &topScoreList_arg, Point position_arg, int newHighScore_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func913::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func914::func;
 	return execfunc(this, topScoreList, position, newHighScore);
 }
 
-namespace _func914
+namespace _func915
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12567,11 +12581,11 @@ namespace _func914
 void ScoreKeeper::CycleLeft()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func914::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func915::func;
 	return execfunc(this);
 }
 
-namespace _func915
+namespace _func916
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12581,11 +12595,11 @@ namespace _func915
 void ScoreKeeper::CycleRight()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func915::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func916::func;
 	return execfunc(this);
 }
 
-namespace _func916
+namespace _func917
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12595,11 +12609,11 @@ namespace _func916
 void ScoreKeeper::Open(bool fromGameOver)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool fromGameOver_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func916::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func917::func;
 	return execfunc(this, fromGameOver);
 }
 
-namespace _func917
+namespace _func918
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12609,11 +12623,11 @@ namespace _func917
 bool ScoreKeeper::KeyDown(SDLKey key)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func917::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func918::func;
 	return execfunc(this, key);
 }
 
-namespace _func918
+namespace _func919
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12623,11 +12637,11 @@ namespace _func918
 void ScoreKeeper::AddScrapCollected(int scrap)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int scrap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func918::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func919::func;
 	return execfunc(this, scrap);
 }
 
-namespace _func919
+namespace _func920
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12637,11 +12651,11 @@ namespace _func919
 void ScoreKeeper::SaveScores(int file, std::vector<TopScore> &topScores)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int file_arg, std::vector<TopScore> &topScores_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func919::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func920::func;
 	return execfunc(this, file, topScores);
 }
 
-namespace _func920
+namespace _func921
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12651,11 +12665,11 @@ namespace _func920
 void ScoreKeeper::SaveGame(int fd)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func920::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func921::func;
 	return execfunc(this, fd);
 }
 
-namespace _func921
+namespace _func922
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12665,11 +12679,11 @@ namespace _func921
 void ScoreKeeper::LoadGame(int fd)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func921::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func922::func;
 	return execfunc(this, fd);
 }
 
-namespace _func922
+namespace _func923
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12679,11 +12693,11 @@ namespace _func922
 void ScoreKeeper::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func922::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func923::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func923
+namespace _func924
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12693,18 +12707,18 @@ namespace _func923
 void ScoreKeeper::SetSector(int sector)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int sector_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func923::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func924::func;
 	return execfunc(this, sector);
 }
 
 ScoreKeeper *Global_ScoreKeeper_Keeper;
 
-namespace _var924
+namespace _var925
 {
     static VariableDefinition varObj("Global_ScoreKeeper_Keeper", "!c744240401000000c70424(???????\?)e8????????89742408", &Global_ScoreKeeper_Keeper);
 }
 
-namespace _func925
+namespace _func926
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -12714,11 +12728,11 @@ namespace _func925
 char Settings::GetCommandConsole()
 {
 	typedef char __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func925::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func926::func;
 	return execfunc();
 }
 
-namespace _func926
+namespace _func927
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -12728,11 +12742,11 @@ namespace _func926
 bool Settings::GetDlcEnabled()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func926::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func927::func;
 	return execfunc();
 }
 
-namespace _func927
+namespace _func928
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12742,11 +12756,11 @@ namespace _func927
 std::string Settings::GetHotkeyName(const std::string &name)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func927::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func928::func;
 	return execfunc(name);
 }
 
-namespace _func928
+namespace _func929
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12756,11 +12770,11 @@ namespace _func928
 SDLKey Settings::GetHotkey(const std::string &hotkeyName)
 {
 	typedef SDLKey __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &hotkeyName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func928::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func929::func;
 	return execfunc(hotkeyName);
 }
 
-namespace _func929
+namespace _func930
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12770,11 +12784,11 @@ namespace _func929
 void Settings::SetHotkey(const std::string &hotkeyName, SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &hotkeyName_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func929::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func930::func;
 	return execfunc(hotkeyName, key);
 }
 
-namespace _func930
+namespace _func931
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -12782,20 +12796,6 @@ namespace _func930
 }
 
 void Settings::SaveSettings()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func930::func;
-	return execfunc();
-}
-
-namespace _func931
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("Settings::ResetHotkeys", typeid(void (*)()), "5557bf????????565383ec4c8d6c2430", argdata, 0, 6, &func);
-}
-
-void Settings::ResetHotkeys()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func931::func;
@@ -12806,24 +12806,38 @@ namespace _func932
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("Settings::LoadSettings", typeid(void (*)()), "5589e557565381ec9c01000065a114000000", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("Settings::ResetHotkeys", typeid(void (*)()), "5557bf????????565383ec4c8d6c2430", argdata, 0, 6, &func);
 }
 
-void Settings::LoadSettings()
+void Settings::ResetHotkeys()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func932::func;
 	return execfunc();
 }
 
+namespace _func933
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("Settings::LoadSettings", typeid(void (*)()), "5589e557565381ec9c01000065a114000000", argdata, 0, 6, &func);
+}
+
+void Settings::LoadSettings()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func933::func;
+	return execfunc();
+}
+
 SettingValues *Global_Settings_Settings;
 
-namespace _var933
+namespace _var934
 {
     static VariableDefinition varObj("Global_Settings_Settings", "!89c557565383ec2cc744241c(???????\?)", &Global_Settings_Settings);
 }
 
-namespace _func934
+namespace _func935
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12833,11 +12847,11 @@ namespace _func934
 void Shields::SetHackingLevel(int hackingLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func934::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func935::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func935
+namespace _func936
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0xdff, 0x1ff};
@@ -12847,11 +12861,11 @@ namespace _func935
 CollisionResponse Shields::CollisionReal(float x, float y, Damage damage, bool force)
 {
 	typedef CollisionResponse __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg, float x_arg, float y_arg, Damage damage_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func935::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func936::func;
 	return execfunc(this, x, y, damage, force);
 }
 
-namespace _func936
+namespace _func937
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -12861,11 +12875,11 @@ namespace _func936
 void Shields::constructor(int roomId, int shipId, int startingPower, const std::string &shieldFile)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg, int roomId_arg, int shipId_arg, int startingPower_arg, const std::string &shieldFile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func936::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func937::func;
 	return execfunc(this, roomId, shipId, startingPower, shieldFile);
 }
 
-namespace _func937
+namespace _func938
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff};
@@ -12875,11 +12889,11 @@ namespace _func937
 void Shields::SetBaseEllipse(Globals::Ellipse ellipse)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg, Globals::Ellipse ellipse_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func937::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func938::func;
 	return execfunc(this, ellipse);
 }
 
-namespace _func938
+namespace _func939
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12887,20 +12901,6 @@ namespace _func938
 }
 
 void Shields::InstantCharge()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func938::func;
-	return execfunc(this);
-}
-
-namespace _func939
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("Shields::Jump", typeid(void (Shields::*)()), "57565383ec208b5c24308d74241c891c24", argdata, 1, 6, &func);
-}
-
-void Shields::Jump()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func939::func;
@@ -12911,10 +12911,10 @@ namespace _func940
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("Shields::OnLoop", typeid(void (Shields::*)()), "5557565383ec3c8b5c24508d74242c891c24e8????????8d44242a", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("Shields::Jump", typeid(void (Shields::*)()), "57565383ec208b5c24308d74241c891c24", argdata, 1, 6, &func);
 }
 
-void Shields::OnLoop()
+void Shields::Jump()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func940::func;
@@ -12924,6 +12924,20 @@ void Shields::OnLoop()
 namespace _func941
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("Shields::OnLoop", typeid(void (Shields::*)()), "5557565383ec3c8b5c24508d74242c891c24e8????????8d44242a", argdata, 1, 6, &func);
+}
+
+void Shields::OnLoop()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func941::func;
+	return execfunc(this);
+}
+
+namespace _func942
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
 	static FunctionDefinition funcObj("Shields::AddSuperShield", typeid(void (Shields::*)(Point )), "57ba05000000565383ec108b5c24208b7424248b7c2428", argdata, 2, 6, &func);
 }
@@ -12931,11 +12945,11 @@ namespace _func941
 void Shields::AddSuperShield(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func941::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func942::func;
 	return execfunc(this, pos);
 }
 
-namespace _func942
+namespace _func943
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12945,11 +12959,11 @@ namespace _func942
 void Shields::RenderBase(float alpha, float superShieldOverwrite)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg, float alpha_arg, float superShieldOverwrite_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func942::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func943::func;
 	return execfunc(this, alpha, superShieldOverwrite);
 }
 
-namespace _func943
+namespace _func944
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0xdff};
@@ -12959,18 +12973,18 @@ namespace _func943
 CollisionResponse Shields::CollisionTest(float x, float y, Damage damage)
 {
 	typedef CollisionResponse __attribute__((cdecl)) (*custom_arg_funcptr_t)(Shields *this_arg, float x_arg, float y_arg, Damage damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func943::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func944::func;
 	return execfunc(this, x, y, damage);
 }
 
 GL_Color *Global_COLOR_GREEN;
 
-namespace _var944
+namespace _var945
 {
     static VariableDefinition varObj("Global_COLOR_GREEN", "!f30f101d(???????\?)f30f1025????????f30f1015", &Global_COLOR_GREEN);
 }
 
-namespace _func945
+namespace _func946
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -12980,11 +12994,11 @@ namespace _func945
 std::pair<int, int> Ship::ContainsHullBreach(int roomId)
 {
 	typedef std::pair<int, int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func945::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func946::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func946
+namespace _func947
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -12994,11 +13008,11 @@ namespace _func946
 int Ship::GetSelectedRoomId(int x, int y, bool unk)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int x_arg, int y_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func946::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func947::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func947
+namespace _func948
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff};
@@ -13008,11 +13022,11 @@ namespace _func947
 void Ship::LockdownRoom(int roomId, Pointf pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, Pointf pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func947::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func948::func;
 	return execfunc(this, roomId, pos);
 }
 
-namespace _func948
+namespace _func949
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13022,11 +13036,11 @@ namespace _func948
 bool Ship::RoomLocked(int roomId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func948::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func949::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func949
+namespace _func950
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13036,11 +13050,11 @@ namespace _func949
 bool Ship::DestroyedDone()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func949::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func950::func;
 	return execfunc(this);
 }
 
-namespace _func950
+namespace _func951
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13050,11 +13064,11 @@ namespace _func950
 bool Ship::FullRoom(int roomId, bool intruder)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func950::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func951::func;
 	return execfunc(this, roomId, intruder);
 }
 
-namespace _func951
+namespace _func952
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13064,11 +13078,11 @@ namespace _func951
 int Ship::EmptySlots(int roomId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func951::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func952::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func952
+namespace _func953
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13078,11 +13092,11 @@ namespace _func952
 int Ship::GetAvailableRoomSlot(int roomId, bool intruder)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func952::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func953::func;
 	return execfunc(this, roomId, intruder);
 }
 
-namespace _func953
+namespace _func954
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13092,11 +13106,11 @@ namespace _func953
 void Ship::OnRenderBreaches()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func953::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func954::func;
 	return execfunc(this);
 }
 
-namespace _func954
+namespace _func955
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13106,11 +13120,11 @@ namespace _func954
 void Ship::OnRenderWalls(bool forceView, bool doorControlMode)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, bool forceView_arg, bool doorControlMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func954::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func955::func;
 	return execfunc(this, forceView, doorControlMode);
 }
 
-namespace _func955
+namespace _func956
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13120,11 +13134,11 @@ namespace _func955
 void Ship::OnInit(ShipBlueprint *bp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, ShipBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func955::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func956::func;
 	return execfunc(this, bp);
 }
 
-namespace _func956
+namespace _func957
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13134,11 +13148,11 @@ namespace _func956
 void Ship::OnRenderSparks()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func956::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func957::func;
 	return execfunc(this);
 }
 
-namespace _func957
+namespace _func958
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13148,11 +13162,11 @@ namespace _func957
 void Ship::SetRoomBlackout(int roomId, bool blackout)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool blackout_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func957::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func958::func;
 	return execfunc(this, roomId, blackout);
 }
 
-namespace _func958
+namespace _func959
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13160,20 +13174,6 @@ namespace _func958
 }
 
 void Ship::OnRenderBase(bool unk)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func958::func;
-	return execfunc(this, unk);
-}
-
-namespace _func959
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("Ship::OnRenderFloor", typeid(void (Ship::*)(bool )), "565383ec248b5c24308b74243480bbf002000000", argdata, 2, 6, &func);
-}
-
-void Ship::OnRenderFloor(bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func959::func;
@@ -13184,17 +13184,31 @@ namespace _func960
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("Ship::OnRenderFloor", typeid(void (Ship::*)(bool )), "565383ec248b5c24308b74243480bbf002000000", argdata, 2, 6, &func);
+}
+
+void Ship::OnRenderFloor(bool unk)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func960::func;
+	return execfunc(this, unk);
+}
+
+namespace _func961
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("Ship::OnRenderJump", typeid(void (Ship::*)(float )), "5557565383ec5c8b5c24708b4304890424", argdata, 2, 6, &func);
 }
 
 void Ship::OnRenderJump(float progress)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, float progress_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func960::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func961::func;
 	return execfunc(this, progress);
 }
 
-namespace _func961
+namespace _func962
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13204,11 +13218,11 @@ namespace _func961
 Point Ship::GetShipCorner()
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func961::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func962::func;
 	return execfunc(this);
 }
 
-namespace _func962
+namespace _func963
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13218,11 +13232,11 @@ namespace _func962
 Globals::Ellipse Ship::GetBaseEllipse()
 {
 	typedef Globals::Ellipse __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func962::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func963::func;
 	return execfunc(this);
 }
 
-namespace _func963
+namespace _func964
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13232,11 +13246,11 @@ namespace _func963
 void Ship::SetSelectedRoom(int roomId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func963::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func964::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func964
+namespace _func965
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13246,11 +13260,11 @@ namespace _func964
 void Ship::OnLoop(std::vector<float> &oxygenLevels)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, std::vector<float> &oxygenLevels_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func964::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func965::func;
 	return execfunc(this, oxygenLevels);
 }
 
-namespace _func965
+namespace _func966
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13260,11 +13274,11 @@ namespace _func965
 void Ship::BreachRandomHull(int roomId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func965::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func966::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func966
+namespace _func967
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13274,11 +13288,11 @@ namespace _func966
 int Ship::GetAvailableRoom(int preferred, bool intruder)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int preferred_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func966::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func967::func;
 	return execfunc(this, preferred, intruder);
 }
 
-namespace _func967
+namespace _func968
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13288,11 +13302,11 @@ namespace _func967
 bool Ship::BreachSpecificHull(int grid_x, int grid_y)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, int grid_x_arg, int grid_y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func967::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func968::func;
 	return execfunc(this, grid_x, grid_y);
 }
 
-namespace _func968
+namespace _func969
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13302,41 +13316,41 @@ namespace _func968
 std::vector<Repairable*> Ship::GetHullBreaches(bool onlyDamaged)
 {
 	typedef std::vector<Repairable*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(Ship *this_arg, bool onlyDamaged_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func968::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func969::func;
 	return execfunc(this, onlyDamaged);
-}
-
-namespace _noop969
-{
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_0", "!39d07d0b(c6840d74fefeff01)");
 }
 
 namespace _noop970
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_1", "!39d07d03(c60101)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_0", "!39d07d0b(c6840d74fefeff01)");
 }
 
 namespace _noop971
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_2", "!89d37d03(c60101)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_1", "!39d07d03(c60101)");
 }
 
 namespace _noop972
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_3", "!39c27d0b(c6840d70fefeff01)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_2", "!89d37d03(c60101)");
 }
 
 namespace _noop973
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_4", "!39c27d03(c60101)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_3", "!39c27d0b(c6840d70fefeff01)");
 }
 
 namespace _noop974
 {
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_4", "!39c27d03(c60101)");
+}
+
+namespace _noop975
+{
     static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_5", "!89c37e03(c60101)");
 }
 
-namespace _func975
+namespace _func976
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13346,11 +13360,11 @@ namespace _func975
 void ShipAI::constructor(bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipAI *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func975::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func976::func;
 	return execfunc(this, unk);
 }
 
-namespace _func976
+namespace _func977
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13360,11 +13374,11 @@ namespace _func976
 void ShipAI::SetStalemate(bool stalemate)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipAI *this_arg, bool stalemate_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func976::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func977::func;
 	return execfunc(this, stalemate);
 }
 
-namespace _func977
+namespace _func978
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13374,11 +13388,11 @@ namespace _func977
 void ShipAI::OnLoop(bool hostile)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipAI *this_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func977::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func978::func;
 	return execfunc(this, hostile);
 }
 
-namespace _func978
+namespace _func979
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13388,11 +13402,11 @@ namespace _func978
 std::pair<int, int> ShipAI::GetTeleportCommand()
 {
 	typedef std::pair<int, int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func978::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func979::func;
 	return execfunc(this);
 }
 
-namespace _func979
+namespace _func980
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13402,11 +13416,11 @@ namespace _func979
 void ShipBlueprint::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func979::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func980::func;
 	return execfunc(this);
 }
 
-namespace _func980
+namespace _func981
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13416,11 +13430,11 @@ namespace _func980
 void ShipBuilder::CheckTypes()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func980::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func981::func;
 	return execfunc(this);
 }
 
-namespace _func981
+namespace _func982
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13430,11 +13444,11 @@ namespace _func981
 void ShipBuilder::MouseClick(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func981::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func982::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func982
+namespace _func983
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13444,11 +13458,11 @@ namespace _func982
 void ShipBuilder::SwitchShip(int shipType, int shipVariant)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int shipType_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func982::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func983::func;
 	return execfunc(this, shipType, shipVariant);
 }
 
-namespace _func983
+namespace _func984
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13456,20 +13470,6 @@ namespace _func983
 }
 
 void ShipBuilder::CreateEquipmentBoxes()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func983::func;
-	return execfunc(this);
-}
-
-namespace _func984
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::CreateSystemBoxes", typeid(void (ShipBuilder::*)()), "5557565383ec3c8b6c24508b8dc80e0000", argdata, 1, 6, &func);
-}
-
-void ShipBuilder::CreateSystemBoxes()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func984::func;
@@ -13480,10 +13480,10 @@ namespace _func985
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::SetupShipAchievements", typeid(void (ShipBuilder::*)()), "5589e557565383ec4c8b75088d7dd88d5db8", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CreateSystemBoxes", typeid(void (ShipBuilder::*)()), "5557565383ec3c8b6c24508b8dc80e0000", argdata, 1, 6, &func);
 }
 
-void ShipBuilder::SetupShipAchievements()
+void ShipBuilder::CreateSystemBoxes()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func985::func;
@@ -13494,10 +13494,10 @@ namespace _func986
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::ClearShipAchievements", typeid(void (ShipBuilder::*)()), "8b4424048b9058170000c78064170000ffffffff", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipBuilder::SetupShipAchievements", typeid(void (ShipBuilder::*)()), "5589e557565383ec4c8b75088d7dd88d5db8", argdata, 1, 6, &func);
 }
 
-void ShipBuilder::ClearShipAchievements()
+void ShipBuilder::SetupShipAchievements()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func986::func;
@@ -13507,6 +13507,20 @@ void ShipBuilder::ClearShipAchievements()
 namespace _func987
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ShipBuilder::ClearShipAchievements", typeid(void (ShipBuilder::*)()), "8b4424048b9058170000c78064170000ffffffff", argdata, 1, 6, &func);
+}
+
+void ShipBuilder::ClearShipAchievements()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func987::func;
+	return execfunc(this);
+}
+
+namespace _func988
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipBuilder::SwapType", typeid(void (ShipBuilder::*)(int )), "5383ec188b5c24208b0385c0", argdata, 2, 6, &func);
 }
@@ -13514,11 +13528,11 @@ namespace _func987
 void ShipBuilder::SwapType(int variant)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int variant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func987::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func988::func;
 	return execfunc(this, variant);
 }
 
-namespace _func988
+namespace _func989
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13526,20 +13540,6 @@ namespace _func988
 }
 
 void ShipBuilder::CycleShipNext()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func988::func;
-	return execfunc(this);
-}
-
-namespace _func989
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::CycleShipPrevious", typeid(void (ShipBuilder::*)()), "5756be020000005383ec108b7c24208b8700170000", argdata, 1, 6, &func);
-}
-
-void ShipBuilder::CycleShipPrevious()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func989::func;
@@ -13550,10 +13550,10 @@ namespace _func990
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::Open", typeid(void (ShipBuilder::*)()), "5589e557565381ec2c0300008b4508c6808c17000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CycleShipPrevious", typeid(void (ShipBuilder::*)()), "5756be020000005383ec108b7c24208b8700170000", argdata, 1, 6, &func);
 }
 
-void ShipBuilder::Open()
+void ShipBuilder::CycleShipPrevious()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func990::func;
@@ -13564,10 +13564,10 @@ namespace _func991
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::OnRender", typeid(void (ShipBuilder::*)()), "5589e557565381ecbc0000008b5d0880bb4410000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipBuilder::Open", typeid(void (ShipBuilder::*)()), "5589e557565381ec2c0300008b4508c6808c17000000", argdata, 1, 6, &func);
 }
 
-void ShipBuilder::OnRender()
+void ShipBuilder::Open()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func991::func;
@@ -13578,10 +13578,10 @@ namespace _func992
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::OnLoop", typeid(void (ShipBuilder::*)()), "5589e557565383ec5c8b5d08c70424????????", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipBuilder::OnRender", typeid(void (ShipBuilder::*)()), "5589e557565381ecbc0000008b5d0880bb4410000000", argdata, 1, 6, &func);
 }
 
-void ShipBuilder::OnLoop()
+void ShipBuilder::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func992::func;
@@ -13592,10 +13592,10 @@ namespace _func993
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::constructor", typeid(void (ShipBuilder::*)()), "565383ec348b5c24408d74242c8d430c", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipBuilder::OnLoop", typeid(void (ShipBuilder::*)()), "5589e557565383ec5c8b5d08c70424????????", argdata, 1, 6, &func);
 }
 
-void ShipBuilder::constructor()
+void ShipBuilder::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func993::func;
@@ -13605,6 +13605,20 @@ void ShipBuilder::constructor()
 namespace _func994
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ShipBuilder::constructor", typeid(void (ShipBuilder::*)()), "565383ec348b5c24408d74242c8d430c", argdata, 1, 6, &func);
+}
+
+void ShipBuilder::constructor()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func994::func;
+	return execfunc(this);
+}
+
+namespace _func995
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipBuilder::MouseMove", typeid(void (ShipBuilder::*)(int , int )), "5589e557565381ecac0000008b7d088d873c0e0000", argdata, 3, 6, &func);
 }
@@ -13612,11 +13626,11 @@ namespace _func994
 void ShipBuilder::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func994::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func995::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func995
+namespace _func996
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13626,11 +13640,11 @@ namespace _func995
 void ShipBuilder::OnKeyDown(SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func995::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func996::func;
 	return execfunc(this, key);
 }
 
-namespace _func996
+namespace _func997
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13640,20 +13654,6 @@ namespace _func996
 ShipManager *ShipBuilder::GetShip()
 {
 	typedef ShipManager *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func996::func;
-	return execfunc(this);
-}
-
-namespace _func997
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::CycleTypeNext", typeid(void (ShipBuilder::*)()), "575631f65383ec108b7c????8b87001700008d5801eb??", argdata, 1, 6, &func);
-}
-
-void ShipBuilder::CycleTypeNext()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func997::func;
 	return execfunc(this);
 }
@@ -13662,10 +13662,10 @@ namespace _func998
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::CycleTypePrev", typeid(void (ShipBuilder::*)()), "5756be020000005383ec108b7c????8b87001700008d58ff", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CycleTypeNext", typeid(void (ShipBuilder::*)()), "575631f65383ec108b7c????8b87001700008d5801eb??", argdata, 1, 6, &func);
 }
 
-void ShipBuilder::CycleTypePrev()
+void ShipBuilder::CycleTypeNext()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func998::func;
@@ -13676,10 +13676,10 @@ namespace _func999
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipBuilder::Close", typeid(void (ShipBuilder::*)()), "565383ec148b5c????8b8b340e00008b93300e000089c829d0c1f80285c074??", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CycleTypePrev", typeid(void (ShipBuilder::*)()), "5756be020000005383ec108b7c????8b87001700008d58ff", argdata, 1, 6, &func);
 }
 
-void ShipBuilder::Close()
+void ShipBuilder::CycleTypePrev()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func999::func;
@@ -13689,6 +13689,20 @@ void ShipBuilder::Close()
 namespace _func1000
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ShipBuilder::Close", typeid(void (ShipBuilder::*)()), "565383ec148b5c????8b8b340e00008b93300e000089c829d0c1f80285c074??", argdata, 1, 6, &func);
+}
+
+void ShipBuilder::Close()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1000::func;
+	return execfunc(this);
+}
+
+namespace _func1001
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipButton::constructor", typeid(void (ShipButton::*)(int , int )), "5589e557565381ecbc0100008b5d088d??????????", argdata, 3, 6, &func);
 }
@@ -13696,11 +13710,11 @@ namespace _func1000
 void ShipButton::constructor(int shipType, int shipVariant)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipButton *this_arg, int shipType_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1000::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1001::func;
 	return execfunc(this, shipType, shipVariant);
 }
 
-namespace _func1001
+namespace _func1002
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff};
@@ -13710,11 +13724,11 @@ namespace _func1001
 void ShipButton::OnInit(const std::string &imgName, Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipButton *this_arg, const std::string &imgName_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1001::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1002::func;
 	return execfunc(this, imgName, pos);
 }
 
-namespace _func1002
+namespace _func1003
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13724,11 +13738,11 @@ namespace _func1002
 void ShipButton::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipButton *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1002::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1003::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1003
+namespace _func1004
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13738,11 +13752,11 @@ namespace _func1003
 void ShipButton::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1003::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1004::func;
 	return execfunc(this);
 }
 
-namespace _func1004
+namespace _func1005
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13752,11 +13766,11 @@ namespace _func1004
 void ShipEvent::constructor(const ShipEvent &event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipEvent *this_arg, const ShipEvent &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1004::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1005::func;
 	return execfunc(this, event);
 }
 
-namespace _func1005
+namespace _func1006
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13766,11 +13780,11 @@ namespace _func1005
 ShipManager *ShipGenerator::CreateShip(const std::string &name, int sector, ShipEvent &event)
 {
 	typedef ShipManager *__attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &name_arg, int sector_arg, ShipEvent &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1005::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1006::func;
 	return execfunc(name, sector, event);
 }
 
-namespace _func1006
+namespace _func1007
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13780,11 +13794,11 @@ namespace _func1006
 std::vector<int> ShipGenerator::GenerateSystemMaxes(const ShipBlueprint &ship, int level)
 {
 	typedef std::vector<int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(const ShipBlueprint &ship_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1006::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1007::func;
 	return execfunc(ship, level);
 }
 
-namespace _func1007
+namespace _func1008
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13794,11 +13808,11 @@ namespace _func1007
 bool ShipGenerator::UpgradeSystem(ShipManager *ship, std::vector<int> &systemMaxes, unsigned int sysId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, unsigned int sysId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1007::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1008::func;
 	return execfunc(ship, systemMaxes, sysId);
 }
 
-namespace _func1008
+namespace _func1009
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13808,20 +13822,6 @@ namespace _func1008
 std::vector<int> ShipGenerator::GetPossibleSystemUpgrades(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1008::func;
-	return execfunc(ship, systemMaxes, scrap, type);
-}
-
-namespace _func1009
-{
-    static void *func = 0;
-	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades2", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), "5589e55789cf565383ec5c8945acc70000000000c7400400000000c7400800000000", argdata, 5, 18, &func);
-}
-
-std::vector<int> ShipGenerator::GetPossibleSystemUpgrades2(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
-{
-	typedef std::vector<int> __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1009::func;
 	return execfunc(ship, systemMaxes, scrap, type);
 }
@@ -13830,10 +13830,10 @@ namespace _func1010
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades0", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".5589e55789cf565383ec5c8945acc70000000000c7400400000000c7400800000000", argdata, 5, 18, &func);
+	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades2", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), "5589e55789cf565383ec5c8945acc70000000000c7400400000000c7400800000000", argdata, 5, 18, &func);
 }
 
-std::vector<int> ShipGenerator::GetPossibleSystemUpgrades0(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
+std::vector<int> ShipGenerator::GetPossibleSystemUpgrades2(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1010::func;
@@ -13844,10 +13844,10 @@ namespace _func1011
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades1", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".5589e55789cf565383ec5c8945acc70000000000c7400400000000c7400800000000", argdata, 5, 18, &func);
+	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades0", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".5589e55789cf565383ec5c8945acc70000000000c7400400000000c7400800000000", argdata, 5, 18, &func);
 }
 
-std::vector<int> ShipGenerator::GetPossibleSystemUpgrades1(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
+std::vector<int> ShipGenerator::GetPossibleSystemUpgrades0(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1011::func;
@@ -13857,6 +13857,20 @@ std::vector<int> ShipGenerator::GetPossibleSystemUpgrades1(ShipManager *ship, st
 namespace _func1012
 {
     static void *func = 0;
+	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades1", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".5589e55789cf565383ec5c8945acc70000000000c7400400000000c7400800000000", argdata, 5, 18, &func);
+}
+
+std::vector<int> ShipGenerator::GetPossibleSystemUpgrades1(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
+{
+	typedef std::vector<int> __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1012::func;
+	return execfunc(ship, systemMaxes, scrap, type);
+}
+
+namespace _func1013
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipGenerator::GetPossibleWeaponList", typeid(std::vector<WeaponBlueprint*> (*)(ShipManager *, const std::string &, int , unsigned int )), "5589e557565383ec5c8b450c890424", argdata, 5, 18, &func);
 }
@@ -13864,11 +13878,11 @@ namespace _func1012
 std::vector<WeaponBlueprint*> ShipGenerator::GetPossibleWeaponList(ShipManager *ship, const std::string &weaponList, int scrap, unsigned int flags)
 {
 	typedef std::vector<WeaponBlueprint*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &weaponList_arg, int scrap_arg, unsigned int flags_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1012::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1013::func;
 	return execfunc(ship, weaponList, scrap, flags);
 }
 
-namespace _func1013
+namespace _func1014
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13878,11 +13892,11 @@ namespace _func1013
 std::vector<DroneBlueprint*> ShipGenerator::GetPossibleDroneList(ShipManager *ship, const std::string &droneList, int scrap, unsigned int flags, bool repeat)
 {
 	typedef std::vector<DroneBlueprint*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &droneList_arg, int scrap_arg, unsigned int flags_arg, bool repeat_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1013::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1014::func;
 	return execfunc(ship, droneList, scrap, flags, repeat);
 }
 
-namespace _func1014
+namespace _func1015
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13892,11 +13906,11 @@ namespace _func1014
 std::vector<CrewBlueprint> ShipGenerator::GetPossibleCrewList(ShipManager *ship, const std::string &crewList, unsigned int flags)
 {
 	typedef std::vector<CrewBlueprint> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &crewList_arg, unsigned int flags_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1014::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1015::func;
 	return execfunc(ship, crewList, flags);
 }
 
-namespace _func1015
+namespace _func1016
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13906,11 +13920,11 @@ namespace _func1015
 ShipGraph *ShipGraph::GetShipInfo(int shipId)
 {
 	typedef ShipGraph *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1015::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1016::func;
 	return execfunc(shipId);
 }
 
-namespace _func1016
+namespace _func1017
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13920,11 +13934,11 @@ namespace _func1016
 Point ShipGraph::GetSlotWorldPosition(int slotId, int roomId)
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int slotId_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1016::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1017::func;
 	return execfunc(this, slotId, roomId);
 }
 
-namespace _func1017
+namespace _func1018
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13934,11 +13948,11 @@ namespace _func1017
 Point ShipGraph::GetSlotRenderPosition(int slotId, int roomId, bool intruder)
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int slotId_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1017::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1018::func;
 	return execfunc(this, slotId, roomId, intruder);
 }
 
-namespace _func1018
+namespace _func1019
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -13948,11 +13962,11 @@ namespace _func1018
 int ShipGraph::DoorCount(int roomId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1018::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1019::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1019
+namespace _func1020
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13962,11 +13976,11 @@ namespace _func1019
 std::vector<Door*> ShipGraph::GetDoors(int roomId)
 {
 	typedef std::vector<Door*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1019::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1020::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1020
+namespace _func1021
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13976,11 +13990,11 @@ namespace _func1020
 bool ShipGraph::IsRoomConnected(int room1, int room2)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room1_arg, int room2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1020::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1021::func;
 	return execfunc(this, room1, room2);
 }
 
-namespace _func1021
+namespace _func1022
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13990,11 +14004,11 @@ namespace _func1021
 Door *ShipGraph::ConnectingDoor(int x1, int y1, int x2, int y2)
 {
 	typedef Door *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x1_arg, int y1_arg, int x2_arg, int y2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1021::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1022::func;
 	return execfunc(this, x1, y1, x2, y2);
 }
 
-namespace _func1022
+namespace _func1023
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -14004,11 +14018,11 @@ namespace _func1022
 int ShipGraph::ConnectedGridSquares(int x1, int y1, int x2, int y2)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x1_arg, int y1_arg, int x2_arg, int y2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1022::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1023::func;
 	return execfunc(this, x1, y1, x2, y2);
 }
 
-namespace _func1023
+namespace _func1024
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x2ff};
@@ -14018,11 +14032,11 @@ namespace _func1023
 int ShipGraph::ConnectedGridSquaresPoint(Point p1, Point p2)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1023::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1024::func;
 	return execfunc(this, p1, p2);
 }
 
-namespace _func1024
+namespace _func1025
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x2ff};
@@ -14032,11 +14046,11 @@ namespace _func1024
 Door *ShipGraph::ConnectingDoor(Point p1, Point p2)
 {
 	typedef Door *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1024::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1025::func;
 	return execfunc(this, p1, p2);
 }
 
-namespace _func1025
+namespace _func1026
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14046,11 +14060,11 @@ namespace _func1025
 int ShipGraph::GetNumSlots(int room)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1025::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1026::func;
 	return execfunc(this, room);
 }
 
-namespace _func1026
+namespace _func1027
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14060,11 +14074,11 @@ namespace _func1026
 int ShipGraph::PopClosestDoor(std::vector<int> &doors, std::vector<float> &distances)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, std::vector<int> &doors_arg, std::vector<float> &distances_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1026::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1027::func;
 	return execfunc(this, doors, distances);
 }
 
-namespace _func1027
+namespace _func1028
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x2ff, 0x1ff};
@@ -14074,11 +14088,11 @@ namespace _func1027
 Path ShipGraph::Dijkstra(Point start, Point goal, int shipId)
 {
 	typedef Path __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point start_arg, Point goal_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1027::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1028::func;
 	return execfunc(this, start, goal, shipId);
 }
 
-namespace _func1028
+namespace _func1029
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x2ff, 0x1ff};
@@ -14088,11 +14102,11 @@ namespace _func1028
 Path ShipGraph::FindPath(Point p1, Point p2, int shipId)
 {
 	typedef Path __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1028::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1029::func;
 	return execfunc(this, p1, p2, shipId);
 }
 
-namespace _func1029
+namespace _func1030
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14102,11 +14116,11 @@ namespace _func1029
 float ShipGraph::ConvertToWorldAngle(float ang)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, float ang_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1029::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1030::func;
 	return execfunc(this, ang);
 }
 
-namespace _func1030
+namespace _func1031
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14116,11 +14130,11 @@ namespace _func1030
 float ShipGraph::ConvertToLocalAngle(float ang)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, float ang_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1030::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1031::func;
 	return execfunc(this, ang);
 }
 
-namespace _func1031
+namespace _func1032
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff};
@@ -14130,11 +14144,11 @@ namespace _func1031
 Pointf ShipGraph::ConvertToWorldPosition(Pointf local)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Pointf local_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1031::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1032::func;
 	return execfunc(this, local);
 }
 
-namespace _func1032
+namespace _func1033
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -14144,11 +14158,11 @@ namespace _func1032
 Pointf ShipGraph::ConvertToLocalPosition(Pointf world, bool past)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Pointf world_arg, bool past_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1032::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1033::func;
 	return execfunc(this, world, past);
 }
 
-namespace _func1033
+namespace _func1034
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14158,11 +14172,11 @@ namespace _func1033
 void ShipGraph::ComputeCenter()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1033::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1034::func;
 	return execfunc(this);
 }
 
-namespace _func1034
+namespace _func1035
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14172,11 +14186,11 @@ namespace _func1034
 bool ShipGraph::ContainsPoint(int x, int y)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1034::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1035::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1035
+namespace _func1036
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -14186,11 +14200,11 @@ namespace _func1035
 int ShipGraph::GetSelectedRoom(int x, int y, bool unk)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x_arg, int y_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1035::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1036::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func1036
+namespace _func1037
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14200,11 +14214,11 @@ namespace _func1036
 int ShipGraph::RoomCount()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1036::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1037::func;
 	return execfunc(this);
 }
 
-namespace _func1037
+namespace _func1038
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14214,11 +14228,11 @@ namespace _func1037
 Globals::Rect ShipGraph::GetRoomShape(int room)
 {
 	typedef Globals::Rect __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1037::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1038::func;
 	return execfunc(this, room);
 }
 
-namespace _func1038
+namespace _func1039
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14228,11 +14242,11 @@ namespace _func1038
 float ShipGraph::GetRoomOxygen(int room)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1038::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1039::func;
 	return execfunc(this, room);
 }
 
-namespace _func1039
+namespace _func1040
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14242,11 +14256,11 @@ namespace _func1039
 bool ShipGraph::GetRoomBlackedOut(int room)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1039::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1040::func;
 	return execfunc(this, room);
 }
 
-namespace _func1040
+namespace _func1041
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -14256,11 +14270,11 @@ namespace _func1040
 void ShipGraph::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1040::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1041::func;
 	return execfunc();
 }
 
-namespace _func1041
+namespace _func1042
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -14270,11 +14284,11 @@ namespace _func1041
 Slot ShipGraph::GetClosestSlot(Point pos, int shipId, bool intruder)
 {
 	typedef Slot __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point pos_arg, int shipId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1041::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1042::func;
 	return execfunc(this, pos, shipId, intruder);
 }
 
-namespace _func1042
+namespace _func1043
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14284,11 +14298,11 @@ namespace _func1042
 std::vector<int> ShipGraph::ConnectivityDFS(int roomId)
 {
 	typedef std::vector<int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1042::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1043::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1043
+namespace _func1044
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14298,11 +14312,11 @@ namespace _func1043
 char ShipInfo::AddAugmentation(const std::string &augment)
 {
 	typedef char __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1043::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1044::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1044
+namespace _func1045
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14312,11 +14326,11 @@ namespace _func1044
 bool ShipInfo::HasAugmentation(const std::string &augment)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1044::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1045::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1045
+namespace _func1046
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14326,11 +14340,11 @@ namespace _func1045
 float ShipInfo::GetAugmentationValue(const std::string &augment)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1045::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1046::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1046
+namespace _func1047
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14340,11 +14354,11 @@ namespace _func1046
 int ShipManager::constructor(int shipId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1046::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1047::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func1047
+namespace _func1048
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14354,11 +14368,11 @@ namespace _func1047
 void ShipManager::AddInitialCrew(std::vector<CrewBlueprint> &blueprints)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, std::vector<CrewBlueprint> &blueprints_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1047::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1048::func;
 	return execfunc(this, blueprints);
 }
 
-namespace _func1048
+namespace _func1049
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14368,11 +14382,11 @@ namespace _func1048
 int ShipManager::GetDodgeFactor()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1048::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1049::func;
 	return execfunc(this);
 }
 
-namespace _func1049
+namespace _func1050
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14382,11 +14396,11 @@ namespace _func1049
 int ShipManager::GetNetDodgeFactor()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1049::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1050::func;
 	return execfunc(this);
 }
 
-namespace _func1050
+namespace _func1051
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14396,11 +14410,11 @@ namespace _func1050
 void ShipManager::OnRender(bool showInterior, bool doorControlMode)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool showInterior_arg, bool doorControlMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1050::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1051::func;
 	return execfunc(this, showInterior, doorControlMode);
 }
 
-namespace _func1051
+namespace _func1052
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14410,11 +14424,11 @@ namespace _func1051
 int ShipManager::CountCrew(bool boarders)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool boarders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1051::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1052::func;
 	return execfunc(this, boarders);
 }
 
-namespace _func1052
+namespace _func1053
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -14424,11 +14438,11 @@ namespace _func1052
 std::vector<CrewMember*> ShipManager::TeleportCrew(int roomId, bool intruders)
 {
 	typedef std::vector<CrewMember*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1052::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1053::func;
 	return execfunc(this, roomId, intruders);
 }
 
-namespace _func1053
+namespace _func1054
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14438,11 +14452,11 @@ namespace _func1053
 int ShipManager::OnInit(ShipBlueprint *bp, int shipLevel)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, ShipBlueprint *bp_arg, int shipLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1053::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1054::func;
 	return execfunc(this, bp, shipLevel);
 }
 
-namespace _func1054
+namespace _func1055
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14452,11 +14466,11 @@ namespace _func1054
 bool ShipManager::HasSystem(int systemId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1054::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1055::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1055
+namespace _func1056
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14466,11 +14480,11 @@ namespace _func1055
 int ShipManager::SystemRoom(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1055::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1056::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1056
+namespace _func1057
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14480,11 +14494,11 @@ namespace _func1056
 ShipSystem *ShipManager::GetSystemInRoom(int roomId)
 {
 	typedef ShipSystem *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1056::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1057::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1057
+namespace _func1058
 {
     static void *func = 0;
 	static short argdata[] = {0x100};
@@ -14494,11 +14508,11 @@ namespace _func1057
 void ShipManager::OnLoop()
 {
 	typedef void __attribute__((regparm(1))) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1057::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1058::func;
 	return execfunc(this);
 }
 
-namespace _func1058
+namespace _func1059
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14508,11 +14522,11 @@ namespace _func1058
 void ShipManager::SetSystemPowerLimit(int systemId, int limit)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int limit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1058::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1059::func;
 	return execfunc(this, systemId, limit);
 }
 
-namespace _func1059
+namespace _func1060
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14522,11 +14536,11 @@ namespace _func1059
 void ShipManager::SetSystemPowerLoss(int systemId, int powerLoss)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int powerLoss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1059::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1060::func;
 	return execfunc(this, systemId, powerLoss);
 }
 
-namespace _func1060
+namespace _func1061
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14536,11 +14550,11 @@ namespace _func1060
 void ShipManager::SetSystemDividePower(int systemId, int amount)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1060::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1061::func;
 	return execfunc(this, systemId, amount);
 }
 
-namespace _func1061
+namespace _func1062
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14550,11 +14564,11 @@ namespace _func1061
 int ShipManager::GetSystemAvailablePower(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1061::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1062::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1062
+namespace _func1063
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14564,11 +14578,11 @@ namespace _func1062
 int ShipManager::GetSystemDamage(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1062::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1063::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1063
+namespace _func1064
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14578,11 +14592,11 @@ namespace _func1063
 int ShipManager::CreateSystems()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1063::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1064::func;
 	return execfunc(this);
 }
 
-namespace _func1064
+namespace _func1065
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14592,11 +14606,11 @@ namespace _func1064
 int ShipManager::AddSystem(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1064::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1065::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1065
+namespace _func1066
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14606,11 +14620,11 @@ namespace _func1065
 void ShipManager::UpdateCrewMembers()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1065::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1066::func;
 	return execfunc(this);
 }
 
-namespace _func1066
+namespace _func1067
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14620,11 +14634,11 @@ namespace _func1066
 void ShipManager::KillEveryone(bool noClone)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool noClone_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1066::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1067::func;
 	return execfunc(this, noClone);
 }
 
-namespace _func1067
+namespace _func1068
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -14634,11 +14648,11 @@ namespace _func1067
 bool ShipManager::PowerDrone(Drone *drone, int roomId, bool userDriven, bool force)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Drone *drone_arg, int roomId_arg, bool userDriven_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1067::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1068::func;
 	return execfunc(this, drone, roomId, userDriven, force);
 }
 
-namespace _func1068
+namespace _func1069
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14648,11 +14662,11 @@ namespace _func1068
 void ShipManager::UpdateEnvironment()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1068::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1069::func;
 	return execfunc(this);
 }
 
-namespace _func1069
+namespace _func1070
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -14662,11 +14676,11 @@ namespace _func1069
 CrewMember *ShipManager::AddCrewMemberFromBlueprint(CrewBlueprint *bp, int slot, bool init, int roomId, bool intruder)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewBlueprint *bp_arg, int slot_arg, bool init_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1069::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1070::func;
 	return execfunc(this, bp, slot, init, roomId, intruder);
 }
 
-namespace _func1070
+namespace _func1071
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -14676,11 +14690,11 @@ namespace _func1070
 CrewMember *ShipManager::AddCrewMemberFromString(const std::string &name, const std::string &race, bool intruder, int roomId, bool init, bool male)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const std::string &name_arg, const std::string &race_arg, bool intruder_arg, int roomId_arg, bool init_arg, bool male_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1070::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1071::func;
 	return execfunc(this, name, race, intruder, roomId, init, male);
 }
 
-namespace _func1071
+namespace _func1072
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14690,11 +14704,11 @@ namespace _func1071
 int ShipManager::GetOxygenPercentage()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1071::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1072::func;
 	return execfunc(this);
 }
 
-namespace _func1072
+namespace _func1073
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14704,11 +14718,11 @@ namespace _func1072
 float ShipManager::GetOxygenLevel(int roomId)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1072::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1073::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1073
+namespace _func1074
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14718,11 +14732,11 @@ namespace _func1073
 std::vector<float> ShipManager::GetOxygenLevels()
 {
 	typedef std::vector<float> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1073::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1074::func;
 	return execfunc(this);
 }
 
-namespace _func1074
+namespace _func1075
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0xdff};
@@ -14732,11 +14746,11 @@ namespace _func1074
 bool ShipManager::DamageCrew(CrewMember *crew, Damage dmg)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, Damage dmg_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1074::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1075::func;
 	return execfunc(this, crew, dmg);
 }
 
-namespace _func1075
+namespace _func1076
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14746,11 +14760,11 @@ namespace _func1075
 void ShipManager::RemoveItem(const std::string &name)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1075::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1076::func;
 	return execfunc(this, name);
 }
 
-namespace _func1076
+namespace _func1077
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0xdff, 0x1ff};
@@ -14760,11 +14774,11 @@ namespace _func1076
 bool ShipManager::DamageArea(Pointf location, Damage dmg, bool forceHit)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf location_arg, Damage dmg_arg, bool forceHit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1076::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1077::func;
 	return execfunc(this, location, dmg, forceHit);
 }
 
-namespace _func1077
+namespace _func1078
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x2ff, 0xdff};
@@ -14774,11 +14788,11 @@ namespace _func1077
 bool ShipManager::DamageBeam(Pointf location1, Pointf location2, Damage dmg)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf location1_arg, Pointf location2_arg, Damage dmg_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1077::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1078::func;
 	return execfunc(this, location1, location2, dmg);
 }
 
-namespace _func1078
+namespace _func1079
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -14788,11 +14802,11 @@ namespace _func1078
 CrewBlueprint ShipManager::SelectRandomCrew(int seed, const std::string &racePref)
 {
 	typedef CrewBlueprint __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int seed_arg, const std::string &racePref_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1078::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1079::func;
 	return execfunc(this, seed, racePref);
 }
 
-namespace _func1079
+namespace _func1080
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14800,20 +14814,6 @@ namespace _func1079
 }
 
 void ShipManager::ClearStatusAll()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1079::func;
-	return execfunc(this);
-}
-
-namespace _func1080
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipManager::PrepareSuperDrones", typeid(void (ShipManager::*)()), "5557565383ec7c8bbc24900000008b87ec050000", argdata, 1, 6, &func);
-}
-
-void ShipManager::PrepareSuperDrones()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1080::func;
@@ -14824,10 +14824,10 @@ namespace _func1081
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipManager::JumpLeave", typeid(void (ShipManager::*)()), "5631c05383ec248b742430", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipManager::PrepareSuperDrones", typeid(void (ShipManager::*)()), "5557565383ec7c8bbc24900000008b87ec050000", argdata, 1, 6, &func);
 }
 
-void ShipManager::JumpLeave()
+void ShipManager::PrepareSuperDrones()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1081::func;
@@ -14837,6 +14837,20 @@ void ShipManager::JumpLeave()
 namespace _func1082
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ShipManager::JumpLeave", typeid(void (ShipManager::*)()), "5631c05383ec248b742430", argdata, 1, 6, &func);
+}
+
+void ShipManager::JumpLeave()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1082::func;
+	return execfunc(this);
+}
+
+namespace _func1083
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipManager::ModifyScrapCount", typeid(void (ShipManager::*)(int , bool )), "5557565383ec3c8b7424548b5c24508b442458", argdata, 3, 6, &func);
 }
@@ -14844,11 +14858,11 @@ namespace _func1082
 void ShipManager::ModifyScrapCount(int scrap, bool income)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int scrap_arg, bool income_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1082::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1083::func;
 	return execfunc(this, scrap, income);
 }
 
-namespace _func1083
+namespace _func1084
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14858,11 +14872,11 @@ namespace _func1083
 void ShipManager::ModifyMissileCount(int missiles)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int missiles_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1083::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1084::func;
 	return execfunc(this, missiles);
 }
 
-namespace _func1084
+namespace _func1085
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14872,11 +14886,11 @@ namespace _func1084
 int ShipManager::GetMissileCount()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1084::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1085::func;
 	return execfunc(this);
 }
 
-namespace _func1085
+namespace _func1086
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14886,11 +14900,11 @@ namespace _func1085
 void ShipManager::ModifyDroneCount(int drones)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int drones_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1085::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1086::func;
 	return execfunc(this, drones);
 }
 
-namespace _func1086
+namespace _func1087
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14900,11 +14914,11 @@ namespace _func1086
 bool ShipManager::DoSensorsProvide(int vision)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int vision_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1086::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1087::func;
 	return execfunc(this, vision);
 }
 
-namespace _func1087
+namespace _func1088
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14914,11 +14928,11 @@ namespace _func1087
 bool ShipManager::IsCrewFull()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1087::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1088::func;
 	return execfunc(this);
 }
 
-namespace _func1088
+namespace _func1089
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -14928,11 +14942,11 @@ namespace _func1088
 bool ShipManager::IsCrewOverFull()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1088::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1089::func;
 	return execfunc(this);
 }
 
-namespace _func1089
+namespace _func1090
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14942,11 +14956,11 @@ namespace _func1089
 CrewDrone *ShipManager::CreateCrewDrone(const DroneBlueprint *bp)
 {
 	typedef CrewDrone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1089::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1090::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1090
+namespace _func1091
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14956,11 +14970,11 @@ namespace _func1090
 SpaceDrone *ShipManager::CreateSpaceDrone(const DroneBlueprint *bp)
 {
 	typedef SpaceDrone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1090::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1091::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1091
+namespace _func1092
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -14970,11 +14984,11 @@ namespace _func1091
 bool ShipManager::CommandCrewMoveRoom(CrewMember *crew, int roomId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1091::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1092::func;
 	return execfunc(this, crew, roomId);
 }
 
-namespace _func1092
+namespace _func1093
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14984,11 +14998,11 @@ namespace _func1092
 int ShipManager::GetSystemRoom(int sysId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int sysId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1092::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1093::func;
 	return execfunc(this, sysId);
 }
 
-namespace _func1093
+namespace _func1094
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -14998,11 +15012,11 @@ namespace _func1093
 std::vector<ProjectileFactory*> ShipManager::GetWeaponList()
 {
 	typedef std::vector<ProjectileFactory*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1093::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1094::func;
 	return execfunc(this);
 }
 
-namespace _func1094
+namespace _func1095
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -15012,11 +15026,11 @@ namespace _func1094
 Drone *ShipManager::AddDrone(const DroneBlueprint *bp, int slot)
 {
 	typedef Drone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1094::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1095::func;
 	return execfunc(this, bp, slot);
 }
 
-namespace _func1095
+namespace _func1096
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15026,11 +15040,11 @@ namespace _func1095
 void ShipManager::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1095::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1096::func;
 	return execfunc(this);
 }
 
-namespace _func1096
+namespace _func1097
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15040,11 +15054,11 @@ namespace _func1096
 int ShipManager::GetSystemPower(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1096::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1097::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1097
+namespace _func1098
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -15054,11 +15068,11 @@ namespace _func1097
 int ShipManager::CountCrewShipId(int roomId, int shipId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1097::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1098::func;
 	return execfunc(this, roomId, shipId);
 }
 
-namespace _func1098
+namespace _func1099
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15068,11 +15082,11 @@ namespace _func1098
 ShipSystem *ShipManager::GetSystem(int systemId)
 {
 	typedef ShipSystem *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1098::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1099::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1099
+namespace _func1100
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15082,11 +15096,11 @@ namespace _func1099
 bool ShipManager::DoorsFunction()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1099::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1100::func;
 	return execfunc(this);
 }
 
-namespace _func1100
+namespace _func1101
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15096,11 +15110,11 @@ namespace _func1100
 bool ShipManager::SystemLocked(int systemId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1100::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1101::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1101
+namespace _func1102
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15110,11 +15124,11 @@ namespace _func1101
 void ShipManager::ExportShip(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1101::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1102::func;
 	return execfunc(this, file);
 }
 
-namespace _func1102
+namespace _func1103
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15124,11 +15138,11 @@ namespace _func1102
 void ShipManager::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1102::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1103::func;
 	return execfunc(this);
 }
 
-namespace _func1103
+namespace _func1104
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15138,11 +15152,11 @@ namespace _func1103
 void ShipManager::destructor2()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1103::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1104::func;
 	return execfunc(this);
 }
 
-namespace _func1104
+namespace _func1105
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15152,11 +15166,11 @@ namespace _func1104
 void ShipManager::ImportShip(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1104::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1105::func;
 	return execfunc(this, file);
 }
 
-namespace _func1105
+namespace _func1106
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15166,11 +15180,11 @@ namespace _func1105
 void ShipManager::CheckVision()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1105::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1106::func;
 	return execfunc(this);
 }
 
-namespace _func1106
+namespace _func1107
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15180,11 +15194,11 @@ namespace _func1106
 int ShipManager::IsSystemHacked(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1106::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1107::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1107
+namespace _func1108
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15194,11 +15208,11 @@ namespace _func1107
 void ShipManager::SaveCrewPositions()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1107::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1108::func;
 	return execfunc(this);
 }
 
-namespace _func1108
+namespace _func1109
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -15208,11 +15222,11 @@ namespace _func1108
 CrewMember *ShipManager::GetSelectedCrewPoint(int x, int y, bool intruder)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int x_arg, int y_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1108::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1109::func;
 	return execfunc(this, x, y, intruder);
 }
 
-namespace _func1109
+namespace _func1110
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15222,11 +15236,11 @@ namespace _func1109
 void ShipManager::RenderWeapons()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1109::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1110::func;
 	return execfunc(this);
 }
 
-namespace _func1110
+namespace _func1111
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15236,11 +15250,11 @@ namespace _func1110
 void ShipManager::ClearStatusSystem(int system)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int system_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1110::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1111::func;
 	return execfunc(this, system);
 }
 
-namespace _func1111
+namespace _func1112
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15248,20 +15262,6 @@ namespace _func1111
 }
 
 void ShipManager::ResetScrapLevel()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1111::func;
-	return execfunc(this);
-}
-
-namespace _func1112
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipManager::JumpArrive", typeid(void (ShipManager::*)()), "565383ec248b7424308b86f4030000c786c403000000000000", argdata, 1, 6, &func);
-}
-
-void ShipManager::JumpArrive()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1112::func;
@@ -15272,10 +15272,10 @@ namespace _func1113
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("ShipManager::CheckSpreadDamage", typeid(void (ShipManager::*)()), "5589e557565383ec5c8b7d08c745b000000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("ShipManager::JumpArrive", typeid(void (ShipManager::*)()), "565383ec248b7424308b86f4030000c786c403000000000000", argdata, 1, 6, &func);
 }
 
-void ShipManager::CheckSpreadDamage()
+void ShipManager::JumpArrive()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1113::func;
@@ -15285,6 +15285,20 @@ void ShipManager::CheckSpreadDamage()
 namespace _func1114
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("ShipManager::CheckSpreadDamage", typeid(void (ShipManager::*)()), "5589e557565383ec5c8b7d08c745b000000000", argdata, 1, 6, &func);
+}
+
+void ShipManager::CheckSpreadDamage()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1114::func;
+	return execfunc(this);
+}
+
+namespace _func1115
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipManager::GetSystemHealth", typeid(int (ShipManager::*)(int )), "8b54????8b4c????8b82000400008b048883f8ff74??8b52188b04828b80ec000000", argdata, 2, 2, &func);
 }
@@ -15292,11 +15306,11 @@ namespace _func1114
 int ShipManager::GetSystemHealth(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1114::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1115::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1115
+namespace _func1116
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15306,11 +15320,11 @@ namespace _func1115
 bool ShipManager::IncreaseSystemPower(int systemId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1115::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1116::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1116
+namespace _func1117
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15318,20 +15332,6 @@ namespace _func1116
 }
 
 bool ShipManager::ForceIncreaseSystemPower(int sys)
-{
-	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1116::func;
-	return execfunc(this, sys);
-}
-
-namespace _func1117
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipManager::ForceDecreaseSystemPower", typeid(bool (ShipManager::*)(int )), ".8b4424088b54240483f8ff74??8b8a000400008b048183f8ff74??8b52188b048285c074??8b10c744240801000000894424048b8284000000", argdata, 2, 2, &func);
-}
-
-bool ShipManager::ForceDecreaseSystemPower(int sys)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int sys_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1117::func;
@@ -15342,17 +15342,31 @@ namespace _func1118
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("ShipManager::ForceDecreaseSystemPower", typeid(bool (ShipManager::*)(int )), ".8b4424088b54240483f8ff74??8b8a000400008b048183f8ff74??8b52188b048285c074??8b10c744240801000000894424048b8284000000", argdata, 2, 2, &func);
+}
+
+bool ShipManager::ForceDecreaseSystemPower(int sys)
+{
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int sys_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1118::func;
+	return execfunc(this, sys);
+}
+
+namespace _func1119
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipManager::GetShieldPower", typeid(ShieldPower (ShipManager::*)()), "8b5424088b4424048b524485d2", argdata, 2, 18, &func);
 }
 
 ShieldPower ShipManager::GetShieldPower()
 {
 	typedef ShieldPower __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1118::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1119::func;
 	return execfunc(this);
 }
 
-namespace _func1119
+namespace _func1120
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15362,11 +15376,11 @@ namespace _func1119
 void ShipManager::CloneHealing()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1119::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1120::func;
 	return execfunc(this);
 }
 
-namespace _func1120
+namespace _func1121
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15376,11 +15390,11 @@ namespace _func1120
 int ShipManager::IsSystemHacked2(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1120::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1121::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1121
+namespace _func1122
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -15390,11 +15404,11 @@ namespace _func1121
 int ShipManager::AddWeapon(const WeaponBlueprint *bp, int slot)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const WeaponBlueprint *bp_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1121::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1122::func;
 	return execfunc(this, bp, slot);
 }
 
-namespace _func1122
+namespace _func1123
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15404,11 +15418,11 @@ namespace _func1122
 void ShipManager::AddEquipmentFromList(std::vector<std::string> *equipmentList)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, std::vector<std::string> *equipmentList_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1122::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1123::func;
 	return execfunc(this, equipmentList);
 }
 
-namespace _func1123
+namespace _func1124
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15418,11 +15432,11 @@ namespace _func1123
 void ShipManager::RenderChargeBars()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1123::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1124::func;
 	return execfunc(this);
 }
 
-namespace _func1124
+namespace _func1125
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15430,20 +15444,6 @@ namespace _func1124
 }
 
 void ShipManager::ExportBattleState(int file)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1124::func;
-	return execfunc(this, file);
-}
-
-namespace _func1125
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipManager::ImportBattleState", typeid(void (ShipManager::*)(int )), "5557565383ec3c8b7424508b5c24548b8600040000", argdata, 2, 6, &func);
-}
-
-void ShipManager::ImportBattleState(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1125::func;
@@ -15454,24 +15454,24 @@ namespace _func1126
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipManager::SystemFunctions", typeid(bool (ShipManager::*)(int )), "8b5424048b4c24088b82000400008b048883f8ff74??8b52188b04828b10894424048b422c", argdata, 2, 2, &func);
+	static FunctionDefinition funcObj("ShipManager::ImportBattleState", typeid(void (ShipManager::*)(int )), "5557565383ec3c8b7424508b5c24548b8600040000", argdata, 2, 6, &func);
 }
 
-bool ShipManager::SystemFunctions(int systemId)
+void ShipManager::ImportBattleState(int file)
 {
-	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1126::func;
-	return execfunc(this, systemId);
+	return execfunc(this, file);
 }
 
 namespace _func1127
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipManager::CanFitSystem", typeid(bool (ShipManager::*)(int )), "57565383ec108b4424248b7c242083f805", argdata, 2, 2, &func);
+	static FunctionDefinition funcObj("ShipManager::SystemFunctions", typeid(bool (ShipManager::*)(int )), "8b5424048b4c24088b82000400008b048883f8ff74??8b52188b04828b10894424048b422c", argdata, 2, 2, &func);
 }
 
-bool ShipManager::CanFitSystem(int systemId)
+bool ShipManager::SystemFunctions(int systemId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1127::func;
@@ -15482,10 +15482,10 @@ namespace _func1128
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipManager::CanFitSubsystem", typeid(bool (ShipManager::*)(int )), "57565383ec108b7c24208b57188b471c", argdata, 2, 2, &func);
+	static FunctionDefinition funcObj("ShipManager::CanFitSystem", typeid(bool (ShipManager::*)(int )), "57565383ec108b4424248b7c242083f805", argdata, 2, 2, &func);
 }
 
-bool ShipManager::CanFitSubsystem(int systemId)
+bool ShipManager::CanFitSystem(int systemId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1128::func;
@@ -15495,6 +15495,20 @@ bool ShipManager::CanFitSubsystem(int systemId)
 namespace _func1129
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("ShipManager::CanFitSubsystem", typeid(bool (ShipManager::*)(int )), "57565383ec108b7c24208b57188b471c", argdata, 2, 2, &func);
+}
+
+bool ShipManager::CanFitSubsystem(int systemId)
+{
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1129::func;
+	return execfunc(this, systemId);
+}
+
+namespace _func1130
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipManager::DamageHull", typeid(int (ShipManager::*)(int , bool )), "565383ec148b5c24208b7424288b03891c24", argdata, 3, 2, &func);
 }
@@ -15502,11 +15516,11 @@ namespace _func1129
 int ShipManager::DamageHull(int dmg, bool force)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int dmg_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1129::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1130::func;
 	return execfunc(this, dmg, force);
 }
 
-namespace _func1130
+namespace _func1131
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0xdff};
@@ -15516,11 +15530,11 @@ namespace _func1130
 void ShipManager::DamageSystem(int systemId, Damage damage)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, Damage damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1130::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1131::func;
 	return execfunc(this, systemId, damage);
 }
 
-namespace _func1131
+namespace _func1132
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15530,11 +15544,11 @@ namespace _func1131
 void ShipManager::StartFire(int roomId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1131::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1132::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1132
+namespace _func1133
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15544,11 +15558,11 @@ namespace _func1132
 CrewMember *ShipManager::FindCrew(const CrewBlueprint *bp)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const CrewBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1132::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1133::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1133
+namespace _func1134
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15558,11 +15572,11 @@ namespace _func1133
 bool ShipManager::GetDodged()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1133::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1134::func;
 	return execfunc(this);
 }
 
-namespace _func1134
+namespace _func1135
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15572,11 +15586,11 @@ namespace _func1134
 void ShipManager::PrepareSuperBarrage()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1134::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1135::func;
 	return execfunc(this);
 }
 
-namespace _func1135
+namespace _func1136
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -15586,11 +15600,11 @@ namespace _func1135
 std::string ShipManager::GetTooltip(int x, int y)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1135::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1136::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1136
+namespace _func1137
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15600,11 +15614,11 @@ namespace _func1136
 bool ShipManager::RestoreCrewPositions()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1136::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1137::func;
 	return execfunc(this);
 }
 
-namespace _func1137
+namespace _func1138
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -15614,11 +15628,11 @@ namespace _func1137
 CrewMember *ShipManager::GetCrewmember(int slot, bool present)
 {
 	typedef CrewMember *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int slot_arg, bool present_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1137::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1138::func;
 	return execfunc(this, slot, present);
 }
 
-namespace _func1138
+namespace _func1139
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15628,11 +15642,11 @@ namespace _func1138
 void ShipManager::RemoveCrewmember(CrewMember *crew)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1138::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1139::func;
 	return execfunc(this, crew);
 }
 
-namespace _func1139
+namespace _func1140
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -15642,11 +15656,11 @@ namespace _func1139
 int ShipManager::CanUpgrade(int systemId, int amount)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1139::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1140::func;
 	return execfunc(this, systemId, amount);
 }
 
-namespace _func1140
+namespace _func1141
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -15656,11 +15670,11 @@ namespace _func1140
 ShipBlueprint ShipManager::SaveToBlueprint(bool overwrite)
 {
 	typedef ShipBlueprint __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool overwrite_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1140::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1141::func;
 	return execfunc(this, overwrite);
 }
 
-namespace _func1141
+namespace _func1142
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -15670,11 +15684,11 @@ namespace _func1141
 void ShipManager::CheckCrystalAugment(Pointf pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1141::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1142::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1142
+namespace _func1143
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -15684,11 +15698,11 @@ namespace _func1142
 CollisionResponse ShipManager::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1142::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1143::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func1143
+namespace _func1144
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15698,11 +15712,11 @@ namespace _func1143
 int ShipManager::GetSystemPowerMax(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1143::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1144::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1144
+namespace _func1145
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15712,11 +15726,11 @@ namespace _func1144
 std::vector<Drone*> ShipManager::GetDroneList()
 {
 	typedef std::vector<Drone*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1144::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1145::func;
 	return execfunc(this);
 }
 
-namespace _func1145
+namespace _func1146
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15726,11 +15740,11 @@ namespace _func1145
 int ShipManager::GetDroneCount()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1145::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1146::func;
 	return execfunc(this);
 }
 
-namespace _func1146
+namespace _func1147
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15740,11 +15754,11 @@ namespace _func1146
 void ShipManager::InstantPowerShields()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1146::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1147::func;
 	return execfunc(this);
 }
 
-namespace _func1147
+namespace _func1148
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15754,11 +15768,11 @@ namespace _func1147
 void ShipManager::SetDestroyed()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1147::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1148::func;
 	return execfunc(this);
 }
 
-namespace _func1148
+namespace _func1149
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15768,11 +15782,11 @@ namespace _func1148
 int ShipManager::GetFireCount(int roomId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1148::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1149::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1149
+namespace _func1150
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -15782,11 +15796,11 @@ namespace _func1149
 void ShipManager::AddCrewMember(CrewMember *crew, int roomId)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1149::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1150::func;
 	return execfunc(this, crew, roomId);
 }
 
-namespace _func1150
+namespace _func1151
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15796,11 +15810,11 @@ namespace _func1150
 void ShipManager::PulsarDamage()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1150::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1151::func;
 	return execfunc(this);
 }
 
-namespace _func1151
+namespace _func1152
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -15810,11 +15824,11 @@ namespace _func1151
 std::vector<CrewMember*> ShipManager::GetLeavingCrew(bool intruders)
 {
 	typedef std::vector<CrewMember*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1151::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1152::func;
 	return execfunc(this, intruders);
 }
 
-namespace _func1152
+namespace _func1153
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -15824,11 +15838,11 @@ namespace _func1152
 void ShipManager::UpgradeSystem(int id, int amount)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int id_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1152::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1153::func;
 	return execfunc(this, id, amount);
 }
 
-namespace _func1153
+namespace _func1154
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -15838,11 +15852,11 @@ namespace _func1153
 CollisionResponse ShipManager::CollisionShield(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1153::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1154::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func1154
+namespace _func1155
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15852,11 +15866,11 @@ namespace _func1154
 bool ShipManager::IsCloaked()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1154::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1155::func;
 	return execfunc(this);
 }
 
-namespace _func1155
+namespace _func1156
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15866,11 +15880,11 @@ namespace _func1155
 int ShipManager::CountPlayerCrew()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1155::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1156::func;
 	return execfunc(this);
 }
 
-namespace _func1156
+namespace _func1157
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15880,11 +15894,11 @@ namespace _func1156
 void ShipManager::Wait()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1156::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1157::func;
 	return execfunc(this);
 }
 
-namespace _func1157
+namespace _func1158
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -15894,11 +15908,11 @@ namespace _func1157
 void ShipManager::CreateArmory()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1157::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1158::func;
 	return execfunc(this);
 }
 
-namespace _func1158
+namespace _func1159
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15908,11 +15922,11 @@ namespace _func1158
 Drone *ShipManager::CreateDrone(DroneBlueprint *drone)
 {
 	typedef Drone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *this_arg, DroneBlueprint *drone_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1158::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1159::func;
 	return execfunc(this, drone);
 }
 
-namespace _func1159
+namespace _func1160
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15922,11 +15936,11 @@ namespace _func1159
 int ShipObject::HasAugmentation(const std::string &augment)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1159::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1160::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1160
+namespace _func1161
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15936,11 +15950,11 @@ namespace _func1160
 float ShipObject::GetAugmentationValue(const std::string &augment)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1160::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1161::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1161
+namespace _func1162
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15950,11 +15964,11 @@ namespace _func1161
 void ShipObject::RemoveAugmentation(const std::string &augment)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1161::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1162::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1162
+namespace _func1163
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15964,11 +15978,11 @@ namespace _func1162
 int ShipObject::HasEquipment(const std::string &equip)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1162::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1163::func;
 	return execfunc(this, equip);
 }
 
-namespace _func1163
+namespace _func1164
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15978,11 +15992,11 @@ namespace _func1163
 std::vector<std::string> ShipObject::GetAugmentationList()
 {
 	typedef std::vector<std::string> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1163::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1164::func;
 	return execfunc(this);
 }
 
-namespace _func1164
+namespace _func1165
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -15992,11 +16006,11 @@ namespace _func1164
 bool ShipObject::AddAugmentation(const std::string &augment)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1164::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1165::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1165
+namespace _func1166
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -16006,11 +16020,11 @@ namespace _func1165
 void ShipObject::RemoveEquipment(const std::string &blueName, bool completely)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &blueName_arg, bool completely_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1165::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1166::func;
 	return execfunc(this, blueName, completely);
 }
 
-namespace _func1166
+namespace _func1167
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16020,11 +16034,11 @@ namespace _func1166
 int ShipObject::GetAugmentationCount()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1166::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1167::func;
 	return execfunc(this);
 }
 
-namespace _func1167
+namespace _func1168
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16034,18 +16048,18 @@ namespace _func1167
 void ShipObject::ClearShipInfo()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1167::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1168::func;
 	return execfunc(this);
 }
 
 ShipInfo **Global_ShipObject_ShipInfoList;
 
-namespace _var1168
+namespace _var1169
 {
     static VariableDefinition varObj("Global_ShipObject_ShipInfoList", "!6bc0340305(???????\?)8b4030c3", &Global_ShipObject_ShipInfoList);
 }
 
-namespace _func1169
+namespace _func1170
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102};
@@ -16055,11 +16069,11 @@ namespace _func1169
 void ShipSelect::SelectShip(int shipType)
 {
 	typedef void __attribute__((regparm(2))) (*custom_arg_funcptr_t)(ShipSelect *this_arg, int shipType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1169::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1170::func;
 	return execfunc(this, shipType);
 }
 
-namespace _func1170
+namespace _func1171
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16069,11 +16083,11 @@ namespace _func1170
 void ShipSelect::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1170::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1171::func;
 	return execfunc(this);
 }
 
-namespace _func1171
+namespace _func1172
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16083,11 +16097,11 @@ namespace _func1171
 void ShipSelect::ClearShipButtons()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1171::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1172::func;
 	return execfunc(this);
 }
 
-namespace _func1172
+namespace _func1173
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -16097,11 +16111,11 @@ namespace _func1172
 void ShipSelect::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1172::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1173::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1173
+namespace _func1174
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16111,11 +16125,11 @@ namespace _func1173
 void ShipSelect::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1173::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1174::func;
 	return execfunc(this);
 }
 
-namespace _func1174
+namespace _func1175
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16125,11 +16139,11 @@ namespace _func1174
 int ShipSelect::KeyDown(SDLKey key)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1174::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1175::func;
 	return execfunc(this, key);
 }
 
-namespace _func1175
+namespace _func1176
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16139,11 +16153,11 @@ namespace _func1175
 void ShipSelect::MouseClick()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1175::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1176::func;
 	return execfunc(this);
 }
 
-namespace _func1176
+namespace _func1177
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16153,11 +16167,11 @@ namespace _func1176
 void ShipSelect::PreSelectShip(int shipType)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, int shipType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1176::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1177::func;
 	return execfunc(this, shipType);
 }
 
-namespace _func1177
+namespace _func1178
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16167,11 +16181,11 @@ namespace _func1177
 void ShipSelect::Close()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1177::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1178::func;
 	return execfunc(this);
 }
 
-namespace _func1178
+namespace _func1179
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16181,11 +16195,11 @@ namespace _func1178
 int ShipSelect::GetSelectedShip()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1178::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1179::func;
 	return execfunc(this);
 }
 
-namespace _func1179
+namespace _func1180
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -16195,11 +16209,11 @@ namespace _func1179
 void ShipSelect::Open(int currentId, int currentType)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, int currentId_arg, int currentType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1179::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1180::func;
 	return execfunc(this, currentId, currentType);
 }
 
-namespace _func1180
+namespace _func1181
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16209,11 +16223,11 @@ namespace _func1180
 void ShipSelect::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1180::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1181::func;
 	return execfunc(this);
 }
 
-namespace _func1181
+namespace _func1182
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16223,11 +16237,11 @@ namespace _func1181
 void ShipStatus::RenderHealth(bool renderText)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool renderText_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1181::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1182::func;
 	return execfunc(this, renderText);
 }
 
-namespace _func1182
+namespace _func1183
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
@@ -16237,11 +16251,11 @@ namespace _func1182
 void ShipStatus::OnInit(Point location, float size)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipStatus *this_arg, Point location_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1182::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1183::func;
 	return execfunc(this, location, size);
 }
 
-namespace _func1183
+namespace _func1184
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16251,11 +16265,11 @@ namespace _func1183
 void ShipStatus::RenderResources(bool renderText)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool renderText_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1183::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1184::func;
 	return execfunc(this, renderText);
 }
 
-namespace _func1184
+namespace _func1185
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16265,11 +16279,11 @@ namespace _func1184
 void ShipStatus::RenderEvadeOxygen(bool renderText)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool renderText_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1184::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1185::func;
 	return execfunc(this, renderText);
 }
 
-namespace _func1185
+namespace _func1186
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16279,11 +16293,11 @@ namespace _func1185
 void ShipStatus::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1185::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1186::func;
 	return execfunc(this);
 }
 
-namespace _func1186
+namespace _func1187
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102};
@@ -16293,11 +16307,11 @@ namespace _func1186
 void ShipStatus::RenderShields(bool renderText)
 {
 	typedef void __attribute__((regparm(2))) (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool renderText_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1186::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1187::func;
 	return execfunc(this, renderText);
 }
 
-namespace _func1187
+namespace _func1188
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16307,11 +16321,11 @@ namespace _func1187
 void ShipStatus::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1187::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1188::func;
 	return execfunc(this);
 }
 
-namespace _func1188
+namespace _func1189
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16321,11 +16335,11 @@ namespace _func1188
 void ShipSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1188::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1189::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func1189
+namespace _func1190
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16335,11 +16349,11 @@ namespace _func1189
 bool ShipSystem::DamageOverTime(float unk)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, float unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1189::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1190::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1190
+namespace _func1191
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16349,11 +16363,11 @@ namespace _func1190
 void ShipSystem::CheckForRepower()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1190::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1191::func;
 	return execfunc(this);
 }
 
-namespace _func1191
+namespace _func1192
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16363,11 +16377,11 @@ namespace _func1191
 int ShipSystem::NameToSystemId(const std::string &name)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1191::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1192::func;
 	return execfunc(name);
 }
 
-namespace _func1192
+namespace _func1193
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16377,11 +16391,11 @@ namespace _func1192
 int ShipSystem::IsMannedBoost()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1192::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1193::func;
 	return execfunc(this);
 }
 
-namespace _func1193
+namespace _func1194
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16391,11 +16405,11 @@ namespace _func1193
 std::string ShipSystem::SystemIdToName(int systemId)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1193::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1194::func;
 	return execfunc(systemId);
 }
 
-namespace _func1194
+namespace _func1195
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16405,11 +16419,11 @@ namespace _func1194
 void ShipSystem::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1194::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1195::func;
 	return execfunc(this);
 }
 
-namespace _func1195
+namespace _func1196
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16419,11 +16433,11 @@ namespace _func1195
 bool ShipSystem::Ioned(int num)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int num_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1195::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1196::func;
 	return execfunc(this, num);
 }
 
-namespace _func1196
+namespace _func1197
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16433,11 +16447,11 @@ namespace _func1196
 int ShipSystem::SetPowerLoss(int power)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int power_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1196::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1197::func;
 	return execfunc(this, power);
 }
 
-namespace _func1197
+namespace _func1198
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16447,11 +16461,11 @@ namespace _func1197
 void ShipSystem::SetDividePower(int val)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int val_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1197::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1198::func;
 	return execfunc(this, val);
 }
 
-namespace _func1198
+namespace _func1199
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -16461,11 +16475,11 @@ namespace _func1198
 void ShipSystem::constructor(int systemId, int roomId, int shipId, int startingPower)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int systemId_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1198::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1199::func;
 	return execfunc(this, systemId, roomId, shipId, startingPower);
 }
 
-namespace _func1199
+namespace _func1200
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16475,11 +16489,11 @@ namespace _func1199
 int ShipSystem::GetPowerCap()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1199::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1200::func;
 	return execfunc(this);
 }
 
-namespace _func1200
+namespace _func1201
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16489,11 +16503,11 @@ namespace _func1200
 bool ShipSystem::BlockedBoosted(bool countLimit)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool countLimit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1200::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1201::func;
 	return execfunc(this, countLimit);
 }
 
-namespace _func1201
+namespace _func1202
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16503,11 +16517,11 @@ namespace _func1201
 void ShipSystem::SetPowerCap(int cap)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int cap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1201::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1202::func;
 	return execfunc(this, cap);
 }
 
-namespace _func1202
+namespace _func1203
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16517,11 +16531,11 @@ namespace _func1202
 void ShipSystem::LockSystem(int lock)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1202::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1203::func;
 	return execfunc(this, lock);
 }
 
-namespace _func1203
+namespace _func1204
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16531,11 +16545,11 @@ namespace _func1203
 bool ShipSystem::ForceDecreasePower(int powerLoss)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int powerLoss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1203::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1204::func;
 	return execfunc(this, powerLoss);
 }
 
-namespace _func1204
+namespace _func1205
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16545,11 +16559,11 @@ namespace _func1204
 int ShipSystem::GetEffectivePower()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1204::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1205::func;
 	return execfunc(this);
 }
 
-namespace _func1205
+namespace _func1206
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16559,11 +16573,11 @@ namespace _func1205
 int ShipSystem::GetMaxPower()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1205::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1206::func;
 	return execfunc(this);
 }
 
-namespace _func1206
+namespace _func1207
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -16573,11 +16587,11 @@ namespace _func1206
 void ShipSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1206::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1207::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func1207
+namespace _func1208
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16587,11 +16601,11 @@ namespace _func1207
 void ShipSystem::CheckMaxPower()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1207::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1208::func;
 	return execfunc(this);
 }
 
-namespace _func1208
+namespace _func1209
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16601,11 +16615,11 @@ namespace _func1208
 bool ShipSystem::PartialDamage(float amount)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, float amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1208::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1209::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1209
+namespace _func1210
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16615,11 +16629,11 @@ namespace _func1209
 bool ShipSystem::IsSubsystem(int systemType)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int systemType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1209::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1210::func;
 	return execfunc(systemType);
 }
 
-namespace _func1210
+namespace _func1211
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16629,11 +16643,11 @@ namespace _func1210
 void ShipSystem::ClearStatus()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1210::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1211::func;
 	return execfunc(this);
 }
 
-namespace _func1211
+namespace _func1212
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -16643,11 +16657,11 @@ namespace _func1211
 std::string ShipSystem::GetLevelDescription(int systemId, int level, bool tooltip)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(int systemId_arg, int level_arg, bool tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1211::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1212::func;
 	return execfunc(systemId, level, tooltip);
 }
 
-namespace _func1212
+namespace _func1213
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16657,11 +16671,11 @@ namespace _func1212
 void ShipSystem::AddLock(int lock)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1212::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1213::func;
 	return execfunc(this, lock);
 }
 
-namespace _func1213
+namespace _func1214
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16671,11 +16685,11 @@ namespace _func1213
 void ShipSystem::IonDamage(int amount)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1213::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1214::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1214
+namespace _func1215
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16685,11 +16699,11 @@ namespace _func1214
 bool ShipSystem::GetLocked()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1214::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1215::func;
 	return execfunc(this);
 }
 
-namespace _func1215
+namespace _func1216
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16699,11 +16713,11 @@ namespace _func1215
 void ShipSystem::StopHacking()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1215::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1216::func;
 	return execfunc(this);
 }
 
-namespace _func1216
+namespace _func1217
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16711,20 +16725,6 @@ namespace _func1216
 }
 
 void ShipSystem::SaveState(int file)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1216::func;
-	return execfunc(this, file);
-}
-
-namespace _func1217
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipSystem::LoadState", typeid(void (ShipSystem::*)(int )), "565383ec148b7424248b5c2420893424e8????????898308010000", argdata, 2, 6, &func);
-}
-
-void ShipSystem::LoadState(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1217::func;
@@ -16735,17 +16735,31 @@ namespace _func1218
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("ShipSystem::LoadState", typeid(void (ShipSystem::*)(int )), "565383ec148b7424248b5c2420893424e8????????898308010000", argdata, 2, 6, &func);
+}
+
+void ShipSystem::LoadState(int file)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1218::func;
+	return execfunc(this, file);
+}
+
+namespace _func1219
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipSystem::UpgradeSystem", typeid(bool (ShipSystem::*)(int )), "565383ec148b5c24208b7424248b03891c24ff5010", argdata, 2, 2, &func);
 }
 
 bool ShipSystem::UpgradeSystem(int amount)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1218::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1219::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1219
+namespace _func1220
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -16755,11 +16769,11 @@ namespace _func1219
 bool ShipSystem::IncreasePower(int amount, bool force)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1219::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1220::func;
 	return execfunc(this, amount, force);
 }
 
-namespace _func1220
+namespace _func1221
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16769,11 +16783,11 @@ namespace _func1220
 bool ShipSystem::DecreasePower(bool force)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1220::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1221::func;
 	return execfunc(this, force);
 }
 
-namespace _func1221
+namespace _func1222
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -16783,11 +16797,11 @@ namespace _func1221
 bool ShipSystem::PartialRepair(float speed, bool autoRepair)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, float speed_arg, bool autoRepair_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1221::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1222::func;
 	return execfunc(this, speed, autoRepair);
 }
 
-namespace _func1222
+namespace _func1223
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -16797,11 +16811,11 @@ namespace _func1222
 int ShipSystem::RenderPowerBoxes(int x, int y, int width, int height, int gap, int heightMod, bool flash)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int x_arg, int y_arg, int width_arg, int height_arg, int gap_arg, int heightMod_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1222::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1223::func;
 	return execfunc(this, x, y, width, height, gap, heightMod, flash);
 }
 
-namespace _func1223
+namespace _func1224
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16811,11 +16825,11 @@ namespace _func1223
 bool ShipSystem::RawDecreasePower()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1223::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1224::func;
 	return execfunc(this);
 }
 
-namespace _func1224
+namespace _func1225
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16825,11 +16839,11 @@ namespace _func1224
 void ShipSystem::AddDamage(int amount)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1224::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1225::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1225
+namespace _func1226
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16839,11 +16853,11 @@ namespace _func1225
 void ShipSystem::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1225::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1226::func;
 	return execfunc(this);
 }
 
-namespace _func1226
+namespace _func1227
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -16853,11 +16867,11 @@ namespace _func1226
 int ShipSystem::RenderPowerBoxesPlain(int x, int y, int width, int height, int gap, int current, int temp, int max)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int x_arg, int y_arg, int width_arg, int height_arg, int gap_arg, int current_arg, int temp_arg, int max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1226::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1227::func;
 	return execfunc(x, y, width, height, gap, current, temp, max);
 }
 
-namespace _func1227
+namespace _func1228
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -16867,11 +16881,11 @@ namespace _func1227
 void ShipSystem::RenderSystemSymbol(bool forPowerUI, int forceColor)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool forPowerUI_arg, int forceColor_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1227::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1228::func;
 	return execfunc(this, forPowerUI, forceColor);
 }
 
-namespace _func1228
+namespace _func1229
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16881,116 +16895,116 @@ namespace _func1228
 TimerHelper ShipSystem::GetLockTimer()
 {
 	typedef TimerHelper __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1228::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1229::func;
 	return execfunc(this);
 }
 
 GL_Primitive **ShipSystem__lockBlue;
 
-namespace _var1229
+namespace _var1230
 {
     static VariableDefinition varObj("ShipSystem__lockBlue", "!8b3d(???????\?)84d28b8580010000", &ShipSystem__lockBlue);
 }
 
 GL_Primitive **ShipSystem__fireImage;
 
-namespace _var1230
+namespace _var1231
 {
     static VariableDefinition varObj("ShipSystem__fireImage", "!.a1(???????\?)890424", &ShipSystem__fireImage);
 }
 
 GL_Primitive **ShipSystem__lockHack;
 
-namespace _var1231
+namespace _var1232
 {
     static VariableDefinition varObj("ShipSystem__lockHack", "!.a1(???????\?)890424", &ShipSystem__lockHack);
 }
 
 GL_Primitive **ShipSystem__manningBarIon;
 
-namespace _var1232
+namespace _var1233
 {
     static VariableDefinition varObj("ShipSystem__manningBarIon", "!.84c0a1(???????\?)0f4405(???????\?)", &ShipSystem__manningBarIon);
 }
 
 GL_Primitive **ShipSystem__manningBarOff;
 
-namespace _var1233
+namespace _var1234
 {
     static VariableDefinition varObj("ShipSystem__manningBarOff", "", &ShipSystem__manningBarOff);
 }
 
 GL_Primitive **ShipSystem__lockWhite;
 
-namespace _var1234
+namespace _var1235
 {
     static VariableDefinition varObj("ShipSystem__lockWhite", "!.8b3d(???????\?)b9ff000000", &ShipSystem__lockWhite);
 }
 
 GL_Primitive **ShipSystem__sabotageImage;
 
-namespace _var1235
+namespace _var1236
 {
     static VariableDefinition varObj("ShipSystem__sabotageImage", "!.a1(???????\?)890424", &ShipSystem__sabotageImage);
 }
 
 GL_Primitive **ShipSystem__manningOutline;
 
-namespace _var1236
+namespace _var1237
 {
     static VariableDefinition varObj("ShipSystem__manningOutline", "!.a1(???????\?)bef0ffffffbb10000000", &ShipSystem__manningOutline);
 }
 
 GL_Primitive **ShipSystem__manningBarOn;
 
-namespace _var1237
+namespace _var1238
 {
     static VariableDefinition varObj("ShipSystem__manningBarOn", "!.0f85????????a1(???????\?)e9", &ShipSystem__manningBarOn);
 }
 
 GL_Primitive **ShipSystem__manningWhite;
 
-namespace _var1238
+namespace _var1239
 {
     static VariableDefinition varObj("ShipSystem__manningWhite", "!.a1(???????\?)bef0ffffffbb10000000", &ShipSystem__manningWhite);
 }
 
 GL_Primitive **ShipSystem__manningGreen;
 
-namespace _var1239
+namespace _var1240
 {
     static VariableDefinition varObj("ShipSystem__manningGreen", "!.a1(???????\?)bee8ffffffbb18000000", &ShipSystem__manningGreen);
 }
 
 GL_Primitive **ShipSystem__manningYellow;
 
-namespace _var1240
+namespace _var1241
 {
     static VariableDefinition varObj("ShipSystem__manningYellow", "!.a1(???????\?)bee8ffffffbb18000000", &ShipSystem__manningYellow);
 }
 
 GL_Primitive **ShipSystem__glowBlue;
 
-namespace _var1241
+namespace _var1242
 {
     static VariableDefinition varObj("ShipSystem__glowBlue", "!.f30f116c2404e8????????a1(???????\?)890424", &ShipSystem__glowBlue);
 }
 
 GL_Primitive **ShipSystem__glowRed;
 
-namespace _var1242
+namespace _var1243
 {
     static VariableDefinition varObj("ShipSystem__glowRed", "!.f30f116c2404e8????????a1(???????\?)890424", &ShipSystem__glowRed);
 }
 
 GL_Primitive **ShipSystem__glowWhite;
 
-namespace _var1243
+namespace _var1244
 {
     static VariableDefinition varObj("ShipSystem__glowWhite", "!.8b153c114a08c7865801000000000000", &ShipSystem__glowWhite);
 }
 
-namespace _func1244
+namespace _func1245
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -17000,11 +17014,11 @@ namespace _func1244
 int SoundControl::PlaySoundMix(const std::string &soundName, float volume, bool loop)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(SoundControl *this_arg, const std::string &soundName_arg, float volume_arg, bool loop_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1244::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1245::func;
 	return execfunc(this, soundName, volume, loop);
 }
 
-namespace _func1245
+namespace _func1246
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17014,11 +17028,11 @@ namespace _func1245
 void SoundControl::StopPlaylist(int fadeOut)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SoundControl *this_arg, int fadeOut_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1245::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1246::func;
 	return execfunc(this, fadeOut);
 }
 
-namespace _func1246
+namespace _func1247
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17028,11 +17042,11 @@ namespace _func1246
 void SoundControl::StartPlaylist(std::vector<std::string> &playlist)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SoundControl *this_arg, std::vector<std::string> &playlist_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1246::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1247::func;
 	return execfunc(this, playlist);
 }
 
-namespace _func1247
+namespace _func1248
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17042,11 +17056,11 @@ namespace _func1247
 void SoundControl::UpdateSoundLoop(const std::string &loopId, float count)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SoundControl *this_arg, const std::string &loopId_arg, float count_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1247::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1248::func;
 	return execfunc(this, loopId, count);
 }
 
-namespace _func1248
+namespace _func1249
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17056,18 +17070,18 @@ namespace _func1248
 void SoundControl::StopChannel(int channel, float fade)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SoundControl *this_arg, int channel_arg, float fade_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1248::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1249::func;
 	return execfunc(this, channel, fade);
 }
 
 SoundControl *Global_SoundControl_Sounds;
 
-namespace _var1249
+namespace _var1250
 {
     static VariableDefinition varObj("Global_SoundControl_Sounds", "!e8????????897c240889742404c70424(???????\?)e8", &Global_SoundControl_Sounds);
 }
 
-namespace _func1250
+namespace _func1251
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -17077,11 +17091,11 @@ namespace _func1250
 float SpaceDrone::UpdateAimingAngle(Pointf location, float percentage, float forceDesired)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Pointf location_arg, float percentage_arg, float forceDesired_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1250::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1251::func;
 	return execfunc(this, location, percentage, forceDesired);
 }
 
-namespace _func1251
+namespace _func1252
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17091,11 +17105,11 @@ namespace _func1251
 void SpaceDrone::SetDeployed(bool deployed)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, bool deployed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1251::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1252::func;
 	return execfunc(this, deployed);
 }
 
-namespace _func1252
+namespace _func1253
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17105,11 +17119,11 @@ namespace _func1252
 void SpaceDrone::SetMovementTarget(Targetable *target)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1252::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1253::func;
 	return execfunc(this, target);
 }
 
-namespace _func1253
+namespace _func1254
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -17119,11 +17133,11 @@ namespace _func1253
 CollisionResponse SpaceDrone::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1253::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1254::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func1254
+namespace _func1255
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17133,11 +17147,11 @@ namespace _func1254
 Projectile *SpaceDrone::GetNextProjectile()
 {
 	typedef Projectile *__attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1254::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1255::func;
 	return execfunc(this);
 }
 
-namespace _func1255
+namespace _func1256
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -17147,11 +17161,11 @@ namespace _func1255
 void SpaceDrone::constructor(int iShipId, int selfId, DroneBlueprint *blueprint)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, int iShipId_arg, int selfId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1255::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1256::func;
 	return execfunc(this, iShipId, selfId, blueprint);
 }
 
-namespace _func1256
+namespace _func1257
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17161,11 +17175,11 @@ namespace _func1256
 void SpaceDrone::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1256::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1257::func;
 	return execfunc(this);
 }
 
-namespace _func1257
+namespace _func1258
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17175,11 +17189,11 @@ namespace _func1257
 void SpaceManager::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1257::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1258::func;
 	return execfunc(this);
 }
 
-namespace _func1258
+namespace _func1259
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17189,11 +17203,11 @@ namespace _func1258
 int SpaceManager::GetScreenShake()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1258::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1259::func;
 	return execfunc(this);
 }
 
-namespace _func1259
+namespace _func1260
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17203,11 +17217,11 @@ namespace _func1259
 void SpaceManager::SaveSpace(int fileHelper)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1259::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1260::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1260
+namespace _func1261
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17217,11 +17231,11 @@ namespace _func1260
 ImageDesc SpaceManager::SwitchBeacon()
 {
 	typedef ImageDesc __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1260::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1261::func;
 	return execfunc(this);
 }
 
-namespace _func1261
+namespace _func1262
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17231,11 +17245,11 @@ namespace _func1261
 ImageDesc SpaceManager::SwitchPlanet(const std::string &name)
 {
 	typedef ImageDesc __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1261::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1262::func;
 	return execfunc(this, name);
 }
 
-namespace _func1262
+namespace _func1263
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17245,11 +17259,11 @@ namespace _func1262
 void SpaceManager::UpdatePlanetImage()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1262::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1263::func;
 	return execfunc(this);
 }
 
-namespace _func1263
+namespace _func1264
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x7ff, 0x7ff, 0x7ff};
@@ -17259,11 +17273,11 @@ namespace _func1263
 void SpaceManager::SwitchImages(ImageDesc planet, ImageDesc unk1, ImageDesc unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, ImageDesc planet_arg, ImageDesc unk1_arg, ImageDesc unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1263::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1264::func;
 	return execfunc(this, planet, unk1, unk2);
 }
 
-namespace _func1264
+namespace _func1265
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17273,11 +17287,11 @@ namespace _func1264
 ImageDesc SpaceManager::SwitchBackground(const std::string &name)
 {
 	typedef ImageDesc __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1264::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1265::func;
 	return execfunc(this, name);
 }
 
-namespace _func1265
+namespace _func1266
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17287,11 +17301,11 @@ namespace _func1265
 void SpaceManager::StartAsteroids(int shieldCount, bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int shieldCount_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1265::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1266::func;
 	return execfunc(this, shieldCount, unk);
 }
 
-namespace _func1266
+namespace _func1267
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17301,11 +17315,11 @@ namespace _func1266
 void SpaceManager::SetPlanetaryDefense(char state, int target)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, char state_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1266::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1267::func;
 	return execfunc(this, state, target);
 }
 
-namespace _func1267
+namespace _func1268
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17315,11 +17329,11 @@ namespace _func1267
 void SpaceManager::SetPulsarLevel(bool pulsarLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool pulsarLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1267::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1268::func;
 	return execfunc(this, pulsarLevel);
 }
 
-namespace _func1268
+namespace _func1269
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17329,11 +17343,11 @@ namespace _func1268
 bool SpaceManager::DangerousEnvironment()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1268::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1269::func;
 	return execfunc(this);
 }
 
-namespace _func1269
+namespace _func1270
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -17343,11 +17357,11 @@ namespace _func1269
 void SpaceManager::MouseMove(int x, int y, int unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int x_arg, int y_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1269::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1270::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func1270
+namespace _func1271
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -17357,11 +17371,11 @@ namespace _func1270
 SpaceDrone *SpaceManager::GetSelectedDrone(int x, int y, int unk)
 {
 	typedef SpaceDrone *__attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int x_arg, int y_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1270::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1271::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func1271
+namespace _func1272
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17371,11 +17385,11 @@ namespace _func1271
 float SpaceManager::GetFlashOpacity()
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1271::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1272::func;
 	return execfunc(this);
 }
 
-namespace _func1272
+namespace _func1273
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17385,20 +17399,6 @@ namespace _func1272
 GL_Color SpaceManager::GetColorTint()
 {
 	typedef GL_Color __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1272::func;
-	return execfunc(this);
-}
-
-namespace _func1273
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::OnRenderBackground", typeid(void (SpaceManager::*)()), "565383ec448b7424500f2805????????", argdata, 1, 6, &func);
-}
-
-void SpaceManager::OnRenderBackground()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1273::func;
 	return execfunc(this);
 }
@@ -17407,10 +17407,10 @@ namespace _func1274
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::OnRenderFleet", typeid(void (SpaceManager::*)()), "57565383ec508b7c2460", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnRenderBackground", typeid(void (SpaceManager::*)()), "565383ec448b7424500f2805????????", argdata, 1, 6, &func);
 }
 
-void SpaceManager::OnRenderFleet()
+void SpaceManager::OnRenderBackground()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1274::func;
@@ -17421,10 +17421,10 @@ namespace _func1275
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::OnRenderForeground", typeid(void (SpaceManager::*)()), "5557565383ec6c8b9c24800000000f2805????????", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnRenderFleet", typeid(void (SpaceManager::*)()), "57565383ec508b7c2460", argdata, 1, 6, &func);
 }
 
-void SpaceManager::OnRenderForeground()
+void SpaceManager::OnRenderFleet()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1275::func;
@@ -17434,6 +17434,20 @@ void SpaceManager::OnRenderForeground()
 namespace _func1276
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("SpaceManager::OnRenderForeground", typeid(void (SpaceManager::*)()), "5557565383ec6c8b9c24800000000f2805????????", argdata, 1, 6, &func);
+}
+
+void SpaceManager::OnRenderForeground()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1276::func;
+	return execfunc(this);
+}
+
+namespace _func1277
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("SpaceManager::SetDangerZone", typeid(void (SpaceManager::*)(int )), "5557565383ec3c8b4424548b7c245085c0", argdata, 2, 6, &func);
 }
@@ -17441,11 +17455,11 @@ namespace _func1276
 void SpaceManager::SetDangerZone(int fleetType)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fleetType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1276::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1277::func;
 	return execfunc(this, fleetType);
 }
 
-namespace _func1277
+namespace _func1278
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17455,11 +17469,11 @@ namespace _func1277
 void SpaceManager::OnRenderAsteroids(int fieldLayers, float unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fieldLayers_arg, float unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1277::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1278::func;
 	return execfunc(this, fieldLayers, unk2);
 }
 
-namespace _func1278
+namespace _func1279
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17469,11 +17483,11 @@ namespace _func1278
 void SpaceManager::OnRenderProjectiles(int iShipId, int layerCommand)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int iShipId_arg, int layerCommand_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1278::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1279::func;
 	return execfunc(this, iShipId, layerCommand);
 }
 
-namespace _func1279
+namespace _func1280
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17481,20 +17495,6 @@ namespace _func1279
 }
 
 void SpaceManager::OnInit()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1279::func;
-	return execfunc(this);
-}
-
-namespace _func1280
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::Restart", typeid(void (SpaceManager::*)()), ".57565383ec108b7424208b168b4604", argdata, 1, 6, &func);
-}
-
-void SpaceManager::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1280::func;
@@ -17505,10 +17505,10 @@ namespace _func1281
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::ClearEnvironment", typeid(void (SpaceManager::*)()), "8b442404c6807402000000c6807502000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::Restart", typeid(void (SpaceManager::*)()), ".57565383ec108b7424208b168b4604", argdata, 1, 6, &func);
 }
 
-void SpaceManager::ClearEnvironment()
+void SpaceManager::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1281::func;
@@ -17519,10 +17519,10 @@ namespace _func1282
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::Clear", typeid(void (SpaceManager::*)()), "57565383ec108b5c24208b839c000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::ClearEnvironment", typeid(void (SpaceManager::*)()), "8b442404c6807402000000c6807502000000", argdata, 1, 6, &func);
 }
 
-void SpaceManager::Clear()
+void SpaceManager::ClearEnvironment()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1282::func;
@@ -17533,10 +17533,10 @@ namespace _func1283
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::ClearProjectiles", typeid(void (SpaceManager::*)()), ".57565383ec108b7424208b168b4604", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::Clear", typeid(void (SpaceManager::*)()), "57565383ec108b5c24208b839c000000", argdata, 1, 6, &func);
 }
 
-void SpaceManager::ClearProjectiles()
+void SpaceManager::Clear()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1283::func;
@@ -17546,25 +17546,25 @@ void SpaceManager::ClearProjectiles()
 namespace _func1284
 {
     static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::UpdateProjectile", typeid(void (SpaceManager::*)(Projectile *)), "555731ff565383ec1c8b5c24348b7424308b03", argdata, 2, 6, &func);
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("SpaceManager::ClearProjectiles", typeid(void (SpaceManager::*)()), ".57565383ec108b7424208b168b4604", argdata, 1, 6, &func);
 }
 
-void SpaceManager::UpdateProjectile(Projectile *proj)
+void SpaceManager::ClearProjectiles()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1284::func;
-	return execfunc(this, proj);
+	return execfunc(this);
 }
 
 namespace _func1285
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::TransferProjectile", typeid(void (SpaceManager::*)(Projectile *)), "565383ec148b5c24248b038b7370", argdata, 2, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::UpdateProjectile", typeid(void (SpaceManager::*)(Projectile *)), "555731ff565383ec1c8b5c24348b7424308b03", argdata, 2, 6, &func);
 }
 
-void SpaceManager::TransferProjectile(Projectile *proj)
+void SpaceManager::UpdateProjectile(Projectile *proj)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1285::func;
@@ -17575,17 +17575,31 @@ namespace _func1286
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("SpaceManager::TransferProjectile", typeid(void (SpaceManager::*)(Projectile *)), "565383ec148b5c24248b038b7370", argdata, 2, 6, &func);
+}
+
+void SpaceManager::TransferProjectile(Projectile *proj)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1286::func;
+	return execfunc(this, proj);
+}
+
+namespace _func1287
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("SpaceManager::AddShip", typeid(void (SpaceManager::*)(ShipManager *)), "5589e557565383ec2c8b5d088b83a00000003b83a4000000", argdata, 2, 6, &func);
 }
 
 void SpaceManager::AddShip(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1286::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1287::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1287
+namespace _func1288
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17595,11 +17609,11 @@ namespace _func1287
 void SpaceManager::AddProjectile(Projectile *proj)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1287::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1288::func;
 	return execfunc(this, proj);
 }
 
-namespace _func1288
+namespace _func1289
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17609,11 +17623,11 @@ namespace _func1288
 void SpaceManager::LoadSpace(int fileHelper)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1288::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1289::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1289
+namespace _func1290
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17621,20 +17635,6 @@ namespace _func1289
 }
 
 void SpaceManager::UpdatePDS()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1289::func;
-	return execfunc(this);
-}
-
-namespace _func1290
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::OnLoopNebulas", typeid(void (SpaceManager::*)()), "5557565331db81ec8c0000008b8424a00000008bbc24a0000000", argdata, 1, 6, &func);
-}
-
-void SpaceManager::OnLoopNebulas()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1290::func;
@@ -17645,10 +17645,10 @@ namespace _func1291
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::OnLoop", typeid(void (SpaceManager::*)()), "5589e557565383ec6c8b75088d860c030000890424", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnLoopNebulas", typeid(void (SpaceManager::*)()), "5557565331db81ec8c0000008b8424a00000008bbc24a0000000", argdata, 1, 6, &func);
 }
 
-void SpaceManager::OnLoop()
+void SpaceManager::OnLoopNebulas()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1291::func;
@@ -17658,25 +17658,25 @@ void SpaceManager::OnLoop()
 namespace _func1292
 {
     static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::SetNebula", typeid(void (SpaceManager::*)(bool )), "5557565381ec9c0000008b9c24b00000008b8424b4000000", argdata, 2, 6, &func);
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("SpaceManager::OnLoop", typeid(void (SpaceManager::*)()), "5589e557565383ec6c8b75088d860c030000890424", argdata, 1, 6, &func);
 }
 
-void SpaceManager::SetNebula(bool state)
+void SpaceManager::OnLoop()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1292::func;
-	return execfunc(this, state);
+	return execfunc(this);
 }
 
 namespace _func1293
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::SetStorm", typeid(void (SpaceManager::*)(bool )), "5383ec288b4424308d5c241cc6802a03000001", argdata, 2, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::SetNebula", typeid(void (SpaceManager::*)(bool )), "5557565381ec9c0000008b9c24b00000008b8424b4000000", argdata, 2, 6, &func);
 }
 
-void SpaceManager::SetStorm(bool state)
+void SpaceManager::SetNebula(bool state)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1293::func;
@@ -17687,10 +17687,10 @@ namespace _func1294
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::SetFireLevel", typeid(void (SpaceManager::*)(bool )), "5557565383ec2c8b7424408d7c241a8b4424448d9ea4020000888674020000", argdata, 2, 6, &func);
+	static FunctionDefinition funcObj("SpaceManager::SetStorm", typeid(void (SpaceManager::*)(bool )), "5383ec288b4424308d5c241cc6802a03000001", argdata, 2, 6, &func);
 }
 
-void SpaceManager::SetFireLevel(bool state)
+void SpaceManager::SetStorm(bool state)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1294::func;
@@ -17700,6 +17700,20 @@ void SpaceManager::SetFireLevel(bool state)
 namespace _func1295
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("SpaceManager::SetFireLevel", typeid(void (SpaceManager::*)(bool )), "5557565383ec2c8b7424408d7c241a8b4424448d9ea4020000888674020000", argdata, 2, 6, &func);
+}
+
+void SpaceManager::SetFireLevel(bool state)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1295::func;
+	return execfunc(this, state);
+}
+
+namespace _func1296
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff};
 	static FunctionDefinition funcObj("SpaceStatus::OnInit", typeid(void (SpaceStatus::*)(SpaceManager *, Point )), "55575631f65383ec7c8b9c24????????", argdata, 3, 6, &func);
 }
@@ -17707,11 +17721,11 @@ namespace _func1295
 void SpaceStatus::OnInit(SpaceManager *space, Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg, SpaceManager *space_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1295::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1296::func;
 	return execfunc(this, space, pos);
 }
 
-namespace _func1296
+namespace _func1297
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17721,11 +17735,11 @@ namespace _func1296
 void SpaceStatus::RenderWarningText(int effect, int textOffset)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg, int effect_arg, int textOffset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1296::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1297::func;
 	return execfunc(this, effect, textOffset);
 }
 
-namespace _func1297
+namespace _func1298
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17735,11 +17749,11 @@ namespace _func1297
 void SpaceStatus::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1297::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1298::func;
 	return execfunc(this);
 }
 
-namespace _func1298
+namespace _func1299
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17749,11 +17763,11 @@ namespace _func1298
 void SpaceStatus::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1298::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1299::func;
 	return execfunc(this);
 }
 
-namespace _func1299
+namespace _func1300
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -17763,11 +17777,11 @@ namespace _func1299
 void SpaceStatus::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1299::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1300::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1300
+namespace _func1301
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17777,11 +17791,11 @@ namespace _func1300
 int Spreader_Fire::CounterRoom(int roomId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(Spreader_Fire *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1300::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1301::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1301
+namespace _func1302
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17791,11 +17805,11 @@ namespace _func1301
 void Spreader_Fire::UpdateSpread()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Spreader_Fire *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1301::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1302::func;
 	return execfunc(this);
 }
 
-namespace _func1302
+namespace _func1303
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -17805,11 +17819,11 @@ namespace _func1302
 void StarMap::SetPosition(Point unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1302::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1303::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1303
+namespace _func1304
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17819,11 +17833,11 @@ namespace _func1303
 void StarMap::KeyDown(int unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1303::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1304::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1304
+namespace _func1305
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17833,11 +17847,11 @@ namespace _func1304
 int StarMap::GetNextDangerMove()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1304::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1305::func;
 	return execfunc(this);
 }
 
-namespace _func1305
+namespace _func1306
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17847,11 +17861,11 @@ namespace _func1305
 void StarMap::Open()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1305::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1306::func;
 	return execfunc(this);
 }
 
-namespace _func1306
+namespace _func1307
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17861,11 +17875,11 @@ namespace _func1306
 void StarMap::Close()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1306::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1307::func;
 	return execfunc(this);
 }
 
-namespace _func1307
+namespace _func1308
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17875,11 +17889,11 @@ namespace _func1307
 void StarMap::SetOpen(bool unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, bool unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1307::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1308::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1308
+namespace _func1309
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17887,20 +17901,6 @@ namespace _func1308
 }
 
 void StarMap::InitMapTitle()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1308::func;
-	return execfunc(this);
-}
-
-namespace _func1309
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::InitNoFuelText", typeid(void (StarMap::*)()), "5557565383ec5c8b6c24708d5c24408d7c243f8b8568040000", argdata, 1, 6, &func);
-}
-
-void StarMap::InitNoFuelText()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1309::func;
@@ -17911,10 +17911,10 @@ namespace _func1310
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::InitBossMessageBox", typeid(void (StarMap::*)()), "5589e557565383ec3c8b5d088bb3cc050000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StarMap::InitNoFuelText", typeid(void (StarMap::*)()), "5557565383ec5c8b6c24708d5c24408d7c243f8b8568040000", argdata, 1, 6, &func);
 }
 
-void StarMap::InitBossMessageBox()
+void StarMap::InitNoFuelText()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1310::func;
@@ -17925,10 +17925,10 @@ namespace _func1311
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::OnLanguageChange", typeid(void (StarMap::*)()), "5383ec188b5c2420891c24e8????????891c24e8????????895c2420", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StarMap::InitBossMessageBox", typeid(void (StarMap::*)()), "5589e557565383ec3c8b5d088bb3cc050000", argdata, 1, 6, &func);
 }
 
-void StarMap::OnLanguageChange()
+void StarMap::InitBossMessageBox()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1311::func;
@@ -17939,17 +17939,31 @@ namespace _func1312
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("StarMap::OnLanguageChange", typeid(void (StarMap::*)()), "5383ec188b5c2420891c24e8????????891c24e8????????895c2420", argdata, 1, 6, &func);
+}
+
+void StarMap::OnLanguageChange()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1312::func;
+	return execfunc(this);
+}
+
+namespace _func1313
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("StarMap::GetRandomSectorChoice", typeid(int (StarMap::*)()), "83ec0c803d????????0075??e8????????89c1", argdata, 1, 2, &func);
 }
 
 int StarMap::GetRandomSectorChoice()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1312::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1313::func;
 	return execfunc(this);
 }
 
-namespace _func1313
+namespace _func1314
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17959,11 +17973,11 @@ namespace _func1313
 bool StarMap::NeighboringSector(int potentialSector)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int potentialSector_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1313::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1314::func;
 	return execfunc(this, potentialSector);
 }
 
-namespace _func1314
+namespace _func1315
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -17973,11 +17987,11 @@ namespace _func1314
 void StarMap::GetSelectedSector(int unk0, int unk1, int unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg, int unk1_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1314::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1315::func;
 	return execfunc(this, unk0, unk1, unk2);
 }
 
-namespace _func1315
+namespace _func1316
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -17987,11 +18001,11 @@ namespace _func1315
 void StarMap::StartSecretSector()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1315::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1316::func;
 	return execfunc(this);
 }
 
-namespace _func1316
+namespace _func1317
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -17999,20 +18013,6 @@ namespace _func1316
 }
 
 void StarMap::ReachSector(Sector *unk0)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1316::func;
-	return execfunc(this, unk0);
-}
-
-namespace _func1317
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("StarMap::UpdateSectorMap", typeid(void (StarMap::*)(Sector *)), "5756538b7c24148b74241085ff", argdata, 2, 6, &func);
-}
-
-void StarMap::UpdateSectorMap(Sector *unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1317::func;
@@ -18023,17 +18023,31 @@ namespace _func1318
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("StarMap::UpdateSectorMap", typeid(void (StarMap::*)(Sector *)), "5756538b7c24148b74241085ff", argdata, 2, 6, &func);
+}
+
+void StarMap::UpdateSectorMap(Sector *unk0)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1318::func;
+	return execfunc(this, unk0);
+}
+
+namespace _func1319
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::SaveGame", typeid(void (StarMap::*)(int )), "5557565383ec3c8b6c24508b5c24548b857c060000", argdata, 2, 6, &func);
 }
 
 void StarMap::SaveGame(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1318::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1319::func;
 	return execfunc(this, file);
 }
 
-namespace _func1319
+namespace _func1320
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18041,20 +18055,6 @@ namespace _func1319
 }
 
 void StarMap::InitStatistics()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1319::func;
-	return execfunc(this);
-}
-
-namespace _func1320
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::PrintStatistics", typeid(void (StarMap::*)()), ".f3c38db426000000008dbc2700000000f3c38db4", argdata, 1, 6, &func);
-}
-
-void StarMap::PrintStatistics()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1320::func;
@@ -18065,10 +18065,10 @@ namespace _func1321
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::AnalyzeMap", typeid(void (StarMap::*)()), ".f3c38db426000000008dbc27000000008b442404", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StarMap::PrintStatistics", typeid(void (StarMap::*)()), ".f3c38db426000000008dbc2700000000f3c38db4", argdata, 1, 6, &func);
 }
 
-void StarMap::AnalyzeMap()
+void StarMap::PrintStatistics()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1321::func;
@@ -18078,6 +18078,20 @@ void StarMap::AnalyzeMap()
 namespace _func1322
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("StarMap::AnalyzeMap", typeid(void (StarMap::*)()), ".f3c38db426000000008dbc27000000008b442404", argdata, 1, 6, &func);
+}
+
+void StarMap::AnalyzeMap()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1322::func;
+	return execfunc(this);
+}
+
+namespace _func1323
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::ModifyPursuit", typeid(void (StarMap::*)(int )), "8b4424048b542408019020040000", argdata, 2, 6, &func);
 }
@@ -18085,11 +18099,11 @@ namespace _func1322
 void StarMap::ModifyPursuit(int unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1322::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1323::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1323
+namespace _func1324
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18097,20 +18111,6 @@ namespace _func1323
 }
 
 void StarMap::AtBeacon()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1323::func;
-	return execfunc(this);
-}
-
-namespace _func1324
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::GetWaitLocation", typeid(void (StarMap::*)()), "8b44240480787c00", argdata, 1, 6, &func);
-}
-
-void StarMap::GetWaitLocation()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1324::func;
@@ -18121,10 +18121,10 @@ namespace _func1325
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::StartBeacon", typeid(void (StarMap::*)()), "5631c0538b54240c8b8a18040000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StarMap::GetWaitLocation", typeid(void (StarMap::*)()), "8b44240480787c00", argdata, 1, 6, &func);
 }
 
-void StarMap::StartBeacon()
+void StarMap::GetWaitLocation()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1325::func;
@@ -18134,6 +18134,20 @@ void StarMap::StartBeacon()
 namespace _func1326
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("StarMap::StartBeacon", typeid(void (StarMap::*)()), "5631c0538b54240c8b8a18040000", argdata, 1, 6, &func);
+}
+
+void StarMap::StartBeacon()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1326::func;
+	return execfunc(this);
+}
+
+namespace _func1327
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::LocationsConnected", typeid(bool (StarMap::*)(Location *, Location *)), "538b44240c8b5c24108b48088b500c", argdata, 3, 2, &func);
 }
@@ -18141,11 +18155,11 @@ namespace _func1326
 bool StarMap::LocationsConnected(Location *unk0, Location *unk1)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg, Location *unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1326::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1327::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1327
+namespace _func1328
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18155,11 +18169,11 @@ namespace _func1327
 Point StarMap::PointToGrid(float x, float y)
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, float x_arg, float y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1327::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1328::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1328
+namespace _func1329
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18169,11 +18183,11 @@ namespace _func1328
 void StarMap::TravelToLocation(Location *unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1328::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1329::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1329
+namespace _func1330
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18183,11 +18197,11 @@ namespace _func1329
 void StarMap::ForceExitBeacon()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1329::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1330::func;
 	return execfunc(this);
 }
 
-namespace _func1330
+namespace _func1331
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18197,11 +18211,11 @@ namespace _func1330
 void StarMap::OnRenderFogEffect()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1330::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1331::func;
 	return execfunc(this);
 }
 
-namespace _func1331
+namespace _func1332
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18209,20 +18223,6 @@ namespace _func1331
 }
 
 void StarMap::LocationHasBoss(Location *unk0)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1331::func;
-	return execfunc(this, unk0);
-}
-
-namespace _func1332
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("StarMap::LocationHasStore", typeid(void (StarMap::*)(Location *)), "56538b5424108b4c240c8b422085c0", argdata, 2, 6, &func);
-}
-
-void StarMap::LocationHasStore(Location *unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1332::func;
@@ -18233,10 +18233,10 @@ namespace _func1333
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("StarMap::LocationHasShip", typeid(void (StarMap::*)(Location *)), "8b4424088b402085c0", argdata, 2, 6, &func);
+	static FunctionDefinition funcObj("StarMap::LocationHasStore", typeid(void (StarMap::*)(Location *)), "56538b5424108b4c240c8b422085c0", argdata, 2, 6, &func);
 }
 
-void StarMap::LocationHasShip(Location *unk0)
+void StarMap::LocationHasStore(Location *unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1333::func;
@@ -18246,25 +18246,25 @@ void StarMap::LocationHasShip(Location *unk0)
 namespace _func1334
 {
     static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::AdvanceWorldLevel", typeid(void (StarMap::*)()), "5557565383ec5c8b7424708b8618040000", argdata, 1, 6, &func);
+	static short argdata[] = {0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("StarMap::LocationHasShip", typeid(void (StarMap::*)(Location *)), "8b4424088b402085c0", argdata, 2, 6, &func);
 }
 
-void StarMap::AdvanceWorldLevel()
+void StarMap::LocationHasShip(Location *unk0)
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1334::func;
-	return execfunc(this);
+	return execfunc(this, unk0);
 }
 
 namespace _func1335
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::ReverseBossPath", typeid(void (StarMap::*)()), "56538b5c240c8b8bc4070000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StarMap::AdvanceWorldLevel", typeid(void (StarMap::*)()), "5557565383ec5c8b7424708b8618040000", argdata, 1, 6, &func);
 }
 
-void StarMap::ReverseBossPath()
+void StarMap::AdvanceWorldLevel()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1335::func;
@@ -18275,10 +18275,10 @@ namespace _func1336
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::ForceBossJump", typeid(void (StarMap::*)()), "5756538b5c241080bbbc07000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StarMap::ReverseBossPath", typeid(void (StarMap::*)()), "56538b5c240c8b8bc4070000", argdata, 1, 6, &func);
 }
 
-void StarMap::ForceBossJump()
+void StarMap::ReverseBossPath()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1336::func;
@@ -18289,10 +18289,10 @@ namespace _func1337
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StarMap::ClearBoss", typeid(void (StarMap::*)()), "565331db83ec148b7424208b56208b4624c686cc07000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StarMap::ForceBossJump", typeid(void (StarMap::*)()), "5756538b5c241080bbbc07000000", argdata, 1, 6, &func);
 }
 
-void StarMap::ClearBoss()
+void StarMap::ForceBossJump()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1337::func;
@@ -18302,6 +18302,20 @@ void StarMap::ClearBoss()
 namespace _func1338
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("StarMap::ClearBoss", typeid(void (StarMap::*)()), "565331db83ec148b7424208b56208b4624c686cc07000000", argdata, 1, 6, &func);
+}
+
+void StarMap::ClearBoss()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1338::func;
+	return execfunc(this);
+}
+
+namespace _func1339
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::SetBossStage", typeid(void (StarMap::*)(int )), "8b5424088b4424048990f4080000", argdata, 2, 6, &func);
 }
@@ -18309,11 +18323,11 @@ namespace _func1338
 void StarMap::SetBossStage(int stage)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int stage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1338::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1339::func;
 	return execfunc(this, stage);
 }
 
-namespace _func1339
+namespace _func1340
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18323,11 +18337,11 @@ namespace _func1339
 void StarMap::CheckGameOver()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1339::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1340::func;
 	return execfunc(this);
 }
 
-namespace _func1340
+namespace _func1341
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18337,11 +18351,11 @@ namespace _func1340
 std::string StarMap::GetPotentialSectorChoiceName()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1340::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1341::func;
 	return execfunc(this);
 }
 
-namespace _func1341
+namespace _func1342
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18351,11 +18365,11 @@ namespace _func1341
 void StarMap::RenderLabels()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1341::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1342::func;
 	return execfunc(this);
 }
 
-namespace _func1342
+namespace _func1343
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18365,11 +18379,11 @@ namespace _func1342
 void StarMap::DeleteMap()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1342::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1343::func;
 	return execfunc(this);
 }
 
-namespace _func1343
+namespace _func1344
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -18379,11 +18393,11 @@ namespace _func1343
 void StarMap::MouseClick(int unk0, int unk1)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg, int unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1343::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1344::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1344
+namespace _func1345
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18393,11 +18407,11 @@ namespace _func1344
 void StarMap::AddSectorColumn()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1344::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1345::func;
 	return execfunc(this);
 }
 
-namespace _func1345
+namespace _func1346
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18407,11 +18421,11 @@ namespace _func1345
 void StarMap::PushSectorColumn()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1345::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1346::func;
 	return execfunc(this);
 }
 
-namespace _func1346
+namespace _func1347
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18421,11 +18435,11 @@ namespace _func1346
 void StarMap::SelectNewSector(int unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1346::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1347::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1347
+namespace _func1348
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18435,11 +18449,11 @@ namespace _func1347
 void StarMap::GenerateSectorMap()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1347::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1348::func;
 	return execfunc(this);
 }
 
-namespace _func1348
+namespace _func1349
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18449,11 +18463,11 @@ namespace _func1348
 void StarMap::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1348::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1349::func;
 	return execfunc(this);
 }
 
-namespace _func1349
+namespace _func1350
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x4ff};
@@ -18463,11 +18477,11 @@ namespace _func1349
 void StarMap::RenderSectorName(Sector *unk0, GL_Color unk1)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg, GL_Color unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1349::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1350::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1350
+namespace _func1351
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18477,11 +18491,11 @@ namespace _func1350
 void StarMap::UpdateDangerZone()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1350::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1351::func;
 	return execfunc(this);
 }
 
-namespace _func1351
+namespace _func1352
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18491,11 +18505,11 @@ namespace _func1351
 Location *StarMap::GetNewLocation()
 {
 	typedef Location *__attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1351::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1352::func;
 	return execfunc(this);
 }
 
-namespace _func1352
+namespace _func1353
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18505,11 +18519,11 @@ namespace _func1352
 void StarMap::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1352::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1353::func;
 	return execfunc(this);
 }
 
-namespace _func1353
+namespace _func1354
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18519,11 +18533,11 @@ namespace _func1353
 void StarMap::GenerateEvents(bool tutorial)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, bool tutorial_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1353::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1354::func;
 	return execfunc(this, tutorial);
 }
 
-namespace _func1354
+namespace _func1355
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18533,11 +18547,11 @@ namespace _func1354
 void StarMap::AddConnections(Location *unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1354::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1355::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1355
+namespace _func1356
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18547,11 +18561,11 @@ namespace _func1355
 bool StarMap::MapConnected()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1355::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1356::func;
 	return execfunc(this);
 }
 
-namespace _func1356
+namespace _func1357
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x2ff};
@@ -18561,11 +18575,11 @@ namespace _func1356
 void StarMap::ConnectLocations(Point unk0, Point unk1)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg, Point unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1356::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1357::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1357
+namespace _func1358
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -18575,11 +18589,11 @@ namespace _func1357
 void StarMap::PopulateGrid(Point unk0)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1357::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1358::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1358
+namespace _func1359
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -18589,11 +18603,11 @@ namespace _func1358
 Location *StarMap::PopClosestLoc(std::vector<Location*> &vec, std::map<Location*, int> &map)
 {
 	typedef Location *__attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, std::vector<Location*> &vec_arg, std::map<Location*, int> &map_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1358::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1359::func;
 	return execfunc(this, vec, map);
 }
 
-namespace _func1359
+namespace _func1360
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -18603,11 +18617,11 @@ namespace _func1359
 bool StarMap::AddQuest(const std::string &questEvent, bool force)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, const std::string &questEvent_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1359::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1360::func;
 	return execfunc(this, questEvent, force);
 }
 
-namespace _func1360
+namespace _func1361
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -18617,11 +18631,11 @@ namespace _func1360
 Location *StarMap::GenerateMap(bool tutorial, bool seed)
 {
 	typedef Location *__attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, bool tutorial_arg, bool seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1360::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1361::func;
 	return execfunc(this, tutorial, seed);
 }
 
-namespace _func1361
+namespace _func1362
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18631,11 +18645,11 @@ namespace _func1361
 Location *StarMap::NewGame(bool unk0)
 {
 	typedef Location *__attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, bool unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1361::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1362::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1362
+namespace _func1363
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18645,11 +18659,11 @@ namespace _func1362
 std::vector<Location*> StarMap::Dijkstra(Location *start, Location *finish, bool include_unknown)
 {
 	typedef std::vector<Location*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *start_arg, Location *finish_arg, bool include_unknown_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1362::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1363::func;
 	return execfunc(this, start, finish, include_unknown);
 }
 
-namespace _func1363
+namespace _func1364
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -18659,11 +18673,11 @@ namespace _func1363
 void StarMap::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1363::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1364::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1364
+namespace _func1365
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18673,11 +18687,11 @@ namespace _func1364
 void StarMap::OnTouch(TouchAction unk0, int unk1, int unk2, int unk3, int unk4, int unk5)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, TouchAction unk0_arg, int unk1_arg, int unk2_arg, int unk3_arg, int unk4_arg, int unk5_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1364::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1365::func;
 	return execfunc(this, unk0, unk1, unk2, unk3, unk4, unk5);
 }
 
-namespace _func1365
+namespace _func1366
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18687,11 +18701,11 @@ namespace _func1365
 Location *StarMap::LoadGame(int fileHelper)
 {
 	typedef Location *__attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1365::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1366::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1366
+namespace _func1367
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18701,11 +18715,11 @@ namespace _func1366
 void StarMap::RenderLeftInsetButton(float unk0, float unk1, bool unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, float unk0_arg, float unk1_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1366::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1367::func;
 	return execfunc(this, unk0, unk1, unk2);
 }
 
-namespace _func1367
+namespace _func1368
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18715,11 +18729,11 @@ namespace _func1367
 void StarMap::RenderDistressButtons()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1367::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1368::func;
 	return execfunc(this);
 }
 
-namespace _func1368
+namespace _func1369
 {
     static void *func = 0;
 	static short argdata[] = {0x100};
@@ -18729,11 +18743,11 @@ namespace _func1368
 void StarMap::OnRender()
 {
 	typedef void __attribute__((regparm(1))) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1368::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1369::func;
 	return execfunc(this);
 }
 
-namespace _func1369
+namespace _func1370
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18743,11 +18757,11 @@ namespace _func1369
 void StarMap::DrawConnection(const Pointf &pos1, const Pointf &pos2, const GL_Color *color)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, const Pointf &pos1_arg, const Pointf &pos2_arg, const GL_Color *color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1369::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1370::func;
 	return execfunc(this, pos1, pos2, color);
 }
 
-namespace _func1370
+namespace _func1371
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18757,11 +18771,11 @@ namespace _func1370
 void StarMap::TurnIntoFleetLocation(Location *loc)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1370::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1371::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1371
+namespace _func1372
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -18771,11 +18785,11 @@ namespace _func1371
 std::string StarMap::GetLocationText(const Location *loc)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, const Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1371::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1372::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1372
+namespace _func1373
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -18785,11 +18799,11 @@ namespace _func1372
 void StarMap::SetupNoFuel(int seed, const std::string &forceEscape)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, int seed_arg, const std::string &forceEscape_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1372::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1373::func;
 	return execfunc(this, seed, forceEscape);
 }
 
-namespace _func1373
+namespace _func1374
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18799,11 +18813,11 @@ namespace _func1373
 void StarMap::GenerateNebulas(const std::vector<std::string> &names)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StarMap *this_arg, const std::vector<std::string> &names_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1373::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1374::func;
 	return execfunc(this, names);
 }
 
-namespace _func1374
+namespace _func1375
 {
     static void *func = 0;
 	static short argdata[] = {0x100};
@@ -18813,11 +18827,11 @@ namespace _func1374
 void StarMap::UpdateBoss()
 {
 	typedef void __attribute__((regparm(1))) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1374::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1375::func;
 	return execfunc(this);
 }
 
-namespace _func1375
+namespace _func1376
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18827,11 +18841,11 @@ namespace _func1375
 StatusEffect StatusEffect::GetNebulaEffect()
 {
 	typedef StatusEffect __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1375::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1376::func;
 	return execfunc();
 }
 
-namespace _func1376
+namespace _func1377
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18841,11 +18855,11 @@ namespace _func1376
 void Store::OnInit(ShipManager *shopper, Equipment *equip, int worldLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, ShipManager *shopper_arg, Equipment *equip_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1376::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1377::func;
 	return execfunc(this, shopper, equip, worldLevel);
 }
 
-namespace _func1377
+namespace _func1378
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -18855,11 +18869,11 @@ namespace _func1377
 void Store::CreateStoreBoxes(int type, Equipment *equip)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, int type_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1377::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1378::func;
 	return execfunc(this, type, equip);
 }
 
-namespace _func1378
+namespace _func1379
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18869,11 +18883,11 @@ namespace _func1378
 bool Store::KeyDown(SDLKey key)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1378::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1379::func;
 	return execfunc(this, key);
 }
 
-namespace _func1379
+namespace _func1380
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18883,11 +18897,11 @@ namespace _func1379
 void Store::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1379::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1380::func;
 	return execfunc(this);
 }
 
-namespace _func1380
+namespace _func1381
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18897,11 +18911,11 @@ namespace _func1380
 void Store::Close()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1380::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1381::func;
 	return execfunc(this);
 }
 
-namespace _func1381
+namespace _func1382
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -18911,11 +18925,11 @@ namespace _func1381
 void Store::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1381::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1382::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1382
+namespace _func1383
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18925,11 +18939,11 @@ namespace _func1382
 void Store::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1382::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1383::func;
 	return execfunc(this);
 }
 
-namespace _func1383
+namespace _func1384
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18939,11 +18953,11 @@ namespace _func1383
 void Store::SaveStore(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1383::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1384::func;
 	return execfunc(this, file);
 }
 
-namespace _func1384
+namespace _func1385
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -18953,11 +18967,11 @@ namespace _func1384
 void Store::RelinkShip(ShipManager *ship, Equipment *equip)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, ShipManager *ship_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1384::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1385::func;
 	return execfunc(this, ship, equip);
 }
 
-namespace _func1385
+namespace _func1386
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -18967,11 +18981,11 @@ namespace _func1385
 bool Store::HasType(int type)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1385::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1386::func;
 	return execfunc(this, type);
 }
 
-namespace _func1386
+namespace _func1387
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18981,11 +18995,11 @@ namespace _func1386
 void Store::Clear()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1386::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1387::func;
 	return execfunc(this);
 }
 
-namespace _func1387
+namespace _func1388
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff};
@@ -18995,11 +19009,11 @@ namespace _func1387
 void Store::InitHeading(int index, Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, int index_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1387::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1388::func;
 	return execfunc(this, index, pos);
 }
 
-namespace _func1388
+namespace _func1389
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -19009,11 +19023,11 @@ namespace _func1388
 void Store::DrawBuySellTabText()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1388::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1389::func;
 	return execfunc();
 }
 
-namespace _func1389
+namespace _func1390
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19023,11 +19037,11 @@ namespace _func1389
 void Store::MouseClick(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1389::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1390::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1390
+namespace _func1391
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19037,11 +19051,11 @@ namespace _func1390
 void Store::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1390::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1391::func;
 	return execfunc(this);
 }
 
-namespace _func1391
+namespace _func1392
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19051,11 +19065,11 @@ namespace _func1391
 void Store::SetPositions()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1391::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1392::func;
 	return execfunc(this);
 }
 
-namespace _func1392
+namespace _func1393
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19065,11 +19079,11 @@ namespace _func1392
 void Store::LoadStore(int file, int worldLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, int file_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1392::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1393::func;
 	return execfunc(this, file, worldLevel);
 }
 
-namespace _func1393
+namespace _func1394
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -19079,11 +19093,11 @@ namespace _func1393
 void Store::SetPosition(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1393::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1394::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1394
+namespace _func1395
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19093,11 +19107,11 @@ namespace _func1394
 void Store::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1394::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1395::func;
 	return execfunc(this);
 }
 
-namespace _func1395
+namespace _func1396
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19107,11 +19121,11 @@ namespace _func1395
 void StoreBox::MouseClick(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1395::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1396::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1396
+namespace _func1397
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19121,11 +19135,11 @@ namespace _func1396
 void StoreBox::Activate()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1396::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1397::func;
 	return execfunc(this);
 }
 
-namespace _func1397
+namespace _func1398
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19135,11 +19149,11 @@ namespace _func1397
 void StoreBox::InitBlueprint(Blueprint *bp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg, Blueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1397::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1398::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1398
+namespace _func1399
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -19149,11 +19163,11 @@ namespace _func1398
 void StoreBox::constructor(const std::string &buttonImage, ShipManager *shopper, Equipment *equip)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg, const std::string &buttonImage_arg, ShipManager *shopper_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1398::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1399::func;
 	return execfunc(this, buttonImage, shopper, equip);
 }
 
-namespace _func1399
+namespace _func1400
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -19163,11 +19177,11 @@ namespace _func1399
 void StoreBox::SetPosition(Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1399::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1400::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1400
+namespace _func1401
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19175,20 +19189,6 @@ namespace _func1400
 }
 
 void StoreBox::OnRender()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1400::func;
-	return execfunc(this);
-}
-
-namespace _func1401
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StoreBox::OnLoop", typeid(void (StoreBox::*)()), "5331c083ec188b5c24208b93b800000085d2", argdata, 1, 6, &func);
-}
-
-void StoreBox::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1401::func;
@@ -19199,10 +19199,10 @@ namespace _func1402
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("StoreBox::Purchase", typeid(void (StoreBox::*)()), ".5557565383ec2c8d74241c8b5c24408d7c241a", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("StoreBox::OnLoop", typeid(void (StoreBox::*)()), "5331c083ec188b5c24208b93b800000085d2", argdata, 1, 6, &func);
 }
 
-void StoreBox::Purchase()
+void StoreBox::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1402::func;
@@ -19213,17 +19213,31 @@ namespace _func1403
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("StoreBox::Purchase", typeid(void (StoreBox::*)()), ".5557565383ec2c8d74241c8b5c24408d7c241a", argdata, 1, 6, &func);
+}
+
+void StoreBox::Purchase()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1403::func;
+	return execfunc(this);
+}
+
+namespace _func1404
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("SuperShieldDrone::GetWeaponCooldown", typeid(float (SuperShieldDrone::*)()), "5589e583ec288b15????????8b????8b801401000085c074??", argdata, 1, 2, &func);
 }
 
 float SuperShieldDrone::GetWeaponCooldown()
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(SuperShieldDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1403::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1404::func;
 	return execfunc(this);
 }
 
-namespace _func1404
+namespace _func1405
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19233,11 +19247,11 @@ namespace _func1404
 void SuperShieldDrone::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SuperShieldDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1404::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1405::func;
 	return execfunc(this);
 }
 
-namespace _func1405
+namespace _func1406
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -19247,11 +19261,11 @@ namespace _func1405
 void SuperShieldDrone::constructor(int iShipId, int selfId, DroneBlueprint *blueprint)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SuperShieldDrone *this_arg, int iShipId_arg, int selfId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1405::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1406::func;
 	return execfunc(this, iShipId, selfId, blueprint);
 }
 
-namespace _func1406
+namespace _func1407
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19261,11 +19275,11 @@ namespace _func1406
 void SystemBox::OnRender(bool ignoreStatus)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemBox *this_arg, bool ignoreStatus_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1406::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1407::func;
 	return execfunc(this, ignoreStatus);
 }
 
-namespace _func1407
+namespace _func1408
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19275,11 +19289,11 @@ namespace _func1407
 void SystemBox::MouseRightClick(bool force)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemBox *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1407::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1408::func;
 	return execfunc(this, force);
 }
 
-namespace _func1408
+namespace _func1409
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -19289,11 +19303,11 @@ namespace _func1408
 void SystemBox::constructor(Point pos, ShipSystem *sys, bool playerUI)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, bool playerUI_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1408::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1409::func;
 	return execfunc(this, pos, sys, playerUI);
 }
 
-namespace _func1409
+namespace _func1410
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19303,11 +19317,11 @@ namespace _func1409
 void SystemBox::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1409::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1410::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1410
+namespace _func1411
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19317,11 +19331,11 @@ namespace _func1410
 bool SystemBox::MouseClick(bool shift)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemBox *this_arg, bool shift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1410::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1411::func;
 	return execfunc(this, shift);
 }
 
-namespace _func1411
+namespace _func1412
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19331,11 +19345,11 @@ namespace _func1411
 void SystemBox::KeyDown(SDLKey key, bool shift)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemBox *this_arg, SDLKey key_arg, bool shift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1411::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1412::func;
 	return execfunc(this, key, shift);
 }
 
-namespace _func1412
+namespace _func1413
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19345,11 +19359,11 @@ namespace _func1412
 void SystemBox::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1412::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1413::func;
 	return execfunc(this);
 }
 
-namespace _func1413
+namespace _func1414
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19359,11 +19373,11 @@ namespace _func1413
 void SystemControl::CreateSystemBoxes()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1413::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1414::func;
 	return execfunc(this);
 }
 
-namespace _func1414
+namespace _func1415
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19373,11 +19387,11 @@ namespace _func1414
 SystemBox *SystemControl::GetSystemBox(int systemId)
 {
 	typedef SystemBox *__attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemControl *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1414::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1415::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1415
+namespace _func1416
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19387,11 +19401,11 @@ namespace _func1415
 void SystemControl::RenderPowerBar()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1415::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1416::func;
 	return execfunc(this);
 }
 
-namespace _func1416
+namespace _func1417
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19401,11 +19415,11 @@ namespace _func1416
 void SystemControl::OnRender(bool front)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemControl *this_arg, bool front_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1416::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1417::func;
 	return execfunc(this, front);
 }
 
-namespace _func1417
+namespace _func1418
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -19415,11 +19429,11 @@ namespace _func1417
 SystemControl::PowerBars *SystemControl::GetPowerBars(int width, int height, int gap, bool useShieldGap)
 {
 	typedef SystemControl::PowerBars *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int width_arg, int height_arg, int gap_arg, bool useShieldGap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1417::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1418::func;
 	return execfunc(width, height, gap, useShieldGap);
 }
 
-namespace _func1418
+namespace _func1419
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19429,25 +19443,25 @@ namespace _func1418
 void SystemControl::UpdateSubSystemBox()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1418::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1419::func;
 	return execfunc(this);
 }
 
 Point *Global_SystemControl_weapon_position;
 
-namespace _var1419
+namespace _var1420
 {
     static VariableDefinition varObj("Global_SystemControl_weapon_position", "!a3(???????\?)8915????????e8????????8b5424448b4424408b4b0c8915????????8b5308a3(???????\?)", &Global_SystemControl_weapon_position);
 }
 
 Point *Global_SystemControl_drone_position;
 
-namespace _var1420
+namespace _var1421
 {
     static VariableDefinition varObj("Global_SystemControl_drone_position", "", &Global_SystemControl_drone_position);
 }
 
-namespace _func1421
+namespace _func1422
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -19457,11 +19471,11 @@ namespace _func1421
 void SystemCustomBox::constructor(Point pos, ShipSystem *sys, ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemCustomBox *this_arg, Point pos_arg, ShipSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1421::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1422::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func1422
+namespace _func1423
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19471,11 +19485,11 @@ namespace _func1422
 void SystemStoreBox::SetExtraData(int droneChoice)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, int droneChoice_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1422::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1423::func;
 	return execfunc(this, droneChoice);
 }
 
-namespace _func1423
+namespace _func1424
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19485,11 +19499,11 @@ namespace _func1423
 TextString SystemStoreBox::GetConfirmText()
 {
 	typedef TextString __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1423::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1424::func;
 	return execfunc(this);
 }
 
-namespace _func1424
+namespace _func1425
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -19499,11 +19513,11 @@ namespace _func1424
 void SystemStoreBox::constructor(ShipManager *shopper, Equipment *equip, int sys)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, ShipManager *shopper_arg, Equipment *equip_arg, int sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1424::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1425::func;
 	return execfunc(this, shopper, equip, sys);
 }
 
-namespace _func1425
+namespace _func1426
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19513,11 +19527,11 @@ namespace _func1425
 bool SystemStoreBox::CanHold()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1425::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1426::func;
 	return execfunc(this);
 }
 
-namespace _func1426
+namespace _func1427
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19527,11 +19541,11 @@ namespace _func1426
 void SystemStoreBox::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1426::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1427::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1427
+namespace _func1428
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19541,11 +19555,11 @@ namespace _func1427
 void SystemStoreBox::Activate()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1427::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1428::func;
 	return execfunc(this);
 }
 
-namespace _func1428
+namespace _func1429
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19555,11 +19569,11 @@ namespace _func1428
 int SystemStoreBox::SetInfoBox(InfoBox *box, int forceSystemInfoWidth)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, InfoBox *box_arg, int forceSystemInfoWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1428::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1429::func;
 	return execfunc(this, box, forceSystemInfoWidth);
 }
 
-namespace _func1429
+namespace _func1430
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19569,11 +19583,11 @@ namespace _func1429
 void SystemStoreBox::Purchase()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1429::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1430::func;
 	return execfunc(this);
 }
 
-namespace _func1430
+namespace _func1431
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19583,11 +19597,11 @@ namespace _func1430
 void TabbedWindow::Close()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TabbedWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1430::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1431::func;
 	return execfunc(this);
 }
 
-namespace _func1431
+namespace _func1432
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19597,11 +19611,11 @@ namespace _func1431
 void TabbedWindow::SetTab(unsigned int tab)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TabbedWindow *this_arg, unsigned int tab_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1431::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1432::func;
 	return execfunc(this, tab);
 }
 
-namespace _func1432
+namespace _func1433
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -19611,11 +19625,11 @@ namespace _func1432
 void TabbedWindow::AddWindow(const std::string &name, Button *button, FocusWindow *window)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TabbedWindow *this_arg, const std::string &name_arg, Button *button_arg, FocusWindow *window_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1432::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1433::func;
 	return execfunc(this, name, button, window);
 }
 
-namespace _func1433
+namespace _func1434
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19625,11 +19639,11 @@ namespace _func1433
 void TabbedWindow::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TabbedWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1433::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1434::func;
 	return execfunc(this);
 }
 
-namespace _func1434
+namespace _func1435
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -19639,11 +19653,11 @@ namespace _func1434
 void TabbedWindow::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TabbedWindow *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1434::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1435::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1435
+namespace _func1436
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
@@ -19653,11 +19667,11 @@ namespace _func1435
 void TeleportBox::constructor(Point pos, TeleportSystem *sys)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportBox *this_arg, Point pos_arg, TeleportSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1435::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1436::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func1436
+namespace _func1437
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19667,11 +19681,11 @@ namespace _func1436
 void TeleportSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1436::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1437::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func1437
+namespace _func1438
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19681,11 +19695,11 @@ namespace _func1437
 void TeleportSystem::OnRenderFloor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1437::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1438::func;
 	return execfunc(this);
 }
 
-namespace _func1438
+namespace _func1439
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -19695,11 +19709,11 @@ namespace _func1438
 void TeleportSystem::constructor(int systemId, int roomId, int shipId, int startingPower)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int systemId_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1438::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1439::func;
 	return execfunc(this, systemId, roomId, shipId, startingPower);
 }
 
-namespace _func1439
+namespace _func1440
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19709,11 +19723,11 @@ namespace _func1439
 float TeleportSystem::GetChargedPercent()
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1439::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1440::func;
 	return execfunc(this);
 }
 
-namespace _func1440
+namespace _func1441
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19723,11 +19737,11 @@ namespace _func1440
 bool TeleportSystem::Charged()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1440::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1441::func;
 	return execfunc(this);
 }
 
-namespace _func1441
+namespace _func1442
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19737,11 +19751,11 @@ namespace _func1441
 void TeleportSystem::ClearCrewLocations()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1441::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1442::func;
 	return execfunc(this);
 }
 
-namespace _func1442
+namespace _func1443
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19751,11 +19765,11 @@ namespace _func1442
 void TeleportSystem::UpdateCrewLocation(int unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1442::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1443::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1443
+namespace _func1444
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19765,11 +19779,11 @@ namespace _func1443
 void TeleportSystem::SetArmed(int armed)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int armed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1443::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1444::func;
 	return execfunc(this, armed);
 }
 
-namespace _func1444
+namespace _func1445
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19779,20 +19793,6 @@ namespace _func1444
 void TeleportSystem::ForceReady()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1444::func;
-	return execfunc(this);
-}
-
-namespace _func1445
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("TeleportSystem::CanSend", typeid(bool (TeleportSystem::*)()), "57565383ec208b5c24308b4b0c", argdata, 1, 2, &func);
-}
-
-bool TeleportSystem::CanSend()
-{
-	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1445::func;
 	return execfunc(this);
 }
@@ -19801,10 +19801,10 @@ namespace _func1446
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("TeleportSystem::CanReceive", typeid(bool (TeleportSystem::*)()), "565383ec148b5c24208b74242480bb9d01000000", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("TeleportSystem::CanSend", typeid(bool (TeleportSystem::*)()), "57565383ec208b5c24308b4b0c", argdata, 1, 2, &func);
 }
 
-bool TeleportSystem::CanReceive()
+bool TeleportSystem::CanSend()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1446::func;
@@ -19815,12 +19815,12 @@ namespace _func1447
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("TeleportSystem::InitiateTeleport", typeid(void (TeleportSystem::*)()), "5383ec288b5c2430891c24", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("TeleportSystem::CanReceive", typeid(bool (TeleportSystem::*)()), "565383ec148b5c24208b74242480bb9d01000000", argdata, 1, 2, &func);
 }
 
-void TeleportSystem::InitiateTeleport()
+bool TeleportSystem::CanReceive()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1447::func;
 	return execfunc(this);
 }
@@ -19829,10 +19829,10 @@ namespace _func1448
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("TeleportSystem::OnLoop", typeid(void (TeleportSystem::*)()), "57565383ec308b5c2440891c24e8????????8b03891c24ff502c84c0", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("TeleportSystem::InitiateTeleport", typeid(void (TeleportSystem::*)()), "5383ec288b5c2430891c24", argdata, 1, 6, &func);
 }
 
-void TeleportSystem::OnLoop()
+void TeleportSystem::InitiateTeleport()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1448::func;
@@ -19843,10 +19843,10 @@ namespace _func1449
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("TeleportSystem::Jump", typeid(void (TeleportSystem::*)()), "5383ec188b5c2420891c24e8????????c7839801000000000000", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("TeleportSystem::OnLoop", typeid(void (TeleportSystem::*)()), "57565383ec308b5c2440891c24e8????????8b03891c24ff502c84c0", argdata, 1, 6, &func);
 }
 
-void TeleportSystem::Jump()
+void TeleportSystem::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1449::func;
@@ -19857,17 +19857,31 @@ namespace _func1450
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("TeleportSystem::Jump", typeid(void (TeleportSystem::*)()), "5383ec188b5c2420891c24e8????????c7839801000000000000", argdata, 1, 6, &func);
+}
+
+void TeleportSystem::Jump()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1450::func;
+	return execfunc(this);
+}
+
+namespace _func1451
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("TextButton::ResetPrimitives", typeid(void (TextButton::*)()), "565331db83ec148b7424208b449e48", argdata, 1, 6, &func);
 }
 
 void TextButton::ResetPrimitives()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1450::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1451::func;
 	return execfunc(this);
 }
 
-namespace _func1451
+namespace _func1452
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19877,11 +19891,11 @@ namespace _func1451
 int TextButton::GetIdealButtonWidth()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1451::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1452::func;
 	return execfunc(this);
 }
 
-namespace _func1452
+namespace _func1453
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x2ff, 0x1ff, 0x1ff, 0x1ff};
@@ -19891,11 +19905,11 @@ namespace _func1452
 void TextButton::OnInit(Point pos, Point size, int cornerInset, TextString *buttonLabel, int font)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, Point pos_arg, Point size_arg, int cornerInset_arg, TextString *buttonLabel_arg, int font_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1452::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1453::func;
 	return execfunc(this, pos, size, cornerInset, buttonLabel, font);
 }
 
-namespace _func1453
+namespace _func1454
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19905,11 +19919,11 @@ namespace _func1453
 void TextButton::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1453::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1454::func;
 	return execfunc(this);
 }
 
-namespace _func1454
+namespace _func1455
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19919,11 +19933,11 @@ namespace _func1454
 void TextButton::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1454::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1455::func;
 	return execfunc(this);
 }
 
-namespace _func1455
+namespace _func1456
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -19933,11 +19947,11 @@ namespace _func1455
 Point TextButton::GetSize()
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1455::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1456::func;
 	return execfunc(this);
 }
 
-namespace _func1456
+namespace _func1457
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -19947,11 +19961,11 @@ namespace _func1456
 void TextButton::OnInitRect(Globals::Rect &rect, int cornerInset, TextString &buttonLabel, int font)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, Globals::Rect &rect_arg, int cornerInset_arg, TextString &buttonLabel_arg, int font_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1456::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1457::func;
 	return execfunc(this, rect, cornerInset, buttonLabel, font);
 }
 
-namespace _func1457
+namespace _func1458
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -19961,11 +19975,11 @@ namespace _func1457
 void TextButton::SetBaseImage(const std::string &name, Point pos, int autoWidthMin)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, const std::string &name_arg, Point pos_arg, int autoWidthMin_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1457::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1458::func;
 	return execfunc(this, name, pos, autoWidthMin);
 }
 
-namespace _func1458
+namespace _func1459
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -19975,11 +19989,11 @@ namespace _func1458
 void TextButton::SetAutoWidth(bool autoWidth, bool autoRightAlign, int margin, int min)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, bool autoWidth_arg, bool autoRightAlign_arg, int margin_arg, int min_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1458::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1459::func;
 	return execfunc(this, autoWidth, autoRightAlign, margin, min);
 }
 
-namespace _func1459
+namespace _func1460
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -19989,11 +20003,11 @@ namespace _func1459
 void TextButton::UpdateAutoWidth()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1459::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1460::func;
 	return execfunc(this);
 }
 
-namespace _func1460
+namespace _func1461
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20003,11 +20017,11 @@ namespace _func1460
 void TextButton::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1460::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1461::func;
 	return execfunc(this);
 }
 
-namespace _func1461
+namespace _func1462
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff};
@@ -20015,20 +20029,6 @@ namespace _func1461
 }
 
 void TextButton::SetInactiveColor(GL_Color color)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1461::func;
-	return execfunc(this, color);
-}
-
-namespace _func1462
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x4ff};
-	static FunctionDefinition funcObj("TextButton::SetActiveColor", typeid(void (TextButton::*)(GL_Color )), ".!8b44240480786400", argdata, 2, 6, &func);
-}
-
-void TextButton::SetActiveColor(GL_Color color)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1462::func;
@@ -20039,10 +20039,10 @@ namespace _func1463
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff};
-	static FunctionDefinition funcObj("TextButton::SetSelectedColor", typeid(void (TextButton::*)(GL_Color )), ".!8b44240480786400", argdata, 2, 6, &func);
+	static FunctionDefinition funcObj("TextButton::SetActiveColor", typeid(void (TextButton::*)(GL_Color )), ".!8b44240480786400", argdata, 2, 6, &func);
 }
 
-void TextButton::SetSelectedColor(GL_Color color)
+void TextButton::SetActiveColor(GL_Color color)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1463::func;
@@ -20053,10 +20053,10 @@ namespace _func1464
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff};
-	static FunctionDefinition funcObj("TextButton::SetTextColor", typeid(void (TextButton::*)(GL_Color )), ".8b44240480786400", argdata, 2, 6, &func);
+	static FunctionDefinition funcObj("TextButton::SetSelectedColor", typeid(void (TextButton::*)(GL_Color )), ".!8b44240480786400", argdata, 2, 6, &func);
 }
 
-void TextButton::SetTextColor(GL_Color color)
+void TextButton::SetSelectedColor(GL_Color color)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1464::func;
@@ -20066,6 +20066,20 @@ void TextButton::SetTextColor(GL_Color color)
 namespace _func1465
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff, 0x4ff};
+	static FunctionDefinition funcObj("TextButton::SetTextColor", typeid(void (TextButton::*)(GL_Color )), ".8b44240480786400", argdata, 2, 6, &func);
+}
+
+void TextButton::SetTextColor(GL_Color color)
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1465::func;
+	return execfunc(this, color);
+}
+
+namespace _func1466
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("TextButton::InitPrimitives", typeid(void (TextButton::*)()), "5557565381eccc0000008bb424e0000000807e6400", argdata, 1, 6, &func);
 }
@@ -20073,11 +20087,11 @@ namespace _func1465
 void TextButton::InitPrimitives()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1465::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1466::func;
 	return execfunc(this);
 }
 
-namespace _func1466
+namespace _func1467
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20087,11 +20101,11 @@ namespace _func1466
 void TextInput::constructor(int maxChars, TextInput::AllowedCharType allowedCharType, const std::string &prompt)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg, int maxChars_arg, TextInput::AllowedCharType allowedCharType_arg, const std::string &prompt_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1466::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1467::func;
 	return execfunc(this, maxChars, allowedCharType, prompt);
 }
 
-namespace _func1467
+namespace _func1468
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff};
@@ -20101,11 +20115,11 @@ namespace _func1467
 void TextInput::OnRender(int font, Point pos)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg, int font_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1467::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1468::func;
 	return execfunc(this, font, pos);
 }
 
-namespace _func1468
+namespace _func1469
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20115,11 +20129,11 @@ namespace _func1468
 void TextInput::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1468::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1469::func;
 	return execfunc(this);
 }
 
-namespace _func1469
+namespace _func1470
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20129,11 +20143,11 @@ namespace _func1469
 void TextInput::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1469::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1470::func;
 	return execfunc(this, event);
 }
 
-namespace _func1470
+namespace _func1471
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20143,11 +20157,11 @@ namespace _func1470
 bool TextInput::GetActive()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1470::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1471::func;
 	return execfunc(this);
 }
 
-namespace _func1471
+namespace _func1472
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20157,11 +20171,11 @@ namespace _func1471
 std::string TextInput::GetText()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1471::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1472::func;
 	return execfunc(this);
 }
 
-namespace _func1472
+namespace _func1473
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20171,11 +20185,11 @@ namespace _func1472
 void TextInput::Start()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1472::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1473::func;
 	return execfunc(this);
 }
 
-namespace _func1473
+namespace _func1474
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20185,11 +20199,11 @@ namespace _func1473
 void TextInput::Stop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1473::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1474::func;
 	return execfunc(this);
 }
 
-namespace _func1474
+namespace _func1475
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20199,11 +20213,11 @@ namespace _func1474
 int TextInput::SetText(const std::string &text)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1474::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1475::func;
 	return execfunc(this, text);
 }
 
-namespace _func1475
+namespace _func1476
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20213,11 +20227,11 @@ namespace _func1475
 void TextInput::OnTextInput(int asciiChar)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextInput *this_arg, int asciiChar_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1475::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1476::func;
 	return execfunc(this, asciiChar);
 }
 
-namespace _func1476
+namespace _func1477
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20227,11 +20241,11 @@ namespace _func1476
 std::string TextLibrary::GetText(const std::string &name, const std::string &lang)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextLibrary *this_arg, const std::string &name_arg, const std::string &lang_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1476::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1477::func;
 	return execfunc(this, name, lang);
 }
 
-namespace _func1477
+namespace _func1478
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20241,11 +20255,11 @@ namespace _func1477
 std::string TextString::GetText()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(TextString *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1477::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1478::func;
 	return execfunc(this);
 }
 
-namespace _func1478
+namespace _func1479
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20255,11 +20269,11 @@ namespace _func1478
 void TimerHelper::Start(int goal)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TimerHelper *this_arg, int goal_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1478::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1479::func;
 	return execfunc(this, goal);
 }
 
-namespace _func1479
+namespace _func1480
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20269,11 +20283,11 @@ namespace _func1479
 bool TimerHelper::Running()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1479::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1480::func;
 	return execfunc(this);
 }
 
-namespace _func1480
+namespace _func1481
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -20283,11 +20297,11 @@ namespace _func1480
 void TimerHelper::ResetMinMax(int min, int max)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TimerHelper *this_arg, int min_arg, int max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1480::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1481::func;
 	return execfunc(this, min, max);
 }
 
-namespace _func1481
+namespace _func1482
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20297,11 +20311,11 @@ namespace _func1481
 void TimerHelper::SetMaxTime(float max)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TimerHelper *this_arg, float max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1481::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1482::func;
 	return execfunc(this, max);
 }
 
-namespace _func1482
+namespace _func1483
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20309,20 +20323,6 @@ namespace _func1482
 }
 
 void TimerHelper::Stop()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1482::func;
-	return execfunc(this);
-}
-
-namespace _func1483
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("TimerHelper::Update", typeid(void (TimerHelper::*)()), ".5383ec188b5c2420807b1100", argdata, 1, 6, &func);
-}
-
-void TimerHelper::Update()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1483::func;
@@ -20333,17 +20333,31 @@ namespace _func1484
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("TimerHelper::Update", typeid(void (TimerHelper::*)()), ".5383ec188b5c2420807b1100", argdata, 1, 6, &func);
+}
+
+void TimerHelper::Update()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1484::func;
+	return execfunc(this);
+}
+
+namespace _func1485
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("TimerHelper::Done", typeid(bool (TimerHelper::*)()), ".57565383ec108b5c24200fb6431184c0", argdata, 1, 2, &func);
 }
 
 bool TimerHelper::Done()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1484::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1485::func;
 	return execfunc(this);
 }
 
-namespace _func1485
+namespace _func1486
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20353,20 +20367,6 @@ namespace _func1485
 void TutorialManager::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1485::func;
-	return execfunc(this);
-}
-
-namespace _func1486
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("TutorialManager::Running", typeid(bool (TutorialManager::*)()), ".8b4424040fb600", argdata, 1, 2, &func);
-}
-
-bool TutorialManager::Running()
-{
-	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1486::func;
 	return execfunc(this);
 }
@@ -20375,10 +20375,10 @@ namespace _func1487
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("TutorialManager::AllowJumping", typeid(bool (TutorialManager::*)()), ".565383ec348b7424408d4424", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("TutorialManager::Running", typeid(bool (TutorialManager::*)()), ".8b4424040fb600", argdata, 1, 2, &func);
 }
 
-bool TutorialManager::AllowJumping()
+bool TutorialManager::Running()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1487::func;
@@ -20389,10 +20389,10 @@ namespace _func1488
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("TutorialManager::AllowUpgrades", typeid(bool (TutorialManager::*)()), ".5756be010000005383ec30", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("TutorialManager::AllowJumping", typeid(bool (TutorialManager::*)()), ".565383ec348b7424408d4424", argdata, 1, 2, &func);
 }
 
-bool TutorialManager::AllowUpgrades()
+bool TutorialManager::AllowJumping()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1488::func;
@@ -20402,6 +20402,20 @@ bool TutorialManager::AllowUpgrades()
 namespace _func1489
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("TutorialManager::AllowUpgrades", typeid(bool (TutorialManager::*)()), ".5756be010000005383ec30", argdata, 1, 2, &func);
+}
+
+bool TutorialManager::AllowUpgrades()
+{
+	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1489::func;
+	return execfunc(this);
+}
+
+namespace _func1490
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("TutorialManager::MouseMove", typeid(void (TutorialManager::*)(int , int )), ".5589e557565383ec5c8b450880380075??8d65", argdata, 3, 6, &func);
 }
@@ -20409,11 +20423,11 @@ namespace _func1489
 void TutorialManager::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TutorialManager *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1489::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1490::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1490
+namespace _func1491
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20423,11 +20437,11 @@ namespace _func1490
 bool TutorialManager::MouseClick()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1490::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1491::func;
 	return execfunc(this);
 }
 
-namespace _func1491
+namespace _func1492
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20437,11 +20451,11 @@ namespace _func1491
 void TutorialManager::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1491::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1492::func;
 	return execfunc(this);
 }
 
-namespace _func1492
+namespace _func1493
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20451,11 +20465,11 @@ namespace _func1492
 void TutorialManager::LoadTutorial()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1492::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1493::func;
 	return execfunc(this);
 }
 
-namespace _func1493
+namespace _func1494
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20465,11 +20479,11 @@ namespace _func1493
 void TutorialManager::OnInit(ShipManager *ship, CommandGui *gui, CrewControl *crewControl, Upgrades *upgradesScreen, CombatControl *combatControl, SystemControl *sysControl, TabbedWindow *unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TutorialManager *this_arg, ShipManager *ship_arg, CommandGui *gui_arg, CrewControl *crewControl_arg, Upgrades *upgradesScreen_arg, CombatControl *combatControl_arg, SystemControl *sysControl_arg, TabbedWindow *unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1493::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1494::func;
 	return execfunc(this, ship, gui, crewControl, upgradesScreen, combatControl, sysControl, unk);
 }
 
-namespace _func1494
+namespace _func1495
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20479,18 +20493,18 @@ namespace _func1494
 void TutorialManager::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1494::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1495::func;
 	return execfunc(this);
 }
 
 TutorialManager *Global_TutorialManager_Tutorial;
 
-namespace _var1495
+namespace _var1496
 {
     static VariableDefinition varObj("Global_TutorialManager_Tutorial", "!c70424(???????\?)e8????????84c075??8383c800000001", &Global_TutorialManager_Tutorial);
 }
 
-namespace _func1496
+namespace _func1497
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -20500,11 +20514,11 @@ namespace _func1496
 void UnlockArrow::constructor(Point pos, int unk1, int unk2)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UnlockArrow *this_arg, Point pos_arg, int unk1_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1496::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1497::func;
 	return execfunc(this, pos, unk1, unk2);
 }
 
-namespace _func1497
+namespace _func1498
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -20514,11 +20528,11 @@ namespace _func1497
 bool UnlockArrow::MouseMove(int x, int y)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(UnlockArrow *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1497::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1498::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1498
+namespace _func1499
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20528,11 +20542,11 @@ namespace _func1498
 void UnlockArrow::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UnlockArrow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1498::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1499::func;
 	return execfunc(this);
 }
 
-namespace _func1499
+namespace _func1500
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff};
@@ -20542,11 +20556,11 @@ namespace _func1499
 void UpgradeBox::constructorEmpty(Point pos, bool subsystem)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, Point pos_arg, bool subsystem_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1499::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1500::func;
 	return execfunc(this, pos, subsystem);
 }
 
-namespace _func1500
+namespace _func1501
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -20556,11 +20570,11 @@ namespace _func1500
 void UpgradeBox::constructorSystem(ShipManager *ship, ShipSystem *sys, Point pos, bool subsystem)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, ShipManager *ship_arg, ShipSystem *sys_arg, Point pos_arg, bool subsystem_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1500::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1501::func;
 	return execfunc(this, ship, sys, pos, subsystem);
 }
 
-namespace _func1501
+namespace _func1502
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20570,11 +20584,11 @@ namespace _func1501
 void UpgradeBox::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1501::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1502::func;
 	return execfunc(this);
 }
 
-namespace _func1502
+namespace _func1503
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20584,11 +20598,11 @@ namespace _func1502
 void UpgradeBox::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1502::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1503::func;
 	return execfunc(this);
 }
 
-namespace _func1503
+namespace _func1504
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -20596,20 +20610,6 @@ namespace _func1503
 }
 
 void UpgradeBox::MouseMove(int mX, int mY)
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1503::func;
-	return execfunc(this, mX, mY);
-}
-
-namespace _func1504
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("UpgradeBox::MouseClick", typeid(void (UpgradeBox::*)(int , int )), "5383ec288b5c24308b0385c0", argdata, 3, 6, &func);
-}
-
-void UpgradeBox::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1504::func;
@@ -20620,10 +20620,10 @@ namespace _func1505
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("UpgradeBox::MouseRightClick", typeid(void (UpgradeBox::*)(int , int )), ".565383ec248b5c24308b0385c0", argdata, 3, 6, &func);
+	static FunctionDefinition funcObj("UpgradeBox::MouseClick", typeid(void (UpgradeBox::*)(int , int )), "5383ec288b5c24308b0385c0", argdata, 3, 6, &func);
 }
 
-void UpgradeBox::MouseRightClick(int mX, int mY)
+void UpgradeBox::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1505::func;
@@ -20633,25 +20633,25 @@ void UpgradeBox::MouseRightClick(int mX, int mY)
 namespace _func1506
 {
     static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("UpgradeBox::Undo", typeid(void (UpgradeBox::*)()), "565383ec148b5c24208b431485c0", argdata, 1, 6, &func);
+	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("UpgradeBox::MouseRightClick", typeid(void (UpgradeBox::*)(int , int )), ".565383ec248b5c24308b0385c0", argdata, 3, 6, &func);
 }
 
-void UpgradeBox::Undo()
+void UpgradeBox::MouseRightClick(int mX, int mY)
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1506::func;
-	return execfunc(this);
+	return execfunc(this, mX, mY);
 }
 
 namespace _func1507
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("UpgradeBox::Accept", typeid(void (UpgradeBox::*)()), ".565383ec248b5c24308b0385c0", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("UpgradeBox::Undo", typeid(void (UpgradeBox::*)()), "565383ec148b5c24208b431485c0", argdata, 1, 6, &func);
 }
 
-void UpgradeBox::Accept()
+void UpgradeBox::Undo()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1507::func;
@@ -20661,6 +20661,20 @@ void UpgradeBox::Accept()
 namespace _func1508
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("UpgradeBox::Accept", typeid(void (UpgradeBox::*)()), ".565383ec248b5c24308b0385c0", argdata, 1, 6, &func);
+}
+
+void UpgradeBox::Accept()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1508::func;
+	return execfunc(this);
+}
+
+namespace _func1509
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("Upgrades::OnInit", typeid(void (Upgrades::*)(ShipManager *)), "5557565381eccc0000008b9c24e00000008db424a0000000", argdata, 2, 6, &func);
 }
@@ -20668,11 +20682,11 @@ namespace _func1508
 void Upgrades::OnInit(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1508::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1509::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1509
+namespace _func1510
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20682,11 +20696,11 @@ namespace _func1509
 void Upgrades::Open()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1509::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1510::func;
 	return execfunc(this);
 }
 
-namespace _func1510
+namespace _func1511
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20696,11 +20710,11 @@ namespace _func1510
 void Upgrades::ClearUpgradeBoxes()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1510::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1511::func;
 	return execfunc(this);
 }
 
-namespace _func1511
+namespace _func1512
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -20710,11 +20724,11 @@ namespace _func1511
 void Upgrades::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1511::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1512::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1512
+namespace _func1513
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20724,11 +20738,11 @@ namespace _func1512
 void Upgrades::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1512::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1513::func;
 	return execfunc(this);
 }
 
-namespace _func1513
+namespace _func1514
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -20738,11 +20752,11 @@ namespace _func1513
 void Upgrades::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1513::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1514::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1514
+namespace _func1515
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -20752,11 +20766,11 @@ namespace _func1514
 void Upgrades::MouseRightClick(int mX, int mY)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1514::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1515::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1515
+namespace _func1516
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20764,20 +20778,6 @@ namespace _func1515
 }
 
 void Upgrades::Close()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1515::func;
-	return execfunc(this);
-}
-
-namespace _func1516
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("Upgrades::OnRender", typeid(void (Upgrades::*)()), "5589e557565383ec7c8b5d080f2805????????", argdata, 1, 6, &func);
-}
-
-void Upgrades::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1516::func;
@@ -20788,10 +20788,10 @@ namespace _func1517
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("Upgrades::ConfirmUpgrades", typeid(void (Upgrades::*)()), "5589e5575631f65383ec3c8b7d088b4f248b4720", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("Upgrades::OnRender", typeid(void (Upgrades::*)()), "5589e557565383ec7c8b5d080f2805????????", argdata, 1, 6, &func);
 }
 
-void Upgrades::ConfirmUpgrades()
+void Upgrades::OnRender()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1517::func;
@@ -20802,12 +20802,12 @@ namespace _func1518
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("WarningMessage::Start", typeid(void (WarningMessage::*)()), "5383ec188b5c2420807b1400", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("Upgrades::ConfirmUpgrades", typeid(void (Upgrades::*)()), "5589e5575631f65383ec3c8b7d088b4f248b4720", argdata, 1, 6, &func);
 }
 
-void WarningMessage::Start()
+void Upgrades::ConfirmUpgrades()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1518::func;
 	return execfunc(this);
 }
@@ -20816,10 +20816,10 @@ namespace _func1519
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("WarningMessage::OnRender", typeid(void (WarningMessage::*)()), "5383ec188b5c2420807b1600", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("WarningMessage::Start", typeid(void (WarningMessage::*)()), "5383ec188b5c2420807b1400", argdata, 1, 6, &func);
 }
 
-void WarningMessage::OnRender()
+void WarningMessage::Start()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1519::func;
@@ -20829,6 +20829,20 @@ void WarningMessage::OnRender()
 namespace _func1520
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("WarningMessage::OnRender", typeid(void (WarningMessage::*)()), "5383ec188b5c2420807b1600", argdata, 1, 6, &func);
+}
+
+void WarningMessage::OnRender()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1520::func;
+	return execfunc(this);
+}
+
+namespace _func1521
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("WarningMessage::RenderWithAlpha", typeid(void (WarningMessage::*)(float )), "5589e557565383ec7c8b5d08807b2800", argdata, 2, 6, &func);
 }
@@ -20836,11 +20850,11 @@ namespace _func1520
 void WarningMessage::RenderWithAlpha(float alpha)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1520::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1521::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func1521
+namespace _func1522
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20850,11 +20864,11 @@ namespace _func1521
 void WarningMessage::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1521::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1522::func;
 	return execfunc(this);
 }
 
-namespace _func1522
+namespace _func1523
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -20864,11 +20878,11 @@ namespace _func1522
 void WarningMessage::InitImage(const std::string &imageName, Point position, float time, bool flash)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &imageName_arg, Point position_arg, float time_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1522::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1523::func;
 	return execfunc(this, imageName, position, time, flash);
 }
 
-namespace _func1523
+namespace _func1524
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x2ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -20878,11 +20892,11 @@ namespace _func1523
 void WarningMessage::InitText(const TextString &text, Point position, float time, GL_Color textColor, bool centerText, bool flash)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg, Point position_arg, float time_arg, GL_Color textColor_arg, bool centerText_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1523::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1524::func;
 	return execfunc(this, text, position, time, textColor, centerText, flash);
 }
 
-namespace _func1524
+namespace _func1525
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -20892,11 +20906,11 @@ namespace _func1524
 void WarningMessage::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1524::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1525::func;
 	return execfunc(this);
 }
 
-namespace _func1525
+namespace _func1526
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20906,11 +20920,11 @@ namespace _func1525
 void WarningMessage::SetImage(const std::string &imageName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &imageName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1525::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1526::func;
 	return execfunc(this, imageName);
 }
 
-namespace _func1526
+namespace _func1527
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20920,11 +20934,11 @@ namespace _func1526
 void WarningMessage::SetText(const TextString &text)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1526::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1527::func;
 	return execfunc(this, text);
 }
 
-namespace _func1527
+namespace _func1528
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x4ff};
@@ -20934,11 +20948,11 @@ namespace _func1527
 void WarningMessage::SetText(const TextString &text, GL_Color textColor)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg, GL_Color textColor_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1527::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1528::func;
 	return execfunc(this, text, textColor);
 }
 
-namespace _func1528
+namespace _func1529
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff};
@@ -20948,11 +20962,11 @@ namespace _func1528
 void WarningMessage::SetPosition(Point position)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, Point position_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1528::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1529::func;
 	return execfunc(this, position);
 }
 
-namespace _func1529
+namespace _func1530
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20962,11 +20976,11 @@ namespace _func1529
 void WarningMessage::SetLoop(bool loop)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, bool loop_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1529::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1530::func;
 	return execfunc(this, loop);
 }
 
-namespace _func1530
+namespace _func1531
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20976,11 +20990,11 @@ namespace _func1530
 void WarningMessage::SetSound(const std::string &sound)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &sound_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1530::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1531::func;
 	return execfunc(this, sound);
 }
 
-namespace _func1531
+namespace _func1532
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -20990,11 +21004,11 @@ namespace _func1531
 void WeaponAnimation::SaveState(int fd)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1531::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1532::func;
 	return execfunc(this, fd);
 }
 
-namespace _func1532
+namespace _func1533
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21004,11 +21018,11 @@ namespace _func1532
 void WeaponAnimation::SetBoostLevel(int value)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, int value_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1532::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1533::func;
 	return execfunc(this, value);
 }
 
-namespace _func1533
+namespace _func1534
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21018,11 +21032,11 @@ namespace _func1533
 void WeaponAnimation::SetChargedLevel(float charged)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float charged_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1533::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1534::func;
 	return execfunc(this, charged);
 }
 
-namespace _func1534
+namespace _func1535
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21032,11 +21046,11 @@ namespace _func1534
 bool WeaponAnimation::StartFire()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1534::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1535::func;
 	return execfunc(this);
 }
 
-namespace _func1535
+namespace _func1536
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21046,11 +21060,11 @@ namespace _func1535
 void WeaponAnimation::SetFireTime(float time)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float time_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1535::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1536::func;
 	return execfunc(this, time);
 }
 
-namespace _func1536
+namespace _func1537
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21060,11 +21074,11 @@ namespace _func1536
 Pointf WeaponAnimation::GetSlide()
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1536::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1537::func;
 	return execfunc(this);
 }
 
-namespace _func1537
+namespace _func1538
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21074,11 +21088,11 @@ namespace _func1537
 void WeaponAnimation::SetPowered()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1537::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1538::func;
 	return execfunc(this);
 }
 
-namespace _func1538
+namespace _func1539
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21088,11 +21102,11 @@ namespace _func1538
 void WeaponAnimation::Update()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1538::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1539::func;
 	return execfunc(this);
 }
 
-namespace _func1539
+namespace _func1540
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21102,11 +21116,11 @@ namespace _func1539
 Point WeaponAnimation::GetFireLocation()
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1539::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1540::func;
 	return execfunc(this);
 }
 
-namespace _func1540
+namespace _func1541
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21116,11 +21130,11 @@ namespace _func1540
 void WeaponAnimation::OnRender(float alpha)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1540::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1541::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func1541
+namespace _func1542
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21130,32 +21144,32 @@ namespace _func1541
 void WeaponAnimation::RenderChargeBar(float alpha)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1541::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1542::func;
 	return execfunc(this, alpha);
-}
-
-namespace _func1542
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("WeaponBlueprint::__DO_NOT_HOOK", typeid(void (WeaponBlueprint::*)()), "565383ec248b5c24308d74241f8d4304c703????????89742408890424", argdata, 0, 4, &func);
 }
 
 namespace _func1543
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("WeaponBlueprint::__DO_NOT_HOOK2", typeid(void (WeaponBlueprint::*)()), ".565383ec248b5c24308d74241f8d4304c703????????89742408890424", argdata, 0, 4, &func);
+	static FunctionDefinition funcObj("WeaponBlueprint::__DO_NOT_HOOK", typeid(void (WeaponBlueprint::*)()), "565383ec248b5c24308d74241f8d4304c703????????89742408890424", argdata, 0, 4, &func);
 }
 
 namespace _func1544
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("WeaponBlueprint::__DO_NOT_HOOK3", typeid(void (WeaponBlueprint::*)()), ".565383ec248b5c24308d74241f8d4304c703????????89742408890424", argdata, 0, 4, &func);
+	static FunctionDefinition funcObj("WeaponBlueprint::__DO_NOT_HOOK2", typeid(void (WeaponBlueprint::*)()), ".565383ec248b5c24308d74241f8d4304c703????????89742408890424", argdata, 0, 4, &func);
 }
 
 namespace _func1545
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("WeaponBlueprint::__DO_NOT_HOOK3", typeid(void (WeaponBlueprint::*)()), ".565383ec248b5c24308d74241f8d4304c703????????89742408890424", argdata, 0, 4, &func);
+}
+
+namespace _func1546
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21165,11 +21179,11 @@ namespace _func1545
 void WeaponBlueprint::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1545::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1546::func;
 	return execfunc(this);
 }
 
-namespace _func1546
+namespace _func1547
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21179,11 +21193,11 @@ namespace _func1546
 void WeaponBlueprint::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1546::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1547::func;
 	return execfunc(this);
 }
 
-namespace _func1547
+namespace _func1548
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -21193,11 +21207,11 @@ namespace _func1547
 std::string WeaponBlueprint::GetDescription(bool tooltip)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg, bool tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1547::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1548::func;
 	return execfunc(this, tooltip);
 }
 
-namespace _func1548
+namespace _func1549
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21207,11 +21221,11 @@ namespace _func1548
 void WeaponBlueprint::RenderIcon(float scale)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg, float scale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1548::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1549::func;
 	return execfunc(this, scale);
 }
 
-namespace _func1549
+namespace _func1550
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21221,11 +21235,11 @@ namespace _func1549
 Point WeaponBlueprint::GetDimensions()
 {
 	typedef Point __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1549::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1550::func;
 	return execfunc(this);
 }
 
-namespace _func1550
+namespace _func1551
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -21235,11 +21249,11 @@ namespace _func1550
 void WeaponBox::RenderBox(bool dragging, bool flashPowerBox)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponBox *this_arg, bool dragging_arg, bool flashPowerBox_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1550::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1551::func;
 	return execfunc(this, dragging, flashPowerBox);
 }
 
-namespace _func1551
+namespace _func1552
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21249,11 +21263,11 @@ namespace _func1551
 std::string WeaponBox::GenerateTooltip()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1551::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1552::func;
 	return execfunc(this);
 }
 
-namespace _func1552
+namespace _func1553
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21263,11 +21277,11 @@ namespace _func1552
 void WeaponControl::RenderWarnings()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1552::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1553::func;
 	return execfunc(this);
 }
 
-namespace _func1553
+namespace _func1554
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21277,11 +21291,11 @@ namespace _func1553
 TextString WeaponControl::HolderLabel()
 {
 	typedef TextString __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1553::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1554::func;
 	return execfunc(this);
 }
 
-namespace _func1554
+namespace _func1555
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21291,11 +21305,11 @@ namespace _func1554
 SDLKey WeaponControl::ArmamentHotkey(unsigned int i)
 {
 	typedef SDLKey __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, unsigned int i_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1554::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1555::func;
 	return execfunc(this, i);
 }
 
-namespace _func1555
+namespace _func1556
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21305,11 +21319,11 @@ namespace _func1555
 void WeaponControl::SelectArmament(unsigned int armamentSlot)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, unsigned int armamentSlot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1555::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1556::func;
 	return execfunc(this, armamentSlot);
 }
 
-namespace _func1556
+namespace _func1557
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21319,11 +21333,11 @@ namespace _func1556
 void WeaponControl::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1556::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1557::func;
 	return execfunc(this);
 }
 
-namespace _func1557
+namespace _func1558
 {
     static void *func = 0;
 	static short argdata[] = {0x2ff, 0x2ff, 0x1ff};
@@ -21333,11 +21347,11 @@ namespace _func1557
 void WeaponControl::RenderBeamAiming(Pointf one, Pointf two, bool bAutoFire)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf one_arg, Pointf two_arg, bool bAutoFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1557::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1558::func;
 	return execfunc(one, two, bAutoFire);
 }
 
-namespace _func1558
+namespace _func1559
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21347,11 +21361,11 @@ namespace _func1558
 void WeaponControl::RenderAiming()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1558::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1559::func;
 	return execfunc(this);
 }
 
-namespace _func1559
+namespace _func1560
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21361,11 +21375,11 @@ namespace _func1559
 void WeaponControl::RenderSelfAiming()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1559::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1560::func;
 	return execfunc(this);
 }
 
-namespace _func1560
+namespace _func1561
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -21375,11 +21389,11 @@ namespace _func1560
 void WeaponControl::SetAutofiring(bool on, bool simple)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, bool on_arg, bool simple_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1560::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1561::func;
 	return execfunc(this, on, simple);
 }
 
-namespace _func1561
+namespace _func1562
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -21389,11 +21403,11 @@ namespace _func1561
 void WeaponControl::Fire(std::vector<Pointf> &points, int target, bool autoFire)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, std::vector<Pointf> &points_arg, int target_arg, bool autoFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1561::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1562::func;
 	return execfunc(this, points, target, autoFire);
 }
 
-namespace _func1562
+namespace _func1563
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21403,11 +21417,11 @@ namespace _func1562
 void WeaponControl::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1562::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1563::func;
 	return execfunc(this);
 }
 
-namespace _func1563
+namespace _func1564
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21417,11 +21431,11 @@ namespace _func1563
 void WeaponControl::OnLanguageChange()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1563::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1564::func;
 	return execfunc(this);
 }
 
-namespace _func1564
+namespace _func1565
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21431,11 +21445,11 @@ namespace _func1564
 void WeaponControl::OnRender(bool unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1564::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1565::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1565
+namespace _func1566
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -21445,11 +21459,11 @@ namespace _func1565
 bool WeaponControl::LButton(int x, int y, bool holdingShift)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, int x_arg, int y_arg, bool holdingShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1565::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1566::func;
 	return execfunc(this, x, y, holdingShift);
 }
 
-namespace _func1566
+namespace _func1567
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -21459,11 +21473,11 @@ namespace _func1566
 void WeaponControl::MouseMove(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1566::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1567::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1567
+namespace _func1568
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21473,11 +21487,11 @@ namespace _func1567
 void WeaponControl::LinkShip(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1567::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1568::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1568
+namespace _func1569
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21487,11 +21501,11 @@ namespace _func1568
 bool WeaponControl::KeyDown(SDLKey key)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1568::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1569::func;
 	return execfunc(this, key);
 }
 
-namespace _func1569
+namespace _func1570
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -21501,11 +21515,11 @@ namespace _func1569
 void WeaponEquipBox::constructor(Point location, WeaponSystem *sys, int slot)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponEquipBox *this_arg, Point location_arg, WeaponSystem *sys_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1569::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1570::func;
 	return execfunc(this, location, sys, slot);
 }
 
-namespace _func1570
+namespace _func1571
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -21515,18 +21529,18 @@ namespace _func1570
 void DroneEquipBox::constructor(Point location, DroneSystem *sys, int slot)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneEquipBox *this_arg, Point location_arg, DroneSystem *sys_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1570::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1571::func;
 	return execfunc(this, location, sys, slot);
 }
 
-namespace _func1571
+namespace _func1572
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("WeaponStoreBox::__DO_NOT_HOOK", typeid(void (WeaponStoreBox::*)()), "5557565383ec2c8d44241a8b5c24408d7c241c8b74244c89442408", argdata, 0, 4, &func);
 }
 
-namespace _func1572
+namespace _func1573
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -21536,11 +21550,11 @@ namespace _func1572
 void WeaponStoreBox::constructor(ShipManager *ship, Equipment *equip, const WeaponBlueprint *weaponBp)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponStoreBox *this_arg, ShipManager *ship_arg, Equipment *equip_arg, const WeaponBlueprint *weaponBp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1572::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1573::func;
 	return execfunc(this, ship, equip, weaponBp);
 }
 
-namespace _func1573
+namespace _func1574
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21550,11 +21564,11 @@ namespace _func1573
 void WeaponStoreBox::Purchase()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1573::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1574::func;
 	return execfunc(this);
 }
 
-namespace _func1574
+namespace _func1575
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21564,11 +21578,11 @@ namespace _func1574
 void DroneStoreBox::Purchase()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(DroneStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1574::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1575::func;
 	return execfunc(this);
 }
 
-namespace _func1575
+namespace _func1576
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21578,11 +21592,11 @@ namespace _func1575
 bool WeaponSystem::ForceIncreasePower(int amount)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1575::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1576::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1576
+namespace _func1577
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21592,11 +21606,11 @@ namespace _func1576
 ProjectileFactory *WeaponSystem::RemoveWeapon(int slot)
 {
 	typedef ProjectileFactory *__attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1576::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1577::func;
 	return execfunc(this, slot);
 }
 
-namespace _func1577
+namespace _func1578
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -21606,11 +21620,11 @@ namespace _func1577
 void WeaponSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1577::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1578::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func1578
+namespace _func1579
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21620,11 +21634,11 @@ namespace _func1578
 void WeaponSystem::OnLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1578::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1579::func;
 	return execfunc(this);
 }
 
-namespace _func1579
+namespace _func1580
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -21634,11 +21648,11 @@ namespace _func1579
 bool WeaponSystem::PowerWeapon(ProjectileFactory *weapon, bool userDriven, bool force)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg, ProjectileFactory *weapon_arg, bool userDriven_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1579::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1580::func;
 	return execfunc(this, weapon, userDriven, force);
 }
 
-namespace _func1580
+namespace _func1581
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -21648,11 +21662,11 @@ namespace _func1580
 bool WeaponSystem::DePowerWeapon(ProjectileFactory *weapon, bool userDriven)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg, ProjectileFactory *weapon_arg, bool userDriven_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1580::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1581::func;
 	return execfunc(this, weapon, userDriven);
 }
 
-namespace _func1581
+namespace _func1582
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -21662,11 +21676,11 @@ namespace _func1581
 void WeaponSystemBox::constructor(Point pos, ShipSystem *sys, WeaponControl *weapCtrl)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WeaponSystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, WeaponControl *weapCtrl_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1581::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1582::func;
 	return execfunc(this, pos, sys, weapCtrl);
 }
 
-namespace _func1582
+namespace _func1583
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -21676,11 +21690,11 @@ namespace _func1582
 void WindowFrame::Draw(int x, int y)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WindowFrame *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1582::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1583::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1583
+namespace _func1584
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21690,11 +21704,11 @@ namespace _func1583
 void WindowFrame::DrawMask(int unk)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WindowFrame *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1583::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1584::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1584
+namespace _func1585
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -21704,11 +21718,11 @@ namespace _func1584
 void WindowFrame::constructor(int x, int y, int w, int h)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WindowFrame *this_arg, int x_arg, int y_arg, int w_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1584::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1585::func;
 	return execfunc(this, x, y, w, h);
 }
 
-namespace _func1585
+namespace _func1586
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21718,11 +21732,11 @@ namespace _func1585
 void WindowFrame::destructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WindowFrame *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1585::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1586::func;
 	return execfunc(this);
 }
 
-namespace _func1586
+namespace _func1587
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21732,11 +21746,11 @@ namespace _func1586
 void WorldManager::constructor()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1586::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1587::func;
 	return execfunc(this);
 }
 
-namespace _func1587
+namespace _func1588
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21746,11 +21760,11 @@ namespace _func1587
 int WorldManager::OnInit()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1587::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1588::func;
 	return execfunc(this);
 }
 
-namespace _func1588
+namespace _func1589
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -21760,11 +21774,11 @@ namespace _func1588
 CompleteShip *WorldManager::CreateShip(ShipEvent *shipEvent, bool boss)
 {
 	typedef CompleteShip *__attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, ShipEvent *shipEvent_arg, bool boss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1588::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1589::func;
 	return execfunc(this, shipEvent, boss);
 }
 
-namespace _func1589
+namespace _func1590
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21774,11 +21788,11 @@ namespace _func1589
 void WorldManager::CreateLocation(Location *loc)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1589::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1590::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1590
+namespace _func1591
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21788,11 +21802,11 @@ namespace _func1590
 void WorldManager::ClearLocation()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1590::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1591::func;
 	return execfunc(this);
 }
 
-namespace _func1591
+namespace _func1592
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21802,11 +21816,11 @@ namespace _func1591
 void WorldManager::SaveGame()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1591::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1592::func;
 	return execfunc(this);
 }
 
-namespace _func1592
+namespace _func1593
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102};
@@ -21816,11 +21830,11 @@ namespace _func1592
 void WorldManager::CreateChoiceBox(LocationEvent *event)
 {
 	typedef void __attribute__((regparm(2))) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1592::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1593::func;
 	return execfunc(this, event);
 }
 
-namespace _func1593
+namespace _func1594
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21830,11 +21844,11 @@ namespace _func1593
 void WorldManager::CreateChoiceBox0(LocationEvent *event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1593::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1594::func;
 	return execfunc(this, event);
 }
 
-namespace _func1594
+namespace _func1595
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102};
@@ -21844,11 +21858,11 @@ namespace _func1594
 void WorldManager::UpdateLocation(LocationEvent *event)
 {
 	typedef void __attribute__((regparm(2))) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1594::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1595::func;
 	return execfunc(this, event);
 }
 
-namespace _func1595
+namespace _func1596
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21858,11 +21872,11 @@ namespace _func1595
 void WorldManager::UpdateLocation0(LocationEvent *event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1595::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1596::func;
 	return execfunc(this, event);
 }
 
-namespace _func1596
+namespace _func1597
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21872,11 +21886,11 @@ namespace _func1596
 LocationEvent *WorldManager::ModifyResources(LocationEvent *event)
 {
 	typedef LocationEvent *__attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1596::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1597::func;
 	return execfunc(this, event);
 }
 
-namespace _func1597
+namespace _func1598
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -21886,11 +21900,11 @@ namespace _func1597
 void WorldManager::ModifyEnvironment(int envFlag, int envTarget)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, int envFlag_arg, int envTarget_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1597::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1598::func;
 	return execfunc(this, envFlag, envTarget);
 }
 
-namespace _func1598
+namespace _func1599
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21900,11 +21914,11 @@ namespace _func1598
 void WorldManager::CheckStatusEffects(std::vector<StatusEffect> &vec)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, std::vector<StatusEffect> &vec_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1598::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1599::func;
 	return execfunc(this, vec);
 }
 
-namespace _func1599
+namespace _func1600
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -21914,11 +21928,11 @@ namespace _func1599
 void WorldManager::ModifyStatusEffect(StatusEffect effect, ShipManager *target, int targetType)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, StatusEffect effect_arg, ShipManager *target_arg, int targetType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1599::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1600::func;
 	return execfunc(this, effect, target, targetType);
 }
 
-namespace _func1600
+namespace _func1601
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21928,11 +21942,11 @@ namespace _func1600
 void WorldManager::StartGame(ShipManager *ship)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1600::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1601::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1601
+namespace _func1602
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21942,11 +21956,11 @@ namespace _func1601
 void WorldManager::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1601::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1602::func;
 	return execfunc(this);
 }
 
-namespace _func1602
+namespace _func1603
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -21956,11 +21970,11 @@ namespace _func1602
 void WorldManager::LoadGame(const std::string &fileName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1602::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1603::func;
 	return execfunc(this, fileName);
 }
 
-namespace _func1603
+namespace _func1604
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -21968,20 +21982,6 @@ namespace _func1603
 }
 
 void WorldManager::OnLoop()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1603::func;
-	return execfunc(this);
-}
-
-namespace _func1604
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("WorldManager::PauseLoop", typeid(void (WorldManager::*)()), "5589e557565383ec4c8b75088b068b10", argdata, 1, 6, &func);
-}
-
-void WorldManager::PauseLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1604::func;
@@ -21992,10 +21992,10 @@ namespace _func1605
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("WorldManager::CreateNewGame", typeid(void (WorldManager::*)()), "57565383ec208b7424308d5c241c8d7c241b8b068b4008", argdata, 1, 6, &func);
+	static FunctionDefinition funcObj("WorldManager::PauseLoop", typeid(void (WorldManager::*)()), "5589e557565383ec4c8b75088b068b10", argdata, 1, 6, &func);
 }
 
-void WorldManager::CreateNewGame()
+void WorldManager::PauseLoop()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1605::func;
@@ -22006,17 +22006,31 @@ namespace _func1606
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("WorldManager::CreateNewGame", typeid(void (WorldManager::*)()), "57565383ec208b7424308d5c241c8d7c241b8b068b4008", argdata, 1, 6, &func);
+}
+
+void WorldManager::CreateNewGame()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1606::func;
+	return execfunc(this);
+}
+
+namespace _func1607
+{
+    static void *func = 0;
+	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("WorldManager::HostileEnvironment", typeid(bool (WorldManager::*)()), "5383ec188b5c24208d4308890424", argdata, 1, 2, &func);
 }
 
 bool WorldManager::HostileEnvironment()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1606::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1607::func;
 	return execfunc(this);
 }
 
-namespace _func1607
+namespace _func1608
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -22026,11 +22040,11 @@ namespace _func1607
 bool WorldManager::AddBoarders(BoardingEvent &boardingEvent)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, BoardingEvent &boardingEvent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1607::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1608::func;
 	return execfunc(this, boardingEvent);
 }
 
-namespace _func1608
+namespace _func1609
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -22040,11 +22054,11 @@ namespace _func1608
 void WorldManager::CreateStore(LocationEvent *event)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1608::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1609::func;
 	return execfunc(this, event);
 }
 
-namespace _func1609
+namespace _func1610
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -22054,11 +22068,11 @@ namespace _func1609
 bool WorldManager::CheckRequirements(LocationEvent *event, bool hidden)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg, bool hidden_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1609::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1610::func;
 	return execfunc(this, event, hidden);
 }
 
-namespace _func1610
+namespace _func1611
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22068,11 +22082,11 @@ namespace _func1610
 void freetype::font_data::init(const void *buffer, int bufferSize, unsigned int h, bool glow)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(freetype::font_data *this_arg, const void *buffer_arg, int bufferSize_arg, unsigned int h_arg, bool glow_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1610::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1611::func;
 	return execfunc(this, buffer, bufferSize, h, glow);
 }
 
-namespace _func1611
+namespace _func1612
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22082,11 +22096,11 @@ namespace _func1611
 void freetype::font_data::init_bitmap(const void *buffer, int bufferSize, int size, int h)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(freetype::font_data *this_arg, const void *buffer_arg, int bufferSize_arg, int size_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1611::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1612::func;
 	return execfunc(this, buffer, bufferSize, size, h);
 }
 
-namespace _func1612
+namespace _func1613
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -22096,11 +22110,11 @@ namespace _func1612
 void freetype::font_data::clean()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(freetype::font_data *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1612::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1613::func;
 	return execfunc(this);
 }
 
-namespace _func1613
+namespace _func1614
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22110,11 +22124,11 @@ namespace _func1613
 Pointf freetype::easy_measurePrintLines(int fontSize, float x, float y, int line_length, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1613::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1614::func;
 	return execfunc(fontSize, x, y, line_length, text);
 }
 
-namespace _func1614
+namespace _func1615
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -22124,11 +22138,11 @@ namespace _func1614
 int freetype::easy_measureWidth(int fontSize, const std::string &text)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1614::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1615::func;
 	return execfunc(fontSize, text);
 }
 
-namespace _func1615
+namespace _func1616
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22138,11 +22152,11 @@ namespace _func1615
 Pointf freetype::easy_print(int fontSize, float x, float y, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1615::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1616::func;
 	return execfunc(fontSize, x, y, text);
 }
 
-namespace _func1616
+namespace _func1617
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22152,11 +22166,11 @@ namespace _func1616
 Pointf freetype::easy_printRightAlign(int fontSize, float x, float y, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1616::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1617::func;
 	return execfunc(fontSize, x, y, text);
 }
 
-namespace _func1617
+namespace _func1618
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22166,11 +22180,11 @@ namespace _func1617
 Pointf freetype::easy_printNewlinesCentered(int fontSize, float x, float y, int line_length, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1617::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1618::func;
 	return execfunc(fontSize, x, y, line_length, text);
 }
 
-namespace _func1618
+namespace _func1619
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22180,11 +22194,11 @@ namespace _func1618
 Pointf freetype::easy_printAutoNewlines(int fontSize, float x, float y, int line_length, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1618::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1619::func;
 	return execfunc(fontSize, x, y, line_length, text);
 }
 
-namespace _func1619
+namespace _func1620
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22194,11 +22208,11 @@ namespace _func1619
 Pointf freetype::easy_printCenter(int fontSize, float x, float y, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1619::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1620::func;
 	return execfunc(fontSize, x, y, text);
 }
 
-namespace _func1620
+namespace _func1621
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22208,11 +22222,11 @@ namespace _func1620
 void freetype::easy_printAutoShrink(int fontId, float x, float y, int maxWidth, bool centered, const std::string &text)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontId_arg, float x_arg, float y_arg, int maxWidth_arg, bool centered_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1620::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1621::func;
 	return execfunc(fontId, x, y, maxWidth, centered, text);
 }
 
-namespace _func1621
+namespace _func1622
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -22222,11 +22236,11 @@ namespace _func1621
 float __stdcall font_height(int font_id, float size)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(int font_id_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1621::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1622::func;
 	return execfunc(font_id, size);
 }
 
-namespace _func1622
+namespace _func1623
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -22236,13 +22250,13 @@ namespace _func1622
 float __stdcall font_baseline(int font_id, float size)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(int font_id_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1622::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1623::func;
 	return execfunc(font_id, size);
 }
 
 float *Global_freetype_sil_freetype_outline;
 
-namespace _var1623
+namespace _var1624
 {
     static VariableDefinition varObj("Global_freetype_sil_freetype_outline", "!.f30f5905(???????\?)c744240801000000f30f2dc0", &Global_freetype_sil_freetype_outline);
 }

--- a/FTLGameELF32.h
+++ b/FTLGameELF32.h
@@ -4705,6 +4705,7 @@ struct CommandGui
 {
 	LIBZHL_API void AddEnemyShip(CompleteShip *ship);
 	LIBZHL_API void CheckGameover();
+	LIBZHL_API void ClearLocation();
 	LIBZHL_API Store *CreateNewStore(int sectorNumber);
 	LIBZHL_API Point GetWorldCoordinates(Point point, bool fromTarget);
 	LIBZHL_API bool IsGameOver();

--- a/FTLGameELF64.cpp
+++ b/FTLGameELF64.cpp
@@ -3664,17 +3664,30 @@ void CommandGui::AddEnemyShip(CompleteShip *ship)
 namespace _func283
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CommandGui::ClearLocation", typeid(void (CommandGui::*)()), ".53??8b8770190000??89fb??8dbf88050000??8b40108bb08c020000", nullptr, 0, 0, &func);
+}
+
+void CommandGui::ClearLocation()
+{
+	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func283::func;
+	return execfunc(this);
+}
+
+namespace _func284
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::LinkShip", typeid(void (CommandGui::*)(CompleteShip *)), ".415731d2415641554154554889", nullptr, 0, 0, &func);
 }
 
 void CommandGui::LinkShip(CompleteShip *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg, CompleteShip *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func283::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func284::func;
 	return execfunc(this, ship);
 }
 
-namespace _func284
+namespace _func285
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::GetWorldCoordinates", typeid(Point (CommandGui::*)(Point , bool )), ".41544189d4554889fd534889f34883ec204889e7", nullptr, 0, 0, &func);
@@ -3683,11 +3696,11 @@ namespace _func284
 Point CommandGui::GetWorldCoordinates(Point point, bool fromTarget)
 {
 	typedef Point (*custom_arg_funcptr_t)(CommandGui *this_arg, Point point_arg, bool fromTarget_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func284::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func285::func;
 	return execfunc(this, point, fromTarget);
 }
 
-namespace _func285
+namespace _func286
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::RenderPlayerShip", typeid(void (CommandGui::*)(Point &, float )), ".415431d2554889f531f6534889fb4883ec30", nullptr, 0, 0, &func);
@@ -3696,11 +3709,11 @@ namespace _func285
 void CommandGui::RenderPlayerShip(Point &shipCenter, float jumpScale)
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg, Point &shipCenter_arg, float jumpScale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func285::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func286::func;
 	return execfunc(this, shipCenter, jumpScale);
 }
 
-namespace _func286
+namespace _func287
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::LButtonUp", typeid(void (CommandGui::*)(int , int , bool )), ".4154555380bf????????004889fb", nullptr, 0, 0, &func);
@@ -3709,11 +3722,11 @@ namespace _func286
 void CommandGui::LButtonUp(int mX, int mY, bool shiftHeld)
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg, int mX_arg, int mY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func286::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func287::func;
 	return execfunc(this, mX, mY, shiftHeld);
 }
 
-namespace _func287
+namespace _func288
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::NewLocation", typeid(void (CommandGui::*)(const std::string &, std::vector<ChoiceText> *, ResourceEvent &, bool )), ".415741564155415455534889d34881ec58020000", nullptr, 0, 0, &func);
@@ -3722,11 +3735,11 @@ namespace _func287
 void CommandGui::NewLocation(const std::string &mainText, std::vector<ChoiceText> *choices, ResourceEvent &resources, bool testingEvents)
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg, const std::string &mainText_arg, std::vector<ChoiceText> *choices_arg, ResourceEvent &resources_arg, bool testingEvents_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func287::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func288::func;
 	return execfunc(this, mainText, choices, resources, testingEvents);
 }
 
-namespace _func288
+namespace _func289
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::RunCommand", typeid(void (CommandGui::*)(std::string &)), ".4157415641554989fd41544989f45531ed5331db4883ec58488b06", nullptr, 0, 0, &func);
@@ -3735,11 +3748,11 @@ namespace _func288
 void CommandGui::RunCommand(std::string &command)
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg, std::string &command_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func288::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func289::func;
 	return execfunc(this, command);
 }
 
-namespace _func289
+namespace _func290
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::CreateNewStore", typeid(Store *(CommandGui::*)(int )), ".41554189f5415455534889fbbf580600004c8da3????0000", nullptr, 0, 0, &func);
@@ -3748,11 +3761,11 @@ namespace _func289
 Store *CommandGui::CreateNewStore(int sectorNumber)
 {
 	typedef Store *(*custom_arg_funcptr_t)(CommandGui *this_arg, int sectorNumber_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func289::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func290::func;
 	return execfunc(this, sectorNumber);
 }
 
-namespace _func290
+namespace _func291
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::Restart", typeid(void (CommandGui::*)()), "!.4155415455488daf68020000", nullptr, 0, 0, &func);
@@ -3761,11 +3774,11 @@ namespace _func290
 void CommandGui::Restart()
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func290::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func291::func;
 	return execfunc(this);
 }
 
-namespace _func291
+namespace _func292
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::KeyDown", typeid(void (CommandGui::*)(SDLKey , bool )), ".415541545589f5534889fb4883ec38", nullptr, 0, 0, &func);
@@ -3774,11 +3787,11 @@ namespace _func291
 void CommandGui::KeyDown(SDLKey key, bool shiftHeld)
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg, SDLKey key_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func291::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func292::func;
 	return execfunc(this, key, shiftHeld);
 }
 
-namespace _func292
+namespace _func293
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::RenderStatic", typeid(void (CommandGui::*)()), ".41564155415455534889fb4883ec40", nullptr, 0, 0, &func);
@@ -3787,11 +3800,11 @@ namespace _func292
 void CommandGui::RenderStatic()
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func292::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func293::func;
 	return execfunc(this);
 }
 
-namespace _func293
+namespace _func294
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::LButtonDown", typeid(void (CommandGui::*)(int , int , bool )), ".415541544189d45589f5534889fb4883ec28", nullptr, 0, 0, &func);
@@ -3800,11 +3813,11 @@ namespace _func293
 void CommandGui::LButtonDown(int mX, int mY, bool shiftHeld)
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg, int mX_arg, int mY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func293::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func294::func;
 	return execfunc(this, mX, mY, shiftHeld);
 }
 
-namespace _func294
+namespace _func295
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::MouseMove", typeid(void (CommandGui::*)(int , int )), ".41544189d45589f5534889fb4883ec50", nullptr, 0, 0, &func);
@@ -3813,30 +3826,17 @@ namespace _func294
 void CommandGui::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func294::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func295::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func295
+namespace _func296
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CommandGui::OnLoop", typeid(void (CommandGui::*)()), ".41564155415455534889fb4883ec20", nullptr, 0, 0, &func);
 }
 
 void CommandGui::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func295::func;
-	return execfunc(this);
-}
-
-namespace _func296
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CommandGui::constructor", typeid(void (CommandGui::*)()), ".41574156415541545548c7c5ffffffff534889fb", nullptr, 0, 0, &func);
-}
-
-void CommandGui::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func296::func;
@@ -3846,12 +3846,12 @@ void CommandGui::constructor()
 namespace _func297
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CompleteShip::PauseLoop", typeid(void (CompleteShip::*)()), "!488b7f10e9????????90660f1f440000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CommandGui::constructor", typeid(void (CommandGui::*)()), ".41574156415541545548c7c5ffffffff534889fb", nullptr, 0, 0, &func);
 }
 
-void CompleteShip::PauseLoop()
+void CommandGui::constructor()
 {
-	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
+	typedef void (*custom_arg_funcptr_t)(CommandGui *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func297::func;
 	return execfunc(this);
 }
@@ -3859,10 +3859,10 @@ void CompleteShip::PauseLoop()
 namespace _func298
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CompleteShip::Restart", typeid(void (CompleteShip::*)()), "!.534889fb488b7f10", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CompleteShip::PauseLoop", typeid(void (CompleteShip::*)()), "!488b7f10e9????????90660f1f440000", nullptr, 0, 0, &func);
 }
 
-void CompleteShip::Restart()
+void CompleteShip::PauseLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func298::func;
@@ -3872,17 +3872,30 @@ void CompleteShip::Restart()
 namespace _func299
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CompleteShip::Restart", typeid(void (CompleteShip::*)()), "!.534889fb488b7f10", nullptr, 0, 0, &func);
+}
+
+void CompleteShip::Restart()
+{
+	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func299::func;
+	return execfunc(this);
+}
+
+namespace _func300
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::constructor", typeid(void (CompleteShip::*)(SpaceManager *, bool , int )), ".534889fb48897718", nullptr, 0, 0, &func);
 }
 
 void CompleteShip::constructor(SpaceManager *space, bool unk, int unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, SpaceManager *space_arg, bool unk_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func299::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func300::func;
 	return execfunc(this, space, unk, unk2);
 }
 
-namespace _func300
+namespace _func301
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::SetShip", typeid(void (CompleteShip::*)(ShipManager *)), "!.8b96ac08000048897710", nullptr, 0, 0, &func);
@@ -3891,11 +3904,11 @@ namespace _func300
 void CompleteShip::SetShip(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func300::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func301::func;
 	return execfunc(this, ship);
 }
 
-namespace _func301
+namespace _func302
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::OnInit", typeid(void (CompleteShip::*)(const ShipBlueprint *, int )), "!.41554189d541544989f455534889fbbf580a0000", nullptr, 0, 0, &func);
@@ -3904,11 +3917,11 @@ namespace _func301
 void CompleteShip::OnInit(const ShipBlueprint *blueprint, int unk)
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, const ShipBlueprint *blueprint_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func301::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func302::func;
 	return execfunc(this, blueprint, unk);
 }
 
-namespace _func302
+namespace _func303
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::AddBoarders", typeid(void (CompleteShip::*)(int , const std::string &, bool )), ".415741564189ce415541544189f4be02000000554889fd534881ec88000000", nullptr, 0, 0, &func);
@@ -3917,11 +3930,11 @@ namespace _func302
 void CompleteShip::AddBoarders(int amount, const std::string &race, bool unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, int amount_arg, const std::string &race_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func302::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func303::func;
 	return execfunc(this, amount, race, unk2);
 }
 
-namespace _func303
+namespace _func304
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::AddCrewMember", typeid(CrewMember *(CompleteShip::*)(const CrewBlueprint *, bool )), ".415741564989f6415541544189d455488dae88000000534881ec38010000", nullptr, 0, 0, &func);
@@ -3930,11 +3943,11 @@ namespace _func303
 CrewMember *CompleteShip::AddCrewMember(const CrewBlueprint *blueprint, bool hostile)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(CompleteShip *this_arg, const CrewBlueprint *blueprint_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func303::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func304::func;
 	return execfunc(this, blueprint, hostile);
 }
 
-namespace _func304
+namespace _func305
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::AddCrewMember1", typeid(CrewMember *(CompleteShip::*)(const std::string &, const std::string &, bool )), ".41574889f04989ff415641554189cd415455534889d34883ec58", nullptr, 0, 0, &func);
@@ -3943,11 +3956,11 @@ namespace _func304
 CrewMember *CompleteShip::AddCrewMember1(const std::string &race, const std::string &name, bool hostile)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(CompleteShip *this_arg, const std::string &race_arg, const std::string &name_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func304::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func305::func;
 	return execfunc(this, race, name, hostile);
 }
 
-namespace _func305
+namespace _func306
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::AddDrone", typeid(Drone *(CompleteShip::*)(const DroneBlueprint *, int )), "!.488b7f10e9????????90660f1f440000", nullptr, 0, 0, &func);
@@ -3956,11 +3969,11 @@ namespace _func305
 Drone *CompleteShip::AddDrone(const DroneBlueprint *blueprint, int unk)
 {
 	typedef Drone *(*custom_arg_funcptr_t)(CompleteShip *this_arg, const DroneBlueprint *blueprint_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func305::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func306::func;
 	return execfunc(this, blueprint, unk);
 }
 
-namespace _func306
+namespace _func307
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::AddCrewMember2", typeid(CrewMember *(CompleteShip::*)(CrewMember *, int )), ".41544885f655534889f3", nullptr, 0, 0, &func);
@@ -3969,30 +3982,17 @@ namespace _func306
 CrewMember *CompleteShip::AddCrewMember2(CrewMember *member, int unk)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(CompleteShip *this_arg, CrewMember *member_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func306::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func307::func;
 	return execfunc(this, member, unk);
 }
 
-namespace _func307
+namespace _func308
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::SaveState", typeid(void (CompleteShip::*)(int )), "!.89f08bb71002000089c7", nullptr, 0, 0, &func);
 }
 
 void CompleteShip::SaveState(int unk)
-{
-	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func307::func;
-	return execfunc(this, unk);
-}
-
-namespace _func308
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CompleteShip::LoadState", typeid(void (CompleteShip::*)(int )), ".534889fb89f74883ec20", nullptr, 0, 0, &func);
-}
-
-void CompleteShip::LoadState(int unk)
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, int unk_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func308::func;
@@ -4002,17 +4002,30 @@ void CompleteShip::LoadState(int unk)
 namespace _func309
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CompleteShip::LoadState", typeid(void (CompleteShip::*)(int )), ".534889fb89f74883ec20", nullptr, 0, 0, &func);
+}
+
+void CompleteShip::LoadState(int unk)
+{
+	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, int unk_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func309::func;
+	return execfunc(this, unk);
+}
+
+namespace _func310
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::InitiateTeleport", typeid(void (CompleteShip::*)(int , int )), ".415455534889fb4883ec40488b87e0010000", nullptr, 0, 0, &func);
 }
 
 void CompleteShip::InitiateTeleport(int targetRoom, int command)
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, int targetRoom_arg, int command_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func309::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func310::func;
 	return execfunc(this, targetRoom, command);
 }
 
-namespace _func310
+namespace _func311
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::OnLoop", typeid(void (CompleteShip::*)()), "!.4157415641554989fd415455498d6d305331db4883ec18488b7f10", nullptr, 0, 0, &func);
@@ -4021,11 +4034,11 @@ namespace _func310
 void CompleteShip::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func310::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func311::func;
 	return execfunc(this);
 }
 
-namespace _func311
+namespace _func312
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::GetTeleportingParty", typeid(std::vector<CrewMember*> (CompleteShip::*)()), ".4154554889f553488b86000200004889fb", nullptr, 0, 0, &func);
@@ -4034,11 +4047,11 @@ namespace _func311
 std::vector<CrewMember*> CompleteShip::GetTeleportingParty()
 {
 	typedef std::vector<CrewMember*> (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func311::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func312::func;
 	return execfunc(this);
 }
 
-namespace _func312
+namespace _func313
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::KillRandomCrew", typeid(void (CompleteShip::*)()), "!.488b7f10e9????????90660f1f440000", nullptr, 0, 0, &func);
@@ -4047,11 +4060,11 @@ namespace _func312
 void CompleteShip::KillRandomCrew()
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func312::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func313::func;
 	return execfunc(this);
 }
 
-namespace _func313
+namespace _func314
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::CountCrew", typeid(int (CompleteShip::*)(bool )), "!.488b7f10400fb6f6", nullptr, 0, 0, &func);
@@ -4060,11 +4073,11 @@ namespace _func313
 int CompleteShip::CountCrew(bool boarders)
 {
 	typedef int (*custom_arg_funcptr_t)(CompleteShip *this_arg, bool boarders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func313::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func314::func;
 	return execfunc(this, boarders);
 }
 
-namespace _func314
+namespace _func315
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::Jump", typeid(void (CompleteShip::*)()), ".488b87e0010000488987e8010000", nullptr, 0, 0, &func);
@@ -4073,11 +4086,11 @@ namespace _func314
 void CompleteShip::Jump()
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func314::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func315::func;
 	return execfunc(this);
 }
 
-namespace _func315
+namespace _func316
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::SetEnemyShip", typeid(void (CompleteShip::*)(CompleteShip *)), "!.4885f648897720", nullptr, 0, 0, &func);
@@ -4086,11 +4099,11 @@ namespace _func315
 void CompleteShip::SetEnemyShip(CompleteShip *other)
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, CompleteShip *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func315::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func316::func;
 	return execfunc(this, other);
 }
 
-namespace _func316
+namespace _func317
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::DeadCrew", typeid(bool (CompleteShip::*)()), ".55534889fb4883ec080fb67728", nullptr, 0, 0, &func);
@@ -4099,11 +4112,11 @@ namespace _func316
 bool CompleteShip::DeadCrew()
 {
 	typedef bool (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func316::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func317::func;
 	return execfunc(this);
 }
 
-namespace _func317
+namespace _func318
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::TeleportCrew", typeid(std::vector<CrewMember*> (CompleteShip::*)(int , bool )), ".53488b76104889fb0fb6c9", nullptr, 0, 0, &func);
@@ -4112,30 +4125,17 @@ namespace _func317
 std::vector<CrewMember*> CompleteShip::TeleportCrew(int roomId, bool intruders)
 {
 	typedef std::vector<CrewMember*> (*custom_arg_funcptr_t)(CompleteShip *this_arg, int roomId_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func317::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func318::func;
 	return execfunc(this, roomId, intruders);
 }
 
-namespace _func318
+namespace _func319
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::OnRender", typeid(void (CompleteShip::*)()), "!.534889fb8b7708488b7f18ba02000000", nullptr, 0, 0, &func);
 }
 
 void CompleteShip::OnRender()
-{
-	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func318::func;
-	return execfunc(this);
-}
-
-namespace _func319
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CompleteShip::OnRenderSpace", typeid(void (CompleteShip::*)()), "!.488b7f18f30f1005????????be03000000", nullptr, 0, 0, &func);
-}
-
-void CompleteShip::OnRenderSpace()
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func319::func;
@@ -4145,17 +4145,30 @@ void CompleteShip::OnRenderSpace()
 namespace _func320
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CompleteShip::OnRenderSpace", typeid(void (CompleteShip::*)()), "!.488b7f18f30f1005????????be03000000", nullptr, 0, 0, &func);
+}
+
+void CompleteShip::OnRenderSpace()
+{
+	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func320::func;
+	return execfunc(this);
+}
+
+namespace _func321
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CompleteShip::OnRenderShip", typeid(void (CompleteShip::*)(bool , bool )), "!.41544189d4ba020000005589f5534889fb8b7708488b7f18", nullptr, 0, 0, &func);
 }
 
 void CompleteShip::OnRenderShip(bool unk1, bool unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(CompleteShip *this_arg, bool unk1_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func320::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func321::func;
 	return execfunc(this, unk1, unk2);
 }
 
-namespace _func321
+namespace _func322
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ConfirmWindow::Close", typeid(void (ConfirmWindow::*)()), "!534889fb488b7f70", nullptr, 0, 0, &func);
@@ -4164,11 +4177,11 @@ namespace _func321
 void ConfirmWindow::Close()
 {
 	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func321::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func322::func;
 	return execfunc(this);
 }
 
-namespace _func322
+namespace _func323
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ConfirmWindow::MouseClick", typeid(void (ConfirmWindow::*)(int , int )), ".807f0800741a", nullptr, 0, 0, &func);
@@ -4177,11 +4190,11 @@ namespace _func322
 void ConfirmWindow::MouseClick(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func322::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func323::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func323
+namespace _func324
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ConfirmWindow::constructor", typeid(void (ConfirmWindow::*)()), ".534889fb4883ec10e8????????488d7b20488d54240f", nullptr, 0, 0, &func);
@@ -4190,11 +4203,11 @@ namespace _func323
 void ConfirmWindow::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func323::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func324::func;
 	return execfunc(this);
 }
 
-namespace _func324
+namespace _func325
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ConfirmWindow::SetText", typeid(void (ConfirmWindow::*)(const TextString &, int , bool , const TextString &, const TextString &)), ".41574189cf41564189d641554989f541544d89cc554c89c5534889fb4883ec38", nullptr, 0, 0, &func);
@@ -4203,11 +4216,11 @@ namespace _func324
 void ConfirmWindow::SetText(const TextString &text_, int minWidth, bool autoCenter, const TextString &yesText_, const TextString &noText_)
 {
 	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, const TextString &text__arg, int minWidth_arg, bool autoCenter_arg, const TextString &yesText__arg, const TextString &noText__arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func324::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func325::func;
 	return execfunc(this, text_, minWidth, autoCenter, yesText_, noText_);
 }
 
-namespace _func325
+namespace _func326
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ConfirmWindow::SetPosition", typeid(void (ConfirmWindow::*)(Point )), ".41564155415455534889fb4883ec10", nullptr, 0, 0, &func);
@@ -4216,30 +4229,17 @@ namespace _func325
 void ConfirmWindow::SetPosition(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func325::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func326::func;
 	return execfunc(this, pos);
 }
 
-namespace _func326
+namespace _func327
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ConfirmWindow::Open", typeid(void (ConfirmWindow::*)()), ".415741564155415455534889fb4883ec28", nullptr, 0, 0, &func);
 }
 
 void ConfirmWindow::Open()
-{
-	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func326::func;
-	return execfunc(this);
-}
-
-namespace _func327
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ConfirmWindow::OnRender", typeid(void (ConfirmWindow::*)()), ".41574156415541544989fc55534881ec98000000488b7f70", nullptr, 0, 0, &func);
-}
-
-void ConfirmWindow::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func327::func;
@@ -4249,17 +4249,30 @@ void ConfirmWindow::OnRender()
 namespace _func328
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ConfirmWindow::OnRender", typeid(void (ConfirmWindow::*)()), ".41574156415541544989fc55534881ec98000000488b7f70", nullptr, 0, 0, &func);
+}
+
+void ConfirmWindow::OnRender()
+{
+	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func328::func;
+	return execfunc(this);
+}
+
+namespace _func329
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ConfirmWindow::MouseMove", typeid(void (ConfirmWindow::*)(int , int )), ".41545553807f08004889fb", nullptr, 0, 0, &func);
 }
 
 void ConfirmWindow::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func328::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func329::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func329
+namespace _func330
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ControlButton::OnRender", typeid(void (ControlButton::*)()), "415455534889fb4883ec608b4730", nullptr, 0, 0, &func);
@@ -4268,19 +4281,6 @@ namespace _func329
 void ControlButton::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(ControlButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func329::func;
-	return execfunc(this);
-}
-
-namespace _func330
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ControlsScreen::OnInit", typeid(void (ControlsScreen::*)()), "41574156415541544989fc55534881ece80000004883bf3006000000", nullptr, 0, 0, &func);
-}
-
-void ControlsScreen::OnInit()
-{
-	typedef void (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func330::func;
 	return execfunc(this);
 }
@@ -4288,10 +4288,10 @@ void ControlsScreen::OnInit()
 namespace _func331
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ControlsScreen::OnLoop", typeid(void (ControlsScreen::*)()), "41564155415449bcb76ddbb66ddbb66d554889fd534883ec4048638728060000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ControlsScreen::OnInit", typeid(void (ControlsScreen::*)()), "41574156415541544989fc55534881ece80000004883bf3006000000", nullptr, 0, 0, &func);
 }
 
-void ControlsScreen::OnLoop()
+void ControlsScreen::OnInit()
 {
 	typedef void (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func331::func;
@@ -4301,10 +4301,10 @@ void ControlsScreen::OnLoop()
 namespace _func332
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ControlsScreen::OnRender", typeid(void (ControlsScreen::*)()), "415741564155415455534889fb4881ec1802000080bf7001000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ControlsScreen::OnLoop", typeid(void (ControlsScreen::*)()), "41564155415449bcb76ddbb66ddbb66d554889fd534883ec4048638728060000", nullptr, 0, 0, &func);
 }
 
-void ControlsScreen::OnRender()
+void ControlsScreen::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func332::func;
@@ -4314,17 +4314,30 @@ void ControlsScreen::OnRender()
 namespace _func333
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ControlsScreen::OnRender", typeid(void (ControlsScreen::*)()), "415741564155415455534889fb4881ec1802000080bf7001000000", nullptr, 0, 0, &func);
+}
+
+void ControlsScreen::OnRender()
+{
+	typedef void (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func333::func;
+	return execfunc(this);
+}
+
+namespace _func334
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CooldownSystemBox::constructor", typeid(void (CooldownSystemBox::*)(Point , ShipSystem *, bool )), "4157415641554989fd41545589cdb901000000534889f34881ece8010000", nullptr, 0, 0, &func);
 }
 
 void CooldownSystemBox::constructor(Point pos, ShipSystem *sys, bool roundDown)
 {
 	typedef void (*custom_arg_funcptr_t)(CooldownSystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, bool roundDown_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func333::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func334::func;
 	return execfunc(this, pos, sys, roundDown);
 }
 
-namespace _func334
+namespace _func335
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CooldownSystemBox::OnRender", typeid(void (CooldownSystemBox::*)(bool )), "4154400fb6f655534889fb4883ec50", nullptr, 0, 0, &func);
@@ -4333,30 +4346,17 @@ namespace _func334
 void CooldownSystemBox::OnRender(bool ignoreStatus)
 {
 	typedef void (*custom_arg_funcptr_t)(CooldownSystemBox *this_arg, bool ignoreStatus_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func334::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func335::func;
 	return execfunc(this, ignoreStatus);
 }
 
-namespace _func335
+namespace _func336
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CreditScreen::OnRender", typeid(void (CreditScreen::*)()), "415641554154554889fd534883ec60", nullptr, 0, 0, &func);
 }
 
 void CreditScreen::OnRender()
-{
-	typedef void (*custom_arg_funcptr_t)(CreditScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func335::func;
-	return execfunc(this);
-}
-
-namespace _func336
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CreditScreen::constructor", typeid(void (CreditScreen::*)()), "48c74708????????48c74710????????c747180000000048c7472800000000", nullptr, 0, 0, &func);
-}
-
-void CreditScreen::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CreditScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func336::func;
@@ -4366,17 +4366,30 @@ void CreditScreen::constructor()
 namespace _func337
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CreditScreen::constructor", typeid(void (CreditScreen::*)()), "48c74708????????48c74710????????c747180000000048c7472800000000", nullptr, 0, 0, &func);
+}
+
+void CreditScreen::constructor()
+{
+	typedef void (*custom_arg_funcptr_t)(CreditScreen *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func337::func;
+	return execfunc(this);
+}
+
+namespace _func338
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CreditScreen::Start", typeid(void (CreditScreen::*)(const std::string &, const std::vector<std::string> &)), "4157415641554154554889d5534889fb4881ecd8010000", nullptr, 0, 0, &func);
 }
 
 void CreditScreen::Start(const std::string &shipName, const std::vector<std::string> &crewNames)
 {
 	typedef void (*custom_arg_funcptr_t)(CreditScreen *this_arg, const std::string &shipName_arg, const std::vector<std::string> &crewNames_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func337::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func338::func;
 	return execfunc(this, shipName, crewNames);
 }
 
-namespace _func338
+namespace _func339
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CreditScreen::Done", typeid(bool (CreditScreen::*)()), "488b4730482b472848baabaaaaaaaaaaaaaa", nullptr, 0, 0, &func);
@@ -4385,11 +4398,11 @@ namespace _func338
 bool CreditScreen::Done()
 {
 	typedef bool (*custom_arg_funcptr_t)(CreditScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func338::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func339::func;
 	return execfunc(this);
 }
 
-namespace _func339
+namespace _func340
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAI::PrioritizeIntruderRoom", typeid(int (CrewAI::*)(CrewMember *, int , int )), "41574156415541544989f45589d5534889fb4883ec18", nullptr, 0, 0, &func);
@@ -4398,11 +4411,11 @@ namespace _func339
 int CrewAI::PrioritizeIntruderRoom(CrewMember *crew, int roomId, int target)
 {
 	typedef int (*custom_arg_funcptr_t)(CrewAI *this_arg, CrewMember *crew_arg, int roomId_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func339::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func340::func;
 	return execfunc(this, crew, roomId, target);
 }
 
-namespace _func340
+namespace _func341
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAI::DangerRating", typeid(int (CrewAI::*)(int , int )), ".415641554989fd4154554863ea5389f34883ec50", nullptr, 0, 0, &func);
@@ -4411,11 +4424,11 @@ namespace _func340
 int CrewAI::DangerRating(int roomId, int crewId)
 {
 	typedef int (*custom_arg_funcptr_t)(CrewAI *this_arg, int roomId_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func340::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func341::func;
 	return execfunc(this, roomId, crewId);
 }
 
-namespace _func341
+namespace _func342
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAI::CheckForHealing", typeid(void (CrewAI::*)()), ".4156415541544531e45531ed534889fb4883ec20", nullptr, 0, 0, &func);
@@ -4424,11 +4437,11 @@ namespace _func341
 void CrewAI::CheckForHealing()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func341::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func342::func;
 	return execfunc(this);
 }
 
-namespace _func342
+namespace _func343
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAI::PrioritizeTask", typeid(int (CrewAI::*)(CrewTask , int )), ".415641554989fd41544189d4554863e95389f34883ec10", nullptr, 0, 0, &func);
@@ -4437,11 +4450,11 @@ namespace _func342
 int CrewAI::PrioritizeTask(CrewTask task, int crewId)
 {
 	typedef int (*custom_arg_funcptr_t)(CrewAI *this_arg, CrewTask task_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func342::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func343::func;
 	return execfunc(this, task, crewId);
 }
 
-namespace _func343
+namespace _func344
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAI::AssignCrewmembers", typeid(void (CrewAI::*)()), ".415631d241554531ed415449bcabaaaaaaaaaaaaaa5553", nullptr, 0, 0, &func);
@@ -4450,11 +4463,11 @@ namespace _func343
 void CrewAI::AssignCrewmembers()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func343::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func344::func;
 	return execfunc(this);
 }
 
-namespace _func344
+namespace _func345
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAI::UpdateCrewMember", typeid(void (CrewAI::*)(int )), ".41574863f641564155415455534889fb4883ec38", nullptr, 0, 0, &func);
@@ -4463,30 +4476,17 @@ namespace _func344
 void CrewAI::UpdateCrewMember(int crewId)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAI *this_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func344::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func345::func;
 	return execfunc(this, crewId);
 }
 
-namespace _func345
+namespace _func346
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAI::UpdateIntruders", typeid(void (CrewAI::*)()), ".415641554154554889fd534883ec10488b4730488b57284839d0", nullptr, 0, 0, &func);
 }
 
 void CrewAI::UpdateIntruders()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func345::func;
-	return execfunc(this);
-}
-
-namespace _func346
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewAI::CheckForProblems", typeid(void (CrewAI::*)()), ".41574989ff41564d89fe4155415455534881ec88000000488b07", nullptr, 0, 0, &func);
-}
-
-void CrewAI::CheckForProblems()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAI *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func346::func;
@@ -4496,10 +4496,10 @@ void CrewAI::CheckForProblems()
 namespace _func347
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewAI::UpdateDrones", typeid(void (CrewAI::*)()), ".415741564531f6415541545531ed534889fb4881eca8000000488b5710", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewAI::CheckForProblems", typeid(void (CrewAI::*)()), ".41574989ff41564d89fe4155415455534881ec88000000488b07", nullptr, 0, 0, &func);
 }
 
-void CrewAI::UpdateDrones()
+void CrewAI::CheckForProblems()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAI *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func347::func;
@@ -4509,10 +4509,10 @@ void CrewAI::UpdateDrones()
 namespace _func348
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewAI::OnLoop", typeid(void (CrewAI::*)()), ".415741564155415455534889fb4883ec48488b37", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewAI::UpdateDrones", typeid(void (CrewAI::*)()), ".415741564531f6415541545531ed534889fb4881eca8000000488b5710", nullptr, 0, 0, &func);
 }
 
-void CrewAI::OnLoop()
+void CrewAI::UpdateDrones()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAI *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func348::func;
@@ -4522,17 +4522,30 @@ void CrewAI::OnLoop()
 namespace _func349
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewAI::OnLoop", typeid(void (CrewAI::*)()), ".415741564155415455534889fb4883ec48488b37", nullptr, 0, 0, &func);
+}
+
+void CrewAI::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewAI *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func349::func;
+	return execfunc(this);
+}
+
+namespace _func350
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::destructor", typeid(void (CrewAnimation::*)()), "41574889f841564155415455534883ec68", nullptr, 0, 0, &func);
 }
 
 void CrewAnimation::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func349::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func350::func;
 	return execfunc(this);
 }
 
-namespace _func350
+namespace _func351
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::GetFiringFrame", typeid(int (CrewAnimation::*)()), ".8b475c83f8ff", nullptr, 0, 0, &func);
@@ -4541,11 +4554,11 @@ namespace _func350
 int CrewAnimation::GetFiringFrame()
 {
 	typedef int (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func350::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func351::func;
 	return execfunc(this);
 }
 
-namespace _func351
+namespace _func352
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::OnRenderProps", typeid(void (CrewAnimation::*)()), "!.41554531ed415449bc000000000000803f55", nullptr, 0, 0, &func);
@@ -4554,11 +4567,11 @@ namespace _func351
 void CrewAnimation::OnRenderProps()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func351::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func352::func;
 	return execfunc(this);
 }
 
-namespace _func352
+namespace _func353
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::OnRender", typeid(void (CrewAnimation::*)(float , int , bool )), ".41544189f45589d5534889fb4883ec50", nullptr, 0, 0, &func);
@@ -4567,11 +4580,11 @@ namespace _func352
 void CrewAnimation::OnRender(float scale, int selectedState, bool outlineOnly)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg, float scale_arg, int selectedState_arg, bool outlineOnly_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func352::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func353::func;
 	return execfunc(this, scale, selectedState, outlineOnly);
 }
 
-namespace _func353
+namespace _func354
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::FireShot", typeid(bool (CrewAnimation::*)()), "!.53488d9fd80800004889df", nullptr, 0, 0, &func);
@@ -4580,11 +4593,11 @@ namespace _func353
 bool CrewAnimation::FireShot()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func353::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func354::func;
 	return execfunc(this);
 }
 
-namespace _func354
+namespace _func355
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::RenderIcon", typeid(void (CrewAnimation::*)(bool )), ".4155415455534889fb4881ecf80000004084f6", nullptr, 0, 0, &func);
@@ -4593,11 +4606,11 @@ namespace _func354
 void CrewAnimation::RenderIcon(bool border)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg, bool border_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func354::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func355::func;
 	return execfunc(this, border);
 }
 
-namespace _func355
+namespace _func356
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::OnUpdate", typeid(void (CrewAnimation::*)(Pointf , bool , bool , bool , bool , bool )), ".415455534889fb4883ec308b4760", nullptr, 0, 0, &func);
@@ -4606,30 +4619,17 @@ namespace _func355
 void CrewAnimation::OnUpdate(Pointf position, bool moving, bool fighting, bool repairing, bool dying, bool onFire)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg, Pointf position_arg, bool moving_arg, bool fighting_arg, bool repairing_arg, bool dying_arg, bool onFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func355::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func356::func;
 	return execfunc(this, position, moving, fighting, repairing, dying, onFire);
 }
 
-namespace _func356
+namespace _func357
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::GetDeathSound", typeid(std::string (CrewAnimation::*)()), ".534889fb4883ec3080beec09000000", nullptr, 0, 0, &func);
 }
 
 std::string CrewAnimation::GetDeathSound()
-{
-	typedef std::string (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func356::func;
-	return execfunc(this);
-}
-
-namespace _func357
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewAnimation::GetShootingSound", typeid(std::string (CrewAnimation::*)()), ".534889fb4883ec30", nullptr, 0, 0, &func);
-}
-
-std::string CrewAnimation::GetShootingSound()
 {
 	typedef std::string (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func357::func;
@@ -4639,17 +4639,30 @@ std::string CrewAnimation::GetShootingSound()
 namespace _func358
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewAnimation::GetShootingSound", typeid(std::string (CrewAnimation::*)()), ".534889fb4883ec30", nullptr, 0, 0, &func);
+}
+
+std::string CrewAnimation::GetShootingSound()
+{
+	typedef std::string (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func358::func;
+	return execfunc(this);
+}
+
+namespace _func359
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::SetupStrips", typeid(void (CrewAnimation::*)()), ".4157488d87e009000041564889c64155415455534889fb4881ec08020000", nullptr, 0, 0, &func);
 }
 
 void CrewAnimation::SetupStrips()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func358::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func359::func;
 	return execfunc(this);
 }
 
-namespace _func359
+namespace _func360
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::OnInit", typeid(void (CrewAnimation::*)(const std::string &, Pointf , bool )), ".415783f20141564155415455534889fb4889f74881ec08010000", nullptr, 0, 0, &func);
@@ -4658,11 +4671,11 @@ namespace _func359
 void CrewAnimation::OnInit(const std::string &name, Pointf position, bool enemy)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg, const std::string &name_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func359::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func360::func;
 	return execfunc(this, name, position, enemy);
 }
 
-namespace _func360
+namespace _func361
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::constructor", typeid(void (CrewAnimation::*)(int , const std::string &, Pointf , bool )), ".415741564155415455534881ec98000000", nullptr, 0, 0, &func);
@@ -4671,11 +4684,11 @@ namespace _func360
 void CrewAnimation::constructor(int shipId, const std::string &race, Pointf unk, bool hostile)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg, int shipId_arg, const std::string &race_arg, Pointf unk_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func360::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func361::func;
 	return execfunc(this, shipId, race, unk, hostile);
 }
 
-namespace _func361
+namespace _func362
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewAnimation::OnUpdateEffects", typeid(void (CrewAnimation::*)()), ".415741564155415455534889fb4883ec6848897c2430", nullptr, 0, 0, &func);
@@ -4684,11 +4697,11 @@ namespace _func361
 void CrewAnimation::OnUpdateEffects()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func361::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func362::func;
 	return execfunc(this);
 }
 
-namespace _func362
+namespace _func363
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBlueprint::destructor", typeid(void (CrewBlueprint::*)()), "4154554889fd534883ec1048c707????????488bbfe8000000", nullptr, 0, 0, &func);
@@ -4697,11 +4710,11 @@ namespace _func362
 void CrewBlueprint::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func362::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func363::func;
 	return execfunc(this);
 }
 
-namespace _func363
+namespace _func364
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBlueprint::RenderSkill", typeid(void (CrewBlueprint::*)(int , int , int , int , int )), "415641554189d54963d141544189f45589cd534489c34883ec40488b87b8000000", nullptr, 0, 0, &func);
@@ -4710,11 +4723,11 @@ namespace _func363
 void CrewBlueprint::RenderSkill(int x, int y, int length, int height, int skill)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int x_arg, int y_arg, int length_arg, int height_arg, int skill_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func363::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func364::func;
 	return execfunc(this, x, y, length, height, skill);
 }
 
-namespace _func364
+namespace _func365
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBlueprint::RandomSkills", typeid(void (CrewBlueprint::*)(int )), "415431c0554889fd534883ec4085f6", nullptr, 0, 0, &func);
@@ -4723,11 +4736,11 @@ namespace _func364
 void CrewBlueprint::RandomSkills(int worldLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func364::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func365::func;
 	return execfunc(this, worldLevel);
 }
 
-namespace _func365
+namespace _func366
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBlueprint::RenderIcon", typeid(void (CrewBlueprint::*)(float )), "4157415641554154554889fd53488d5f084881ece80200004889de", nullptr, 0, 0, &func);
@@ -4736,11 +4749,11 @@ namespace _func365
 void CrewBlueprint::RenderIcon(float opacity)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, float opacity_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func365::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func366::func;
 	return execfunc(this, opacity);
 }
 
-namespace _func366
+namespace _func367
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBlueprint::GetNameShort", typeid(std::string (CrewBlueprint::*)()), "415541544c8d6678554889fd534889f34883ec28", nullptr, 0, 0, &func);
@@ -4749,11 +4762,11 @@ namespace _func366
 std::string CrewBlueprint::GetNameShort()
 {
 	typedef std::string (*custom_arg_funcptr_t)(CrewBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func366::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func367::func;
 	return execfunc(this);
 }
 
-namespace _func367
+namespace _func368
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBlueprint::GetCurrentSkillColor", typeid(GL_Color (CrewBlueprint::*)(int )), "488b87b80000004863f6", nullptr, 0, 0, &func);
@@ -4762,11 +4775,11 @@ namespace _func367
 GL_Color CrewBlueprint::GetCurrentSkillColor(int skill)
 {
 	typedef GL_Color (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int skill_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func367::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func368::func;
 	return execfunc(this, skill);
 }
 
-namespace _func368
+namespace _func369
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBox::MouseClick", typeid(bool (CrewBox::*)()), "0fb6477884c0", nullptr, 0, 0, &func);
@@ -4775,19 +4788,6 @@ namespace _func368
 bool CrewBox::MouseClick()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func368::func;
-	return execfunc(this);
-}
-
-namespace _func369
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewBox::OnRenderSkillLevel", typeid(void (CrewBox::*)()), ".534889fb4883ec1080bf4c01000000", nullptr, 0, 0, &func);
-}
-
-void CrewBox::OnRenderSkillLevel()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func369::func;
 	return execfunc(this);
 }
@@ -4795,10 +4795,10 @@ void CrewBox::OnRenderSkillLevel()
 namespace _func370
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewBox::RenderIcon", typeid(void (CrewBox::*)()), "!.55534889fb4883ec18488b7f20488b07", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewBox::OnRenderSkillLevel", typeid(void (CrewBox::*)()), ".534889fb4883ec1080bf4c01000000", nullptr, 0, 0, &func);
 }
 
-void CrewBox::RenderIcon()
+void CrewBox::OnRenderSkillLevel()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func370::func;
@@ -4808,10 +4808,10 @@ void CrewBox::RenderIcon()
 namespace _func371
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewBox::RenderLabels", typeid(void (CrewBox::*)()), ".55534889fb4883ec48488b7720488d7c2420", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewBox::RenderIcon", typeid(void (CrewBox::*)()), "!.55534889fb4883ec18488b7f20488b07", nullptr, 0, 0, &func);
 }
 
-void CrewBox::RenderLabels()
+void CrewBox::RenderIcon()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func371::func;
@@ -4821,10 +4821,10 @@ void CrewBox::RenderLabels()
 namespace _func372
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewBox::RenderCloneDying", typeid(void (CrewBox::*)()), ".80bf3401000000755c488b4720", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewBox::RenderLabels", typeid(void (CrewBox::*)()), ".55534889fb4883ec48488b7720488d7c2420", nullptr, 0, 0, &func);
 }
 
-void CrewBox::RenderCloneDying()
+void CrewBox::RenderLabels()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func372::func;
@@ -4834,17 +4834,30 @@ void CrewBox::RenderCloneDying()
 namespace _func373
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewBox::RenderCloneDying", typeid(void (CrewBox::*)()), ".80bf3401000000755c488b4720", nullptr, 0, 0, &func);
+}
+
+void CrewBox::RenderCloneDying()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func373::func;
+	return execfunc(this);
+}
+
+namespace _func374
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewBox::constructor", typeid(void (CrewBox::*)(Point , CrewMember *, int )), ".41574889f048c1f8204156415541544189cc554889d5534889fb4c8d6b304881eca8000000", nullptr, 0, 0, &func);
 }
 
 void CrewBox::constructor(Point pos, CrewMember *crew, int number)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg, Point pos_arg, CrewMember *crew_arg, int number_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func373::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func374::func;
 	return execfunc(this, pos, crew, number);
 }
 
-namespace _func374
+namespace _func375
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBox::destructor", typeid(void (CrewBox::*)()), ".415641554154554889fd534883ec10488bbf58010000", nullptr, 0, 0, &func);
@@ -4853,11 +4866,11 @@ namespace _func374
 void CrewBox::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func374::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func375::func;
 	return execfunc(this);
 }
 
-namespace _func375
+namespace _func376
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBox::OnLoop", typeid(void (CrewBox::*)(bool )), "!.5589f5534889fb4883ec08488b7f20488b07", nullptr, 0, 0, &func);
@@ -4866,11 +4879,11 @@ namespace _func375
 void CrewBox::OnLoop(bool selected)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg, bool selected_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func375::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func376::func;
 	return execfunc(this, selected);
 }
 
-namespace _func376
+namespace _func377
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBox::GetSelected", typeid(CrewMember *(CrewBox::*)(int , int )), ".4157415641554c8daf6803000041544189d431d25589f5", nullptr, 0, 0, &func);
@@ -4879,11 +4892,11 @@ namespace _func376
 CrewMember *CrewBox::GetSelected(int mouseX, int mouseY)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(CrewBox *this_arg, int mouseX_arg, int mouseY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func376::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func377::func;
 	return execfunc(this, mouseX, mouseY);
 }
 
-namespace _func377
+namespace _func378
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewBox::OnRender", typeid(void (CrewBox::*)()), ".415741564155415455534889fb488dbfe0010000", nullptr, 0, 0, &func);
@@ -4892,11 +4905,11 @@ namespace _func377
 void CrewBox::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func377::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func378::func;
 	return execfunc(this);
 }
 
-namespace _func378
+namespace _func379
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::ClearCrewBoxes", typeid(void (CrewControl::*)()), "41544989fc5553488b4f68488b57604889c84829d048c1f80385c0", nullptr, 0, 0, &func);
@@ -4905,11 +4918,11 @@ namespace _func378
 void CrewControl::ClearCrewBoxes()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func378::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func379::func;
 	return execfunc(this);
 }
 
-namespace _func379
+namespace _func380
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::LButton", typeid(void (CrewControl::*)(int , int , int , int , bool )), ".41574589c741564189ce41554189d541544189f455534889fb4883ec38", nullptr, 0, 0, &func);
@@ -4918,11 +4931,11 @@ namespace _func379
 void CrewControl::LButton(int mX, int mY, int wX, int wY, bool shiftHeld)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, int wX_arg, int wY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func379::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func380::func;
 	return execfunc(this, mX, mY, wX, wY, shiftHeld);
 }
 
-namespace _func380
+namespace _func381
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::RButton", typeid(void (CrewControl::*)(int , int , bool )), ".41545553807f54004889fb", nullptr, 0, 0, &func);
@@ -4931,11 +4944,11 @@ namespace _func380
 void CrewControl::RButton(int mX, int mY, bool shiftHeld)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func380::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func381::func;
 	return execfunc(this, mX, mY, shiftHeld);
 }
 
-namespace _func381
+namespace _func382
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::ClearDeadCrew", typeid(void (CrewControl::*)(std::vector<CrewMember*> *)), ".415431c0554889f553488b4e0831db", nullptr, 0, 0, &func);
@@ -4944,11 +4957,11 @@ namespace _func381
 void CrewControl::ClearDeadCrew(std::vector<CrewMember*> *crew)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg, std::vector<CrewMember*> *crew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func381::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func382::func;
 	return execfunc(this, crew);
 }
 
-namespace _func382
+namespace _func383
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::UpdateCrewBoxes", typeid(void (CrewControl::*)()), ".415731d241564155415455534889fb", nullptr, 0, 0, &func);
@@ -4957,11 +4970,11 @@ namespace _func382
 void CrewControl::UpdateCrewBoxes()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func382::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func383::func;
 	return execfunc(this);
 }
 
-namespace _func383
+namespace _func384
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::LinkShip", typeid(void (CrewControl::*)(ShipManager *)), ".534889374889fb", nullptr, 0, 0, &func);
@@ -4970,11 +4983,11 @@ namespace _func383
 void CrewControl::LinkShip(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func383::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func384::func;
 	return execfunc(this, ship);
 }
 
-namespace _func384
+namespace _func385
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::OnLoop", typeid(void (CrewControl::*)()), ".415455488dafc8000000534889fb4889ef4883ec30", nullptr, 0, 0, &func);
@@ -4983,11 +4996,11 @@ namespace _func384
 void CrewControl::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func384::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func385::func;
 	return execfunc(this);
 }
 
-namespace _func385
+namespace _func386
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::SelectCrew", typeid(void (CrewControl::*)(bool )), ".41544084f655534889fb", nullptr, 0, 0, &func);
@@ -4996,11 +5009,11 @@ namespace _func385
 void CrewControl::SelectCrew(bool keep_current)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg, bool keep_current_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func385::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func386::func;
 	return execfunc(this, keep_current);
 }
 
-namespace _func386
+namespace _func387
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::SelectPotentialCrew", typeid(void (CrewControl::*)(CrewMember *, bool )), ".55534889fb4889f74883ec184885f64889742408", nullptr, 0, 0, &func);
@@ -5009,11 +5022,11 @@ namespace _func386
 void CrewControl::SelectPotentialCrew(CrewMember *crew, bool allowTeleportLeaving)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg, CrewMember *crew_arg, bool allowTeleportLeaving_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func386::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func387::func;
 	return execfunc(this, crew, allowTeleportLeaving);
 }
 
-namespace _func387
+namespace _func388
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::KeyDown", typeid(void (CrewControl::*)(SDLKey )), ".4157415641554989fd415455534881ecc8010000", nullptr, 0, 0, &func);
@@ -5022,11 +5035,11 @@ namespace _func387
 void CrewControl::KeyDown(SDLKey key)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func387::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func388::func;
 	return execfunc(this, key);
 }
 
-namespace _func388
+namespace _func389
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::OnRender", typeid(void (CrewControl::*)()), ".415741564c8db7f000000041554989fd415455534883ec58", nullptr, 0, 0, &func);
@@ -5035,11 +5048,11 @@ namespace _func388
 void CrewControl::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func388::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func389::func;
 	return execfunc(this);
 }
 
-namespace _func389
+namespace _func390
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewControl::MouseMove", typeid(void (CrewControl::*)(int , int , int , int )), ".41574989ff415641554589c541544189cc5589d55389f34881ec18010000", nullptr, 0, 0, &func);
@@ -5048,11 +5061,11 @@ namespace _func389
 void CrewControl::MouseMove(int mX, int mY, int wX, int wY)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, int wX_arg, int wY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func389::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func390::func;
 	return execfunc(this, mX, mY, wX, wY);
 }
 
-namespace _func390
+namespace _func391
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewCustomizeBox::CheckContents", typeid(void (CrewCustomizeBox::*)()), "534889fb4883ec2080bf6807000000", nullptr, 0, 0, &func);
@@ -5061,11 +5074,11 @@ namespace _func390
 void CrewCustomizeBox::CheckContents()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewCustomizeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func390::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func391::func;
 	return execfunc(this);
 }
 
-namespace _func391
+namespace _func392
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewCustomizeBox::constructor", typeid(void (CrewCustomizeBox::*)(Point , ShipManager *, int )), "41554154554889f54989ed", nullptr, 0, 0, &func);
@@ -5074,11 +5087,11 @@ namespace _func391
 void CrewCustomizeBox::constructor(Point location, ShipManager *shipManager, int slot)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewCustomizeBox *this_arg, Point location_arg, ShipManager *shipManager_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func391::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func392::func;
 	return execfunc(this, location, shipManager, slot);
 }
 
-namespace _func392
+namespace _func393
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewDrone::OnLoop", typeid(void (CrewDrone::*)()), "41564155415455488daf48070000534889fb4889ef", nullptr, 0, 0, &func);
@@ -5087,11 +5100,11 @@ namespace _func392
 void CrewDrone::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func392::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func393::func;
 	return execfunc(this);
 }
 
-namespace _func393
+namespace _func394
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewDrone::constructor", typeid(void (CrewDrone::*)(const std::string &, const std::string &, int , const DroneBlueprint *, CrewAnimation *)), ".41574989d7415641554189cd41544d89c4554c89cd534889fb4881ec58010000", nullptr, 0, 0, &func);
@@ -5100,11 +5113,11 @@ namespace _func393
 void CrewDrone::constructor(const std::string &type, const std::string &name, int shipId, const DroneBlueprint *blueprint, CrewAnimation *anim)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewDrone *this_arg, const std::string &type_arg, const std::string &name_arg, int shipId_arg, const DroneBlueprint *blueprint_arg, CrewAnimation *anim_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func393::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func394::func;
 	return execfunc(this, type, name, shipId, blueprint, anim);
 }
 
-namespace _func394
+namespace _func395
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewDrone::ProvidesVision", typeid(bool (CrewDrone::*)()), ".8b57084889f885d2", nullptr, 0, 0, &func);
@@ -5113,11 +5126,11 @@ namespace _func394
 bool CrewDrone::ProvidesVision()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func394::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func395::func;
 	return execfunc(this);
 }
 
-namespace _func395
+namespace _func396
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewDrone::destructor", typeid(void (CrewDrone::*)()), ".415641554154554889fd534883ec10488b87e808000048c707????????48c78748070000????????488d78e84881ff????????0f8526030000", nullptr, 0, 0, &func);
@@ -5126,11 +5139,11 @@ namespace _func395
 void CrewDrone::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func395::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func396::func;
 	return execfunc(this);
 }
 
-namespace _func396
+namespace _func397
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewDrone::SetCurrentShip", typeid(void (CrewDrone::*)(int )), ".488b87c000000089b78c010000", nullptr, 0, 0, &func);
@@ -5139,11 +5152,11 @@ namespace _func396
 void CrewDrone::SetCurrentShip(int shipId)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewDrone *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func396::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func397::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func397
+namespace _func398
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::RemoveItem", typeid(void (CrewEquipBox::*)()), "534889fb488bbf800000004885ff", nullptr, 0, 0, &func);
@@ -5152,11 +5165,11 @@ namespace _func397
 void CrewEquipBox::RemoveItem()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func397::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func398::func;
 	return execfunc(this);
 }
 
-namespace _func398
+namespace _func399
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::GetConfirmDelete", typeid(bool (CrewEquipBox::*)()), ".0fb68730030000c6873003000000", nullptr, 0, 0, &func);
@@ -5165,11 +5178,11 @@ namespace _func398
 bool CrewEquipBox::GetConfirmDelete()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func398::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func399::func;
 	return execfunc(this);
 }
 
-namespace _func399
+namespace _func400
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::CloseRename", typeid(void (CrewEquipBox::*)()), ".80bfba020000007507", nullptr, 0, 0, &func);
@@ -5178,11 +5191,11 @@ namespace _func399
 void CrewEquipBox::CloseRename()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func399::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func400::func;
 	return execfunc(this);
 }
 
-namespace _func400
+namespace _func401
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::RenderLabels", typeid(void (CrewEquipBox::*)(bool , bool )), ".4154554889fd534883ec60488b47704885c0", nullptr, 0, 0, &func);
@@ -5191,11 +5204,11 @@ namespace _func400
 void CrewEquipBox::RenderLabels(bool dragging, bool isNew)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, bool dragging_arg, bool isNew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func400::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func401::func;
 	return execfunc(this, dragging, isNew);
 }
 
-namespace _func401
+namespace _func402
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::MouseClick", typeid(void (CrewEquipBox::*)()), ".55534889fb4883ec3848837f7000", nullptr, 0, 0, &func);
@@ -5204,11 +5217,11 @@ namespace _func401
 void CrewEquipBox::MouseClick()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func401::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func402::func;
 	return execfunc(this);
 }
 
-namespace _func402
+namespace _func403
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::OnTextInput", typeid(void (CrewEquipBox::*)(SDLKey )), ".5589f553488d9fc00200004883ec084889df", nullptr, 0, 0, &func);
@@ -5217,11 +5230,11 @@ namespace _func402
 void CrewEquipBox::OnTextInput(SDLKey key)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func402::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func403::func;
 	return execfunc(this, key);
 }
 
-namespace _func403
+namespace _func404
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::OnTextEvent", typeid(void (CrewEquipBox::*)(CEvent::TextEvent )), ".5589f553488d9fc00200004883ec084889df", nullptr, 0, 0, &func);
@@ -5230,11 +5243,11 @@ namespace _func403
 void CrewEquipBox::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func403::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func404::func;
 	return execfunc(this, event);
 }
 
-namespace _func404
+namespace _func405
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::constructor", typeid(void (CrewEquipBox::*)(Point , ShipManager *, int )), ".415741564189ce41554989d5ba4300000041544989f449c1fc20", nullptr, 0, 0, &func);
@@ -5243,11 +5256,11 @@ namespace _func404
 void CrewEquipBox::constructor(Point pos, ShipManager *ship, int slot)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, Point pos_arg, ShipManager *ship_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func404::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func405::func;
 	return execfunc(this, pos, ship, slot);
 }
 
-namespace _func405
+namespace _func406
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewEquipBox::OnRender", typeid(void (CrewEquipBox::*)(bool )), ".415541545589f5534889fb", nullptr, 0, 0, &func);
@@ -5256,11 +5269,11 @@ namespace _func405
 void CrewEquipBox::OnRender(bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func405::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func406::func;
 	return execfunc(this, unk);
 }
 
-namespace _func406
+namespace _func407
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::constructor", typeid(void (CrewManifest::*)()), "4155415455534889fb4c8d63284881ec88000000", nullptr, 0, 0, &func);
@@ -5269,30 +5282,17 @@ namespace _func406
 void CrewManifest::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func406::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func407::func;
 	return execfunc(this);
 }
 
-namespace _func407
+namespace _func408
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::OnKeyDown", typeid(void (CrewManifest::*)(SDLKey )), ".41554189f541544989fc5531ed5331db4883ec08", nullptr, 0, 0, &func);
 }
 
 void CrewManifest::OnKeyDown(SDLKey key)
-{
-	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func407::func;
-	return execfunc(this, key);
-}
-
-namespace _func408
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewManifest::OnKeyUp", typeid(void (CrewManifest::*)(SDLKey )), ".41554189f541544989fc5531ed5331db4883ec08", nullptr, 0, 0, &func);
-}
-
-void CrewManifest::OnKeyUp(SDLKey key)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func408::func;
@@ -5302,10 +5302,10 @@ void CrewManifest::OnKeyUp(SDLKey key)
 namespace _func409
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewManifest::OnTextInput", typeid(void (CrewManifest::*)(SDLKey )), ".41554189f541544989fc5531ed5331db4883ec08", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewManifest::OnKeyUp", typeid(void (CrewManifest::*)(SDLKey )), ".41554189f541544989fc5531ed5331db4883ec08", nullptr, 0, 0, &func);
 }
 
-void CrewManifest::OnTextInput(SDLKey key)
+void CrewManifest::OnKeyUp(SDLKey key)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func409::func;
@@ -5315,17 +5315,30 @@ void CrewManifest::OnTextInput(SDLKey key)
 namespace _func410
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewManifest::OnTextInput", typeid(void (CrewManifest::*)(SDLKey )), ".41554189f541544989fc5531ed5331db4883ec08", nullptr, 0, 0, &func);
+}
+
+void CrewManifest::OnTextInput(SDLKey key)
+{
+	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func410::func;
+	return execfunc(this, key);
+}
+
+namespace _func411
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::OnTextEvent", typeid(void (CrewManifest::*)(CEvent::TextEvent )), ".41554189f541544989fc5531ed5331db4883ec08", nullptr, 0, 0, &func);
 }
 
 void CrewManifest::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func410::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func411::func;
 	return execfunc(this, event);
 }
 
-namespace _func411
+namespace _func412
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::Update", typeid(void (CrewManifest::*)()), ".415431d231c9554889fd", nullptr, 0, 0, &func);
@@ -5334,11 +5347,11 @@ namespace _func411
 void CrewManifest::Update()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func411::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func412::func;
 	return execfunc(this);
 }
 
-namespace _func412
+namespace _func413
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::OnInit", typeid(void (CrewManifest::*)(ShipManager *)), ".4157415641554989f5415455534889fb4883ec38488b8fc0000000", nullptr, 0, 0, &func);
@@ -5347,30 +5360,17 @@ namespace _func412
 void CrewManifest::OnInit(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func412::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func413::func;
 	return execfunc(this, ship);
 }
 
-namespace _func413
+namespace _func414
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::Close", typeid(void (CrewManifest::*)()), "!.41544989fc5531ed53488b97b8000000", nullptr, 0, 0, &func);
 }
 
 void CrewManifest::Close()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func413::func;
-	return execfunc(this);
-}
-
-namespace _func414
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewManifest::Open", typeid(void (CrewManifest::*)()), "!.534889fbe8????????488dbbd0000000", nullptr, 0, 0, &func);
-}
-
-void CrewManifest::Open()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func414::func;
@@ -5380,17 +5380,30 @@ void CrewManifest::Open()
 namespace _func415
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewManifest::Open", typeid(void (CrewManifest::*)()), "!.534889fbe8????????488dbbd0000000", nullptr, 0, 0, &func);
+}
+
+void CrewManifest::Open()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func415::func;
+	return execfunc(this);
+}
+
+namespace _func416
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::MouseClick", typeid(void (CrewManifest::*)(int , int )), "!.55534889fb4883ec088b87a8010000", nullptr, 0, 0, &func);
 }
 
 void CrewManifest::MouseClick(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func415::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func416::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func416
+namespace _func417
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::OnRender", typeid(void (CrewManifest::*)()), ".4155415455534889fb4883ec68", nullptr, 0, 0, &func);
@@ -5399,11 +5412,11 @@ namespace _func416
 void CrewManifest::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func416::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func417::func;
 	return execfunc(this);
 }
 
-namespace _func417
+namespace _func418
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewManifest::MouseMove", typeid(void (CrewManifest::*)(int , int )), ".4157488d87d0000000415641554189d541544189f4554889fd4889c7534883ec18", nullptr, 0, 0, &func);
@@ -5412,11 +5425,11 @@ namespace _func417
 void CrewManifest::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewManifest *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func417::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func418::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func418
+namespace _func419
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::InsideRoom", typeid(bool (CrewMember::*)(int )), "39b79c0000000f94c0", nullptr, 0, 0, &func);
@@ -5425,11 +5438,11 @@ namespace _func418
 bool CrewMember::InsideRoom(int roomId)
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func418::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func419::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func419
+namespace _func420
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetRoomDamage", typeid(Damage (CrewMember::*)()), ".4889f8c70700000000c7470400000000", nullptr, 0, 0, &func);
@@ -5438,11 +5451,11 @@ namespace _func419
 Damage CrewMember::GetRoomDamage()
 {
 	typedef Damage (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func419::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func420::func;
 	return execfunc(this);
 }
 
-namespace _func420
+namespace _func421
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetUniqueRepairing", typeid(std::string (CrewMember::*)()), ".53be????????4889fb4883ec10", nullptr, 0, 0, &func);
@@ -5451,11 +5464,11 @@ namespace _func420
 std::string CrewMember::GetUniqueRepairing()
 {
 	typedef std::string (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func420::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func421::func;
 	return execfunc(this);
 }
 
-namespace _func421
+namespace _func422
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::CanTeleport", typeid(bool (CrewMember::*)()), ".53488b87c00000004889fb83786003", nullptr, 0, 0, &func);
@@ -5464,11 +5477,11 @@ namespace _func421
 bool CrewMember::CanTeleport()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func421::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func422::func;
 	return execfunc(this);
 }
 
-namespace _func422
+namespace _func423
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::Jump", typeid(void (CrewMember::*)()), "!.488b87e804000083400c01", nullptr, 0, 0, &func);
@@ -5477,11 +5490,11 @@ namespace _func422
 void CrewMember::Jump()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func422::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func423::func;
 	return execfunc(this);
 }
 
-namespace _func423
+namespace _func424
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetIntruder", typeid(bool (CrewMember::*)()), ".80bf31050000008b4708", nullptr, 0, 0, &func);
@@ -5490,11 +5503,11 @@ namespace _func423
 bool CrewMember::GetIntruder()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func423::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func424::func;
 	return execfunc(this);
 }
 
-namespace _func424
+namespace _func425
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetOutOfGame", typeid(void (CrewMember::*)()), ".8b05????????c6871002000001c6872002000001", nullptr, 0, 0, &func);
@@ -5503,11 +5516,11 @@ namespace _func424
 void CrewMember::SetOutOfGame()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func424::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func425::func;
 	return execfunc(this);
 }
 
-namespace _func425
+namespace _func426
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::PositionShift", typeid(float (CrewMember::*)()), ".f30f10470cf30f2a8fb4000000", nullptr, 0, 0, &func);
@@ -5516,11 +5529,11 @@ namespace _func425
 float CrewMember::PositionShift()
 {
 	typedef float (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func425::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func426::func;
 	return execfunc(this);
 }
 
-namespace _func426
+namespace _func427
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::OnRender", typeid(void (CrewMember::*)(bool )), ".55534889fb4883ec1880bf2002000000", nullptr, 0, 0, &func);
@@ -5529,11 +5542,11 @@ namespace _func426
 void CrewMember::OnRender(bool outlineOnly)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool outlineOnly_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func426::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func427::func;
 	return execfunc(this, outlineOnly);
 }
 
-namespace _func427
+namespace _func428
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::CanHeal", typeid(bool (CrewMember::*)()), ".534889fbf30f10472c0f2e4730", nullptr, 0, 0, &func);
@@ -5542,11 +5555,11 @@ namespace _func427
 bool CrewMember::CanHeal()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func427::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func428::func;
 	return execfunc(this);
 }
 
-namespace _func428
+namespace _func429
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SaveState", typeid(void (CrewMember::*)(int )), "!.41544989fc5589f55331dbf30f1087f0060000", nullptr, 0, 0, &func);
@@ -5555,30 +5568,17 @@ namespace _func428
 void CrewMember::SaveState(int fileHelper)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func428::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func429::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func429
+namespace _func430
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::destructor", typeid(void (CrewMember::*)()), ".415641554989fd415455534883ec1048c707", nullptr, 0, 0, &func);
 }
 
 void CrewMember::destructor()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func429::func;
-	return execfunc(this);
-}
-
-namespace _func430
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::Cleanup", typeid(void (CrewMember::*)()), "!.534889fb", nullptr, 0, 0, &func);
-}
-
-void CrewMember::Cleanup()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func430::func;
@@ -5588,17 +5588,30 @@ void CrewMember::Cleanup()
 namespace _func431
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMember::Cleanup", typeid(void (CrewMember::*)()), "!.534889fb", nullptr, 0, 0, &func);
+}
+
+void CrewMember::Cleanup()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func431::func;
+	return execfunc(this);
+}
+
+namespace _func432
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::LoadState", typeid(void (CrewMember::*)(int )), ".41544989fc89f75589f553", nullptr, 0, 0, &func);
 }
 
 void CrewMember::LoadState(int fileHelper)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func431::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func432::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func432
+namespace _func433
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetCurrentSystem", typeid(void (CrewMember::*)(ShipSystem *)), ".554889f5534889fb4883ec08488b07c6872802000000", nullptr, 0, 0, &func);
@@ -5607,11 +5620,11 @@ namespace _func432
 void CrewMember::SetCurrentSystem(ShipSystem *sys)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, ShipSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func432::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func433::func;
 	return execfunc(this, sys);
 }
 
-namespace _func433
+namespace _func434
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::IsManningArtillery", typeid(bool (CrewMember::*)()), ".83bfa00000000b0f94c0", nullptr, 0, 0, &func);
@@ -5620,11 +5633,11 @@ namespace _func433
 bool CrewMember::IsManningArtillery()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func433::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func434::func;
 	return execfunc(this);
 }
 
-namespace _func434
+namespace _func435
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::IncreaseSkill", typeid(void (CrewMember::*)(int )), ".4156415541545589f5534889fb4883ec20488b07", nullptr, 0, 0, &func);
@@ -5633,11 +5646,11 @@ namespace _func434
 void CrewMember::IncreaseSkill(int skillId)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func434::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func435::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func435
+namespace _func436
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::CheckSkills", typeid(void (CrewMember::*)()), ".415455534889fb488bbf30020000", nullptr, 0, 0, &func);
@@ -5646,11 +5659,11 @@ namespace _func435
 void CrewMember::CheckSkills()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func435::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func436::func;
 	return execfunc(this);
 }
 
-namespace _func436
+namespace _func437
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::MasterSkill", typeid(void (CrewMember::*)(int )), ".488b87f80200004863f6", nullptr, 0, 0, &func);
@@ -5659,11 +5672,11 @@ namespace _func436
 void CrewMember::MasterSkill(int skillId)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func436::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func437::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func437
+namespace _func438
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetSkillFromSystem", typeid(int (*)(int )), ".83ff01742b83ff06", nullptr, 0, 0, &func);
@@ -5672,11 +5685,11 @@ namespace _func437
 int CrewMember::GetSkillFromSystem(int systemId)
 {
 	typedef int (*custom_arg_funcptr_t)(int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func437::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func438::func;
 	return execfunc(systemId);
 }
 
-namespace _func438
+namespace _func439
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetResisted", typeid(void (CrewMember::*)(bool )), ".4088b7dc060000", nullptr, 0, 0, &func);
@@ -5685,11 +5698,11 @@ namespace _func438
 void CrewMember::SetResisted(bool resisted)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool resisted_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func438::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func439::func;
 	return execfunc(this, resisted);
 }
 
-namespace _func439
+namespace _func440
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetResisted", typeid(bool (CrewMember::*)()), ".0fb687dc060000", nullptr, 0, 0, &func);
@@ -5698,11 +5711,11 @@ namespace _func439
 bool CrewMember::GetResisted()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func439::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func440::func;
 	return execfunc(this);
 }
 
-namespace _func440
+namespace _func441
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetSkillProgress", typeid(void (CrewMember::*)(int , int )), ".488b87f80200004863f6", nullptr, 0, 0, &func);
@@ -5711,11 +5724,11 @@ namespace _func440
 void CrewMember::SetSkillProgress(int skillId, int skillLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg, int skillLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func440::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func441::func;
 	return execfunc(this, skillId, skillLevel);
 }
 
-namespace _func441
+namespace _func442
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetSkillLevel", typeid(int (CrewMember::*)(int )), ".83fe05b801000000", nullptr, 0, 0, &func);
@@ -5724,11 +5737,11 @@ namespace _func441
 int CrewMember::GetSkillLevel(int skillId)
 {
 	typedef int (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func441::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func442::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func442
+namespace _func443
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetSkillProgress", typeid(std::pair<int, int> (CrewMember::*)(int )), ".488b87f80200004863f6488d14f0", nullptr, 0, 0, &func);
@@ -5737,11 +5750,11 @@ namespace _func442
 std::pair<int, int> CrewMember::GetSkillProgress(int skillId)
 {
 	typedef std::pair<int, int> (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func442::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func443::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func443
+namespace _func444
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetSkillModifier", typeid(float (CrewMember::*)(int )), "!.83fe0589f2b801000000", nullptr, 0, 0, &func);
@@ -5750,11 +5763,11 @@ namespace _func443
 float CrewMember::GetSkillModifier(int skillId)
 {
 	typedef float (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func443::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func444::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func444
+namespace _func445
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::BadAtCombat", typeid(bool (CrewMember::*)()), ".488b07534889fb", nullptr, 0, 0, &func);
@@ -5763,11 +5776,11 @@ namespace _func444
 bool CrewMember::BadAtCombat()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func444::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func445::func;
 	return execfunc(this);
 }
 
-namespace _func445
+namespace _func446
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::EmptySlot", typeid(void (CrewMember::*)()), ".534889fb4883ec108b97ac00000085d2", nullptr, 0, 0, &func);
@@ -5776,11 +5789,11 @@ namespace _func445
 void CrewMember::EmptySlot()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func445::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func446::func;
 	return execfunc(this);
 }
 
-namespace _func446
+namespace _func447
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::NeedsSlot", typeid(bool (CrewMember::*)()), ".80bf20020000007509", nullptr, 0, 0, &func);
@@ -5789,11 +5802,11 @@ namespace _func446
 bool CrewMember::NeedsSlot()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func446::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func447::func;
 	return execfunc(this);
 }
 
-namespace _func447
+namespace _func448
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::DirectModifyHealth", typeid(bool (CrewMember::*)(float )), ".530f57d24889fb4883ec30f30f105f2c0f2ed3", nullptr, 0, 0, &func);
@@ -5802,11 +5815,11 @@ namespace _func447
 bool CrewMember::DirectModifyHealth(float health)
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func447::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func448::func;
 	return execfunc(this, health);
 }
 
-namespace _func448
+namespace _func449
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::ModifyHealth", typeid(void (CrewMember::*)(float )), "!.534889fbbf????????4883ec10", nullptr, 0, 0, &func);
@@ -5815,11 +5828,11 @@ namespace _func448
 void CrewMember::ModifyHealth(float health)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func448::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func449::func;
 	return execfunc(this, health);
 }
 
-namespace _func449
+namespace _func450
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::ApplyDamage", typeid(bool (CrewMember::*)(float )), ".534889fb4883ec10f30f104f2cf30f114c240c", nullptr, 0, 0, &func);
@@ -5828,30 +5841,17 @@ namespace _func449
 bool CrewMember::ApplyDamage(float damage)
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg, float damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func449::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func450::func;
 	return execfunc(this, damage);
 }
 
-namespace _func450
+namespace _func451
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::RepairingSystem", typeid(bool (CrewMember::*)()), ".534883bf88000000004889fb", nullptr, 0, 0, &func);
 }
 
 bool CrewMember::RepairingSystem()
-{
-	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func450::func;
-	return execfunc(this);
-}
-
-namespace _func451
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::Sabotaging", typeid(bool (CrewMember::*)()), ".534889fb488bbf880000004885ff", nullptr, 0, 0, &func);
-}
-
-bool CrewMember::Sabotaging()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func451::func;
@@ -5861,10 +5861,10 @@ bool CrewMember::Sabotaging()
 namespace _func452
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::RepairingFire", typeid(bool (CrewMember::*)()), ".31c04883bf8800000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::Sabotaging", typeid(bool (CrewMember::*)()), ".534889fb488bbf880000004885ff", nullptr, 0, 0, &func);
 }
 
-bool CrewMember::RepairingFire()
+bool CrewMember::Sabotaging()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func452::func;
@@ -5874,12 +5874,12 @@ bool CrewMember::RepairingFire()
 namespace _func453
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::SelectSabotageTarget", typeid(Pointf (CrewMember::*)()), ".55534889fb4883ec38488bbf88000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::RepairingFire", typeid(bool (CrewMember::*)()), ".31c04883bf8800000000", nullptr, 0, 0, &func);
 }
 
-Pointf CrewMember::SelectSabotageTarget()
+bool CrewMember::RepairingFire()
 {
-	typedef Pointf (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func453::func;
 	return execfunc(this);
 }
@@ -5887,12 +5887,12 @@ Pointf CrewMember::SelectSabotageTarget()
 namespace _func454
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::SavePosition", typeid(void (CrewMember::*)()), ".488b87ac000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::SelectSabotageTarget", typeid(Pointf (CrewMember::*)()), ".55534889fb4883ec38488bbf88000000", nullptr, 0, 0, &func);
 }
 
-void CrewMember::SavePosition()
+Pointf CrewMember::SelectSabotageTarget()
 {
-	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	typedef Pointf (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func454::func;
 	return execfunc(this);
 }
@@ -5900,10 +5900,10 @@ void CrewMember::SavePosition()
 namespace _func455
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::ClearPosition", typeid(void (CrewMember::*)()), ".c787e4060000ffffffff", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::SavePosition", typeid(void (CrewMember::*)()), ".488b87ac000000", nullptr, 0, 0, &func);
 }
 
-void CrewMember::ClearPosition()
+void CrewMember::SavePosition()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func455::func;
@@ -5913,17 +5913,30 @@ void CrewMember::ClearPosition()
 namespace _func456
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMember::ClearPosition", typeid(void (CrewMember::*)()), ".c787e4060000ffffffff", nullptr, 0, 0, &func);
+}
+
+void CrewMember::ClearPosition()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func456::func;
+	return execfunc(this);
+}
+
+namespace _func457
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetSavedPosition", typeid(Slot (CrewMember::*)()), ".488b87e0060000", nullptr, 0, 0, &func);
 }
 
 Slot CrewMember::GetSavedPosition()
 {
 	typedef Slot (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func456::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func457::func;
 	return execfunc(this);
 }
 
-namespace _func457
+namespace _func458
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetSavePosition", typeid(void (CrewMember::*)(Slot )), ".4889b7e0060000", nullptr, 0, 0, &func);
@@ -5932,11 +5945,11 @@ namespace _func457
 void CrewMember::SetSavePosition(Slot position)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, Slot position_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func457::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func458::func;
 	return execfunc(this, position);
 }
 
-namespace _func458
+namespace _func459
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::StopRepairing", typeid(void (CrewMember::*)()), ".534883bf88000000004889fb", nullptr, 0, 0, &func);
@@ -5945,11 +5958,11 @@ namespace _func458
 void CrewMember::StopRepairing()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func458::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func459::func;
 	return execfunc(this);
 }
 
-namespace _func459
+namespace _func460
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::Repairing", typeid(bool (CrewMember::*)()), ".4883bf88000000000f95c0", nullptr, 0, 0, &func);
@@ -5958,11 +5971,11 @@ namespace _func459
 bool CrewMember::Repairing()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func459::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func460::func;
 	return execfunc(this);
 }
 
-namespace _func460
+namespace _func461
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetFrozen", typeid(void (CrewMember::*)(bool )), ".4084f6741b80bfd401000000", nullptr, 0, 0, &func);
@@ -5971,11 +5984,11 @@ namespace _func460
 void CrewMember::SetFrozen(bool frozen)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool frozen_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func460::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func461::func;
 	return execfunc(this, frozen);
 }
 
-namespace _func461
+namespace _func462
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetFrozenLocation", typeid(void (CrewMember::*)(bool )), ".4088b7d5010000", nullptr, 0, 0, &func);
@@ -5984,11 +5997,11 @@ namespace _func461
 void CrewMember::SetFrozenLocation(bool frozenLocation)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool frozenLocation_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func461::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func462::func;
 	return execfunc(this, frozenLocation);
 }
 
-namespace _func462
+namespace _func463
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetTask", typeid(void (CrewMember::*)(CrewTask )), ".4889b7d80100008997e0010000", nullptr, 0, 0, &func);
@@ -5997,11 +6010,11 @@ namespace _func462
 void CrewMember::SetTask(CrewTask task)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewTask task_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func462::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func463::func;
 	return execfunc(this, task);
 }
 
-namespace _func463
+namespace _func464
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::FindSlot", typeid(Slot (CrewMember::*)(int , int , bool )), ".4155415455534889fb4883ec18488bbff0010000", nullptr, 0, 0, &func);
@@ -6010,11 +6023,11 @@ namespace _func463
 Slot CrewMember::FindSlot(int roomId, int slotId, bool closeEnough)
 {
 	typedef Slot (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg, int slotId_arg, bool closeEnough_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func463::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func464::func;
 	return execfunc(this, roomId, slotId, closeEnough);
 }
 
-namespace _func464
+namespace _func465
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::CheckRoomPath", typeid(bool (CrewMember::*)(int )), ".415531c9baffffffff41544531e4554889fd5389f34883ec38", nullptr, 0, 0, &func);
@@ -6023,11 +6036,11 @@ namespace _func464
 bool CrewMember::CheckRoomPath(int roomId)
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func464::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func465::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func465
+namespace _func466
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetPosition", typeid(void (CrewMember::*)(Point )), ".f30f2ace4889f248c1fa2055f30f2ac2534889fb4883ec18", nullptr, 0, 0, &func);
@@ -6036,30 +6049,17 @@ namespace _func465
 void CrewMember::SetPosition(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func465::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func466::func;
 	return execfunc(this, pos);
 }
 
-namespace _func466
+namespace _func467
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::ClearTask", typeid(void (CrewMember::*)()), ".8b879c000000c787e0010000ffffffff", nullptr, 0, 0, &func);
 }
 
 void CrewMember::ClearTask()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func466::func;
-	return execfunc(this);
-}
-
-namespace _func467
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::ClearPath", typeid(void (CrewMember::*)()), ".55534889fb4883ec38488b07", nullptr, 0, 0, &func);
-}
-
-void CrewMember::ClearPath()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func467::func;
@@ -6069,36 +6069,36 @@ void CrewMember::ClearPath()
 namespace _func468
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMember::ClearPath", typeid(void (CrewMember::*)()), ".55534889fb4883ec38488b07", nullptr, 0, 0, &func);
+}
+
+void CrewMember::ClearPath()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func468::func;
+	return execfunc(this);
+}
+
+namespace _func469
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetRoom", typeid(void (CrewMember::*)(int )), ".4155415455534889fb4883ec184883bff001000000", nullptr, 0, 0, &func);
 }
 
 void CrewMember::SetRoom(int roomId)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func468::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func469::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func469
+namespace _func470
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::IsBusy", typeid(bool (CrewMember::*)()), ".4883bf8800000000b801000000", nullptr, 0, 0, &func);
 }
 
 bool CrewMember::IsBusy()
-{
-	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func469::func;
-	return execfunc(this);
-}
-
-namespace _func470
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::OnInit", typeid(bool (CrewMember::*)()), ".c747241e00000048c7878000000000000000", nullptr, 0, 0, &func);
-}
-
-bool CrewMember::OnInit()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func470::func;
@@ -6108,12 +6108,12 @@ bool CrewMember::OnInit()
 namespace _func471
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::GetFinalGoal", typeid(Point (CrewMember::*)()), ".f30f1005????????0f2e4768", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::OnInit", typeid(bool (CrewMember::*)()), ".c747241e00000048c7878000000000000000", nullptr, 0, 0, &func);
 }
 
-Point CrewMember::GetFinalGoal()
+bool CrewMember::OnInit()
 {
-	typedef Point (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func471::func;
 	return execfunc(this);
 }
@@ -6121,10 +6121,10 @@ Point CrewMember::GetFinalGoal()
 namespace _func472
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::GetNextGoal", typeid(Point (CrewMember::*)()), ".534889fb4883ec20f30f104720", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::GetFinalGoal", typeid(Point (CrewMember::*)()), ".f30f1005????????0f2e4768", nullptr, 0, 0, &func);
 }
 
-Point CrewMember::GetNextGoal()
+Point CrewMember::GetFinalGoal()
 {
 	typedef Point (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func472::func;
@@ -6134,17 +6134,30 @@ Point CrewMember::GetNextGoal()
 namespace _func473
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMember::GetNextGoal", typeid(Point (CrewMember::*)()), ".534889fb4883ec20f30f104720", nullptr, 0, 0, &func);
+}
+
+Point CrewMember::GetNextGoal()
+{
+	typedef Point (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func473::func;
+	return execfunc(this);
+}
+
+namespace _func474
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::CloseDoorBehind", typeid(void (CrewMember::*)(Door *)), ".4889b780000000", nullptr, 0, 0, &func);
 }
 
 void CrewMember::CloseDoorBehind(Door *door)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, Door *door_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func473::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func474::func;
 	return execfunc(this, door);
 }
 
-namespace _func474
+namespace _func475
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetMoveSpeed", typeid(float (CrewMember::*)()), ".55be????????31ed534889fb4883ec38", nullptr, 0, 0, &func);
@@ -6153,11 +6166,11 @@ namespace _func474
 float CrewMember::GetMoveSpeed()
 {
 	typedef float (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func474::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func475::func;
 	return execfunc(this);
 }
 
-namespace _func475
+namespace _func476
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::Restart", typeid(void (CrewMember::*)()), ".4155415449bcabaaaaaaaaaaaaaa5531ed534889fb4883ec18", nullptr, 0, 0, &func);
@@ -6166,11 +6179,11 @@ namespace _func475
 void CrewMember::Restart()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func475::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func476::func;
 	return execfunc(this);
 }
 
-namespace _func476
+namespace _func477
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetDamageBoost", typeid(void (CrewMember::*)(float )), ".f30f1187d4060000", nullptr, 0, 0, &func);
@@ -6179,11 +6192,11 @@ namespace _func476
 void CrewMember::SetDamageBoost(float damageBoost)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, float damageBoost_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func476::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func477::func;
 	return execfunc(this, damageBoost);
 }
 
-namespace _func477
+namespace _func478
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetHealthBoost", typeid(void (CrewMember::*)(int )), ".538b87d00600004889fb39f0", nullptr, 0, 0, &func);
@@ -6192,11 +6205,11 @@ namespace _func477
 void CrewMember::SetHealthBoost(int healthBoost)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int healthBoost_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func477::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func478::func;
 	return execfunc(this, healthBoost);
 }
 
-namespace _func478
+namespace _func479
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::InitializeSkills", typeid(void (CrewMember::*)()), ".554889fd5331db4883ec08", nullptr, 0, 0, &func);
@@ -6205,11 +6218,11 @@ namespace _func478
 void CrewMember::InitializeSkills()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func478::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func479::func;
 	return execfunc(this);
 }
 
-namespace _func479
+namespace _func480
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetCloneReady", typeid(void (CrewMember::*)(bool )), ".534889fb4883ec2080bf2002000000", nullptr, 0, 0, &func);
@@ -6218,11 +6231,11 @@ namespace _func479
 void CrewMember::SetCloneReady(bool cloneReady)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool cloneReady_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func479::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func480::func;
 	return execfunc(this, cloneReady);
 }
 
-namespace _func480
+namespace _func481
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::Kill", typeid(void (CrewMember::*)(bool )), ".5589f5534889fb4883ec284883bf8800000000", nullptr, 0, 0, &func);
@@ -6231,11 +6244,11 @@ namespace _func480
 void CrewMember::Kill(bool noClone)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool noClone_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func480::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func481::func;
 	return execfunc(this, noClone);
 }
 
-namespace _func481
+namespace _func482
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::NeedFrozenLocation", typeid(bool (CrewMember::*)()), ".31c080bfd401000000", nullptr, 0, 0, &func);
@@ -6244,11 +6257,11 @@ namespace _func481
 bool CrewMember::NeedFrozenLocation()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func481::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func482::func;
 	return execfunc(this);
 }
 
-namespace _func482
+namespace _func483
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::CheckForTeleport", typeid(void (CrewMember::*)()), ".55534889fb4883ec08488bafc0000000", nullptr, 0, 0, &func);
@@ -6257,11 +6270,11 @@ namespace _func482
 void CrewMember::CheckForTeleport()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func482::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func483::func;
 	return execfunc(this);
 }
 
-namespace _func483
+namespace _func484
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetCurrentShip", typeid(void (CrewMember::*)(int )), ".488b87c000000089b78c010000", nullptr, 0, 0, &func);
@@ -6270,11 +6283,11 @@ namespace _func483
 void CrewMember::SetCurrentShip(int shipId)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func483::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func484::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func484
+namespace _func485
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::CheckFighting", typeid(void (CrewMember::*)()), ".4883bfb801000000", nullptr, 0, 0, &func);
@@ -6283,11 +6296,11 @@ namespace _func484
 void CrewMember::CheckFighting()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func484::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func485::func;
 	return execfunc(this);
 }
 
-namespace _func485
+namespace _func486
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetDeathNumber", typeid(void (CrewMember::*)(int )), ".3b35????????89b734050000", nullptr, 0, 0, &func);
@@ -6296,11 +6309,11 @@ namespace _func485
 void CrewMember::SetDeathNumber(int deathNum)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int deathNum_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func485::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func486::func;
 	return execfunc(this, deathNum);
 }
 
-namespace _func486
+namespace _func487
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::ForceMindControl", typeid(void (CrewMember::*)(bool )), ".4088b731050000", nullptr, 0, 0, &func);
@@ -6309,11 +6322,11 @@ namespace _func486
 void CrewMember::ForceMindControl(bool force)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func486::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func487::func;
 	return execfunc(this, force);
 }
 
-namespace _func487
+namespace _func488
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::RenderSkillUpAnimation", typeid(void (CrewMember::*)(Point )), ".41574989ff415641554531ed41544989f449c1fc20554889f5534883ec38", nullptr, 0, 0, &func);
@@ -6322,30 +6335,17 @@ namespace _func487
 void CrewMember::RenderSkillUpAnimation(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func487::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func488::func;
 	return execfunc(this, pos);
 }
 
-namespace _func488
+namespace _func489
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::Clone", typeid(void (CrewMember::*)()), ".55534889fb4883ec28c6871002000000", nullptr, 0, 0, &func);
 }
 
 void CrewMember::Clone()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func488::func;
-	return execfunc(this);
-}
-
-namespace _func489
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::UpdateHealth", typeid(void (CrewMember::*)()), ".55534889fb4883ec488b872402000085c0", nullptr, 0, 0, &func);
-}
-
-void CrewMember::UpdateHealth()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func489::func;
@@ -6355,10 +6355,10 @@ void CrewMember::UpdateHealth()
 namespace _func490
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::OnRenderPath", typeid(void (CrewMember::*)()), ".534889fb4883ec108b4f0885c9", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::UpdateHealth", typeid(void (CrewMember::*)()), ".55534889fb4883ec488b872402000085c0", nullptr, 0, 0, &func);
 }
 
-void CrewMember::OnRenderPath()
+void CrewMember::UpdateHealth()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func490::func;
@@ -6368,17 +6368,30 @@ void CrewMember::OnRenderPath()
 namespace _func491
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMember::OnRenderPath", typeid(void (CrewMember::*)()), ".534889fb4883ec108b4f0885c9", nullptr, 0, 0, &func);
+}
+
+void CrewMember::OnRenderPath()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func491::func;
+	return execfunc(this);
+}
+
+namespace _func492
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetPath", typeid(bool (CrewMember::*)(Path *)), ".4157415641554154554889f5534889fb4883ec28", nullptr, 0, 0, &func);
 }
 
 bool CrewMember::SetPath(Path *path)
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg, Path *path_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func491::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func492::func;
 	return execfunc(this, path);
 }
 
-namespace _func492
+namespace _func493
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetRoomPath", typeid(void (CrewMember::*)(int , int )), ".415455534889fb4883ec30488bbff0010000", nullptr, 0, 0, &func);
@@ -6387,11 +6400,11 @@ namespace _func492
 void CrewMember::SetRoomPath(int slotId, int roomId)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int slotId_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func492::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func493::func;
 	return execfunc(this, slotId, roomId);
 }
 
-namespace _func493
+namespace _func494
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetLocation", typeid(Point (CrewMember::*)()), ".534889fb4883ec20f30f104710", nullptr, 0, 0, &func);
@@ -6400,19 +6413,6 @@ namespace _func493
 Point CrewMember::GetLocation()
 {
 	typedef Point (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func493::func;
-	return execfunc(this);
-}
-
-namespace _func494
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::AtGoal", typeid(bool (CrewMember::*)()), ".f30f105f1c", nullptr, 0, 0, &func);
-}
-
-bool CrewMember::AtGoal()
-{
-	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func494::func;
 	return execfunc(this);
 }
@@ -6420,10 +6420,10 @@ bool CrewMember::AtGoal()
 namespace _func495
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::AtFinalGoal", typeid(bool (CrewMember::*)()), ".f30f10470cf30f2a8fb4000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::AtGoal", typeid(bool (CrewMember::*)()), ".f30f105f1c", nullptr, 0, 0, &func);
 }
 
-bool CrewMember::AtFinalGoal()
+bool CrewMember::AtGoal()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func495::func;
@@ -6433,12 +6433,12 @@ bool CrewMember::AtFinalGoal()
 namespace _func496
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::OnRenderHealth", typeid(void (CrewMember::*)()), ".4155415455534889fb4883ec7880bf2002000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::AtFinalGoal", typeid(bool (CrewMember::*)()), ".f30f10470cf30f2a8fb4000000", nullptr, 0, 0, &func);
 }
 
-void CrewMember::OnRenderHealth()
+bool CrewMember::AtFinalGoal()
 {
-	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func496::func;
 	return execfunc(this);
 }
@@ -6446,12 +6446,12 @@ void CrewMember::OnRenderHealth()
 namespace _func497
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::GetIntegerHealth", typeid(int (CrewMember::*)()), ".31c080bf2002000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::OnRenderHealth", typeid(void (CrewMember::*)()), ".4155415455534889fb4883ec7880bf2002000000", nullptr, 0, 0, &func);
 }
 
-int CrewMember::GetIntegerHealth()
+void CrewMember::OnRenderHealth()
 {
-	typedef int (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func497::func;
 	return execfunc(this);
 }
@@ -6459,10 +6459,10 @@ int CrewMember::GetIntegerHealth()
 namespace _func498
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::GetRepairingId", typeid(int (CrewMember::*)()), ".488bbf880000004885ff", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::GetIntegerHealth", typeid(int (CrewMember::*)()), ".31c080bf2002000000", nullptr, 0, 0, &func);
 }
 
-int CrewMember::GetRepairingId()
+int CrewMember::GetIntegerHealth()
 {
 	typedef int (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func498::func;
@@ -6472,17 +6472,30 @@ int CrewMember::GetRepairingId()
 namespace _func499
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMember::GetRepairingId", typeid(int (CrewMember::*)()), ".488bbf880000004885ff", nullptr, 0, 0, &func);
+}
+
+int CrewMember::GetRepairingId()
+{
+	typedef int (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func499::func;
+	return execfunc(this);
+}
+
+namespace _func500
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::WithinRect", typeid(bool (CrewMember::*)(int , int , int , int )), ".85c9784c4585c0783f", nullptr, 0, 0, &func);
 }
 
 bool CrewMember::WithinRect(int x, int y, int w, int h)
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg, int x_arg, int y_arg, int w_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func499::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func500::func;
 	return execfunc(this, x, y, w, h);
 }
 
-namespace _func500
+namespace _func501
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetLongName", typeid(std::string (CrewMember::*)()), ".5380bed0020000004889fb", nullptr, 0, 0, &func);
@@ -6491,11 +6504,11 @@ namespace _func500
 std::string CrewMember::GetLongName()
 {
 	typedef std::string (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func500::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func501::func;
 	return execfunc(this);
 }
 
-namespace _func501
+namespace _func502
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetName", typeid(void (CrewMember::*)(TextString *, bool )), ".41544189d4554889f5534889fb488dbfc80200004883ec40", nullptr, 0, 0, &func);
@@ -6504,11 +6517,11 @@ namespace _func501
 void CrewMember::SetName(TextString *name, bool force)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, TextString *name_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func501::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func502::func;
 	return execfunc(this, name, force);
 }
 
-namespace _func502
+namespace _func503
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetName", typeid(std::string (CrewMember::*)()), ".5380bec0020000004889fb", nullptr, 0, 0, &func);
@@ -6517,11 +6530,11 @@ namespace _func502
 std::string CrewMember::GetName()
 {
 	typedef std::string (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func502::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func503::func;
 	return execfunc(this);
 }
 
-namespace _func503
+namespace _func504
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetCurrentTarget", typeid(void (CrewMember::*)(CrewTarget *, bool )), ".41544189d4554889f553488b074889fb", nullptr, 0, 0, &func);
@@ -6530,11 +6543,11 @@ namespace _func503
 void CrewMember::SetCurrentTarget(CrewTarget *target, bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewTarget *target_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func503::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func504::func;
 	return execfunc(this, target, unk);
 }
 
-namespace _func504
+namespace _func505
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetNewGoal", typeid(bool (CrewMember::*)()), ".41574989ff41564155415455534883ec28", nullptr, 0, 0, &func);
@@ -6543,11 +6556,11 @@ namespace _func504
 bool CrewMember::GetNewGoal()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func504::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func505::func;
 	return execfunc(this);
 }
 
-namespace _func505
+namespace _func506
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::MoveToRoom", typeid(bool (CrewMember::*)(int , int , bool )), ".4157415641554189d541544189cc5589f5534889fb4883ec48", nullptr, 0, 0, &func);
@@ -6556,11 +6569,11 @@ namespace _func505
 bool CrewMember::MoveToRoom(int roomId, int slotId, bool forceMove)
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg, int slotId_arg, bool forceMove_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func505::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func506::func;
 	return execfunc(this, roomId, slotId, forceMove);
 }
 
-namespace _func506
+namespace _func507
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetMindControl", typeid(void (CrewMember::*)(bool )), ".5589f5534889fb4883ec084038b731050000", nullptr, 0, 0, &func);
@@ -6569,11 +6582,11 @@ namespace _func506
 void CrewMember::SetMindControl(bool controlled)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool controlled_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func506::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func507::func;
 	return execfunc(this, controlled);
 }
 
-namespace _func507
+namespace _func508
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::RestorePosition", typeid(bool (CrewMember::*)()), ".415741564155415455534889fb4883ec48488b07", nullptr, 0, 0, &func);
@@ -6582,11 +6595,11 @@ namespace _func507
 bool CrewMember::RestorePosition()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func507::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func508::func;
 	return execfunc(this);
 }
 
-namespace _func508
+namespace _func509
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::ContainsPoint", typeid(bool (CrewMember::*)(int , int )), ".f30f1005????????f30f594718", nullptr, 0, 0, &func);
@@ -6595,11 +6608,11 @@ namespace _func508
 bool CrewMember::ContainsPoint(int x, int y)
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func508::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func509::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func509
+namespace _func510
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetMedbay", typeid(void (CrewMember::*)(float )), ".534889fb4883ec10488b07f30f1144240c", nullptr, 0, 0, &func);
@@ -6608,30 +6621,17 @@ namespace _func509
 void CrewMember::SetMedbay(float health)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func509::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func510::func;
 	return execfunc(this, health);
 }
 
-namespace _func510
+namespace _func511
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::StartTeleport", typeid(void (CrewMember::*)()), "!.53488b9fc000000031f60f57c0", nullptr, 0, 0, &func);
 }
 
 void CrewMember::StartTeleport()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func510::func;
-	return execfunc(this);
-}
-
-namespace _func511
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::StartTeleportArrive", typeid(void (CrewMember::*)()), "!.53488b9fc000000031f60f57c0", nullptr, 0, 0, &func);
-}
-
-void CrewMember::StartTeleportArrive()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func511::func;
@@ -6641,36 +6641,36 @@ void CrewMember::StartTeleportArrive()
 namespace _func512
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMember::StartTeleportArrive", typeid(void (CrewMember::*)()), "!.53488b9fc000000031f60f57c0", nullptr, 0, 0, &func);
+}
+
+void CrewMember::StartTeleportArrive()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func512::func;
+	return execfunc(this);
+}
+
+namespace _func513
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::StartRepair", typeid(void (CrewMember::*)(Repairable *)), ".55534889fb4883ec28f30f10470c", nullptr, 0, 0, &func);
 }
 
 void CrewMember::StartRepair(Repairable *toRepair)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, Repairable *toRepair_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func512::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func513::func;
 	return execfunc(this, toRepair);
 }
 
-namespace _func513
+namespace _func514
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::UpdateRepair", typeid(void (CrewMember::*)()), ".55534889fb4883ec48488bbf88000000", nullptr, 0, 0, &func);
 }
 
 void CrewMember::UpdateRepair()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func513::func;
-	return execfunc(this);
-}
-
-namespace _func514
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::UpdateMovement", typeid(void (CrewMember::*)()), ".534889fb4883ec30488b87c000000083786006", nullptr, 0, 0, &func);
-}
-
-void CrewMember::UpdateMovement()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func514::func;
@@ -6680,10 +6680,10 @@ void CrewMember::UpdateMovement()
 namespace _func515
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::OnLoop", typeid(void (CrewMember::*)()), ".415741564155415455534889fb4883ec7880bf2002000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::UpdateMovement", typeid(void (CrewMember::*)()), ".534889fb4883ec30488b87c000000083786006", nullptr, 0, 0, &func);
 }
 
-void CrewMember::OnLoop()
+void CrewMember::UpdateMovement()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func515::func;
@@ -6693,17 +6693,30 @@ void CrewMember::OnLoop()
 namespace _func516
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMember::OnLoop", typeid(void (CrewMember::*)()), ".415741564155415455534889fb4883ec7880bf2002000000", nullptr, 0, 0, &func);
+}
+
+void CrewMember::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func516::func;
+	return execfunc(this);
+}
+
+namespace _func517
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetTooltip", typeid(std::string (CrewMember::*)()), ".4157415641554154554889f5", nullptr, 0, 0, &func);
 }
 
 std::string CrewMember::GetTooltip()
 {
 	typedef std::string (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func516::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func517::func;
 	return execfunc(this);
 }
 
-namespace _func517
+namespace _func518
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::GetSkillTooltip", typeid(std::string (*)(int , int , std::pair<int, int> , bool )), ".41574589c7415641554189d541544989fc554889cd5389f3", nullptr, 0, 0, &func);
@@ -6712,11 +6725,11 @@ namespace _func517
 std::string CrewMember::GetSkillTooltip(int skillId, int skillLevel, std::pair<int, int> progress, bool infoScreen)
 {
 	typedef std::string (*custom_arg_funcptr_t)(int skillId_arg, int skillLevel_arg, std::pair<int, int> progress_arg, bool infoScreen_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func517::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func518::func;
 	return execfunc(skillId, skillLevel, progress, infoScreen);
 }
 
-namespace _func518
+namespace _func519
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::SetSex", typeid(void (CrewMember::*)(bool )), ".5589f5534889fb4883ec08488bbfc0000000", nullptr, 0, 0, &func);
@@ -6725,11 +6738,11 @@ namespace _func518
 void CrewMember::SetSex(bool male)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, bool male_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func518::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func519::func;
 	return execfunc(this, male);
 }
 
-namespace _func519
+namespace _func520
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::CycleColorLayer", typeid(void (CrewMember::*)(int )), ".4155415449bcabaaaaaaaaaaaaaa55534889fb4883ec48", nullptr, 0, 0, &func);
@@ -6738,11 +6751,11 @@ namespace _func519
 void CrewMember::CycleColorLayer(int unk)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func519::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func520::func;
 	return execfunc(this, unk);
 }
 
-namespace _func520
+namespace _func521
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::constructor", typeid(void (CrewMember::*)(CrewBlueprint &, int , bool , CrewAnimation *)), ".415741564189d641554d89c541544189cc554889f5534889fb488d7f404881ecb8000000", nullptr, 0, 0, &func);
@@ -6751,30 +6764,17 @@ namespace _func520
 void CrewMember::constructor(CrewBlueprint &blueprint, int shipId, bool intruder, CrewAnimation *animation)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewBlueprint &blueprint_arg, int shipId_arg, bool intruder_arg, CrewAnimation *animation_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func520::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func521::func;
 	return execfunc(this, blueprint, shipId, intruder, animation);
 }
 
-namespace _func521
+namespace _func522
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMember::Functional", typeid(bool (CrewMember::*)()), ".4883ec08488b07", nullptr, 0, 0, &func);
 }
 
 bool CrewMember::Functional()
-{
-	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func521::func;
-	return execfunc(this);
-}
-
-namespace _func522
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::CountForVictory", typeid(bool (CrewMember::*)()), ".488b07534889fb", nullptr, 0, 0, &func);
-}
-
-bool CrewMember::CountForVictory()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func522::func;
@@ -6784,10 +6784,10 @@ bool CrewMember::CountForVictory()
 namespace _func523
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::CanSabotage", typeid(bool (CrewMember::*)()), ".0fb687bc000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::CountForVictory", typeid(bool (CrewMember::*)()), ".488b07534889fb", nullptr, 0, 0, &func);
 }
 
-bool CrewMember::CanSabotage()
+bool CrewMember::CountForVictory()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func523::func;
@@ -6797,10 +6797,10 @@ bool CrewMember::CanSabotage()
 namespace _func524
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::CanMan", typeid(bool (CrewMember::*)()), ".31c080bfbc00000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::CanSabotage", typeid(bool (CrewMember::*)()), ".0fb687bc000000", nullptr, 0, 0, &func);
 }
 
-bool CrewMember::CanMan()
+bool CrewMember::CanSabotage()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func524::func;
@@ -6810,10 +6810,10 @@ bool CrewMember::CanMan()
 namespace _func525
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::CanRepair", typeid(bool (CrewMember::*)()), ".5380bfbc00000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::CanMan", typeid(bool (CrewMember::*)()), ".31c080bfbc00000000", nullptr, 0, 0, &func);
 }
 
-bool CrewMember::CanRepair()
+bool CrewMember::CanMan()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func525::func;
@@ -6823,10 +6823,10 @@ bool CrewMember::CanRepair()
 namespace _func526
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMember::GetControllable", typeid(bool (CrewMember::*)()), ".538b570831c04889fb85d2", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::CanRepair", typeid(bool (CrewMember::*)()), ".5380bfbc00000000", nullptr, 0, 0, &func);
 }
 
-bool CrewMember::GetControllable()
+bool CrewMember::CanRepair()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func526::func;
@@ -6836,12 +6836,12 @@ bool CrewMember::GetControllable()
 namespace _func527
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMemberFactory::destructor", typeid(void (CrewMemberFactory::*)()), "554889fd534883ec08488b7718488b57104889f04829d048c1f8034885c0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMember::GetControllable", typeid(bool (CrewMember::*)()), ".538b570831c04889fb85d2", nullptr, 0, 0, &func);
 }
 
-void CrewMemberFactory::destructor()
+bool CrewMember::GetControllable()
 {
-	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
+	typedef bool (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func527::func;
 	return execfunc(this);
 }
@@ -6849,10 +6849,10 @@ void CrewMemberFactory::destructor()
 namespace _func528
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMemberFactory::Restart", typeid(void (CrewMemberFactory::*)()), ".53488b4f184889fb488b47104889ca4829c248c1fa034885d2", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMemberFactory::destructor", typeid(void (CrewMemberFactory::*)()), "554889fd534883ec08488b7718488b57104889f04829d048c1f8034885c0", nullptr, 0, 0, &func);
 }
 
-void CrewMemberFactory::Restart()
+void CrewMemberFactory::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func528::func;
@@ -6862,17 +6862,30 @@ void CrewMemberFactory::Restart()
 namespace _func529
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMemberFactory::Restart", typeid(void (CrewMemberFactory::*)()), ".53488b4f184889fb488b47104889ca4829c248c1fa034885d2", nullptr, 0, 0, &func);
+}
+
+void CrewMemberFactory::Restart()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func529::func;
+	return execfunc(this);
+}
+
+namespace _func530
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::CountCloneReadyCrew", typeid(int (CrewMemberFactory::*)(bool )), ".41564989fe415541545553488b4710488b57184829c2", nullptr, 0, 0, &func);
 }
 
 int CrewMemberFactory::CountCloneReadyCrew(bool player)
 {
 	typedef int (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, bool player_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func529::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func530::func;
 	return execfunc(this, player);
 }
 
-namespace _func530
+namespace _func531
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::GetCrewPortraitList", typeid(void (CrewMemberFactory::*)(std::vector<CrewMember*> *, int )), ".415731c94989ff4156415549bdffffffffffffff1f41544989f45589d55331db4883ec18", nullptr, 0, 0, &func);
@@ -6881,11 +6894,11 @@ namespace _func530
 void CrewMemberFactory::GetCrewPortraitList(std::vector<CrewMember*> *vec, int teamId)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> *vec_arg, int teamId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func530::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func531::func;
 	return execfunc(this, vec, teamId);
 }
 
-namespace _func531
+namespace _func532
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::GetCrewList", typeid(void (CrewMemberFactory::*)(std::vector<CrewMember*> *, int , bool )), ".41574531c04531ff415641554989fd41544989f45589cd5389d34883ec18", nullptr, 0, 0, &func);
@@ -6894,30 +6907,17 @@ namespace _func531
 void CrewMemberFactory::GetCrewList(std::vector<CrewMember*> *vec, int unk, bool unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> *vec_arg, int unk_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func531::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func532::func;
 	return execfunc(this, vec, unk, unk2);
 }
 
-namespace _func532
+namespace _func533
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::GetPlayerCrewCount", typeid(int (CrewMemberFactory::*)()), "!.8b07c3906666662e0f1f840000000000", nullptr, 0, 0, &func);
 }
 
 int CrewMemberFactory::GetPlayerCrewCount()
-{
-	typedef int (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func532::func;
-	return execfunc(this);
-}
-
-namespace _func533
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMemberFactory::GetEnemyCloneCount", typeid(int (CrewMemberFactory::*)()), "!.8b4708c36666662e0f1f840000000000", nullptr, 0, 0, &func);
-}
-
-int CrewMemberFactory::GetEnemyCloneCount()
 {
 	typedef int (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func533::func;
@@ -6927,17 +6927,30 @@ int CrewMemberFactory::GetEnemyCloneCount()
 namespace _func534
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMemberFactory::GetEnemyCloneCount", typeid(int (CrewMemberFactory::*)()), "!.8b4708c36666662e0f1f840000000000", nullptr, 0, 0, &func);
+}
+
+int CrewMemberFactory::GetEnemyCloneCount()
+{
+	typedef int (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func534::func;
+	return execfunc(this);
+}
+
+namespace _func535
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::GetCrewCount", typeid(int (CrewMemberFactory::*)(bool )), ".8b47044084f6", nullptr, 0, 0, &func);
 }
 
 int CrewMemberFactory::GetCrewCount(bool enemy)
 {
 	typedef int (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func534::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func535::func;
 	return execfunc(this, enemy);
 }
 
-namespace _func535
+namespace _func536
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::GetEnemyCrewCount", typeid(int (CrewMemberFactory::*)()), "!.8b4704c36666662e0f1f840000000000", nullptr, 0, 0, &func);
@@ -6946,11 +6959,11 @@ namespace _func535
 int CrewMemberFactory::GetEnemyCrewCount()
 {
 	typedef int (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func535::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func536::func;
 	return execfunc(this);
 }
 
-namespace _func536
+namespace _func537
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::IsRace", typeid(bool (*)(const std::string &)), ".53be????????", nullptr, 0, 0, &func);
@@ -6959,11 +6972,11 @@ namespace _func536
 bool CrewMemberFactory::IsRace(const std::string &species)
 {
 	typedef bool (*custom_arg_funcptr_t)(const std::string &species_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func536::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func537::func;
 	return execfunc(species);
 }
 
-namespace _func537
+namespace _func538
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::CreateBoarderDrone", typeid(BoarderDrone *(CrewMemberFactory::*)(int , const DroneBlueprint *)), ".415641554189f5", nullptr, 0, 0, &func);
@@ -6972,11 +6985,11 @@ namespace _func537
 BoarderDrone *CrewMemberFactory::CreateBoarderDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef BoarderDrone *(*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func537::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func538::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func538
+namespace _func539
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::CreateBattleDrone", typeid(BattleDrone *(CrewMemberFactory::*)(int , const DroneBlueprint *)), ".415641554989d541544189f4554889fdbf20090000534883ec40", nullptr, 0, 0, &func);
@@ -6985,11 +6998,11 @@ namespace _func538
 BattleDrone *CrewMemberFactory::CreateBattleDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef BattleDrone *(*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func538::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func539::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func539
+namespace _func540
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::GetCloneReadyList", typeid(void (CrewMemberFactory::*)(std::vector<CrewMember*> &, bool )), ".4157415641554989fd41544189d431d2554889f55331db4883ec18", nullptr, 0, 0, &func);
@@ -6998,11 +7011,11 @@ namespace _func539
 void CrewMemberFactory::GetCloneReadyList(std::vector<CrewMember*> &vec, bool player)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> &vec_arg, bool player_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func539::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func540::func;
 	return execfunc(this, vec, player);
 }
 
-namespace _func540
+namespace _func541
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::CreateRepairDrone", typeid(RepairDrone *(CrewMemberFactory::*)(int , const DroneBlueprint *)), ".41570f57c94989d741564989fe0f28c1415541545589f5534883ec68", nullptr, 0, 0, &func);
@@ -7011,11 +7024,11 @@ namespace _func540
 RepairDrone *CrewMemberFactory::CreateRepairDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef RepairDrone *(*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func540::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func541::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func541
+namespace _func542
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::GetRandomFriendlyName", typeid(std::pair<std::string, bool> (CrewMemberFactory::*)(const std::string &)), ".4157415641554989f54154554889fd534889d34883ec68", nullptr, 0, 0, &func);
@@ -7024,11 +7037,11 @@ namespace _func541
 std::pair<std::string, bool> CrewMemberFactory::GetRandomFriendlyName(const std::string &race)
 {
 	typedef std::pair<std::string, bool> (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, const std::string &race_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func541::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func542::func;
 	return execfunc(this, race);
 }
 
-namespace _func542
+namespace _func543
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::GetCrewNames", typeid(std::vector<std::string> (CrewMemberFactory::*)()), ".415631d241554989fd41544989f4555331db4883ec20", nullptr, 0, 0, &func);
@@ -7037,19 +7050,6 @@ namespace _func542
 std::vector<std::string> CrewMemberFactory::GetCrewNames()
 {
 	typedef std::vector<std::string> (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func542::func;
-	return execfunc(this);
-}
-
-namespace _func543
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("CrewMemberFactory::OnLoop", typeid(void (CrewMemberFactory::*)()), ".415741564155415455534889fb4881ecb8000000488b5710", nullptr, 0, 0, &func);
-}
-
-void CrewMemberFactory::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func543::func;
 	return execfunc(this);
 }
@@ -7057,10 +7057,10 @@ void CrewMemberFactory::OnLoop()
 namespace _func544
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("CrewMemberFactory::RemoveExcessCrew", typeid(void (CrewMemberFactory::*)()), "!.415431c0554889fd53488b4f1031db488b57184829ca", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("CrewMemberFactory::OnLoop", typeid(void (CrewMemberFactory::*)()), ".415741564155415455534889fb4881ecb8000000488b5710", nullptr, 0, 0, &func);
 }
 
-void CrewMemberFactory::RemoveExcessCrew()
+void CrewMemberFactory::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func544::func;
@@ -7070,24 +7070,37 @@ void CrewMemberFactory::RemoveExcessCrew()
 namespace _func545
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("CrewMemberFactory::RemoveExcessCrew", typeid(void (CrewMemberFactory::*)()), "!.415431c0554889fd53488b4f1031db488b57184829ca", nullptr, 0, 0, &func);
+}
+
+void CrewMemberFactory::RemoveExcessCrew()
+{
+	typedef void (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func545::func;
+	return execfunc(this);
+}
+
+namespace _func546
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("CrewMemberFactory::CreateCrewMember", typeid(CrewMember *(CrewMemberFactory::*)(CrewBlueprint *, int , bool )), ".415741564189ce41554189d541544989f455488d6e08", nullptr, 0, 0, &func);
 }
 
 CrewMember *CrewMemberFactory::CreateCrewMember(CrewBlueprint *bp, int shipId, bool intruder)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, CrewBlueprint *bp_arg, int shipId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func545::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func546::func;
 	return execfunc(this, bp, shipId, intruder);
 }
 
 CrewMemberFactory *Global_CrewMemberFactory_Factory;
 
-namespace _var546
+namespace _var547
 {
     static VariableDefinition varObj("Global_CrewMemberFactory_Factory", "!f30f11834802000031c9bf(???????\?)ba020000004889e6", &Global_CrewMemberFactory_Factory);
 }
 
-namespace _func547
+namespace _func548
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewStoreBox::CanHold", typeid(bool (CrewStoreBox::*)()), "488bbf1801000031c0", nullptr, 0, 0, &func);
@@ -7096,11 +7109,11 @@ namespace _func547
 bool CrewStoreBox::CanHold()
 {
 	typedef bool (*custom_arg_funcptr_t)(CrewStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func547::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func548::func;
 	return execfunc(this);
 }
 
-namespace _func548
+namespace _func549
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewStoreBox::constructor", typeid(void (CrewStoreBox::*)(ShipManager *, int , const std::string &)), ".41574989ff415641554154554889f5", nullptr, 0, 0, &func);
@@ -7109,11 +7122,11 @@ namespace _func548
 void CrewStoreBox::constructor(ShipManager *ship, int worldLevel, const std::string &type)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewStoreBox *this_arg, ShipManager *ship_arg, int worldLevel_arg, const std::string &type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func548::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func549::func;
 	return execfunc(this, ship, worldLevel, type);
 }
 
-namespace _func549
+namespace _func550
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewStoreBox::Purchase", typeid(void (CrewStoreBox::*)()), ".415741564531f641554989fd4154555331db4881ec18010000", nullptr, 0, 0, &func);
@@ -7122,11 +7135,11 @@ namespace _func549
 void CrewStoreBox::Purchase()
 {
 	typedef void (*custom_arg_funcptr_t)(CrewStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func549::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func550::func;
 	return execfunc(this);
 }
 
-namespace _func550
+namespace _func551
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("CrewStoreBox::MouseMove", typeid(void (CrewStoreBox::*)(int , int )), ".534889fb488d7f1831c94883ec30e8????f7ff80", nullptr, 0, 0, &func);
@@ -7135,11 +7148,11 @@ namespace _func550
 void CrewStoreBox::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(CrewStoreBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func550::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func551::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func551
+namespace _func552
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DamageMessage::constructor", typeid(void (DamageMessage::*)(float , Pointf , DamageMessage::MessageType )), "534889fb4883ec5085f648c707", nullptr, 0, 0, &func);
@@ -7148,11 +7161,11 @@ namespace _func551
 void DamageMessage::constructor(float length, Pointf pos, DamageMessage::MessageType type)
 {
 	typedef void (*custom_arg_funcptr_t)(DamageMessage *this_arg, float length_arg, Pointf pos_arg, DamageMessage::MessageType type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func551::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func552::func;
 	return execfunc(this, length, pos, type);
 }
 
-namespace _func552
+namespace _func553
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DamageMessage::constructor2", typeid(void (DamageMessage::*)(float , int , Pointf , bool )), "415741564155415455534889fb4881ec3803000084d2", nullptr, 0, 0, &func);
@@ -7161,11 +7174,11 @@ namespace _func552
 void DamageMessage::constructor2(float length, int amount, Pointf pos, bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(DamageMessage *this_arg, float length_arg, int amount_arg, Pointf pos_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func552::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func553::func;
 	return execfunc(this, length, amount, pos, unk);
 }
 
-namespace _func553
+namespace _func554
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DefenseDrone::ValidTargetObject", typeid(bool (DefenseDrone::*)(Targetable *)), "4885f60f84b7000000", nullptr, 0, 0, &func);
@@ -7174,11 +7187,11 @@ namespace _func553
 bool DefenseDrone::ValidTargetObject(Targetable *target)
 {
 	typedef bool (*custom_arg_funcptr_t)(DefenseDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func553::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func554::func;
 	return execfunc(this, target);
 }
 
-namespace _func554
+namespace _func555
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DefenseDrone::PickTarget", typeid(void (DefenseDrone::*)()), "55534889fb4883ec4880bf5d02000000", nullptr, 0, 0, &func);
@@ -7187,11 +7200,11 @@ namespace _func554
 void DefenseDrone::PickTarget()
 {
 	typedef void (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func554::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func555::func;
 	return execfunc(this);
 }
 
-namespace _func555
+namespace _func556
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DefenseDrone::SetWeaponTarget", typeid(void (DefenseDrone::*)(Targetable *)), "4154554889fd53488b074889f3", nullptr, 0, 0, &func);
@@ -7200,11 +7213,11 @@ namespace _func555
 void DefenseDrone::SetWeaponTarget(Targetable *target)
 {
 	typedef void (*custom_arg_funcptr_t)(DefenseDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func555::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func556::func;
 	return execfunc(this, target);
 }
 
-namespace _func556
+namespace _func557
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DefenseDrone::GetTooltip", typeid(std::string (DefenseDrone::*)()), "554889f5be????????534889fb4883ec38488d542420", nullptr, 0, 0, &func);
@@ -7213,11 +7226,11 @@ namespace _func556
 std::string DefenseDrone::GetTooltip()
 {
 	typedef std::string (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func556::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func557::func;
 	return execfunc(this);
 }
 
-namespace _func557
+namespace _func558
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DefenseDrone::OnLoop", typeid(void (DefenseDrone::*)()), "55534889fb4883ec28e8e2a7", nullptr, 0, 0, &func);
@@ -7226,11 +7239,11 @@ namespace _func557
 void DefenseDrone::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func557::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func558::func;
 	return execfunc(this);
 }
 
-namespace _func558
+namespace _func559
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Description::copy_assign_2", typeid(Description &(Description::*)(Description &)), "554889f5534889fb4883ec08e8????????0fb64508488d7510488d7b10884308e8????????0fb64518488d7520488d7b20884318e8????????0fb64528488d7548488d7b488843288b45308943308b45348943348b45388943388b453c89433c0fb64540884340e8????????0fb64550488d7558", nullptr, 0, 0, &func);
@@ -7239,11 +7252,11 @@ namespace _func558
 Description &Description::copy_assign_2(Description &other)
 {
 	typedef Description &(*custom_arg_funcptr_t)(Description *this_arg, Description &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func558::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func559::func;
 	return execfunc(this, other);
 }
 
-namespace _func559
+namespace _func560
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Description::copy_assign_1", typeid(Description &(Description::*)(const Description &)), ".554889f5534889fb4883ec08e8????????0fb64508488d7510488d7b10884308e8????????0fb64518488d7520488d7b20884318e8????????0fb64528488d7548488d7b488843288b45308943308b45348943348b45388943388b453c89433c0fb64540884340e8????????0fb64550488d7558", nullptr, 0, 0, &func);
@@ -7252,11 +7265,11 @@ namespace _func559
 Description &Description::copy_assign_1(const Description &other)
 {
 	typedef Description &(*custom_arg_funcptr_t)(Description *this_arg, const Description &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func559::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func560::func;
 	return execfunc(this, other);
 }
 
-namespace _func560
+namespace _func561
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Description::destructor", typeid(void (Description::*)()), "534889fb4883ec10488b4758488d78e8", nullptr, 0, 0, &func);
@@ -7265,11 +7278,11 @@ namespace _func560
 void Description::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(Description *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func560::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func561::func;
 	return execfunc(this);
 }
 
-namespace _func561
+namespace _func562
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Door::GetPosition", typeid(Point (Door::*)()), "4883ec188b97540200008bb7500200004889e7e8????????8b442404", nullptr, 0, 0, &func);
@@ -7278,11 +7291,11 @@ namespace _func561
 Point Door::GetPosition()
 {
 	typedef Point (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func561::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func562::func;
 	return execfunc(this);
 }
 
-namespace _func562
+namespace _func563
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Door::ApplyDamage", typeid(bool (Door::*)(float )), ".5380bfec01000000", nullptr, 0, 0, &func);
@@ -7291,30 +7304,17 @@ namespace _func562
 bool Door::ApplyDamage(float amount)
 {
 	typedef bool (*custom_arg_funcptr_t)(Door *this_arg, float amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func562::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func563::func;
 	return execfunc(this, amount);
 }
 
-namespace _func563
+namespace _func564
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Door::SaveState", typeid(void (Door::*)(int )), "!.55??89fd5389f3??83ec088bb7cc01000089dfe8????????", nullptr, 0, 0, &func);
 }
 
 void Door::SaveState(int fd)
-{
-	typedef void (*custom_arg_funcptr_t)(Door *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func563::func;
-	return execfunc(this, fd);
-}
-
-namespace _func564
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Door::LoadState", typeid(void (Door::*)(int )), "!.5589f553??89fb89f7??83ec08e8????????89ef8983cc010000", nullptr, 0, 0, &func);
-}
-
-void Door::LoadState(int fd)
 {
 	typedef void (*custom_arg_funcptr_t)(Door *this_arg, int fd_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func564::func;
@@ -7324,23 +7324,23 @@ void Door::LoadState(int fd)
 namespace _func565
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Door::FakeOpen", typeid(void (Door::*)()), ".55534889fb4883ec0883bfb400000004c6472c01", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Door::LoadState", typeid(void (Door::*)(int )), "!.5589f553??89fb89f7??83ec08e8????????89ef8983cc010000", nullptr, 0, 0, &func);
 }
 
-void Door::FakeOpen()
+void Door::LoadState(int fd)
 {
-	typedef void (*custom_arg_funcptr_t)(Door *this_arg);
+	typedef void (*custom_arg_funcptr_t)(Door *this_arg, int fd_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func565::func;
-	return execfunc(this);
+	return execfunc(this, fd);
 }
 
 namespace _func566
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Door::FakeClose", typeid(void (Door::*)()), ".55534889fb4883ec080fb64724c6472c00", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Door::FakeOpen", typeid(void (Door::*)()), ".55534889fb4883ec0883bfb400000004c6472c01", nullptr, 0, 0, &func);
 }
 
-void Door::FakeClose()
+void Door::FakeOpen()
 {
 	typedef void (*custom_arg_funcptr_t)(Door *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func566::func;
@@ -7350,17 +7350,30 @@ void Door::FakeClose()
 namespace _func567
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Door::FakeClose", typeid(void (Door::*)()), ".55534889fb4883ec080fb64724c6472c00", nullptr, 0, 0, &func);
+}
+
+void Door::FakeClose()
+{
+	typedef void (*custom_arg_funcptr_t)(Door *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func567::func;
+	return execfunc(this);
+}
+
+namespace _func568
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Door::IsSealed", typeid(bool (Door::*)(int )), ".8b8f4c0200008b570885c9", nullptr, 0, 0, &func);
 }
 
 bool Door::IsSealed(int shipId)
 {
 	typedef bool (*custom_arg_funcptr_t)(Door *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func567::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func568::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func568
+namespace _func569
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Door::OnLoop", typeid(void (Door::*)()), "!.55534889fb4883ec188b874c02000085c0", nullptr, 0, 0, &func);
@@ -7369,11 +7382,11 @@ namespace _func568
 void Door::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func568::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func569::func;
 	return execfunc(this);
 }
 
-namespace _func569
+namespace _func570
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DoorBox::constructor", typeid(void (DoorBox::*)(Point , ShipSystem *, ShipManager *)), "41554989cdb901000000415455534889fb488dab700200004c8da3000300004883ec48", nullptr, 0, 0, &func);
@@ -7382,11 +7395,11 @@ namespace _func569
 void DoorBox::constructor(Point pos, ShipSystem *sys, ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(DoorBox *this_arg, Point pos_arg, ShipSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func569::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func570::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func570
+namespace _func571
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneBlueprint::RenderIcon", typeid(void (DroneBlueprint::*)(float )), "4156415541544989fc55534881ec20010000", nullptr, 0, 0, &func);
@@ -7395,17 +7408,17 @@ namespace _func570
 void DroneBlueprint::RenderIcon(float scale)
 {
 	typedef void (*custom_arg_funcptr_t)(DroneBlueprint *this_arg, float scale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func570::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func571::func;
 	return execfunc(this, scale);
 }
 
-namespace _func571
+namespace _func572
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneControl::DO_NOT_HOOK", typeid(void (DroneControl::*)()), "!5589d55389f34883ec08488b7f18", nullptr, 0, 0, &func);
 }
 
-namespace _func572
+namespace _func573
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneControl::HolderLabel", typeid(TextString (DroneControl::*)()), ".534889fb", nullptr, 0, 0, &func);
@@ -7414,11 +7427,11 @@ namespace _func572
 TextString DroneControl::HolderLabel()
 {
 	typedef TextString (*custom_arg_funcptr_t)(DroneControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func572::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func573::func;
 	return execfunc(this);
 }
 
-namespace _func573
+namespace _func574
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneControl::SelectArmament", typeid(void (DroneControl::*)(unsigned int )), ".??57??56??55??54??63e6", nullptr, 0, 0, &func);
@@ -7427,11 +7440,11 @@ namespace _func573
 void DroneControl::SelectArmament(unsigned int i)
 {
 	typedef void (*custom_arg_funcptr_t)(DroneControl *this_arg, unsigned int i_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func573::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func574::func;
 	return execfunc(this, i);
 }
 
-namespace _func574
+namespace _func575
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneControl::ArmamentHotkey", typeid(SDLKey (DroneControl::*)(unsigned int )), ".4883ec5883c60189742420488d7c2430488d742420", nullptr, 0, 0, &func);
@@ -7440,11 +7453,11 @@ namespace _func574
 SDLKey DroneControl::ArmamentHotkey(unsigned int i)
 {
 	typedef SDLKey (*custom_arg_funcptr_t)(DroneControl *this_arg, unsigned int i_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func574::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func575::func;
 	return execfunc(this, i);
 }
 
-namespace _func575
+namespace _func576
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneControl::OnLoop", typeid(void (DroneControl::*)()), ".4155be04000000415455534889fb4883ec28", nullptr, 0, 0, &func);
@@ -7453,11 +7466,11 @@ namespace _func575
 void DroneControl::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(DroneControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func575::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func576::func;
 	return execfunc(this);
 }
 
-namespace _func576
+namespace _func577
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneStoreBox::constructor", typeid(void (DroneStoreBox::*)(ShipManager *, Equipment *, const DroneBlueprint *)), "41554989d541544989f4be", nullptr, 0, 0, &func);
@@ -7466,11 +7479,11 @@ namespace _func576
 void DroneStoreBox::constructor(ShipManager *ship, Equipment *equip, const DroneBlueprint *bp)
 {
 	typedef void (*custom_arg_funcptr_t)(DroneStoreBox *this_arg, ShipManager *ship_arg, Equipment *equip_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func576::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func577::func;
 	return execfunc(this, ship, equip, bp);
 }
 
-namespace _func577
+namespace _func578
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneSystem::DePowerDrone", typeid(bool (DroneSystem::*)(Drone *, bool )), "415484d24989f4554889fd53", nullptr, 0, 0, &func);
@@ -7479,11 +7492,11 @@ namespace _func577
 bool DroneSystem::DePowerDrone(Drone *drone, bool unk)
 {
 	typedef bool (*custom_arg_funcptr_t)(DroneSystem *this_arg, Drone *drone_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func577::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func578::func;
 	return execfunc(this, drone, unk);
 }
 
-namespace _func578
+namespace _func579
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneSystem::Jump", typeid(void (DroneSystem::*)()), ".415431c94989fc", nullptr, 0, 0, &func);
@@ -7492,11 +7505,11 @@ namespace _func578
 void DroneSystem::Jump()
 {
 	typedef void (*custom_arg_funcptr_t)(DroneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func578::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func579::func;
 	return execfunc(this);
 }
 
-namespace _func579
+namespace _func580
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneSystem::StringToDrone", typeid(int (*)(std::string &)), ".53be????????4889fb", nullptr, 0, 0, &func);
@@ -7505,11 +7518,11 @@ namespace _func579
 int DroneSystem::StringToDrone(std::string &name)
 {
 	typedef int (*custom_arg_funcptr_t)(std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func579::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func580::func;
 	return execfunc(name);
 }
 
-namespace _func580
+namespace _func581
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneSystem::RemoveDrone", typeid(Drone *(DroneSystem::*)(int )), ".31c085f60f888e00000041545553488b8f48020000", nullptr, 0, 0, &func);
@@ -7518,30 +7531,17 @@ namespace _func580
 Drone *DroneSystem::RemoveDrone(int slot)
 {
 	typedef Drone *(*custom_arg_funcptr_t)(DroneSystem *this_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func580::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func581::func;
 	return execfunc(this, slot);
 }
 
-namespace _func581
+namespace _func582
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneSystem::UpdateBonusPower", typeid(void (DroneSystem::*)()), ".415741564531f6415541545531ed534889fb4883ec18488b9748020000", nullptr, 0, 0, &func);
 }
 
 void DroneSystem::UpdateBonusPower()
-{
-	typedef void (*custom_arg_funcptr_t)(DroneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func581::func;
-	return execfunc(this);
-}
-
-namespace _func582
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("DroneSystem::OnLoop", typeid(void (DroneSystem::*)()), ".41574989ff41564155415455534883ec38", nullptr, 0, 0, &func);
-}
-
-void DroneSystem::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(DroneSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func582::func;
@@ -7551,17 +7551,30 @@ void DroneSystem::OnLoop()
 namespace _func583
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("DroneSystem::OnLoop", typeid(void (DroneSystem::*)()), ".41574989ff41564155415455534883ec38", nullptr, 0, 0, &func);
+}
+
+void DroneSystem::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(DroneSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func583::func;
+	return execfunc(this);
+}
+
+namespace _func584
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("DroneSystem::SetBonusPower", typeid(void (DroneSystem::*)(int , int )), ".5589f5534889fb4883ec08", nullptr, 0, 0, &func);
 }
 
 void DroneSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void (*custom_arg_funcptr_t)(DroneSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func583::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func584::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func584
+namespace _func585
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DropBox::OnRender", typeid(void (DropBox::*)()), "415741564155415455534889fb4883ec78e8", nullptr, 0, 0, &func);
@@ -7570,11 +7583,11 @@ namespace _func584
 void DropBox::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(DropBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func584::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func585::func;
 	return execfunc(this);
 }
 
-namespace _func585
+namespace _func586
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DropBox::GetHeight", typeid(int (DropBox::*)()), "488b57104889d04885c0", nullptr, 0, 0, &func);
@@ -7583,11 +7596,11 @@ namespace _func585
 int DropBox::GetHeight()
 {
 	typedef int (*custom_arg_funcptr_t)(DropBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func585::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func586::func;
 	return execfunc(this);
 }
 
-namespace _func586
+namespace _func587
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DropBox::Contains", typeid(bool (DropBox::*)(int , int )), "8b0f31c0", nullptr, 0, 0, &func);
@@ -7596,11 +7609,11 @@ namespace _func586
 bool DropBox::Contains(int x, int y)
 {
 	typedef bool (*custom_arg_funcptr_t)(DropBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func586::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func587::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func587
+namespace _func588
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DropBox::GetBodySpaceOffset", typeid(int (DropBox::*)()), "415455534889fb4883ec30807f40008b", nullptr, 0, 0, &func);
@@ -7609,11 +7622,11 @@ namespace _func587
 int DropBox::GetBodySpaceOffset()
 {
 	typedef int (*custom_arg_funcptr_t)(DropBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func587::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func588::func;
 	return execfunc(this);
 }
 
-namespace _func588
+namespace _func589
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DropBox::OnInit", typeid(void (DropBox::*)(Point , bool , TextString *, TextString *, int , TextString *)), "415741564589ce41554989cd41544d89c4", nullptr, 0, 0, &func);
@@ -7622,11 +7635,11 @@ namespace _func588
 void DropBox::OnInit(Point p, bool isSellBox_, TextString *titleText_, TextString *bodyText_, int bodySpace_, TextString *lowerText_)
 {
 	typedef void (*custom_arg_funcptr_t)(DropBox *this_arg, Point p_arg, bool isSellBox__arg, TextString *titleText__arg, TextString *bodyText__arg, int bodySpace__arg, TextString *lowerText__arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func588::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func589::func;
 	return execfunc(this, p, isSellBox_, titleText_, bodyText_, bodySpace_, lowerText_);
 }
 
-namespace _func589
+namespace _func590
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EnergyAlien::OnLoop", typeid(void (EnergyAlien::*)()), "534889fbe8????????488b83c000000083786003", nullptr, 0, 0, &func);
@@ -7635,11 +7648,11 @@ namespace _func589
 void EnergyAlien::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(EnergyAlien *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func589::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func590::func;
 	return execfunc(this);
 }
 
-namespace _func590
+namespace _func591
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EnergyAlien::GetRoomDamage", typeid(Damage (EnergyAlien::*)()), "80be41070000004889f8", nullptr, 0, 0, &func);
@@ -7648,19 +7661,6 @@ namespace _func590
 Damage EnergyAlien::GetRoomDamage()
 {
 	typedef Damage (*custom_arg_funcptr_t)(EnergyAlien *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func590::func;
-	return execfunc(this);
-}
-
-namespace _func591
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Equipment::Open", typeid(void (Equipment::*)()), "41544989fc5531ed5331dbe8", nullptr, 0, 0, &func);
-}
-
-void Equipment::Open()
-{
-	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func591::func;
 	return execfunc(this);
 }
@@ -7668,10 +7668,10 @@ void Equipment::Open()
 namespace _func592
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Equipment::Close", typeid(void (Equipment::*)()), "!.e99b61000090662e0f1f840000000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Equipment::Open", typeid(void (Equipment::*)()), "41544989fc5531ed5331dbe8", nullptr, 0, 0, &func);
 }
 
-void Equipment::Close()
+void Equipment::Open()
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func592::func;
@@ -7681,17 +7681,30 @@ void Equipment::Close()
 namespace _func593
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Equipment::Close", typeid(void (Equipment::*)()), "!.e99b61000090662e0f1f840000000000", nullptr, 0, 0, &func);
+}
+
+void Equipment::Close()
+{
+	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func593::func;
+	return execfunc(this);
+}
+
+namespace _func594
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::MouseClick", typeid(void (Equipment::*)(int , int )), ".534889fbe8????????4863831802000083f8ff", nullptr, 0, 0, &func);
 }
 
 void Equipment::MouseClick(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func593::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func594::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func594
+namespace _func595
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::OnLoop", typeid(void (Equipment::*)()), ".41554531ed41545531ed534889fb4883ec08", nullptr, 0, 0, &func);
@@ -7700,11 +7713,11 @@ namespace _func594
 void Equipment::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func594::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func595::func;
 	return execfunc(this);
 }
 
-namespace _func595
+namespace _func596
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::MouseUp", typeid(void (Equipment::*)(int , int )), ".534889fb4883ec7080bf2402000000", nullptr, 0, 0, &func);
@@ -7713,11 +7726,11 @@ namespace _func595
 void Equipment::MouseUp(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func595::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func596::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func596
+namespace _func597
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::AddDrone", typeid(void (Equipment::*)(DroneBlueprint *, bool , bool )), ".41554154554889f5534889fb4883ec4884c9", nullptr, 0, 0, &func);
@@ -7726,11 +7739,11 @@ namespace _func596
 void Equipment::AddDrone(DroneBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg, DroneBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func596::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func597::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func597
+namespace _func598
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::AddAugment", typeid(void (Equipment::*)(AugmentBlueprint *, bool , bool )), ".4154554889f5488d7608534889fb4883ec60", nullptr, 0, 0, &func);
@@ -7739,11 +7752,11 @@ namespace _func597
 void Equipment::AddAugment(AugmentBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg, AugmentBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func597::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func598::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func598
+namespace _func599
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::GetCargoHold", typeid(std::vector<std::string> (Equipment::*)()), ".41554989fd41544989f455534883ec08", nullptr, 0, 0, &func);
@@ -7752,11 +7765,11 @@ namespace _func598
 std::vector<std::string> Equipment::GetCargoHold()
 {
 	typedef std::vector<std::string> (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func598::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func599::func;
 	return execfunc(this);
 }
 
-namespace _func599
+namespace _func600
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::AddWeapon", typeid(void (Equipment::*)(WeaponBlueprint *, bool , bool )), ".415641554989f541545589cd534889fb4883ec5084c9", nullptr, 0, 0, &func);
@@ -7765,11 +7778,11 @@ namespace _func599
 void Equipment::AddWeapon(WeaponBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg, WeaponBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func599::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func600::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func600
+namespace _func601
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::AddToCargo", typeid(void (Equipment::*)(const std::string &)), ".554889fd534889f34883ec38488d7c2420", nullptr, 0, 0, &func);
@@ -7778,11 +7791,11 @@ namespace _func600
 void Equipment::AddToCargo(const std::string &name)
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func600::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func601::func;
 	return execfunc(this, name);
 }
 
-namespace _func601
+namespace _func602
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::OnInit", typeid(void (Equipment::*)(ShipManager *)), ".4157415641554154554889f5534889fb4881ec98000000", nullptr, 0, 0, &func);
@@ -7791,11 +7804,11 @@ namespace _func601
 void Equipment::OnInit(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func601::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func602::func;
 	return execfunc(this, ship);
 }
 
-namespace _func602
+namespace _func603
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::IsCompletelyFull", typeid(bool (Equipment::*)(int )), "415531d24189f5", nullptr, 0, 0, &func);
@@ -7804,11 +7817,11 @@ namespace _func602
 bool Equipment::IsCompletelyFull(int type)
 {
 	typedef bool (*custom_arg_funcptr_t)(Equipment *this_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func602::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func603::func;
 	return execfunc(this, type);
 }
 
-namespace _func603
+namespace _func604
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::Jump", typeid(void (Equipment::*)()), "534889fb488bbf08020000", nullptr, 0, 0, &func);
@@ -7817,11 +7830,11 @@ namespace _func603
 void Equipment::Jump()
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func603::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func604::func;
 	return execfunc(this);
 }
 
-namespace _func604
+namespace _func605
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::MouseMove", typeid(void (Equipment::*)(int , int )), "41574189d741564989fe41554154", nullptr, 0, 0, &func);
@@ -7830,11 +7843,11 @@ namespace _func604
 void Equipment::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func604::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func605::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func605
+namespace _func606
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::OnRender", typeid(void (Equipment::*)()), "41564155415455534889fb4883ec60", nullptr, 0, 0, &func);
@@ -7843,11 +7856,11 @@ namespace _func605
 void Equipment::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func605::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func606::func;
 	return execfunc(this);
 }
 
-namespace _func606
+namespace _func607
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::SetPosition", typeid(void (Equipment::*)(Point )), "41574156415541544989fc55534883ec68", nullptr, 0, 0, &func);
@@ -7856,30 +7869,17 @@ namespace _func606
 void Equipment::SetPosition(Point p)
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg, Point p_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func606::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func607::func;
 	return execfunc(this, p);
 }
 
-namespace _func607
+namespace _func608
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Equipment::constructor", typeid(void (Equipment::*)()), "534889fb4883ec10e8????????488d7b30", nullptr, 0, 0, &func);
 }
 
 void Equipment::constructor()
-{
-	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func607::func;
-	return execfunc(this);
-}
-
-namespace _func608
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Equipment::destructor", typeid(void (Equipment::*)()), "534889fb4883ec10488b8720030000", nullptr, 0, 0, &func);
-}
-
-void Equipment::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func608::func;
@@ -7889,17 +7889,30 @@ void Equipment::destructor()
 namespace _func609
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Equipment::destructor", typeid(void (Equipment::*)()), "534889fb4883ec10488b8720030000", nullptr, 0, 0, &func);
+}
+
+void Equipment::destructor()
+{
+	typedef void (*custom_arg_funcptr_t)(Equipment *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func609::func;
+	return execfunc(this);
+}
+
+namespace _func610
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::SetPosition", typeid(void (EquipmentBox::*)(Point )), "48897758897760", nullptr, 0, 0, &func);
 }
 
 void EquipmentBox::SetPosition(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func609::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func610::func;
 	return execfunc(this, pos);
 }
 
-namespace _func610
+namespace _func611
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::MouseMove", typeid(void (EquipmentBox::*)(int , int )), ".8b476031c939c6", nullptr, 0, 0, &func);
@@ -7908,11 +7921,11 @@ namespace _func610
 void EquipmentBox::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func610::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func611::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func611
+namespace _func612
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::Restart", typeid(void (EquipmentBox::*)()), ".48c747700000000048c7477800000000", nullptr, 0, 0, &func);
@@ -7921,11 +7934,11 @@ namespace _func611
 void EquipmentBox::Restart()
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func611::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func612::func;
 	return execfunc(this);
 }
 
-namespace _func612
+namespace _func613
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::AddItem", typeid(void (EquipmentBox::*)(EquipmentBoxItem )), ".488b44240848894770", nullptr, 0, 0, &func);
@@ -7934,30 +7947,17 @@ namespace _func612
 void EquipmentBox::AddItem(EquipmentBoxItem item)
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, EquipmentBoxItem item_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func612::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func613::func;
 	return execfunc(this, item);
 }
 
-namespace _func613
+namespace _func614
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::CanHoldWeapon", typeid(bool (EquipmentBox::*)()), ".488b47704885c07407", nullptr, 0, 0, &func);
 }
 
 bool EquipmentBox::CanHoldWeapon()
-{
-	typedef bool (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func613::func;
-	return execfunc(this);
-}
-
-namespace _func614
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("EquipmentBox::CanHoldDrone", typeid(bool (EquipmentBox::*)()), ".48837f7000488b4778", nullptr, 0, 0, &func);
-}
-
-bool EquipmentBox::CanHoldDrone()
 {
 	typedef bool (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func614::func;
@@ -7967,17 +7967,30 @@ bool EquipmentBox::CanHoldDrone()
 namespace _func615
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("EquipmentBox::CanHoldDrone", typeid(bool (EquipmentBox::*)()), ".48837f7000488b4778", nullptr, 0, 0, &func);
+}
+
+bool EquipmentBox::CanHoldDrone()
+{
+	typedef bool (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func615::func;
+	return execfunc(this);
+}
+
+namespace _func616
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::GetType", typeid(int (EquipmentBox::*)(bool )), ".48837f70007411", nullptr, 0, 0, &func);
 }
 
 int EquipmentBox::GetType(bool forcedEmpty)
 {
 	typedef int (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool forcedEmpty_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func615::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func616::func;
 	return execfunc(this, forcedEmpty);
 }
 
-namespace _func616
+namespace _func617
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::OnRender", typeid(void (EquipmentBox::*)(bool )), "!.41545589f54189ec534889fb4883ec30", nullptr, 0, 0, &func);
@@ -7986,11 +7999,11 @@ namespace _func616
 void EquipmentBox::OnRender(bool isEmpty)
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool isEmpty_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func616::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func617::func;
 	return execfunc(this, isEmpty);
 }
 
-namespace _func617
+namespace _func618
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::destructor", typeid(void (EquipmentBox::*)()), ".534889fb4883ec1048c707????????488b7f28e8????????488b7b30e8????????488b7b38e8????????488b7b40e8????????488b7b08e8????????488b4320488d78e84881ff????????750e", nullptr, 0, 0, &func);
@@ -7999,30 +8012,17 @@ namespace _func617
 void EquipmentBox::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func617::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func618::func;
 	return execfunc(this);
 }
 
-namespace _func618
+namespace _func619
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::UpdateBoxImage", typeid(void (EquipmentBox::*)(bool )), ".41545589f5", nullptr, 0, 0, &func);
 }
 
 void EquipmentBox::UpdateBoxImage(bool unk)
-{
-	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func618::func;
-	return execfunc(this, unk);
-}
-
-namespace _func619
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("EquipmentBox::RenderLabels", typeid(void (EquipmentBox::*)(bool )), ".5589f5", nullptr, 0, 0, &func);
-}
-
-void EquipmentBox::RenderLabels(bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool unk_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func619::func;
@@ -8032,17 +8032,30 @@ void EquipmentBox::RenderLabels(bool unk)
 namespace _func620
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("EquipmentBox::RenderLabels", typeid(void (EquipmentBox::*)(bool )), ".5589f5", nullptr, 0, 0, &func);
+}
+
+void EquipmentBox::RenderLabels(bool unk)
+{
+	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool unk_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func620::func;
+	return execfunc(this, unk);
+}
+
+namespace _func621
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::constructor", typeid(void (EquipmentBox::*)(Point , int )), ".554889f048c1f820534889fb4883ec38", nullptr, 0, 0, &func);
 }
 
 void EquipmentBox::constructor(Point pos, int slot)
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, Point pos_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func620::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func621::func;
 	return execfunc(this, pos, slot);
 }
 
-namespace _func621
+namespace _func622
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::GetItemValue", typeid(int (EquipmentBox::*)()), ".488b47704885c0740f", nullptr, 0, 0, &func);
@@ -8051,11 +8064,11 @@ namespace _func621
 int EquipmentBox::GetItemValue()
 {
 	typedef int (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func621::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func622::func;
 	return execfunc(this);
 }
 
-namespace _func622
+namespace _func623
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::SetBlueprint", typeid(void (EquipmentBox::*)(InfoBox *, bool )), ".5531c04889f5534889fb4883ec18", nullptr, 0, 0, &func);
@@ -8064,11 +8077,11 @@ namespace _func622
 void EquipmentBox::SetBlueprint(InfoBox *infoBox, bool detailedBox)
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, InfoBox *infoBox_arg, bool detailedBox_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func622::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func623::func;
 	return execfunc(this, infoBox, detailedBox);
 }
 
-namespace _func623
+namespace _func624
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::GetBlueprint", typeid(Blueprint *(EquipmentBox::*)()), ".488b47784885c07407", nullptr, 0, 0, &func);
@@ -8077,11 +8090,11 @@ namespace _func623
 Blueprint *EquipmentBox::GetBlueprint()
 {
 	typedef Blueprint *(*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func623::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func624::func;
 	return execfunc(this);
 }
 
-namespace _func624
+namespace _func625
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::RenderIcon", typeid(void (EquipmentBox::*)()), "488b47704885c074??488b", nullptr, 0, 0, &func);
@@ -8090,11 +8103,11 @@ namespace _func624
 void EquipmentBox::RenderIcon()
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func624::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func625::func;
 	return execfunc(this);
 }
 
-namespace _func625
+namespace _func626
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EquipmentBox::ForceHitBox", typeid(void (EquipmentBox::*)(Globals::Rect *)), "488b0648894760", nullptr, 0, 0, &func);
@@ -8103,11 +8116,11 @@ namespace _func625
 void EquipmentBox::ForceHitBox(Globals::Rect *newBox)
 {
 	typedef void (*custom_arg_funcptr_t)(EquipmentBox *this_arg, Globals::Rect *newBox_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func625::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func626::func;
 	return execfunc(this, newBox);
 }
 
-namespace _func626
+namespace _func627
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventGenerator::GetImageFromList", typeid(std::string (EventGenerator::*)(const std::string &)), "415541544989d455488daec80100004889d6534889fb4889ef4883ec18", nullptr, 0, 0, &func);
@@ -8116,11 +8129,11 @@ namespace _func626
 std::string EventGenerator::GetImageFromList(const std::string &listName)
 {
 	typedef std::string (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &listName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func626::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func627::func;
 	return execfunc(this, listName);
 }
 
-namespace _func627
+namespace _func628
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventGenerator::GetShipEvent", typeid(ShipEvent (EventGenerator::*)(const std::string &)), ".4156415541544989d455488dae98010000", nullptr, 0, 0, &func);
@@ -8129,11 +8142,11 @@ namespace _func627
 ShipEvent EventGenerator::GetShipEvent(const std::string &event)
 {
 	typedef ShipEvent (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func627::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func628::func;
 	return execfunc(this, event);
 }
 
-namespace _func628
+namespace _func629
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventGenerator::GetSectorDescription", typeid(SectorDescription (EventGenerator::*)(const std::string &, int )), ".41574189cf41564989f641554989fd415455498d6e48534889d34883ec58", nullptr, 0, 0, &func);
@@ -8142,11 +8155,11 @@ namespace _func628
 SectorDescription EventGenerator::GetSectorDescription(const std::string &type, int level)
 {
 	typedef SectorDescription (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &type_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func628::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func629::func;
 	return execfunc(this, type, level);
 }
 
-namespace _func629
+namespace _func630
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventGenerator::GetSpecificSector", typeid(SectorDescription (EventGenerator::*)(const std::string &)), ".4157415641554c8d6e1841544989d4554889f5534889fb4881ecd8000000", nullptr, 0, 0, &func);
@@ -8155,11 +8168,11 @@ namespace _func629
 SectorDescription EventGenerator::GetSpecificSector(const std::string &name)
 {
 	typedef SectorDescription (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func629::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func630::func;
 	return execfunc(this, name);
 }
 
-namespace _func630
+namespace _func631
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventGenerator::Clear", typeid(void (EventGenerator::*)()), ".??57??56??55??8daf08010000??5455??89fd53??83ec28??8b9f48010000", nullptr, 0, 0, &func);
@@ -8168,11 +8181,11 @@ namespace _func630
 void EventGenerator::Clear()
 {
 	typedef void (*custom_arg_funcptr_t)(EventGenerator *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func630::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func631::func;
 	return execfunc(this);
 }
 
-namespace _func631
+namespace _func632
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventGenerator::CreateEvent", typeid(LocationEvent *(EventGenerator::*)(const std::string &, int , bool )), ".415741564155415455488d6f78534889f34881ec88020000", nullptr, 0, 0, &func);
@@ -8181,11 +8194,11 @@ namespace _func631
 LocationEvent *EventGenerator::CreateEvent(const std::string &name, int worldLevel, bool ignoreUnique)
 {
 	typedef LocationEvent *(*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg, int worldLevel_arg, bool ignoreUnique_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func631::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func632::func;
 	return execfunc(this, name, worldLevel, ignoreUnique);
 }
 
-namespace _func632
+namespace _func633
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventGenerator::GetBaseEvent", typeid(LocationEvent *(EventGenerator::*)(const std::string &, int , bool , int )), ".5589cd534889fb4883ec184183f8ff", nullptr, 0, 0, &func);
@@ -8194,18 +8207,18 @@ namespace _func632
 LocationEvent *EventGenerator::GetBaseEvent(const std::string &name, int worldLevel, bool ignoreUnique, int seed)
 {
 	typedef LocationEvent *(*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg, int worldLevel_arg, bool ignoreUnique_arg, int seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func632::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func633::func;
 	return execfunc(this, name, worldLevel, ignoreUnique, seed);
 }
 
 EventGenerator *Global_EventGenerator_Generator;
 
-namespace _var633
+namespace _var634
 {
     static VariableDefinition varObj("Global_EventGenerator_Generator", "!.418b97e8090000458b87fc1400004d8da77814000031c9bf(???????\?)", &Global_EventGenerator_Generator);
 }
 
-namespace _func634
+namespace _func635
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventSystem::AddEvent", typeid(void (EventSystem::*)(int )), "85f6781a488b5718488b4720", nullptr, 0, 0, &func);
@@ -8214,11 +8227,11 @@ namespace _func634
 void EventSystem::AddEvent(int id)
 {
 	typedef void (*custom_arg_funcptr_t)(EventSystem *this_arg, int id_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func634::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func635::func;
 	return execfunc(this, id);
 }
 
-namespace _func635
+namespace _func636
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventSystem::PollEvent", typeid(bool (EventSystem::*)(int )), "85f6781c488b0f488b5708", nullptr, 0, 0, &func);
@@ -8227,18 +8240,18 @@ namespace _func635
 bool EventSystem::PollEvent(int id)
 {
 	typedef bool (*custom_arg_funcptr_t)(EventSystem *this_arg, int id_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func635::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func636::func;
 	return execfunc(this, id);
 }
 
 EventSystem *Global_EventSystem_EventManager;
 
-namespace _var636
+namespace _var637
 {
     static VariableDefinition varObj("Global_EventSystem_EventManager", "!488b7b088b348a3bb7700600007e62be06000000bf(???????\?)", &Global_EventSystem_EventManager);
 }
 
-namespace _func637
+namespace _func638
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::PullMinMax", typeid(RandomAmount (EventsParser::*)(rapidxml::xml_node<char> *, const std::string &)), "41544989d4554889f5be????????4883c540", nullptr, 0, 0, &func);
@@ -8247,11 +8260,11 @@ namespace _func637
 RandomAmount EventsParser::PullMinMax(rapidxml::xml_node<char> *node, const std::string &name)
 {
 	typedef RandomAmount (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func637::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func638::func;
 	return execfunc(this, node, name);
 }
 
-namespace _func638
+namespace _func639
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::ProcessModifyItem", typeid(ResourcesTemplate (EventsParser::*)(ResourcesTemplate &, rapidxml::xml_node<char> *, const std::string &)), ".41574d89c741564989f64c89c641554989fd4154554889d5534889cb4883ec38", nullptr, 0, 0, &func);
@@ -8260,11 +8273,11 @@ namespace _func638
 ResourcesTemplate EventsParser::ProcessModifyItem(ResourcesTemplate &resources, rapidxml::xml_node<char> *node, const std::string &unk)
 {
 	typedef ResourcesTemplate (*custom_arg_funcptr_t)(EventsParser *this_arg, ResourcesTemplate &resources_arg, rapidxml::xml_node<char> *node_arg, const std::string &unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func638::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func639::func;
 	return execfunc(this, resources, node, unk);
 }
 
-namespace _func639
+namespace _func640
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::ProcessShipEvent", typeid(ShipTemplate (EventsParser::*)(rapidxml::xml_node<char> *)), ".415741564989d641554989fd41544d8d664055534881ec98030000", nullptr, 0, 0, &func);
@@ -8273,11 +8286,11 @@ namespace _func639
 ShipTemplate EventsParser::ProcessShipEvent(rapidxml::xml_node<char> *node)
 {
 	typedef ShipTemplate (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func639::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func640::func;
 	return execfunc(this, node);
 }
 
-namespace _func640
+namespace _func641
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::ProcessEvent", typeid(std::string (EventsParser::*)(rapidxml::xml_node<char> *, const std::string &)), ".415741564989f6be????????41554989cd4154", nullptr, 0, 0, &func);
@@ -8286,11 +8299,11 @@ namespace _func640
 std::string EventsParser::ProcessEvent(rapidxml::xml_node<char> *node, const std::string &eventName)
 {
 	typedef std::string (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &eventName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func640::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func641::func;
 	return execfunc(this, node, eventName);
 }
 
-namespace _func641
+namespace _func642
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::ProcessEventList", typeid(std::vector<std::string> (EventsParser::*)(rapidxml::xml_node<char> *, const std::string &)), ".41554989cd41544989f4", nullptr, 0, 0, &func);
@@ -8299,11 +8312,11 @@ namespace _func641
 std::vector<std::string> EventsParser::ProcessEventList(rapidxml::xml_node<char> *node, const std::string &listName)
 {
 	typedef std::vector<std::string> (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &listName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func641::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func642::func;
 	return execfunc(this, node, listName);
 }
 
-namespace _func642
+namespace _func643
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::ProcessChoice", typeid(void (EventsParser::*)(EventTemplate *, rapidxml::xml_node<char> *, std::string &)), ".41574989d7415641554989cd41544989f4", nullptr, 0, 0, &func);
@@ -8312,11 +8325,11 @@ namespace _func642
 void EventsParser::ProcessChoice(EventTemplate *event, rapidxml::xml_node<char> *node, std::string &eventName)
 {
 	typedef void (*custom_arg_funcptr_t)(EventsParser *this_arg, EventTemplate *event_arg, rapidxml::xml_node<char> *node_arg, std::string &eventName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func642::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func643::func;
 	return execfunc(this, event, node, eventName);
 }
 
-namespace _func643
+namespace _func644
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::ProcessBaseNode", typeid(void (EventsParser::*)(rapidxml::xml_node<char> *, EventGenerator &)), ".415741564989fe41554989d54154554889f54c8d7d4053", nullptr, 0, 0, &func);
@@ -8325,11 +8338,11 @@ namespace _func643
 void EventsParser::ProcessBaseNode(rapidxml::xml_node<char> *node, EventGenerator &generator)
 {
 	typedef void (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, EventGenerator &generator_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func643::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func644::func;
 	return execfunc(this, node, generator);
 }
 
-namespace _func644
+namespace _func645
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::AddEvents", typeid(void (EventsParser::*)(EventGenerator &, char *, const std::string &)), ".41574989d741564155415455534881ecc8000100", nullptr, 0, 0, &func);
@@ -8338,11 +8351,11 @@ namespace _func644
 void EventsParser::AddEvents(EventGenerator &generator, char *file, const std::string &fileName)
 {
 	typedef void (*custom_arg_funcptr_t)(EventsParser *this_arg, EventGenerator &generator_arg, char *file_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func644::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func645::func;
 	return execfunc(this, generator, file, fileName);
 }
 
-namespace _func645
+namespace _func646
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("EventsParser::AddAllEvents", typeid(void (EventsParser::*)()), ".415531d2", nullptr, 0, 0, &func);
@@ -8351,18 +8364,18 @@ namespace _func645
 void EventsParser::AddAllEvents()
 {
 	typedef void (*custom_arg_funcptr_t)(EventsParser *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func645::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func646::func;
 	return execfunc(this);
 }
 
 EventsParser *Global_EventsParser_Parser;
 
-namespace _var646
+namespace _var647
 {
     static VariableDefinition varObj("Global_EventsParser_Parser", "!488d4c24104889c54889c2be????????bf(???????\?)", &Global_EventsParser_Parser);
 }
 
-namespace _func647
+namespace _func648
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ExplosionAnimation::LoadGibs", typeid(void (ExplosionAnimation::*)()), "41545553488b5748", nullptr, 0, 0, &func);
@@ -8371,11 +8384,11 @@ namespace _func647
 void ExplosionAnimation::LoadGibs()
 {
 	typedef void (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func647::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func648::func;
 	return execfunc(this);
 }
 
-namespace _func648
+namespace _func649
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ExplosionAnimation::OnRender", typeid(void (ExplosionAnimation::*)(Globals::Rect *, ImageDesc , GL_Primitive *)), ".415741564155415455534889fb4883ec38807f1400", nullptr, 0, 0, &func);
@@ -8384,11 +8397,11 @@ namespace _func648
 void ExplosionAnimation::OnRender(Globals::Rect *shipRect, ImageDesc shipImage, GL_Primitive *shipImagePrimitive)
 {
 	typedef void (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg, Globals::Rect *shipRect_arg, ImageDesc shipImage_arg, GL_Primitive *shipImagePrimitive_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func648::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func649::func;
 	return execfunc(this, shipRect, shipImage, shipImagePrimitive);
 }
 
-namespace _func649
+namespace _func650
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ExplosionAnimation::OnInit", typeid(void (ExplosionAnimation::*)(rapidxml::xml_node<char> *, const std::string &, Point )), ".415741564989fe4155415455534889f34881ec380200008b7f28", nullptr, 0, 0, &func);
@@ -8397,11 +8410,11 @@ namespace _func649
 void ExplosionAnimation::OnInit(rapidxml::xml_node<char> *node, const std::string &name, Point glowOffset)
 {
 	typedef void (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &name_arg, Point glowOffset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func649::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func650::func;
 	return execfunc(this, node, name, glowOffset);
 }
 
-namespace _func650
+namespace _func651
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FTLButton::GetPilotTooltip", typeid(std::string (FTLButton::*)()), "554889f5534889fb4883ec28488bbe", nullptr, 0, 0, &func);
@@ -8410,11 +8423,11 @@ namespace _func650
 std::string FTLButton::GetPilotTooltip()
 {
 	typedef std::string (*custom_arg_funcptr_t)(FTLButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func650::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func651::func;
 	return execfunc(this);
 }
 
-namespace _func651
+namespace _func652
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FTLButton::OnRender", typeid(void (FTLButton::*)()), ".4157be0100000041564155415455534889fb4881ecf8000000488bbf10010000", nullptr, 0, 0, &func);
@@ -8423,11 +8436,11 @@ namespace _func651
 void FTLButton::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(FTLButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func651::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func652::func;
 	return execfunc(this);
 }
 
-namespace _func652
+namespace _func653
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FTLButton::MouseMove", typeid(void (FTLButton::*)(int , int , bool )), ".4157415641554189d541544189cc5589f531f6534889fb4883ec08", nullptr, 0, 0, &func);
@@ -8436,11 +8449,11 @@ namespace _func652
 void FTLButton::MouseMove(int mX, int mY, bool silent)
 {
 	typedef void (*custom_arg_funcptr_t)(FTLButton *this_arg, int mX_arg, int mY_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func652::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func653::func;
 	return execfunc(this, mX, mY, silent);
 }
 
-namespace _func653
+namespace _func654
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::deleteFile", typeid(void (*)(const std::string &)), "534889fb488b3f31f6e8????????85c07406", nullptr, 0, 0, &func);
@@ -8449,30 +8462,17 @@ namespace _func653
 void FileHelper::deleteFile(const std::string &fileName)
 {
 	typedef void (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func653::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func654::func;
 	return execfunc(fileName);
 }
 
-namespace _func654
+namespace _func655
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::getResourceFile", typeid(std::string (*)()), ".534889fb4883ec20", nullptr, 0, 0, &func);
 }
 
 std::string FileHelper::getResourceFile()
-{
-	typedef std::string (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func654::func;
-	return execfunc();
-}
-
-namespace _func655
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::getUserFolder", typeid(std::string (*)()), ".534889fb4883ec10", nullptr, 0, 0, &func);
-}
-
-std::string FileHelper::getUserFolder()
 {
 	typedef std::string (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func655::func;
@@ -8482,10 +8482,10 @@ std::string FileHelper::getUserFolder()
 namespace _func656
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::getSaveFile", typeid(std::string (*)()), ".534889fb4883ec20", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("FileHelper::getUserFolder", typeid(std::string (*)()), ".534889fb4883ec10", nullptr, 0, 0, &func);
 }
 
-std::string FileHelper::getSaveFile()
+std::string FileHelper::getUserFolder()
 {
 	typedef std::string (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func656::func;
@@ -8495,17 +8495,30 @@ std::string FileHelper::getSaveFile()
 namespace _func657
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("FileHelper::getSaveFile", typeid(std::string (*)()), ".534889fb4883ec20", nullptr, 0, 0, &func);
+}
+
+std::string FileHelper::getSaveFile()
+{
+	typedef std::string (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func657::func;
+	return execfunc();
+}
+
+namespace _func658
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::initFileHelper", typeid(void (*)()), ".4883ec28c605????????01", nullptr, 0, 0, &func);
 }
 
 void FileHelper::initFileHelper()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func657::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func658::func;
 	return execfunc();
 }
 
-namespace _func658
+namespace _func659
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::fileExists", typeid(bool (*)(const std::string &)), ".4883ec08488b3f31f6", nullptr, 0, 0, &func);
@@ -8514,11 +8527,11 @@ namespace _func658
 bool FileHelper::fileExists(const std::string &fileName)
 {
 	typedef bool (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func658::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func659::func;
 	return execfunc(fileName);
 }
 
-namespace _func659
+namespace _func660
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::renameFile", typeid(void (*)(const std::string &, const std::string &)), "!.488b36488b3f", nullptr, 0, 0, &func);
@@ -8527,11 +8540,11 @@ namespace _func659
 void FileHelper::renameFile(const std::string &fileName, const std::string &newName)
 {
 	typedef void (*custom_arg_funcptr_t)(const std::string &fileName_arg, const std::string &newName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func659::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func660::func;
 	return execfunc(fileName, newName);
 }
 
-namespace _func660
+namespace _func661
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::createBinaryFile", typeid(int (*)(const std::string &)), ".534889fb488b3f31f6", nullptr, 0, 0, &func);
@@ -8540,11 +8553,11 @@ namespace _func660
 int FileHelper::createBinaryFile(const std::string &fileName)
 {
 	typedef int (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func660::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func661::func;
 	return execfunc(fileName);
 }
 
-namespace _func661
+namespace _func662
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::saveFileExists", typeid(bool (*)()), ".4155bf????????415455534883ec28", nullptr, 0, 0, &func);
@@ -8553,19 +8566,6 @@ namespace _func661
 bool FileHelper::saveFileExists()
 {
 	typedef bool (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func661::func;
-	return execfunc();
-}
-
-namespace _func662
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::readSaveFile", typeid(int (*)()), ".4155bf????????415455534883ec28", nullptr, 0, 0, &func);
-}
-
-int FileHelper::readSaveFile()
-{
-	typedef int (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func662::func;
 	return execfunc();
 }
@@ -8573,10 +8573,10 @@ int FileHelper::readSaveFile()
 namespace _func663
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::readStatsFile", typeid(int (*)()), ".4155bf????????415455534883ec28", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("FileHelper::readSaveFile", typeid(int (*)()), ".4155bf????????415455534883ec28", nullptr, 0, 0, &func);
 }
 
-int FileHelper::readStatsFile()
+int FileHelper::readSaveFile()
 {
 	typedef int (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func663::func;
@@ -8586,10 +8586,10 @@ int FileHelper::readStatsFile()
 namespace _func664
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::createSaveFile", typeid(int (*)()), ".488b05????????488905", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("FileHelper::readStatsFile", typeid(int (*)()), ".4155bf????????415455534883ec28", nullptr, 0, 0, &func);
 }
 
-int FileHelper::createSaveFile()
+int FileHelper::readStatsFile()
 {
 	typedef int (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func664::func;
@@ -8599,10 +8599,10 @@ int FileHelper::createSaveFile()
 namespace _func665
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::createStatsFile", typeid(int (*)()), ".488b05????????488905", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("FileHelper::createSaveFile", typeid(int (*)()), ".488b05????????488905", nullptr, 0, 0, &func);
 }
 
-int FileHelper::createStatsFile()
+int FileHelper::createSaveFile()
 {
 	typedef int (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func665::func;
@@ -8612,12 +8612,12 @@ int FileHelper::createStatsFile()
 namespace _func666
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::deleteSaveFile", typeid(void (*)()), "!.53bf????????e8", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("FileHelper::createStatsFile", typeid(int (*)()), ".488b05????????488905", nullptr, 0, 0, &func);
 }
 
-void FileHelper::deleteSaveFile()
+int FileHelper::createStatsFile()
 {
-	typedef void (*custom_arg_funcptr_t)();
+	typedef int (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func666::func;
 	return execfunc();
 }
@@ -8625,10 +8625,10 @@ void FileHelper::deleteSaveFile()
 namespace _func667
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::deleteAllSaveFiles", typeid(void (*)()), ".534883ec20e8", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("FileHelper::deleteSaveFile", typeid(void (*)()), "!.53bf????????e8", nullptr, 0, 0, &func);
 }
 
-void FileHelper::deleteAllSaveFiles()
+void FileHelper::deleteSaveFile()
 {
 	typedef void (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func667::func;
@@ -8638,17 +8638,30 @@ void FileHelper::deleteAllSaveFiles()
 namespace _func668
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("FileHelper::deleteAllSaveFiles", typeid(void (*)()), ".534883ec20e8", nullptr, 0, 0, &func);
+}
+
+void FileHelper::deleteAllSaveFiles()
+{
+	typedef void (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func668::func;
+	return execfunc();
+}
+
+namespace _func669
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::getPosition", typeid(int (*)(int )), "!.8b05????????c3", nullptr, 0, 0, &func);
 }
 
 int FileHelper::getPosition(int file)
 {
 	typedef int (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func668::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func669::func;
 	return execfunc(file);
 }
 
-namespace _func669
+namespace _func670
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::readBinaryFile", typeid(int (*)(const std::string &)), ".53488b3f31f631c0", nullptr, 0, 0, &func);
@@ -8657,11 +8670,11 @@ namespace _func669
 int FileHelper::readBinaryFile(const std::string &fileName)
 {
 	typedef int (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func669::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func670::func;
 	return execfunc(fileName);
 }
 
-namespace _func670
+namespace _func671
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::writeFloat", typeid(bool (*)(int , float )), ".415741564155415455534883ec18", nullptr, 0, 0, &func);
@@ -8670,11 +8683,11 @@ namespace _func670
 bool FileHelper::writeFloat(int file, float data)
 {
 	typedef bool (*custom_arg_funcptr_t)(int file_arg, float data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func670::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func671::func;
 	return execfunc(file, data);
 }
 
-namespace _func671
+namespace _func672
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::writeInt", typeid(bool (*)(int , int )), ".415789f141564155415455534883ec18", nullptr, 0, 0, &func);
@@ -8683,11 +8696,11 @@ namespace _func671
 bool FileHelper::writeInt(int file, int data)
 {
 	typedef bool (*custom_arg_funcptr_t)(int file_arg, int data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func671::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func672::func;
 	return execfunc(file, data);
 }
 
-namespace _func672
+namespace _func673
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::writeData", typeid(bool (*)(int , void *, int )), ".41574156415541544989f455534863da4883ec18", nullptr, 0, 0, &func);
@@ -8696,11 +8709,11 @@ namespace _func672
 bool FileHelper::writeData(int file, void *data, int len)
 {
 	typedef bool (*custom_arg_funcptr_t)(int file_arg, void *data_arg, int len_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func672::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func673::func;
 	return execfunc(file, data, len);
 }
 
-namespace _func673
+namespace _func674
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::writeString", typeid(bool (*)(int , const std::string &)), ".41574156415541545589fd534883ec28", nullptr, 0, 0, &func);
@@ -8709,11 +8722,11 @@ namespace _func673
 bool FileHelper::writeString(int file, const std::string &data)
 {
 	typedef bool (*custom_arg_funcptr_t)(int file_arg, const std::string &data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func673::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func674::func;
 	return execfunc(file, data);
 }
 
-namespace _func674
+namespace _func675
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::closeBinaryFile", typeid(void (*)(int )), ".81fffffeff7f53", nullptr, 0, 0, &func);
@@ -8722,11 +8735,11 @@ namespace _func674
 void FileHelper::closeBinaryFile(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func674::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func675::func;
 	return execfunc(file);
 }
 
-namespace _func675
+namespace _func676
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::readString", typeid(std::string (*)(int )), ".4157415641554989fd4154555389f34883ec28", nullptr, 0, 0, &func);
@@ -8735,11 +8748,11 @@ namespace _func675
 std::string FileHelper::readString(int file)
 {
 	typedef std::string (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func675::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func676::func;
 	return execfunc(file);
 }
 
-namespace _func676
+namespace _func677
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::readFloat", typeid(float (*)(int )), ".41554154555389fb4883ec18", nullptr, 0, 0, &func);
@@ -8748,11 +8761,11 @@ namespace _func676
 float FileHelper::readFloat(int file)
 {
 	typedef float (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func676::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func677::func;
 	return execfunc(file);
 }
 
-namespace _func677
+namespace _func678
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::readInteger", typeid(int (*)(int )), ".41554154555389fb4883ec18", nullptr, 0, 0, &func);
@@ -8761,11 +8774,11 @@ namespace _func677
 int FileHelper::readInteger(int file)
 {
 	typedef int (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func677::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func678::func;
 	return execfunc(file);
 }
 
-namespace _func678
+namespace _func679
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::seekPosition", typeid(bool (*)(int , int )), ".4883ec0831d2", nullptr, 0, 0, &func);
@@ -8774,11 +8787,11 @@ namespace _func678
 bool FileHelper::seekPosition(int file, int pos)
 {
 	typedef bool (*custom_arg_funcptr_t)(int file_arg, int pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func678::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func679::func;
 	return execfunc(file, pos);
 }
 
-namespace _func679
+namespace _func680
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::readBuffer", typeid(char *(*)(int , int , bool )), ".4157415641554189d541545589fd0fb6fa534863de01df4883ec08", nullptr, 0, 0, &func);
@@ -8787,11 +8800,11 @@ namespace _func679
 char *FileHelper::readBuffer(int file, int len, bool nullTerminate)
 {
 	typedef char *(*custom_arg_funcptr_t)(int file_arg, int len_arg, bool nullTerminate_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func679::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func680::func;
 	return execfunc(file, len, nullTerminate);
 }
 
-namespace _func680
+namespace _func681
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::readData", typeid(void (*)(int , void *, int )), ".41554889f141545589d55389fb4883ec08", nullptr, 0, 0, &func);
@@ -8800,11 +8813,11 @@ namespace _func680
 void FileHelper::readData(int file, void *data, int len)
 {
 	typedef void (*custom_arg_funcptr_t)(int file_arg, void *data_arg, int len_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func680::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func681::func;
 	return execfunc(file, data, len);
 }
 
-namespace _func681
+namespace _func682
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Fire::OnLoop", typeid(void (Fire::*)()), "55534889fb4883ec0880bfd801000000", nullptr, 0, 0, &func);
@@ -8813,11 +8826,11 @@ namespace _func681
 void Fire::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(Fire *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func681::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func682::func;
 	return execfunc(this);
 }
 
-namespace _func682
+namespace _func683
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Fire::UpdateDeathTimer", typeid(void (Fire::*)(int )), ".5589f5534889fb4883ec18488b07ff505084c0", nullptr, 0, 0, &func);
@@ -8826,11 +8839,11 @@ namespace _func682
 void Fire::UpdateDeathTimer(int connectedFires)
 {
 	typedef void (*custom_arg_funcptr_t)(Fire *this_arg, int connectedFires_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func682::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func683::func;
 	return execfunc(this, connectedFires);
 }
 
-namespace _func683
+namespace _func684
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Fire::UpdateStartTimer", typeid(void (Fire::*)(int )), ".5589f5534889fb4883ec18488b07ff505084c0", nullptr, 0, 0, &func);
@@ -8839,11 +8852,11 @@ namespace _func683
 void Fire::UpdateStartTimer(int doorLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(Fire *this_arg, int doorLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func683::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func684::func;
 	return execfunc(this, doorLevel);
 }
 
-namespace _func684
+namespace _func685
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FocusWindow::SetPosition", typeid(void (FocusWindow::*)(Point )), "48897718c3", nullptr, 0, 0, &func);
@@ -8852,30 +8865,17 @@ namespace _func684
 void FocusWindow::SetPosition(Point p)
 {
 	typedef void (*custom_arg_funcptr_t)(FocusWindow *this_arg, Point p_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func684::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func685::func;
 	return execfunc(this, p);
 }
 
-namespace _func685
+namespace _func686
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("FocusWindow::Close", typeid(void (FocusWindow::*)()), ".c6470800c3", nullptr, 0, 0, &func);
 }
 
 void FocusWindow::Close()
-{
-	typedef void (*custom_arg_funcptr_t)(FocusWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func685::func;
-	return execfunc(this);
-}
-
-namespace _func686
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("FocusWindow::Open", typeid(void (FocusWindow::*)()), ".c6470801c3", nullptr, 0, 0, &func);
-}
-
-void FocusWindow::Open()
 {
 	typedef void (*custom_arg_funcptr_t)(FocusWindow *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func686::func;
@@ -8885,23 +8885,23 @@ void FocusWindow::Open()
 namespace _func687
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("FocusWindow::MouseClick", typeid(void (FocusWindow::*)(int , int )), "807f1400750af3c3", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("FocusWindow::Open", typeid(void (FocusWindow::*)()), ".c6470801c3", nullptr, 0, 0, &func);
 }
 
-void FocusWindow::MouseClick(int x, int y)
+void FocusWindow::Open()
 {
-	typedef void (*custom_arg_funcptr_t)(FocusWindow *this_arg, int x_arg, int y_arg);
+	typedef void (*custom_arg_funcptr_t)(FocusWindow *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func687::func;
-	return execfunc(this, x, y);
+	return execfunc(this);
 }
 
 namespace _func688
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("FocusWindow::MouseMove", typeid(void (FocusWindow::*)(int , int )), ".8b470c83f8ff7438", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("FocusWindow::MouseClick", typeid(void (FocusWindow::*)(int , int )), "807f1400750af3c3", nullptr, 0, 0, &func);
 }
 
-void FocusWindow::MouseMove(int x, int y)
+void FocusWindow::MouseClick(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(FocusWindow *this_arg, int x_arg, int y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func688::func;
@@ -8911,17 +8911,30 @@ void FocusWindow::MouseMove(int x, int y)
 namespace _func689
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("FocusWindow::MouseMove", typeid(void (FocusWindow::*)(int , int )), ".8b470c83f8ff7438", nullptr, 0, 0, &func);
+}
+
+void FocusWindow::MouseMove(int x, int y)
+{
+	typedef void (*custom_arg_funcptr_t)(FocusWindow *this_arg, int x_arg, int y_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func689::func;
+	return execfunc(this, x, y);
+}
+
+namespace _func690
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("FocusWindow::constructor", typeid(void (FocusWindow::*)()), "!.53baffffffff4889fb48c7", nullptr, 0, 0, &func);
 }
 
 void FocusWindow::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(FocusWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func689::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func690::func;
 	return execfunc(this);
 }
 
-namespace _func690
+namespace _func691
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("GameOver::OpenText", typeid(void (GameOver::*)(const std::string &)), "415741564155415455534889fb488d7f704881ecf8000000", nullptr, 0, 0, &func);
@@ -8930,30 +8943,17 @@ namespace _func690
 void GameOver::OpenText(const std::string &text)
 {
 	typedef void (*custom_arg_funcptr_t)(GameOver *this_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func690::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func691::func;
 	return execfunc(this, text);
 }
 
-namespace _func691
+namespace _func692
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("GameOver::OnRender", typeid(void (GameOver::*)()), "415741564155415455534889fb4881ec1802000080bfd800000000", nullptr, 0, 0, &func);
 }
 
 void GameOver::OnRender()
-{
-	typedef void (*custom_arg_funcptr_t)(GameOver *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func691::func;
-	return execfunc(this);
-}
-
-namespace _func692
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("GameOver::OnLoop", typeid(void (GameOver::*)()), "4154554889fdbf????????534883ec40", nullptr, 0, 0, &func);
-}
-
-void GameOver::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(GameOver *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func692::func;
@@ -8963,17 +8963,30 @@ void GameOver::OnLoop()
 namespace _func693
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("GameOver::OnLoop", typeid(void (GameOver::*)()), "4154554889fdbf????????534883ec40", nullptr, 0, 0, &func);
+}
+
+void GameOver::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(GameOver *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func693::func;
+	return execfunc(this);
+}
+
+namespace _func694
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("GenericButton::SetLocation", typeid(void (GenericButton::*)(Point )), "8b57084889f08b4f0c48c1f82039d6", nullptr, 0, 0, &func);
 }
 
 void GenericButton::SetLocation(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(GenericButton *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func693::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func694::func;
 	return execfunc(this, pos);
 }
 
-namespace _func694
+namespace _func695
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("GenericButton::SetActive", typeid(void (GenericButton::*)(bool )), ".4084f640887748", nullptr, 0, 0, &func);
@@ -8982,11 +8995,11 @@ namespace _func694
 void GenericButton::SetActive(bool active)
 {
 	typedef void (*custom_arg_funcptr_t)(GenericButton *this_arg, bool active_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func694::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func695::func;
 	return execfunc(this, active);
 }
 
-namespace _func695
+namespace _func696
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("GenericButton::MouseMove", typeid(void (GenericButton::*)(int , int , bool )), ".8b4710440fb6474939c6", nullptr, 0, 0, &func);
@@ -8995,36 +9008,23 @@ namespace _func695
 void GenericButton::MouseMove(int x, int y, bool silent)
 {
 	typedef void (*custom_arg_funcptr_t)(GenericButton *this_arg, int x_arg, int y_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func695::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func696::func;
 	return execfunc(this, x, y, silent);
 }
 
-namespace _func696
+namespace _func697
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("GenericButton::DO_NOT_HOOK_1", typeid(void (GenericButton::*)()), "!.f3c3662e0f1f8400000000000f1f4000", nullptr, 0, 0, &func);
 }
 
-namespace _func697
+namespace _func698
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("GenericButton::OnClick", typeid(void (GenericButton::*)()), "!.f3c3662e0f1f8400000000000f1f4000", nullptr, 0, 0, &func);
 }
 
 void GenericButton::OnClick()
-{
-	typedef void (*custom_arg_funcptr_t)(GenericButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func697::func;
-	return execfunc(this);
-}
-
-namespace _func698
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("GenericButton::OnRightClick", typeid(void (GenericButton::*)()), "!.f3c3662e0f1f8400000000000f1f4000", nullptr, 0, 0, &func);
-}
-
-void GenericButton::OnRightClick()
 {
 	typedef void (*custom_arg_funcptr_t)(GenericButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func698::func;
@@ -9034,10 +9034,10 @@ void GenericButton::OnRightClick()
 namespace _func699
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("GenericButton::ResetPrimitives", typeid(void (GenericButton::*)()), "!.f3c3662e0f1f8400000000000f1f4000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("GenericButton::OnRightClick", typeid(void (GenericButton::*)()), "!.f3c3662e0f1f8400000000000f1f4000", nullptr, 0, 0, &func);
 }
 
-void GenericButton::ResetPrimitives()
+void GenericButton::OnRightClick()
 {
 	typedef void (*custom_arg_funcptr_t)(GenericButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func699::func;
@@ -9047,17 +9047,30 @@ void GenericButton::ResetPrimitives()
 namespace _func700
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("GenericButton::ResetPrimitives", typeid(void (GenericButton::*)()), "!.f3c3662e0f1f8400000000000f1f4000", nullptr, 0, 0, &func);
+}
+
+void GenericButton::ResetPrimitives()
+{
+	typedef void (*custom_arg_funcptr_t)(GenericButton *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func700::func;
+	return execfunc(this);
+}
+
+namespace _func701
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("font_text_width", typeid(float (*)(freetype::font_data &, const char *, float )), "85ff7e7e", nullptr, 0, 0, &func);
 }
 
 float __stdcall font_text_width(freetype::font_data &fontData, const char *str, float size)
 {
 	typedef float (*custom_arg_funcptr_t)(freetype::font_data &fontData_arg, const char *str_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func700::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func701::func;
 	return execfunc(fontData, str, size);
 }
 
-namespace _func701
+namespace _func702
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("random32", typeid(int (*)()), "48b82d7f954c2df45158480faf05????????4883c001488905????????48c1e821", nullptr, 0, 0, &func);
@@ -9066,11 +9079,11 @@ namespace _func701
 int __stdcall random32()
 {
 	typedef int (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func701::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func702::func;
 	return execfunc();
 }
 
-namespace _func702
+namespace _func703
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("srandom32", typeid(void (*)(unsigned int )), ".89f8488905", nullptr, 0, 0, &func);
@@ -9079,11 +9092,11 @@ namespace _func702
 void __stdcall srandom32(unsigned int seed)
 {
 	typedef void (*custom_arg_funcptr_t)(unsigned int seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func702::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func703::func;
 	return execfunc(seed);
 }
 
-namespace _func703
+namespace _func704
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("getSkillBonus", typeid(float (*)(int , int )), "83ff05772d89ff", nullptr, 0, 0, &func);
@@ -9092,11 +9105,11 @@ namespace _func703
 float __stdcall getSkillBonus(int skill, int level)
 {
 	typedef float (*custom_arg_funcptr_t)(int skill_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func703::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func704::func;
 	return execfunc(skill, level);
 }
 
-namespace _func704
+namespace _func705
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("GetValue", typeid(void (*)(ResourceEvent &, const std::string &, int , int )), "41554189cd41544c63e2554889fd534889f3", nullptr, 0, 0, &func);
@@ -9105,11 +9118,11 @@ namespace _func704
 void __stdcall GetValue(ResourceEvent &ref, const std::string &type, int level, int worldLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(ResourceEvent &ref_arg, const std::string &type_arg, int level_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func704::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func705::func;
 	return execfunc(ref, type, level, worldLevel);
 }
 
-namespace _func705
+namespace _func706
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("GenerateReward", typeid(void (*)(ResourceEvent &, RewardDesc &, int )), ".41574989f741564155415455534881ec08020000", nullptr, 0, 0, &func);
@@ -9118,11 +9131,11 @@ namespace _func705
 void __stdcall GenerateReward(ResourceEvent &ref, RewardDesc &reward, int worldLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(ResourceEvent &ref_arg, RewardDesc &reward_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func705::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func706::func;
 	return execfunc(ref, reward, worldLevel);
 }
 
-namespace _func706
+namespace _func707
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("sys_graphics_set_window_title", typeid(void (*)(char *)), "534889fb4883ec20488b3d????????e8????????", nullptr, 0, 0, &func);
@@ -9131,11 +9144,11 @@ namespace _func706
 void __stdcall sys_graphics_set_window_title(char *title)
 {
 	typedef void (*custom_arg_funcptr_t)(char *title_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func706::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func707::func;
 	return execfunc(title);
 }
 
-namespace _func707
+namespace _func708
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("graphics_clear", typeid(void (*)(float , float , float , float , float , unsigned int )), "0f57ed4883ec2889fa0f2ee5", nullptr, 0, 0, &func);
@@ -9144,11 +9157,11 @@ namespace _func707
 void __stdcall graphics_clear(float r, float g, float b, float a, float depth, unsigned int stencil)
 {
 	typedef void (*custom_arg_funcptr_t)(float r_arg, float g_arg, float b_arg, float a_arg, float depth_arg, unsigned int stencil_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func707::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func708::func;
 	return execfunc(r, g, b, a, depth, stencil);
 }
 
-namespace _func708
+namespace _func709
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Globals::GetNextPoint", typeid(Pointf (*)(Pointf , float , Pointf )), "55534883ec48660fd6542408", nullptr, 0, 0, &func);
@@ -9157,11 +9170,11 @@ namespace _func708
 Pointf Globals::GetNextPoint(Pointf current, float mag_speed, Pointf dest)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(Pointf current_arg, float mag_speed_arg, Pointf dest_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func708::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func709::func;
 	return execfunc(current, mag_speed, dest);
 }
 
-namespace _func709
+namespace _func710
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Globals::GetNextSpaceId", typeid(int (*)()), ".8b15????????b865000000", nullptr, 0, 0, &func);
@@ -9170,11 +9183,11 @@ namespace _func709
 int Globals::GetNextSpaceId()
 {
 	typedef int (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func709::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func710::func;
 	return execfunc();
 }
 
-namespace _func710
+namespace _func711
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Globals::AimAhead", typeid(float (*)(Pointf , Pointf , float )), ".4883ec18f30f59d2660fd60424488b1424", nullptr, 0, 0, &func);
@@ -9183,11 +9196,11 @@ namespace _func710
 float Globals::AimAhead(Pointf delta, Pointf vr, float muzzleV)
 {
 	typedef float (*custom_arg_funcptr_t)(Pointf delta_arg, Pointf vr_arg, float muzzleV_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func710::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func711::func;
 	return execfunc(delta, vr, muzzleV);
 }
 
-namespace _func711
+namespace _func712
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Globals::GetNextPoint", typeid(Pointf (*)(Pointf , float , float )), ".4883ec38f30f5915", nullptr, 0, 0, &func);
@@ -9196,39 +9209,39 @@ namespace _func711
 Pointf Globals::GetNextPoint(Pointf current, float mag_speed, float heading)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(Pointf current_arg, float mag_speed_arg, float heading_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func711::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func712::func;
 	return execfunc(current, mag_speed, heading);
 }
 
 TextLibrary *Global_Globals_Library;
 
-namespace _var712
+namespace _var713
 {
     static VariableDefinition varObj("Global_Globals_Library", "!4189e8488d4c2460ba010000004c89e7be(???????\?)", &Global_Globals_Library);
 }
 
 int *Globals_GetNextSpaceId_id;
 
-namespace _var713
+namespace _var714
 {
     static VariableDefinition varObj("Globals_GetNextSpaceId_id", "!8b15(???????\?)b865000000", &Globals_GetNextSpaceId_id, true, true);
 }
 
 bool *Globals_RNG;
 
-namespace _var714
+namespace _var715
 {
     static VariableDefinition varObj("Globals_RNG", "!85c00f9505(???????\?)89ef", &Globals_RNG, true, true);
 }
 
 FILE *ftl_log_logfile;
 
-namespace _var715
+namespace _var716
 {
     static VariableDefinition varObj("ftl_log_logfile", "!488d4c24184889dabe01000000e8????????488b3d(???????\?)", &ftl_log_logfile, true, true);
 }
 
-namespace _func716
+namespace _func717
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("HackBox::constructor", typeid(void (HackBox::*)(Point , HackingSystem *, ShipManager *)), "41554989cd31c94154554889d5534889fb4c8da3180300004883ec68", nullptr, 0, 0, &func);
@@ -9237,11 +9250,11 @@ namespace _func716
 void HackBox::constructor(Point pos, HackingSystem *sys, ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(HackBox *this_arg, Point pos_arg, HackingSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func716::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func717::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func717
+namespace _func718
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("HackingDrone::SetMovementTarget", typeid(void (HackingDrone::*)(Targetable *)), "554889f5534889fb4883ec184885f60f84b3000000", nullptr, 0, 0, &func);
@@ -9250,11 +9263,11 @@ namespace _func717
 void HackingDrone::SetMovementTarget(Targetable *target)
 {
 	typedef void (*custom_arg_funcptr_t)(HackingDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func717::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func718::func;
 	return execfunc(this, target);
 }
 
-namespace _func718
+namespace _func719
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("HackingDrone::CollisionMoving", typeid(CollisionResponse (HackingDrone::*)(Pointf , Pointf , Damage , bool )), ".4154554889f5534889fb4883ec60", nullptr, 0, 0, &func);
@@ -9263,11 +9276,11 @@ namespace _func718
 CollisionResponse HackingDrone::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse (*custom_arg_funcptr_t)(HackingDrone *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func718::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func719::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func719
+namespace _func720
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("HackingDrone::OnLoop", typeid(void (HackingDrone::*)()), ".55bd05000000534889fb4883ec48", nullptr, 0, 0, &func);
@@ -9276,19 +9289,6 @@ namespace _func719
 void HackingDrone::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(HackingDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func719::func;
-	return execfunc(this);
-}
-
-namespace _func720
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("HackingSystem::BlowHackingDrone", typeid(void (HackingSystem::*)()), "80bf60020000007507f3c3", nullptr, 0, 0, &func);
-}
-
-void HackingSystem::BlowHackingDrone()
-{
-	typedef void (*custom_arg_funcptr_t)(HackingSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func720::func;
 	return execfunc(this);
 }
@@ -9296,10 +9296,10 @@ void HackingSystem::BlowHackingDrone()
 namespace _func721
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("HackingSystem::OnLoop", typeid(void (HackingSystem::*)()), "55534889fb4883ec38e8????????80bb7002000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("HackingSystem::BlowHackingDrone", typeid(void (HackingSystem::*)()), "80bf60020000007507f3c3", nullptr, 0, 0, &func);
 }
 
-void HackingSystem::OnLoop()
+void HackingSystem::BlowHackingDrone()
 {
 	typedef void (*custom_arg_funcptr_t)(HackingSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func721::func;
@@ -9309,17 +9309,30 @@ void HackingSystem::OnLoop()
 namespace _func722
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("HackingSystem::OnLoop", typeid(void (HackingSystem::*)()), "55534889fb4883ec38e8????????80bb7002000000", nullptr, 0, 0, &func);
+}
+
+void HackingSystem::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(HackingSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func722::func;
+	return execfunc(this);
+}
+
+namespace _func723
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("HackingSystem::SoundLoop", typeid(bool (HackingSystem::*)()), "5380bf44020000004889fb75??31c05bc30f1f8000000000e8????????83f8ff", nullptr, 0, 0, &func);
 }
 
 bool HackingSystem::SoundLoop()
 {
 	typedef bool (*custom_arg_funcptr_t)(HackingSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func722::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func723::func;
 	return execfunc(this);
 }
 
-namespace _func723
+namespace _func724
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::constructor", typeid(void (InfoBox::*)()), "5331d24889fb31f64883ec10e8????????488d7b10", nullptr, 0, 0, &func);
@@ -9328,11 +9341,11 @@ namespace _func723
 void InfoBox::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func723::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func724::func;
 	return execfunc(this);
 }
 
-namespace _func724
+namespace _func725
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetBlueprintWeapon", typeid(void (InfoBox::*)(const WeaponBlueprint *, int , bool , int )), ".41574589c7415641554189d531d24154554889f5534889fb4c8d63304883ec58", nullptr, 0, 0, &func);
@@ -9341,11 +9354,11 @@ namespace _func724
 void InfoBox::SetBlueprintWeapon(const WeaponBlueprint *bp, int status, bool hasWeaponSystem, int yShift)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, const WeaponBlueprint *bp_arg, int status_arg, bool hasWeaponSystem_arg, int yShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func724::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func725::func;
 	return execfunc(this, bp, status, hasWeaponSystem, yShift);
 }
 
-namespace _func725
+namespace _func726
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetBlueprintDrone", typeid(void (InfoBox::*)(const DroneBlueprint *, int , bool , int )), ".41574156415541544989f4488d761055534889fb488d7f104c8d73304881ec18020000", nullptr, 0, 0, &func);
@@ -9354,11 +9367,11 @@ namespace _func725
 void InfoBox::SetBlueprintDrone(const DroneBlueprint *bp, int status, bool hasDroneSystem, int yShift)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, const DroneBlueprint *bp_arg, int status_arg, bool hasDroneSystem_arg, int yShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func725::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func726::func;
 	return execfunc(this, bp, status, hasDroneSystem, yShift);
 }
 
-namespace _func726
+namespace _func727
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetBlueprint", typeid(void (InfoBox::*)(const ItemBlueprint *)), "!.4154554889f5488d7610534889fb", nullptr, 0, 0, &func);
@@ -9367,11 +9380,11 @@ namespace _func726
 void InfoBox::SetBlueprint(const ItemBlueprint *bp)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, const ItemBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func726::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func727::func;
 	return execfunc(this, bp);
 }
 
-namespace _func727
+namespace _func728
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetBlueprintCrew", typeid(void (InfoBox::*)(const CrewBlueprint *, int , bool )), ".415741564c8d771041554989f54154554889fd53488d5e104881ecc8000000", nullptr, 0, 0, &func);
@@ -9380,11 +9393,11 @@ namespace _func727
 void InfoBox::SetBlueprintCrew(const CrewBlueprint *bp, int yShift, bool detailedCrew)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, const CrewBlueprint *bp_arg, int yShift_arg, bool detailedCrew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func727::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func728::func;
 	return execfunc(this, bp, yShift, detailedCrew);
 }
 
-namespace _func728
+namespace _func729
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetBlueprintAugment", typeid(void (InfoBox::*)(const AugmentBlueprint *)), ".4154554889f5488d7610534889fb", nullptr, 0, 0, &func);
@@ -9393,11 +9406,11 @@ namespace _func728
 void InfoBox::SetBlueprintAugment(const AugmentBlueprint *bp)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, const AugmentBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func728::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func729::func;
 	return execfunc(this, bp);
 }
 
-namespace _func729
+namespace _func730
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::IsEmpty", typeid(bool (InfoBox::*)()), ".55534889fb4883ec28837f7cff", nullptr, 0, 0, &func);
@@ -9406,11 +9419,11 @@ namespace _func729
 bool InfoBox::IsEmpty()
 {
 	typedef bool (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func729::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func730::func;
 	return execfunc(this);
 }
 
-namespace _func730
+namespace _func731
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::CalcBoxHeight", typeid(int (InfoBox::*)()), ".4156415541544989fc55534881eca0000000837f7401", nullptr, 0, 0, &func);
@@ -9419,11 +9432,11 @@ namespace _func730
 int InfoBox::CalcBoxHeight()
 {
 	typedef int (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func730::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func731::func;
 	return execfunc(this);
 }
 
-namespace _func731
+namespace _func732
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetSystemId", typeid(void (InfoBox::*)(int , int , int , int , int , int )), ".4157415641554589cd41544189f455534889fb4883ec2883feff", nullptr, 0, 0, &func);
@@ -9432,11 +9445,11 @@ namespace _func731
 void InfoBox::SetSystemId(int systemId, int maxPower, int currentLevel, int upgrade, int yShift, int forceSystemWidth)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, int systemId_arg, int maxPower_arg, int currentLevel_arg, int upgrade_arg, int yShift_arg, int forceSystemWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func731::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func732::func;
 	return execfunc(this, systemId, maxPower, currentLevel, upgrade, yShift, forceSystemWidth);
 }
 
-namespace _func732
+namespace _func733
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetDescription", typeid(void (InfoBox::*)(Description *, int , int , InfoBox::ExpandDir )), ".41564589c641554189d541544189cc554889f5534889fb", nullptr, 0, 0, &func);
@@ -9445,11 +9458,11 @@ namespace _func732
 void InfoBox::SetDescription(Description *desc, int width, int height, InfoBox::ExpandDir dir)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, Description *desc_arg, int width_arg, int height_arg, InfoBox::ExpandDir dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func732::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func733::func;
 	return execfunc(this, desc, width, height, dir);
 }
 
-namespace _func733
+namespace _func734
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetText", typeid(void (InfoBox::*)(const std::string &, const std::string &, int , int , InfoBox::ExpandDir )), ".41574989ff41564589ce41554d8d6f1041545589cd534489c34881eca8000000", nullptr, 0, 0, &func);
@@ -9458,11 +9471,11 @@ namespace _func733
 void InfoBox::SetText(const std::string &title, const std::string &text, int width, int height, InfoBox::ExpandDir dir)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, const std::string &title_arg, const std::string &text_arg, int width_arg, int height_arg, InfoBox::ExpandDir dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func733::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func734::func;
 	return execfunc(this, title, text, width, height, dir);
 }
 
-namespace _func734
+namespace _func735
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::SetSystem", typeid(void (InfoBox::*)(ShipSystem *, int , int , int )), ".4157415641554154554889f5534889fb4883ec384885f6", nullptr, 0, 0, &func);
@@ -9471,11 +9484,11 @@ namespace _func734
 void InfoBox::SetSystem(ShipSystem *system, int upgrade, int yShift, int forceSystemWidth)
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg, ShipSystem *system_arg, int upgrade_arg, int yShift_arg, int forceSystemWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func734::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func735::func;
 	return execfunc(this, system, upgrade, yShift, forceSystemWidth);
 }
 
-namespace _func735
+namespace _func736
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::Clear", typeid(void (InfoBox::*)()), ".55be????????534889fb4883ec28", nullptr, 0, 0, &func);
@@ -9484,11 +9497,11 @@ namespace _func735
 void InfoBox::Clear()
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func735::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func736::func;
 	return execfunc(this);
 }
 
-namespace _func736
+namespace _func737
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InfoBox::OnRender", typeid(void (InfoBox::*)()), ".4157415641554989fd415455534881ec68020000", nullptr, 0, 0, &func);
@@ -9497,25 +9510,25 @@ namespace _func736
 void InfoBox::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func736::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func737::func;
 	return execfunc(this);
 }
 
 GL_Color *Global_InfoBox_detailsBarOff;
 
-namespace _var737
+namespace _var738
 {
     static VariableDefinition varObj("Global_InfoBox_detailsBarOff", "!f30f2a8424b0000000443b642420ba(???????\?)b8(???????\?)", &Global_InfoBox_detailsBarOff);
 }
 
 GL_Color *Global_InfoBox_detailsBarOn;
 
-namespace _var738
+namespace _var739
 {
     static VariableDefinition varObj("Global_InfoBox_detailsBarOn", "", &Global_InfoBox_detailsBarOn);
 }
 
-namespace _func739
+namespace _func740
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InputBox::OnRender", typeid(void (InputBox::*)()), "534889fb4883ec??807f08??0f84????????488d7c2410", nullptr, 0, 0, &func);
@@ -9524,11 +9537,11 @@ namespace _func739
 void InputBox::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(InputBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func739::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func740::func;
 	return execfunc(this);
 }
 
-namespace _func740
+namespace _func741
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InputBox::TextInput", typeid(void (InputBox::*)(int )), ".415683fe??415541545589f5", nullptr, 0, 0, &func);
@@ -9537,11 +9550,11 @@ namespace _func740
 void InputBox::TextInput(int ch)
 {
 	typedef void (*custom_arg_funcptr_t)(InputBox *this_arg, int ch_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func740::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func741::func;
 	return execfunc(this, ch);
 }
 
-namespace _func741
+namespace _func742
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InputBox::TextEvent", typeid(void (InputBox::*)(CEvent::TextEvent )), ".4155415455534889fb4883ec??83fe??0f84????????0f8e????????", nullptr, 0, 0, &func);
@@ -9550,11 +9563,11 @@ namespace _func741
 void InputBox::TextEvent(CEvent::TextEvent event)
 {
 	typedef void (*custom_arg_funcptr_t)(InputBox *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func741::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func742::func;
 	return execfunc(this, event);
 }
 
-namespace _func742
+namespace _func743
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("InputBox::StartInput", typeid(void (InputBox::*)()), ".534889fb488d7f3831d2", nullptr, 0, 0, &func);
@@ -9563,11 +9576,11 @@ namespace _func742
 void InputBox::StartInput()
 {
 	typedef void (*custom_arg_funcptr_t)(InputBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func742::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func743::func;
 	return execfunc(this);
 }
 
-namespace _func743
+namespace _func744
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("IonDrone::GetRoomDamage", typeid(Damage (IonDrone::*)()), "554889f5534889fb4883ec08c70700000000", nullptr, 0, 0, &func);
@@ -9576,11 +9589,11 @@ namespace _func743
 Damage IonDrone::GetRoomDamage()
 {
 	typedef Damage (*custom_arg_funcptr_t)(IonDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func743::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func744::func;
 	return execfunc(this);
 }
 
-namespace _func744
+namespace _func745
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("IonDrone::constructor", typeid(void (IonDrone::*)(int , DroneBlueprint *)), ".41570f57c941560f28c1", nullptr, 0, 0, &func);
@@ -9589,11 +9602,11 @@ namespace _func744
 void IonDrone::constructor(int iShipId, DroneBlueprint *blueprint)
 {
 	typedef void (*custom_arg_funcptr_t)(IonDrone *this_arg, int iShipId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func744::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func745::func;
 	return execfunc(this, iShipId, blueprint);
 }
 
-namespace _func745
+namespace _func746
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("IonDroneAnimation::constructor", typeid(void (IonDroneAnimation::*)(int , Pointf , bool )), "41574156415541544189d45589f5be", nullptr, 0, 0, &func);
@@ -9602,11 +9615,11 @@ namespace _func745
 void IonDroneAnimation::constructor(int iShipId, Pointf position, bool enemy)
 {
 	typedef void (*custom_arg_funcptr_t)(IonDroneAnimation *this_arg, int iShipId_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func745::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func746::func;
 	return execfunc(this, iShipId, position, enemy);
 }
 
-namespace _func746
+namespace _func747
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("IonDroneAnimation::UpdateShooting", typeid(void (IonDroneAnimation::*)()), ".4155415455488dafd8080000", nullptr, 0, 0, &func);
@@ -9615,11 +9628,11 @@ namespace _func746
 void IonDroneAnimation::UpdateShooting()
 {
 	typedef void (*custom_arg_funcptr_t)(IonDroneAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func746::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func747::func;
 	return execfunc(this);
 }
 
-namespace _func747
+namespace _func748
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ItemStoreBox::constructor", typeid(void (ItemStoreBox::*)(ShipManager *, const std::string &)), "41544989f4554889d5534889fb4883ec20488b02", nullptr, 0, 0, &func);
@@ -9628,18 +9641,18 @@ namespace _func747
 void ItemStoreBox::constructor(ShipManager *ship, const std::string &resourceName)
 {
 	typedef void (*custom_arg_funcptr_t)(ItemStoreBox *this_arg, ShipManager *ship_arg, const std::string &resourceName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func747::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func748::func;
 	return execfunc(this, ship, resourceName);
 }
 
 std::vector<std::string> *Global_OptionsScreen_languageList;
 
-namespace _var748
+namespace _var749
 {
     static VariableDefinition varObj("Global_OptionsScreen_languageList", "!4889ee480335(???????\?)", &Global_OptionsScreen_languageList, true, true);
 }
 
-namespace _func749
+namespace _func750
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("LanguageChooser::OnRender", typeid(void (LanguageChooser::*)()), ".4157bef001000041564155", nullptr, 0, 0, &func);
@@ -9648,11 +9661,11 @@ namespace _func749
 void LanguageChooser::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(LanguageChooser *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func749::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func750::func;
 	return execfunc(this);
 }
 
-namespace _func750
+namespace _func751
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("LaserBlast::OnUpdate", typeid(void (LaserBlast::*)()), "534889fb4883ec1080bfc400000000745f", nullptr, 0, 0, &func);
@@ -9661,11 +9674,11 @@ namespace _func750
 void LaserBlast::OnUpdate()
 {
 	typedef void (*custom_arg_funcptr_t)(LaserBlast *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func750::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func751::func;
 	return execfunc(this);
 }
 
-namespace _func751
+namespace _func752
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("LaserBlast::OnInit", typeid(void (LaserBlast::*)()), "538b477c4889fb394778c7474001000000", nullptr, 0, 0, &func);
@@ -9674,25 +9687,25 @@ namespace _func751
 void LaserBlast::OnInit()
 {
 	typedef void (*custom_arg_funcptr_t)(LaserBlast *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func751::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func752::func;
 	return execfunc(this);
 }
 
 void **VTable_LaserBlast;
 
-namespace _var752
+namespace _var753
 {
     static VariableDefinition varObj("VTable_LaserBlast", "!b8b7600bb64589e84c89e741f7ed4489e849c70424(???????\?)c1f81f49c7442408(???????\?)", &VTable_LaserBlast);
 }
 
 void **VTable_Targetable_LaserBlast;
 
-namespace _var753
+namespace _var754
 {
     static VariableDefinition varObj("VTable_Targetable_LaserBlast", "", &VTable_Targetable_LaserBlast);
 }
 
-namespace _func754
+namespace _func755
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("LocationEvent::ClearEvent", typeid(void (LocationEvent::*)(bool )), "4157415641554154554889fd534883ec3883bfc404000001", nullptr, 0, 0, &func);
@@ -9701,11 +9714,11 @@ namespace _func754
 void LocationEvent::ClearEvent(bool force)
 {
 	typedef void (*custom_arg_funcptr_t)(LocationEvent *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func754::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func755::func;
 	return execfunc(this, force);
 }
 
-namespace _func755
+namespace _func756
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("LocationEvent::constructor", typeid(void (LocationEvent::*)()), "53be????????4889fb4883ec10488d54240fe8????????488d7b18", nullptr, 0, 0, &func);
@@ -9714,11 +9727,11 @@ namespace _func755
 void LocationEvent::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(LocationEvent *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func755::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func756::func;
 	return execfunc(this);
 }
 
-namespace _func756
+namespace _func757
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("LockdownShard::Update", typeid(void (LockdownShard::*)()), "534889fbbf????????e8????????f30f5905????????f30f5883d8000000", nullptr, 0, 0, &func);
@@ -9727,19 +9740,6 @@ namespace _func756
 void LockdownShard::Update()
 {
 	typedef void (*custom_arg_funcptr_t)(LockdownShard *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func756::func;
-	return execfunc(this);
-}
-
-namespace _func757
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("MainMenu::constructor", typeid(void (MainMenu::*)()), "41570f57c04156415541544c8d673855534889fb4c8dbbe80100004c8db378020000488dab08030000", nullptr, 0, 0, &func);
-}
-
-void MainMenu::constructor()
-{
-	typedef void (*custom_arg_funcptr_t)(MainMenu *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func757::func;
 	return execfunc(this);
 }
@@ -9747,10 +9747,10 @@ void MainMenu::constructor()
 namespace _func758
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("MainMenu::OnRender", typeid(void (MainMenu::*)()), ".415741564155415455534889fb4881ecf8040000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("MainMenu::constructor", typeid(void (MainMenu::*)()), "41570f57c04156415541544c8d673855534889fb4c8dbbe80100004c8db378020000488dab08030000", nullptr, 0, 0, &func);
 }
 
-void MainMenu::OnRender()
+void MainMenu::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(MainMenu *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func758::func;
@@ -9760,17 +9760,30 @@ void MainMenu::OnRender()
 namespace _func759
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("MainMenu::OnRender", typeid(void (MainMenu::*)()), ".415741564155415455534889fb4881ecf8040000", nullptr, 0, 0, &func);
+}
+
+void MainMenu::OnRender()
+{
+	typedef void (*custom_arg_funcptr_t)(MainMenu *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func759::func;
+	return execfunc(this);
+}
+
+namespace _func760
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("MainMenu::Open", typeid(bool (MainMenu::*)()), ".415741564155415455534889fb488dbfa02200004881ec08020000", nullptr, 0, 0, &func);
 }
 
 bool MainMenu::Open()
 {
 	typedef bool (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func759::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func760::func;
 	return execfunc(this);
 }
 
-namespace _func760
+namespace _func761
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MainMenu::MouseMove", typeid(void (MainMenu::*)(int , int )), ".4155415455534889fb4883ec3880bf????000000", nullptr, 0, 0, &func);
@@ -9779,11 +9792,11 @@ namespace _func760
 void MainMenu::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(MainMenu *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func760::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func761::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func761
+namespace _func762
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MainMenu::OnLoop", typeid(void (MainMenu::*)()), ".415741564155415455534889fb4881ec????0000", nullptr, 0, 0, &func);
@@ -9792,11 +9805,11 @@ namespace _func761
 void MainMenu::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func761::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func762::func;
 	return execfunc(this);
 }
 
-namespace _func762
+namespace _func763
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MainMenu::MouseClick", typeid(void (MainMenu::*)(int , int )), ".534889fb4883ec5080bf????000000", nullptr, 0, 0, &func);
@@ -9805,17 +9818,17 @@ namespace _func762
 void MainMenu::MouseClick(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(MainMenu *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func762::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func763::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func763
+namespace _func764
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MantisAnimation::__DO_NOT_HOOK_1", typeid(void (MantisAnimation::*)()), "!c3660f1f840000000000f3c3660f1f440000f3c3660f1f440000", nullptr, 0, 0, &func);
 }
 
-namespace _func764
+namespace _func765
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MantisAnimation::GetDeathSound", typeid(std::string (MantisAnimation::*)()), ".53be????????4889fb4883ec10", nullptr, 0, 0, &func);
@@ -9824,17 +9837,17 @@ namespace _func764
 std::string MantisAnimation::GetDeathSound()
 {
 	typedef std::string (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func764::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func765::func;
 	return execfunc(this);
 }
 
-namespace _func765
+namespace _func766
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MantisAnimation::__DO_NOT_HOOK_2", typeid(void (MantisAnimation::*)()), ".53486347584889fb488b5710", nullptr, 0, 0, &func);
 }
 
-namespace _func766
+namespace _func767
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MantisAnimation::FireShot", typeid(bool (MantisAnimation::*)()), ".53486347584889fb488b5710", nullptr, 0, 0, &func);
@@ -9843,17 +9856,17 @@ namespace _func766
 bool MantisAnimation::FireShot()
 {
 	typedef bool (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func766::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func767::func;
 	return execfunc(this);
 }
 
-namespace _func767
+namespace _func768
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MantisAnimation::__DO_NOT_HOOK_3", typeid(void (MantisAnimation::*)()), ".534889fb4883ec30803d????????007577e8????????89c1", nullptr, 0, 0, &func);
 }
 
-namespace _func768
+namespace _func769
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MantisAnimation::GetShootingSound", typeid(std::string (MantisAnimation::*)()), ".534889fb4883ec30803d????????007577e8????????89c1", nullptr, 0, 0, &func);
@@ -9862,19 +9875,6 @@ namespace _func768
 std::string MantisAnimation::GetShootingSound()
 {
 	typedef std::string (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func768::func;
-	return execfunc(this);
-}
-
-namespace _func769
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("MenuScreen::OnLanguageChange", typeid(void (MenuScreen::*)()), "415741564155415455534889fb4883ec78488b5720", nullptr, 0, 0, &func);
-}
-
-void MenuScreen::OnLanguageChange()
-{
-	typedef void (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func769::func;
 	return execfunc(this);
 }
@@ -9882,10 +9882,10 @@ void MenuScreen::OnLanguageChange()
 namespace _func770
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("MenuScreen::constructor", typeid(void (MenuScreen::*)()), ".41564155415455534889fb488d6b784881ece0000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("MenuScreen::OnLanguageChange", typeid(void (MenuScreen::*)()), "415741564155415455534889fb4883ec78488b5720", nullptr, 0, 0, &func);
 }
 
-void MenuScreen::constructor()
+void MenuScreen::OnLanguageChange()
 {
 	typedef void (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func770::func;
@@ -9895,10 +9895,10 @@ void MenuScreen::constructor()
 namespace _func771
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("MenuScreen::OnRender", typeid(void (MenuScreen::*)()), ".41564155415455534889fb4881eca000000080bf0803000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("MenuScreen::constructor", typeid(void (MenuScreen::*)()), ".41564155415455534889fb488d6b784881ece0000000", nullptr, 0, 0, &func);
 }
 
-void MenuScreen::OnRender()
+void MenuScreen::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func771::func;
@@ -9908,10 +9908,10 @@ void MenuScreen::OnRender()
 namespace _func772
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("MenuScreen::Open", typeid(void (MenuScreen::*)()), ".415641554989fd488d7f7841", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("MenuScreen::OnRender", typeid(void (MenuScreen::*)()), ".41564155415455534889fb4881eca000000080bf0803000000", nullptr, 0, 0, &func);
 }
 
-void MenuScreen::Open()
+void MenuScreen::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func772::func;
@@ -9921,17 +9921,30 @@ void MenuScreen::Open()
 namespace _func773
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("MenuScreen::Open", typeid(void (MenuScreen::*)()), ".415641554989fd488d7f7841", nullptr, 0, 0, &func);
+}
+
+void MenuScreen::Open()
+{
+	typedef void (*custom_arg_funcptr_t)(MenuScreen *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func773::func;
+	return execfunc(this);
+}
+
+namespace _func774
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("MindBox::constructor", typeid(void (MindBox::*)(Point , MindSystem *)), "415431c9554889d5534889fb4883ec60", nullptr, 0, 0, &func);
 }
 
 void MindBox::constructor(Point pos, MindSystem *sys)
 {
 	typedef void (*custom_arg_funcptr_t)(MindBox *this_arg, Point pos_arg, MindSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func773::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func774::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func774
+namespace _func775
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MindSystem::ReleaseCrew", typeid(void (MindSystem::*)()), "41554989fd415455534883ec28488b8f", nullptr, 0, 0, &func);
@@ -9940,11 +9953,11 @@ namespace _func774
 void MindSystem::ReleaseCrew()
 {
 	typedef void (*custom_arg_funcptr_t)(MindSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func774::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func775::func;
 	return execfunc(this);
 }
 
-namespace _func775
+namespace _func776
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MindSystem::SetHackingLevel", typeid(void (MindSystem::*)(int )), ".5589f553??89fb??83ec08", nullptr, 0, 0, &func);
@@ -9953,11 +9966,11 @@ namespace _func775
 void MindSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(MindSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func775::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func776::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func776
+namespace _func777
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MindSystem::SetArmed", typeid(void (MindSystem::*)(int )), ".83fe01534889fb740f", nullptr, 0, 0, &func);
@@ -9966,30 +9979,17 @@ namespace _func776
 void MindSystem::SetArmed(int armed)
 {
 	typedef void (*custom_arg_funcptr_t)(MindSystem *this_arg, int armed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func776::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func777::func;
 	return execfunc(this, armed);
 }
 
-namespace _func777
+namespace _func778
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MindSystem::InitiateMindControl", typeid(void (MindSystem::*)()), ".415741564155415455534889fb4883ec48488bb780020000", nullptr, 0, 0, &func);
 }
 
 void MindSystem::InitiateMindControl()
-{
-	typedef void (*custom_arg_funcptr_t)(MindSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func777::func;
-	return execfunc(this);
-}
-
-namespace _func778
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("MindSystem::OnLoop", typeid(void (MindSystem::*)()), ".415455534889fb4883ec20e8????????488b8380020000", nullptr, 0, 0, &func);
-}
-
-void MindSystem::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(MindSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func778::func;
@@ -9999,36 +9999,36 @@ void MindSystem::OnLoop()
 namespace _func779
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("MindSystem::OnLoop", typeid(void (MindSystem::*)()), ".415455534889fb4883ec20e8????????488b8380020000", nullptr, 0, 0, &func);
+}
+
+void MindSystem::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(MindSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func779::func;
+	return execfunc(this);
+}
+
+namespace _func780
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Missile::constructor", typeid(void (Missile::*)(Pointf , int , int , Pointf , float )), "41574989ff4156415541545589f55389d34881ecf8000000f30f11542404", nullptr, 0, 0, &func);
 }
 
 void Missile::constructor(Pointf _position, int _ownerId, int _targetId, Pointf _target, float _heading)
 {
 	typedef void (*custom_arg_funcptr_t)(Missile *this_arg, Pointf _position_arg, int _ownerId_arg, int _targetId_arg, Pointf _target_arg, float _heading_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func779::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func780::func;
 	return execfunc(this, _position, _ownerId, _targetId, _target, _heading);
 }
 
-namespace _func780
+namespace _func781
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::OnLoop", typeid(void (MouseControl::*)()), "5380bf0c010000004889fb", nullptr, 0, 0, &func);
 }
 
 void MouseControl::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func780::func;
-	return execfunc(this);
-}
-
-namespace _func781
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("MouseControl::InstantTooltip", typeid(void (MouseControl::*)()), "!.c6872001000001c3", nullptr, 0, 0, &func);
-}
-
-void MouseControl::InstantTooltip()
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func781::func;
@@ -10038,10 +10038,10 @@ void MouseControl::InstantTooltip()
 namespace _func782
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("MouseControl::ResetArmed", typeid(void (MouseControl::*)()), ".c7471000000000c7471400000000c7471800000000c7873801000000000000c7472000000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("MouseControl::InstantTooltip", typeid(void (MouseControl::*)()), "!.c6872001000001c3", nullptr, 0, 0, &func);
 }
 
-void MouseControl::ResetArmed()
+void MouseControl::InstantTooltip()
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func782::func;
@@ -10051,17 +10051,30 @@ void MouseControl::ResetArmed()
 namespace _func783
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("MouseControl::ResetArmed", typeid(void (MouseControl::*)()), ".c7471000000000c7471400000000c7471800000000c7873801000000000000c7472000000000", nullptr, 0, 0, &func);
+}
+
+void MouseControl::ResetArmed()
+{
+	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func783::func;
+	return execfunc(this);
+}
+
+namespace _func784
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::MeasureTooltip", typeid(Point (MouseControl::*)(int )), ".41550f57c941544189f40f28c155534889fb4883ec48", nullptr, 0, 0, &func);
 }
 
 Point MouseControl::MeasureTooltip(int unk)
 {
 	typedef Point (*custom_arg_funcptr_t)(MouseControl *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func783::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func784::func;
 	return execfunc(this, unk);
 }
 
-namespace _func784
+namespace _func785
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::QueueStaticTooltip", typeid(void (MouseControl::*)(Point )), "!.4889b740010000c3", nullptr, 0, 0, &func);
@@ -10070,11 +10083,11 @@ namespace _func784
 void MouseControl::QueueStaticTooltip(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func784::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func785::func;
 	return execfunc(this, pos);
 }
 
-namespace _func785
+namespace _func786
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::RenderTooltip", typeid(void (MouseControl::*)(Point , bool )), ".41574989f749c1ff2041564989f641554189f5", nullptr, 0, 0, &func);
@@ -10083,30 +10096,17 @@ namespace _func785
 void MouseControl::RenderTooltip(Point tooltipPoint, bool staticPos)
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg, Point tooltipPoint_arg, bool staticPos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func785::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func786::func;
 	return execfunc(this, tooltipPoint, staticPos);
 }
 
-namespace _func786
+namespace _func787
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::OnRender", typeid(void (MouseControl::*)()), ".41574989ff41564155415455534881ecc801000080bf0d01000000", nullptr, 0, 0, &func);
 }
 
 void MouseControl::OnRender()
-{
-	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func786::func;
-	return execfunc(this);
-}
-
-namespace _func787
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("MouseControl::Reset", typeid(void (MouseControl::*)()), ".534889fb488dbf0001000031d2", nullptr, 0, 0, &func);
-}
-
-void MouseControl::Reset()
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func787::func;
@@ -10116,36 +10116,36 @@ void MouseControl::Reset()
 namespace _func788
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("MouseControl::Reset", typeid(void (MouseControl::*)()), ".534889fb488dbf0001000031d2", nullptr, 0, 0, &func);
+}
+
+void MouseControl::Reset()
+{
+	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func788::func;
+	return execfunc(this);
+}
+
+namespace _func789
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::LoadTooltip", typeid(void (MouseControl::*)(const std::string &)), ".415541544989fc55534889f34883ec38", nullptr, 0, 0, &func);
 }
 
 void MouseControl::LoadTooltip(const std::string &tooltipName)
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltipName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func788::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func789::func;
 	return execfunc(this, tooltipName);
 }
 
-namespace _func789
+namespace _func790
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::SetTooltip", typeid(void (MouseControl::*)(const std::string &)), ".41544989f4554889fd53488b06488b58e84885db", nullptr, 0, 0, &func);
 }
 
 void MouseControl::SetTooltip(const std::string &tooltip)
-{
-	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func789::func;
-	return execfunc(this, tooltip);
-}
-
-namespace _func790
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("MouseControl::SetTooltipTitle", typeid(void (MouseControl::*)(const std::string &)), ".488b8728010000488378e800", nullptr, 0, 0, &func);
-}
-
-void MouseControl::SetTooltipTitle(const std::string &tooltip)
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltip_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func790::func;
@@ -10155,17 +10155,30 @@ void MouseControl::SetTooltipTitle(const std::string &tooltip)
 namespace _func791
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("MouseControl::SetTooltipTitle", typeid(void (MouseControl::*)(const std::string &)), ".488b8728010000488378e800", nullptr, 0, 0, &func);
+}
+
+void MouseControl::SetTooltipTitle(const std::string &tooltip)
+{
+	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltip_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func791::func;
+	return execfunc(this, tooltip);
+}
+
+namespace _func792
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::SetDoor", typeid(void (MouseControl::*)(int )), ".554889fd5389f34883ec0883fe01", nullptr, 0, 0, &func);
 }
 
 void MouseControl::SetDoor(int state)
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg, int state_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func791::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func792::func;
 	return execfunc(this, state);
 }
 
-namespace _func792
+namespace _func793
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("MouseControl::SetValid", typeid(void (MouseControl::*)(bool , bool )), ".84d2??88771d74??c6471e01", nullptr, 0, 0, &func);
@@ -10174,24 +10187,24 @@ namespace _func792
 void MouseControl::SetValid(bool valid, bool newValid)
 {
 	typedef void (*custom_arg_funcptr_t)(MouseControl *this_arg, bool valid_arg, bool newValid_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func792::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func793::func;
 	return execfunc(this, valid, newValid);
 }
 
 MouseControl *Global_MouseControl_Mouse;
 
-namespace _var793
+namespace _var794
 {
     static VariableDefinition varObj("Global_MouseControl_Mouse", "!0f85570400008b85a401000083f8ff740abf(???????\?)", &Global_MouseControl_Mouse);
 }
 
-namespace _func794
+namespace _func795
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OptionsScreen::DO_NOT_HOOK_2", typeid(void (OptionsScreen::*)()), "!8b50f88d4aff8948f889d0ebc2906690", nullptr, 0, 0, &func);
 }
 
-namespace _func795
+namespace _func796
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OptionsScreen::Open", typeid(void (OptionsScreen::*)(bool )), ".4157", nullptr, 0, 0, &func);
@@ -10200,11 +10213,11 @@ namespace _func795
 void OptionsScreen::Open(bool mainMenu)
 {
 	typedef void (*custom_arg_funcptr_t)(OptionsScreen *this_arg, bool mainMenu_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func795::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func796::func;
 	return execfunc(this, mainMenu);
 }
 
-namespace _func796
+namespace _func797
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OptionsScreen::OnLoop", typeid(void (OptionsScreen::*)()), ".41574156415549bdb76ddbb66ddbb66d4154554889fd", nullptr, 0, 0, &func);
@@ -10213,17 +10226,17 @@ namespace _func796
 void OptionsScreen::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(OptionsScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func796::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func797::func;
 	return execfunc(this);
 }
 
-namespace _func797
+namespace _func798
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OptionsScreen::DO_NOT_HOOK_1", typeid(void (OptionsScreen::*)()), "!.8970f889d0e942ffffff900f1f840000000000", nullptr, 0, 0, &func);
 }
 
-namespace _func798
+namespace _func799
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OptionsScreen::OnInit", typeid(void (OptionsScreen::*)()), ".41", nullptr, 0, 0, &func);
@@ -10232,18 +10245,18 @@ namespace _func798
 void OptionsScreen::OnInit()
 {
 	typedef void (*custom_arg_funcptr_t)(OptionsScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func798::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func799::func;
 	return execfunc(this);
 }
 
 void **VTable_OuterHull;
 
-namespace _var799
+namespace _var800
 {
     static VariableDefinition varObj("VTable_OuterHull", "!498dbd880000000f28caf3410f1195840000000f28c249c74500(???????\?)", &VTable_OuterHull);
 }
 
-namespace _func800
+namespace _func801
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OuterHull::OnLoop", typeid(void (OuterHull::*)()), ".5553??89fb??83ec28??8b07ff505084c0", nullptr, 0, 0, &func);
@@ -10252,11 +10265,11 @@ namespace _func800
 void OuterHull::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(OuterHull *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func800::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func801::func;
 	return execfunc(this);
 }
 
-namespace _func801
+namespace _func802
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OxygenSystem::constructor", typeid(void (OxygenSystem::*)(int , int , int , int )), "4154554863eebe02000000534889fb", nullptr, 0, 0, &func);
@@ -10265,11 +10278,11 @@ namespace _func801
 void OxygenSystem::constructor(int numRooms, int roomId, int shipId, int startingPower)
 {
 	typedef void (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int numRooms_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func801::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func802::func;
 	return execfunc(this, numRooms, roomId, shipId, startingPower);
 }
 
-namespace _func802
+namespace _func803
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OxygenSystem::GetRefillSpeed", typeid(float (OxygenSystem::*)()), ".5380bf24020000004889fb8b8720020000", nullptr, 0, 0, &func);
@@ -10278,11 +10291,11 @@ namespace _func802
 float OxygenSystem::GetRefillSpeed()
 {
 	typedef float (*custom_arg_funcptr_t)(OxygenSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func802::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func803::func;
 	return execfunc(this);
 }
 
-namespace _func803
+namespace _func804
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OxygenSystem::ModifyRoomOxygen", typeid(void (OxygenSystem::*)(int , float )), ".488b87480200004863f6", nullptr, 0, 0, &func);
@@ -10291,11 +10304,11 @@ namespace _func803
 void OxygenSystem::ModifyRoomOxygen(int roomId, float value)
 {
 	typedef void (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, float value_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func803::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func804::func;
 	return execfunc(this, roomId, value);
 }
 
-namespace _func804
+namespace _func805
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OxygenSystem::ComputeAirLoss", typeid(void (OxygenSystem::*)(int , float , bool )), ".415541544989fc5589d55389f34883ec38", nullptr, 0, 0, &func);
@@ -10304,11 +10317,11 @@ namespace _func804
 void OxygenSystem::ComputeAirLoss(int roomId, float base_loss, bool silent)
 {
 	typedef void (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, float base_loss_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func804::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func805::func;
 	return execfunc(this, roomId, base_loss, silent);
 }
 
-namespace _func805
+namespace _func806
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OxygenSystem::UpdateBreach", typeid(void (OxygenSystem::*)(int , int , bool )), ".85d289d07e1a", nullptr, 0, 0, &func);
@@ -10317,11 +10330,11 @@ namespace _func805
 void OxygenSystem::UpdateBreach(int roomId, int count, bool silent)
 {
 	typedef void (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, int count_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func805::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func806::func;
 	return execfunc(this, roomId, count, silent);
 }
 
-namespace _func806
+namespace _func807
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OxygenSystem::UpdateAirlock", typeid(void (OxygenSystem::*)(int , int )), ".4154555389d34883ec2085d2", nullptr, 0, 0, &func);
@@ -10330,11 +10343,11 @@ namespace _func806
 void OxygenSystem::UpdateAirlock(int roomId, int count)
 {
 	typedef void (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, int count_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func806::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func807::func;
 	return execfunc(this, roomId, count);
 }
 
-namespace _func807
+namespace _func808
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OxygenSystem::EmptyOxygen", typeid(void (OxygenSystem::*)(int )), ".488b87480200004863f6", nullptr, 0, 0, &func);
@@ -10343,11 +10356,11 @@ namespace _func807
 void OxygenSystem::EmptyOxygen(int roomId)
 {
 	typedef void (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func807::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func808::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func808
+namespace _func809
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("OxygenSystem::OnLoop", typeid(void (OxygenSystem::*)()), ".5553??89fb??83ec38e8????????80bb2402000000", nullptr, 0, 0, &func);
@@ -10356,11 +10369,11 @@ namespace _func808
 void OxygenSystem::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(OxygenSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func808::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func809::func;
 	return execfunc(this);
 }
 
-namespace _func809
+namespace _func810
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("PDSFire::OnUpdate", typeid(void (PDSFire::*)()), "55534889fb4883ec1880bfc400000000", nullptr, 0, 0, &func);
@@ -10369,11 +10382,11 @@ namespace _func809
 void PDSFire::OnUpdate()
 {
 	typedef void (*custom_arg_funcptr_t)(PDSFire *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func809::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func810::func;
 	return execfunc(this);
 }
 
-namespace _func810
+namespace _func811
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("PDSFire::CollisionCheck", typeid(void (PDSFire::*)(Collideable *)), ".554889f5534889fb4889f74883ec58488b06", nullptr, 0, 0, &func);
@@ -10382,11 +10395,11 @@ namespace _func810
 void PDSFire::CollisionCheck(Collideable *other)
 {
 	typedef void (*custom_arg_funcptr_t)(PDSFire *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func810::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func811::func;
 	return execfunc(this, other);
 }
 
-namespace _func811
+namespace _func812
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("PDSFire::constructor", typeid(void (PDSFire::*)(Point , int , Pointf )), ".415741564989fe415541544989f449c1fc205589d5534889f34881ec08010000", nullptr, 0, 0, &func);
@@ -10395,30 +10408,17 @@ namespace _func811
 void PDSFire::constructor(Point pos, int destinationSpace, Pointf destination)
 {
 	typedef void (*custom_arg_funcptr_t)(PDSFire *this_arg, Point pos_arg, int destinationSpace_arg, Pointf destination_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func811::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func812::func;
 	return execfunc(this, pos, destinationSpace, destination);
 }
 
-namespace _func812
+namespace _func813
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Point::RelativeDistance", typeid(int (Point::*)(Point )), "8b178b470429f248c1fe2029f00fafd20fafc001d0", nullptr, 0, 0, &func);
 }
 
 int Point::RelativeDistance(Point other)
-{
-	typedef int (*custom_arg_funcptr_t)(Point *this_arg, Point other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func812::func;
-	return execfunc(this, other);
-}
-
-namespace _func813
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Point::Distance", typeid(int (Point::*)(Point )), ".8b178b470429f248c1fe2029f00fafd20fafc001d0", nullptr, 0, 0, &func);
-}
-
-int Point::Distance(Point other)
 {
 	typedef int (*custom_arg_funcptr_t)(Point *this_arg, Point other_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func813::func;
@@ -10428,17 +10428,30 @@ int Point::Distance(Point other)
 namespace _func814
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Point::Distance", typeid(int (Point::*)(Point )), ".8b178b470429f248c1fe2029f00fafd20fafc001d0", nullptr, 0, 0, &func);
+}
+
+int Point::Distance(Point other)
+{
+	typedef int (*custom_arg_funcptr_t)(Point *this_arg, Point other_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func814::func;
+	return execfunc(this, other);
+}
+
+namespace _func815
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Pointf::constructor", typeid(void (Pointf::*)(float , float )), "f30f1107f30f114f04c3", nullptr, 0, 0, &func);
 }
 
 void Pointf::constructor(float x, float y)
 {
 	typedef void (*custom_arg_funcptr_t)(Pointf *this_arg, float x_arg, float y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func814::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func815::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func815
+namespace _func816
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Pointf::RelativeDistance", typeid(float (Pointf::*)(Pointf )), "660fd64424f0488b4424f0f30f1007", nullptr, 0, 0, &func);
@@ -10447,11 +10460,11 @@ namespace _func815
 float Pointf::RelativeDistance(Pointf other)
 {
 	typedef float (*custom_arg_funcptr_t)(Pointf *this_arg, Pointf other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func815::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func816::func;
 	return execfunc(this, other);
 }
 
-namespace _func816
+namespace _func817
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Pointf::Normalize", typeid(Pointf (Pointf::*)()), "4883ec28f30f100ff30f104704", nullptr, 0, 0, &func);
@@ -10460,11 +10473,11 @@ namespace _func816
 Pointf Pointf::Normalize()
 {
 	typedef Pointf (*custom_arg_funcptr_t)(Pointf *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func816::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func817::func;
 	return execfunc(this);
 }
 
-namespace _func817
+namespace _func818
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("PowerManager::SetHacked", typeid(void (PowerManager::*)(bool )), "??80fe0119c0f7d083e002894720", nullptr, 0, 0, &func);
@@ -10473,11 +10486,11 @@ namespace _func817
 void PowerManager::SetHacked(bool val)
 {
 	typedef void (*custom_arg_funcptr_t)(PowerManager *this_arg, bool val_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func817::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func818::func;
 	return execfunc(this, val);
 }
 
-namespace _func818
+namespace _func819
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("PowerManager::RestartAll", typeid(void (*)()), ".488b15????????488b05????????48b9", nullptr, 0, 0, &func);
@@ -10486,11 +10499,11 @@ namespace _func818
 void PowerManager::RestartAll()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func818::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func819::func;
 	return execfunc();
 }
 
-namespace _func819
+namespace _func820
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("PowerManager::GetPowerManager", typeid(PowerManager *(*)(int )), ".5389fb4883ec30488b05????????488b0d????????4889c2", nullptr, 0, 0, &func);
@@ -10499,11 +10512,11 @@ namespace _func819
 PowerManager *PowerManager::GetPowerManager(int iShipId)
 {
 	typedef PowerManager *(*custom_arg_funcptr_t)(int iShipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func819::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func820::func;
 	return execfunc(iShipId);
 }
 
-namespace _func820
+namespace _func821
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::ValidTarget", typeid(bool (Projectile::*)()), "0fb6873402000083f001", nullptr, 0, 0, &func);
@@ -10512,11 +10525,11 @@ namespace _func820
 bool Projectile::ValidTarget()
 {
 	typedef bool (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func820::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func821::func;
 	return execfunc(this);
 }
 
-namespace _func821
+namespace _func822
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::ForceRenderLayer", typeid(int (Projectile::*)()), ".!b8ffffffffc3662e0f1f840000000000f3c3662e0f1f8400000000000f1f40004889b7f0020000", nullptr, 0, 32, &func);
@@ -10525,11 +10538,11 @@ namespace _func821
 int Projectile::ForceRenderLayer()
 {
 	typedef int (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func821::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func822::func;
 	return execfunc(this);
 }
 
-namespace _func822
+namespace _func823
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::CollisionMoving", typeid(CollisionResponse (Projectile::*)(Pointf , Pointf , Damage , bool )), ".554889f5534889fb488d7f044883ec18c747fc00000000", nullptr, 0, 0, &func);
@@ -10538,11 +10551,11 @@ namespace _func822
 CollisionResponse Projectile::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse (*custom_arg_funcptr_t)(Projectile *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func822::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func823::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func823
+namespace _func824
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::OnUpdate", typeid(void (Projectile::*)()), ".534889fb4883ec2080bfc400000000", nullptr, 0, 0, &func);
@@ -10551,11 +10564,11 @@ namespace _func823
 void Projectile::OnUpdate()
 {
 	typedef void (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func823::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func824::func;
 	return execfunc(this);
 }
 
-namespace _func824
+namespace _func825
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::CollisionCheck", typeid(void (Projectile::*)(Collideable *)), ".4154554889f5534889fb4883ec60448b673c488b064889f7", nullptr, 0, 0, &func);
@@ -10564,11 +10577,11 @@ namespace _func824
 void Projectile::CollisionCheck(Collideable *other)
 {
 	typedef void (*custom_arg_funcptr_t)(Projectile *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func824::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func825::func;
 	return execfunc(this, other);
 }
 
-namespace _func825
+namespace _func826
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::constructor", typeid(void (Projectile::*)(Pointf , int , int , Pointf )), ".4157415641554154554889fd534881ecf8000000", nullptr, 0, 0, &func);
@@ -10577,11 +10590,11 @@ namespace _func825
 void Projectile::constructor(Pointf position, int ownerId, int targetId, Pointf target)
 {
 	typedef void (*custom_arg_funcptr_t)(Projectile *this_arg, Pointf position_arg, int ownerId_arg, int targetId_arg, Pointf target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func825::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func826::func;
 	return execfunc(this, position, ownerId, targetId, target);
 }
 
-namespace _func826
+namespace _func827
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::Initialize", typeid(void (Projectile::*)(const WeaponBlueprint &)), ".415731d2415641554c8daed000000041544989f4554889fd5331db4881ec28010000", nullptr, 0, 0, &func);
@@ -10590,11 +10603,11 @@ namespace _func826
 void Projectile::Initialize(const WeaponBlueprint &bp)
 {
 	typedef void (*custom_arg_funcptr_t)(Projectile *this_arg, const WeaponBlueprint &bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func826::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func827::func;
 	return execfunc(this, bp);
 }
 
-namespace _func827
+namespace _func828
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::RandomSidePoint", typeid(Pointf (*)(int )), ".53baffffffff89fb89d64883ec30488d7c2420", nullptr, 0, 0, &func);
@@ -10603,11 +10616,11 @@ namespace _func827
 Pointf Projectile::RandomSidePoint(int side)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(int side_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func827::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func828::func;
 	return execfunc(side);
 }
 
-namespace _func828
+namespace _func829
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Projectile::destructor", typeid(void (Projectile::*)()), ".415641554154554889fd534883ec10488b872802000048c707????????48c74708????????48c78738020000????????488d78e84881ff????????0f8507030000", nullptr, 0, 0, &func);
@@ -10616,11 +10629,11 @@ namespace _func828
 void Projectile::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func828::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func829::func;
 	return execfunc(this);
 }
 
-namespace _func829
+namespace _func830
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::constructor", typeid(void (ProjectileFactory::*)(const WeaponBlueprint *, int )), "415741564989fe488d7f284d8dbec8000000415541544d8da680000000554889f553498d9e880000004881ec08010000", nullptr, 0, 0, &func);
@@ -10629,11 +10642,11 @@ namespace _func829
 void ProjectileFactory::constructor(const WeaponBlueprint *bp, int shipId)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, const WeaponBlueprint *bp_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func829::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func830::func;
 	return execfunc(this, bp, shipId);
 }
 
-namespace _func830
+namespace _func831
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::SelectChargeGoal", typeid(void (ProjectileFactory::*)()), ".803d????????00534889fb", nullptr, 0, 0, &func);
@@ -10642,11 +10655,11 @@ namespace _func830
 void ProjectileFactory::SelectChargeGoal()
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func830::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func831::func;
 	return execfunc(this);
 }
 
-namespace _func831
+namespace _func832
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::IsChargedGoal", typeid(bool (ProjectileFactory::*)()), ".488b47208b808401000085c0", nullptr, 0, 0, &func);
@@ -10655,11 +10668,11 @@ namespace _func831
 bool ProjectileFactory::IsChargedGoal()
 {
 	typedef bool (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func831::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func832::func;
 	return execfunc(this);
 }
 
-namespace _func832
+namespace _func833
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::SetHacked", typeid(void (ProjectileFactory::*)(int )), "!.89b7240600004881c758010000", nullptr, 0, 0, &func);
@@ -10668,11 +10681,11 @@ namespace _func832
 void ProjectileFactory::SetHacked(int hacked)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, int hacked_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func832::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func833::func;
 	return execfunc(this, hacked);
 }
 
-namespace _func833
+namespace _func834
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::SetCurrentShip", typeid(void (ProjectileFactory::*)(Targetable *)), ".4839b74801000074274885f6", nullptr, 0, 0, &func);
@@ -10681,11 +10694,11 @@ namespace _func833
 void ProjectileFactory::SetCurrentShip(Targetable *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, Targetable *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func833::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func834::func;
 	return execfunc(this, ship);
 }
 
-namespace _func834
+namespace _func835
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::SetCooldownModifier", typeid(void (ProjectileFactory::*)(float )), ".f30f104f0cf30f5e4f10", nullptr, 0, 0, &func);
@@ -10694,11 +10707,11 @@ namespace _func834
 void ProjectileFactory::SetCooldownModifier(float mod)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float mod_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func834::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func835::func;
 	return execfunc(this, mod);
 }
 
-namespace _func835
+namespace _func836
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::ForceCoolup", typeid(void (ProjectileFactory::*)()), ".5380bff2000000004889fb", nullptr, 0, 0, &func);
@@ -10707,11 +10720,11 @@ namespace _func835
 void ProjectileFactory::ForceCoolup()
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func835::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func836::func;
 	return execfunc(this);
 }
 
-namespace _func836
+namespace _func837
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::RenderChargeBar", typeid(void (ProjectileFactory::*)(float )), "!.4881c758010000", nullptr, 0, 0, &func);
@@ -10720,11 +10733,11 @@ namespace _func836
 void ProjectileFactory::RenderChargeBar(float unk)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func836::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func837::func;
 	return execfunc(this, unk);
 }
 
-namespace _func837
+namespace _func838
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::OnRender", typeid(void (ProjectileFactory::*)(float , bool )), "!.530f28c8488d9f580100004883ec10", nullptr, 0, 0, &func);
@@ -10733,30 +10746,17 @@ namespace _func837
 void ProjectileFactory::OnRender(float alpha, bool forceVisual)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float alpha_arg, bool forceVisual_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func837::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func838::func;
 	return execfunc(this, alpha, forceVisual);
 }
 
-namespace _func838
+namespace _func839
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::ClearAiming", typeid(void (ProjectileFactory::*)()), ".488b97f8000000488b87000100004829d048c1f803", nullptr, 0, 0, &func);
 }
 
 void ProjectileFactory::ClearAiming()
-{
-	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func838::func;
-	return execfunc(this);
-}
-
-namespace _func839
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ProjectileFactory::ClearProjectiles", typeid(void (ProjectileFactory::*)()), ".488b87e8050000488987f0050000", nullptr, 0, 0, &func);
-}
-
-void ProjectileFactory::ClearProjectiles()
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func839::func;
@@ -10766,36 +10766,36 @@ void ProjectileFactory::ClearProjectiles()
 namespace _func840
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ProjectileFactory::ClearProjectiles", typeid(void (ProjectileFactory::*)()), ".488b87e8050000488987f0050000", nullptr, 0, 0, &func);
+}
+
+void ProjectileFactory::ClearProjectiles()
+{
+	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func840::func;
+	return execfunc(this);
+}
+
+namespace _func841
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::SetAutoFire", typeid(void (ProjectileFactory::*)(bool )), ".4084f675", nullptr, 0, 0, &func);
 }
 
 void ProjectileFactory::SetAutoFire(bool autoFire)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, bool autoFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func840::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func841::func;
 	return execfunc(this, autoFire);
 }
 
-namespace _func841
+namespace _func842
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::FireNextShot", typeid(bool (ProjectileFactory::*)()), ".8b972006000031c085d2", nullptr, 0, 0, &func);
 }
 
 bool ProjectileFactory::FireNextShot()
-{
-	typedef bool (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func841::func;
-	return execfunc(this);
-}
-
-namespace _func842
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ProjectileFactory::ReadyToFire", typeid(bool (ProjectileFactory::*)()), ".8b972006000031c085d27e??80bff20000000074????8b47208b972c010000", nullptr, 0, 0, &func);
-}
-
-bool ProjectileFactory::ReadyToFire()
 {
 	typedef bool (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func842::func;
@@ -10805,17 +10805,30 @@ bool ProjectileFactory::ReadyToFire()
 namespace _func843
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ProjectileFactory::ReadyToFire", typeid(bool (ProjectileFactory::*)()), ".8b972006000031c085d27e??80bff20000000074????8b47208b972c010000", nullptr, 0, 0, &func);
+}
+
+bool ProjectileFactory::ReadyToFire()
+{
+	typedef bool (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func843::func;
+	return execfunc(this);
+}
+
+namespace _func844
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::StringToWeapon", typeid(int (*)(const std::string &)), ".53be????????4889fbe8????????85c0", nullptr, 0, 0, &func);
 }
 
 int ProjectileFactory::StringToWeapon(const std::string &str)
 {
 	typedef int (*custom_arg_funcptr_t)(const std::string &str_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func843::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func844::func;
 	return execfunc(str);
 }
 
-namespace _func844
+namespace _func845
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::QueuedShots", typeid(bool (ProjectileFactory::*)()), ".??8b87e8050000??3987f00500000f95??", nullptr, 0, 0, &func);
@@ -10824,11 +10837,11 @@ namespace _func844
 bool ProjectileFactory::QueuedShots()
 {
 	typedef bool (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func844::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func845::func;
 	return execfunc(this);
 }
 
-namespace _func845
+namespace _func846
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::GetProjectile", typeid(Projectile *(ProjectileFactory::*)()), ".4157415641554154554889fd488dbf58010000534883ec58", nullptr, 0, 0, &func);
@@ -10837,19 +10850,6 @@ namespace _func845
 Projectile *ProjectileFactory::GetProjectile()
 {
 	typedef Projectile *(*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func845::func;
-	return execfunc(this);
-}
-
-namespace _func846
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ProjectileFactory::SpendMissiles", typeid(int (ProjectileFactory::*)()), ".55534889fb4883ec288b8708060000", nullptr, 0, 0, &func);
-}
-
-int ProjectileFactory::SpendMissiles()
-{
-	typedef int (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func846::func;
 	return execfunc(this);
 }
@@ -10857,10 +10857,10 @@ int ProjectileFactory::SpendMissiles()
 namespace _func847
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ProjectileFactory::NumTargetsRequired", typeid(int (ProjectileFactory::*)()), ".488b472083b88401000001", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ProjectileFactory::SpendMissiles", typeid(int (ProjectileFactory::*)()), ".55534889fb4883ec288b8708060000", nullptr, 0, 0, &func);
 }
 
-int ProjectileFactory::NumTargetsRequired()
+int ProjectileFactory::SpendMissiles()
 {
 	typedef int (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func847::func;
@@ -10870,17 +10870,30 @@ int ProjectileFactory::NumTargetsRequired()
 namespace _func848
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ProjectileFactory::NumTargetsRequired", typeid(int (ProjectileFactory::*)()), ".488b472083b88401000001", nullptr, 0, 0, &func);
+}
+
+int ProjectileFactory::NumTargetsRequired()
+{
+	typedef int (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func848::func;
+	return execfunc(this);
+}
+
+namespace _func849
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::SaveProjectile", typeid(void (*)(Projectile *, int )), ".5589f5534889fb4883ec08488b07", nullptr, 0, 0, &func);
 }
 
 void ProjectileFactory::SaveProjectile(Projectile *p, int fd)
 {
 	typedef void (*custom_arg_funcptr_t)(Projectile *p_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func848::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func849::func;
 	return execfunc(p, fd);
 }
 
-namespace _func849
+namespace _func850
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::LoadProjectile", typeid(Projectile *(*)(int )), ".5589fd534883ec58", nullptr, 0, 0, &func);
@@ -10889,11 +10902,11 @@ namespace _func849
 Projectile *ProjectileFactory::LoadProjectile(int fd)
 {
 	typedef Projectile *(*custom_arg_funcptr_t)(int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func849::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func850::func;
 	return execfunc(fd);
 }
 
-namespace _func850
+namespace _func851
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::SaveState", typeid(void (ProjectileFactory::*)(int )), ".415541544531e45589f5534889", nullptr, 0, 0, &func);
@@ -10902,11 +10915,11 @@ namespace _func850
 void ProjectileFactory::SaveState(int fd)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func850::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func851::func;
 	return execfunc(this, fd);
 }
 
-namespace _func851
+namespace _func852
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::Fire", typeid(void (ProjectileFactory::*)(std::vector<Pointf> &, int )), ".41544189d4554889f553488b87000100004889fb482b87f800000048c1f80385c0", nullptr, 0, 0, &func);
@@ -10915,11 +10928,11 @@ namespace _func851
 void ProjectileFactory::Fire(std::vector<Pointf> &points, int target)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, std::vector<Pointf> &points_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func851::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func852::func;
 	return execfunc(this, points, target);
 }
 
-namespace _func852
+namespace _func853
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::LoadState", typeid(void (ProjectileFactory::*)(int )), ".??57??56??55??545589f553??89fb89f7??83ec38e8????????", nullptr, 0, 0, &func);
@@ -10928,30 +10941,17 @@ namespace _func852
 void ProjectileFactory::LoadState(int fd)
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func852::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func853::func;
 	return execfunc(this, fd);
 }
 
-namespace _func853
+namespace _func854
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ProjectileFactory::Update", typeid(void (ProjectileFactory::*)()), ".4157415641554989fd415455534881ec88010000", nullptr, 0, 0, &func);
 }
 
 void ProjectileFactory::Update()
-{
-	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func853::func;
-	return execfunc(this);
-}
-
-namespace _func854
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ProjectileFactory::destructor", typeid(void (ProjectileFactory::*)()), ".415641554154554889fd534883ec1048c70770??", nullptr, 0, 0, &func);
-}
-
-void ProjectileFactory::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func854::func;
@@ -10961,12 +10961,12 @@ void ProjectileFactory::destructor()
 namespace _func855
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ReactorButton::Accept", typeid(void (ReactorButton::*)()), "55534889fb4883ec288b878c000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ProjectileFactory::destructor", typeid(void (ProjectileFactory::*)()), ".415641554154554889fd534883ec1048c70770??", nullptr, 0, 0, &func);
 }
 
-void ReactorButton::Accept()
+void ProjectileFactory::destructor()
 {
-	typedef void (*custom_arg_funcptr_t)(ReactorButton *this_arg);
+	typedef void (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func855::func;
 	return execfunc(this);
 }
@@ -10974,10 +10974,10 @@ void ReactorButton::Accept()
 namespace _func856
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ReactorButton::OnClick", typeid(void (ReactorButton::*)()), "55534889fb4883ec28488bbf90000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ReactorButton::Accept", typeid(void (ReactorButton::*)()), "55534889fb4883ec288b878c000000", nullptr, 0, 0, &func);
 }
 
-void ReactorButton::OnClick()
+void ReactorButton::Accept()
 {
 	typedef void (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func856::func;
@@ -10987,10 +10987,10 @@ void ReactorButton::OnClick()
 namespace _func857
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ReactorButton::OnRightClick", typeid(void (ReactorButton::*)()), "534889fb4883ec208b878c000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ReactorButton::OnClick", typeid(void (ReactorButton::*)()), "55534889fb4883ec28488bbf90000000", nullptr, 0, 0, &func);
 }
 
-void ReactorButton::OnRightClick()
+void ReactorButton::OnClick()
 {
 	typedef void (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func857::func;
@@ -11000,24 +11000,37 @@ void ReactorButton::OnRightClick()
 namespace _func858
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ReactorButton::OnRender", typeid(void (ReactorButton::*)()), "415741564155415455534889fb4881ec3805000048897c2440", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ReactorButton::OnRightClick", typeid(void (ReactorButton::*)()), "534889fb4883ec208b878c000000", nullptr, 0, 0, &func);
 }
 
-void ReactorButton::OnRender()
+void ReactorButton::OnRightClick()
 {
 	typedef void (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func858::func;
 	return execfunc(this);
 }
 
+namespace _func859
+{
+    static void *func = 0;
+	static FunctionDefinition funcObj("ReactorButton::OnRender", typeid(void (ReactorButton::*)()), "415741564155415455534889fb4881ec3805000048897c2440", nullptr, 0, 0, &func);
+}
+
+void ReactorButton::OnRender()
+{
+	typedef void (*custom_arg_funcptr_t)(ReactorButton *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func859::func;
+	return execfunc(this);
+}
+
 void **VTable_RepairAnimation;
 
-namespace _var859
+namespace _var860
 {
     static VariableDefinition varObj("VTable_RepairAnimation", "!0f85060100004c8d6c2430bf2009000049c70424(???????\?)", &VTable_RepairAnimation);
 }
 
-namespace _func860
+namespace _func861
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("RepairStoreBox::constructor", typeid(void (RepairStoreBox::*)(ShipManager *, bool , int )), "4157415641554189cd41544989f4", nullptr, 0, 0, &func);
@@ -11026,11 +11039,11 @@ namespace _func860
 void RepairStoreBox::constructor(ShipManager *ship, bool repairAll, int price)
 {
 	typedef void (*custom_arg_funcptr_t)(RepairStoreBox *this_arg, ShipManager *ship_arg, bool repairAll_arg, int price_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func860::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func861::func;
 	return execfunc(this, ship, repairAll, price);
 }
 
-namespace _func861
+namespace _func862
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::constructor", typeid(void (ResourceControl::*)()), "4155be0a00000041545548bdffffffffffffff1f534889fb488d7f20", nullptr, 0, 0, &func);
@@ -11039,11 +11052,11 @@ namespace _func861
 void ResourceControl::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(ResourceControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func861::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func862::func;
 	return execfunc(this);
 }
 
-namespace _func862
+namespace _func863
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::RenderImage", typeid(int (ResourceControl::*)(GL_Texture *, int , int , int , GL_Color , float , bool )), ".4883ec284885f64889f7660fd60424488b0424660fd60c24", nullptr, 0, 0, &func);
@@ -11052,11 +11065,11 @@ namespace _func862
 int ResourceControl::RenderImage(GL_Texture *tex, int x, int y, int rotation, GL_Color color, float opacity, bool mirror)
 {
 	typedef int (*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float opacity_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func862::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func863::func;
 	return execfunc(this, tex, x, y, rotation, color, opacity, mirror);
 }
 
-namespace _func863
+namespace _func864
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::CreateImagePrimitive", typeid(GL_Primitive *(ResourceControl::*)(GL_Texture *, int , int , int , GL_Color , float , bool )), ".4883ec284885f64889f7660fd60424488b0424660fd60c24", nullptr, 0, 0, &func);
@@ -11065,11 +11078,11 @@ namespace _func863
 GL_Primitive *ResourceControl::CreateImagePrimitive(GL_Texture *tex, int unk1, int unk2, int unk3, GL_Color color, float alpha, bool mirror)
 {
 	typedef GL_Primitive *(*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg, int unk1_arg, int unk2_arg, int unk3_arg, GL_Color color_arg, float alpha_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func863::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func864::func;
 	return execfunc(this, tex, unk1, unk2, unk3, color, alpha, mirror);
 }
 
-namespace _func864
+namespace _func865
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::OnInit", typeid(void (ResourceControl::*)(int )), ".534889fb89b7a0000000c7870801000000000000", nullptr, 0, 0, &func);
@@ -11078,11 +11091,11 @@ namespace _func864
 void ResourceControl::OnInit(int imageSwappingMode)
 {
 	typedef void (*custom_arg_funcptr_t)(ResourceControl *this_arg, int imageSwappingMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func864::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func865::func;
 	return execfunc(this, imageSwappingMode);
 }
 
-namespace _func865
+namespace _func866
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::LoadFile", typeid(char *(ResourceControl::*)(const std::string &)), ".415541544531e4554889f5", nullptr, 0, 0, &func);
@@ -11091,11 +11104,11 @@ namespace _func865
 char *ResourceControl::LoadFile(const std::string &fileName)
 {
 	typedef char *(*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func865::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func866::func;
 	return execfunc(this, fileName);
 }
 
-namespace _func866
+namespace _func867
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::LoadFromResourceFile", typeid(char *(ResourceControl::*)(const std::string &, std::size_t &, const std::string *)), ".4156b91000000041554531ed415455", nullptr, 0, 0, &func);
@@ -11104,11 +11117,11 @@ namespace _func866
 char *ResourceControl::LoadFromResourceFile(const std::string &fileName, std::size_t &fileSize, const std::string *unused_resourceFile)
 {
 	typedef char *(*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &fileName_arg, std::size_t &fileSize_arg, const std::string *unused_resourceFile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func866::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func867::func;
 	return execfunc(this, fileName, fileSize, unused_resourceFile);
 }
 
-namespace _func867
+namespace _func868
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::GetImageData", typeid(ImageDesc (ResourceControl::*)(GL_Texture *)), ".534889d04989d14889fb488d7e604883ec10", nullptr, 0, 0, &func);
@@ -11117,11 +11130,11 @@ namespace _func867
 ImageDesc ResourceControl::GetImageData(GL_Texture *tex)
 {
 	typedef ImageDesc (*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func867::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func868::func;
 	return execfunc(this, tex);
 }
 
-namespace _func868
+namespace _func869
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::ImageExists", typeid(bool (ResourceControl::*)(const std::string &)), ".554889f5534889fb4883ec38", nullptr, 0, 0, &func);
@@ -11130,11 +11143,11 @@ namespace _func868
 bool ResourceControl::ImageExists(const std::string &name)
 {
 	typedef bool (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func868::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func869::func;
 	return execfunc(this, name);
 }
 
-namespace _func869
+namespace _func870
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::GetImageId", typeid(GL_Texture *(ResourceControl::*)(const std::string &)), ".4154554889f5be????????534889fb4883ec60", nullptr, 0, 0, &func);
@@ -11143,11 +11156,11 @@ namespace _func869
 GL_Texture *ResourceControl::GetImageId(const std::string &dir)
 {
 	typedef GL_Texture *(*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func869::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func870::func;
 	return execfunc(this, dir);
 }
 
-namespace _func870
+namespace _func871
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::RenderImageString", typeid(int (ResourceControl::*)(std::string &, int , int , int , GL_Color , float , bool )), ".41574589c7415641554589cd41544189d45589cd534883ec38", nullptr, 0, 0, &func);
@@ -11156,11 +11169,11 @@ namespace _func870
 int ResourceControl::RenderImageString(std::string &tex, int x, int y, int rotation, GL_Color color, float opacity, bool mirror)
 {
 	typedef int (*custom_arg_funcptr_t)(ResourceControl *this_arg, std::string &tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float opacity_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func870::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func871::func;
 	return execfunc(this, tex, x, y, rotation, color, opacity, mirror);
 }
 
-namespace _func871
+namespace _func872
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::CreateImagePrimitiveString", typeid(GL_Primitive *(ResourceControl::*)(const std::string &, int , int , int , GL_Color , float , bool )), ".41574589c7415641554589cd41544189d45589cd534883ec38", nullptr, 0, 0, &func);
@@ -11169,11 +11182,11 @@ namespace _func871
 GL_Primitive *ResourceControl::CreateImagePrimitiveString(const std::string &tex, int x, int y, int rotation, GL_Color color, float alpha, bool mirror)
 {
 	typedef GL_Primitive *(*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float alpha_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func871::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func872::func;
 	return execfunc(this, tex, x, y, rotation, color, alpha, mirror);
 }
 
-namespace _func872
+namespace _func873
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::RenderLoadingBar", typeid(void (ResourceControl::*)(float , float )), ".415455534889fb4883ec604883bf5001000000", nullptr, 0, 0, &func);
@@ -11182,11 +11195,11 @@ namespace _func872
 void ResourceControl::RenderLoadingBar(float initialProgress, float finalProgress)
 {
 	typedef void (*custom_arg_funcptr_t)(ResourceControl *this_arg, float initialProgress_arg, float finalProgress_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func872::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func873::func;
 	return execfunc(this, initialProgress, finalProgress);
 }
 
-namespace _func873
+namespace _func874
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::GetFontData", typeid(freetype::font_data &(ResourceControl::*)(int , bool )), ".41548d46fa55534889fb4883ec3083f802", nullptr, 0, 0, &func);
@@ -11195,11 +11208,11 @@ namespace _func873
 freetype::font_data &ResourceControl::GetFontData(int size, bool ignoreLanguage)
 {
 	typedef freetype::font_data &(*custom_arg_funcptr_t)(ResourceControl *this_arg, int size_arg, bool ignoreLanguage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func873::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func874::func;
 	return execfunc(this, size, ignoreLanguage);
 }
 
-namespace _func874
+namespace _func875
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ResourceControl::PreloadResources", typeid(bool (ResourceControl::*)(bool )), ".415741564155415455534889fb4881ec88000000408874241f", nullptr, 0, 0, &func);
@@ -11208,24 +11221,24 @@ namespace _func874
 bool ResourceControl::PreloadResources(bool unk)
 {
 	typedef bool (*custom_arg_funcptr_t)(ResourceControl *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func874::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func875::func;
 	return execfunc(this, unk);
 }
 
 ResourceControl *Global_ResourceControl_GlobalResources;
 
-namespace _var875
+namespace _var876
 {
     static VariableDefinition varObj("Global_ResourceControl_GlobalResources", "!be(???????\?)488983100100004889c24889e7", &Global_ResourceControl_GlobalResources);
 }
 
-namespace _func876
+namespace _func877
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK_1", typeid(void (RockAnimation::*)()), "f3c3660f1f44000053be????????4889fb4883ec10488d54240fe8????????4883c4104889d85bc353be????????4889fb4883ec10", nullptr, 0, 0, &func);
 }
 
-namespace _func877
+namespace _func878
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("RockAnimation::GetDeathSound", typeid(std::string (RockAnimation::*)()), ".53be????????4889fb4883ec10488d54240f", nullptr, 0, 0, &func);
@@ -11234,23 +11247,23 @@ namespace _func877
 std::string RockAnimation::GetDeathSound()
 {
 	typedef std::string (*custom_arg_funcptr_t)(RockAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func877::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func878::func;
 	return execfunc(this);
-}
-
-namespace _func878
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK_2", typeid(void (RockAnimation::*)()), ".534889fb4883ec30803d????????007577e8????????89c1", nullptr, 0, 0, &func);
 }
 
 namespace _func879
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK_3", typeid(void (RockAnimation::*)()), ".534889fb4883ec30803d????????007577e8????????89c1", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK_2", typeid(void (RockAnimation::*)()), ".534889fb4883ec30803d????????007577e8????????89c1", nullptr, 0, 0, &func);
 }
 
 namespace _func880
+{
+    static void *func = 0;
+	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK_3", typeid(void (RockAnimation::*)()), ".534889fb4883ec30803d????????007577e8????????89c1", nullptr, 0, 0, &func);
+}
+
+namespace _func881
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("RockAnimation::GetShootingSound", typeid(std::string (RockAnimation::*)()), ".534889fb4883ec30803d????????007577e8????????89c1", nullptr, 0, 0, &func);
@@ -11259,11 +11272,11 @@ namespace _func880
 std::string RockAnimation::GetShootingSound()
 {
 	typedef std::string (*custom_arg_funcptr_t)(RockAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func880::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func881::func;
 	return execfunc(this);
 }
 
-namespace _func881
+namespace _func882
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("RockAnimation::constructor", typeid(void (RockAnimation::*)(const std::string &, int , Pointf , bool )), ".41544189cc5589d5534889fb4883ec50", nullptr, 0, 0, &func);
@@ -11272,11 +11285,11 @@ namespace _func881
 void RockAnimation::constructor(const std::string &subRace, int iShipId, Pointf position, bool enemy)
 {
 	typedef void (*custom_arg_funcptr_t)(RockAnimation *this_arg, const std::string &subRace_arg, int iShipId_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func881::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func882::func;
 	return execfunc(this, subRace, iShipId, position, enemy);
 }
 
-namespace _func882
+namespace _func883
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::destructor", typeid(void (Room::*)()), "41574156415541544989fc55534883ec5848c707", nullptr, 0, 0, &func);
@@ -11285,11 +11298,11 @@ namespace _func882
 void Room::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(Room *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func882::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func883::func;
 	return execfunc(this);
 }
 
-namespace _func883
+namespace _func884
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::constructor", typeid(void (Room::*)(int , int , int , int , int , int )), ".41574989ff41564589ce4155415455534489c3410fafde4881ec78010000", nullptr, 0, 0, &func);
@@ -11298,11 +11311,11 @@ namespace _func883
 void Room::constructor(int iShipId, int x, int y, int w, int h, int roomId)
 {
 	typedef void (*custom_arg_funcptr_t)(Room *this_arg, int iShipId_arg, int x_arg, int y_arg, int w_arg, int h_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func883::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func884::func;
 	return execfunc(this, iShipId, x, y, w, h, roomId);
 }
 
-namespace _func884
+namespace _func885
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::GetEmptySlots", typeid(int (Room::*)(bool )), ".400fb6f6488b4750488d14b6488d14d0488b4210482b028b4a188b520848c1f80348c1e0064801c84829d0", nullptr, 0, 0, &func);
@@ -11311,11 +11324,11 @@ namespace _func884
 int Room::GetEmptySlots(bool intruder)
 {
 	typedef int (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func884::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func885::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func885
+namespace _func886
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::Full", typeid(bool (Room::*)(bool )), ".488b4750400fb6f6", nullptr, 0, 0, &func);
@@ -11324,11 +11337,11 @@ namespace _func885
 bool Room::Full(bool intruder)
 {
 	typedef bool (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func885::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func886::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func886
+namespace _func887
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::GetEmptySlot", typeid(int (Room::*)(bool )), ".4084f689f2", nullptr, 0, 0, &func);
@@ -11337,17 +11350,17 @@ namespace _func886
 int Room::GetEmptySlot(bool intruder)
 {
 	typedef int (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func886::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func887::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func887
+namespace _func888
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::DO_NOT_HOOK", typeid(void (Room::*)()), ".0fb6d2488b4f504863c64c8d049500000000", nullptr, 0, 0, &func);
 }
 
-namespace _func888
+namespace _func889
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::FillSlot", typeid(void (Room::*)(int , bool )), ".0fb6d2488b4f504863c64c8d049500000000", nullptr, 0, 0, &func);
@@ -11356,11 +11369,11 @@ namespace _func888
 void Room::FillSlot(int slot, bool intruder)
 {
 	typedef void (*custom_arg_funcptr_t)(Room *this_arg, int slot_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func888::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func889::func;
 	return execfunc(this, slot, intruder);
 }
 
-namespace _func889
+namespace _func890
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::OnRenderFloor", typeid(void (Room::*)(float , bool )), ".4883ec28f30f100d????????f30f5c8fb8000000488bbfc0000000", nullptr, 0, 0, &func);
@@ -11369,11 +11382,11 @@ namespace _func889
 void Room::OnRenderFloor(float alpha, bool experimental)
 {
 	typedef void (*custom_arg_funcptr_t)(Room *this_arg, float alpha_arg, bool experimental_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func889::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func890::func;
 	return execfunc(this, alpha, experimental);
 }
 
-namespace _func890
+namespace _func891
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Room::OnRenderWalls", typeid(void (Room::*)(float )), ".534889fb4883ec10807f6800", nullptr, 0, 0, &func);
@@ -11382,11 +11395,11 @@ namespace _func890
 void Room::OnRenderWalls(float alpha)
 {
 	typedef void (*custom_arg_funcptr_t)(Room *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func890::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func891::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func891
+namespace _func892
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::constructor", typeid(void (ScoreKeeper::*)()), "4157415641554c8daf8000000041544c8da78001000055488dafa000000053488d9f900000004883ec48", nullptr, 0, 0, &func);
@@ -11395,11 +11408,11 @@ namespace _func891
 void ScoreKeeper::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func891::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func892::func;
 	return execfunc(this);
 }
 
-namespace _func892
+namespace _func893
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::GetShipId", typeid(std::pair<int, int> (ScoreKeeper::*)(const std::string &)), ".4157415641554531ed41544989f45553", nullptr, 0, 0, &func);
@@ -11408,11 +11421,11 @@ namespace _func892
 std::pair<int, int> ScoreKeeper::GetShipId(const std::string &blueprintName)
 {
 	typedef std::pair<int, int> (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, const std::string &blueprintName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func892::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func893::func;
 	return execfunc(this, blueprintName);
 }
 
-namespace _func893
+namespace _func894
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::GetShipBlueprint", typeid(std::string (ScoreKeeper::*)(int )), ".4863d2534889fb", nullptr, 0, 0, &func);
@@ -11421,30 +11434,17 @@ namespace _func893
 std::string ScoreKeeper::GetShipBlueprint(int index)
 {
 	typedef std::string (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int index_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func893::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func894::func;
 	return execfunc(this, index);
 }
 
-namespace _func894
+namespace _func895
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::SaveGame", typeid(void (ScoreKeeper::*)(int )), "!.41544989fc5589f5", nullptr, 0, 0, &func);
 }
 
 void ScoreKeeper::SaveGame(int fd)
-{
-	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func894::func;
-	return execfunc(this, fd);
-}
-
-namespace _func895
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ScoreKeeper::LoadGame", typeid(void (ScoreKeeper::*)(int )), ".41544989fc89f75589f5534883ec20", nullptr, 0, 0, &func);
-}
-
-void ScoreKeeper::LoadGame(int fd)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int fd_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func895::func;
@@ -11454,17 +11454,30 @@ void ScoreKeeper::LoadGame(int fd)
 namespace _func896
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ScoreKeeper::LoadGame", typeid(void (ScoreKeeper::*)(int )), ".41544989fc89f75589f5534883ec20", nullptr, 0, 0, &func);
+}
+
+void ScoreKeeper::LoadGame(int fd)
+{
+	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int fd_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func896::func;
+	return execfunc(this, fd);
+}
+
+namespace _func897
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::GetShipUnlocked", typeid(bool (ScoreKeeper::*)(int , int )), ".83fa02760b31c0", nullptr, 0, 32, &func);
 }
 
 bool ScoreKeeper::GetShipUnlocked(int shipId, int shipVariant)
 {
 	typedef bool (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int shipId_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func896::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func897::func;
 	return execfunc(this, shipId, shipVariant);
 }
 
-namespace _func897
+namespace _func898
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::SetSector", typeid(void (ScoreKeeper::*)(int )), ".c7471800000000c7473800000000", nullptr, 0, 0, &func);
@@ -11473,11 +11486,11 @@ namespace _func897
 void ScoreKeeper::SetSector(int sector)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int sector_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func897::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func898::func;
 	return execfunc(this, sector);
 }
 
-namespace _func898
+namespace _func899
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::SetVictory", typeid(void (ScoreKeeper::*)(bool )), ".4084f64088b798010000", nullptr, 0, 0, &func);
@@ -11486,11 +11499,11 @@ namespace _func898
 void ScoreKeeper::SetVictory(bool victory)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool victory_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func898::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func899::func;
 	return execfunc(this, victory);
 }
 
-namespace _func899
+namespace _func900
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::AddScrapCollected", typeid(void (ScoreKeeper::*)(int )), ".5589f5534889fb", nullptr, 0, 0, &func);
@@ -11499,11 +11512,11 @@ namespace _func899
 void ScoreKeeper::AddScrapCollected(int scrap)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int scrap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func899::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func900::func;
 	return execfunc(this, scrap);
 }
 
-namespace _func900
+namespace _func901
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::SaveScores", typeid(void (ScoreKeeper::*)(int , std::vector<TopScore> &)), ".415741564989d6415549bdabaaaaaaaaaaaaaa415455534883ec48", nullptr, 0, 0, &func);
@@ -11512,11 +11525,11 @@ namespace _func900
 void ScoreKeeper::SaveScores(int file, std::vector<TopScore> &topScores)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int file_arg, std::vector<TopScore> &topScores_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func900::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func901::func;
 	return execfunc(this, file, topScores);
 }
 
-namespace _func901
+namespace _func902
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::AddTopScoreList", typeid(int (ScoreKeeper::*)(TopScore &, std::vector<TopScore> &)), ".415448b8abaaaaaaaaaaaaaa4989f4554889d5534883ec50", nullptr, 0, 0, &func);
@@ -11525,11 +11538,11 @@ namespace _func901
 int ScoreKeeper::AddTopScoreList(TopScore &score, std::vector<TopScore> &topScoreList)
 {
 	typedef int (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, TopScore &score_arg, std::vector<TopScore> &topScoreList_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func901::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func902::func;
 	return execfunc(this, score, topScoreList);
 }
 
-namespace _func902
+namespace _func903
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::AddTopScoreType", typeid(void (ScoreKeeper::*)(TopScore &, int )), ".4157488d46084189d7baffffffff41564989fe", nullptr, 0, 0, &func);
@@ -11538,11 +11551,11 @@ namespace _func902
 void ScoreKeeper::AddTopScoreType(TopScore &topScore, int type)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, TopScore &topScore_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func902::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func903::func;
 	return execfunc(this, topScore, type);
 }
 
-namespace _func903
+namespace _func904
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::Save", typeid(void (ScoreKeeper::*)(bool )), ".4156415541545589f5534889fb", nullptr, 0, 0, &func);
@@ -11551,11 +11564,11 @@ namespace _func903
 void ScoreKeeper::Save(bool newHighScore)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool newHighScore_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func903::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func904::func;
 	return execfunc(this, newHighScore);
 }
 
-namespace _func904
+namespace _func905
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::WipeProfile", typeid(void (ScoreKeeper::*)(bool )), ".415741564531f641554531ed41544989fc", nullptr, 0, 0, &func);
@@ -11564,11 +11577,11 @@ namespace _func904
 void ScoreKeeper::WipeProfile(bool permanent)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool permanent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func904::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func905::func;
 	return execfunc(this, permanent);
 }
 
-namespace _func905
+namespace _func906
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::UnlockShip", typeid(void (ScoreKeeper::*)(int , int , bool , bool )), ".415741564189ce41554189d541544589c4554889fd5389f34883ec28", nullptr, 0, 0, &func);
@@ -11577,11 +11590,11 @@ namespace _func905
 void ScoreKeeper::UnlockShip(int shipType, int shipVariant, bool save, bool hidePopup)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int shipType_arg, int shipVariant_arg, bool save_arg, bool hidePopup_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func905::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func906::func;
 	return execfunc(this, shipType, shipVariant, save, hidePopup);
 }
 
-namespace _func906
+namespace _func907
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::LoadVersionFour", typeid(void (ScoreKeeper::*)(int , int )), ".41574889f8415641554189d54154555389f34881ec98000000", nullptr, 0, 0, &func);
@@ -11590,11 +11603,11 @@ namespace _func906
 void ScoreKeeper::LoadVersionFour(int file, int version)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int file_arg, int version_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func906::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func907::func;
 	return execfunc(this, file, version);
 }
 
-namespace _func907
+namespace _func908
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::OnInit", typeid(void (ScoreKeeper::*)()), ".415631f64155415455534889fb488dab880500004c8da3a80b00004883ec70", nullptr, 0, 0, &func);
@@ -11603,11 +11616,11 @@ namespace _func907
 void ScoreKeeper::OnInit()
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func907::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func908::func;
 	return execfunc(this);
 }
 
-namespace _func908
+namespace _func909
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::RenderTopScores", typeid(void (ScoreKeeper::*)(const std::vector<TopScore> &, Point , int )), ".4157415641554989f5415455534881ec68020000", nullptr, 0, 0, &func);
@@ -11616,11 +11629,11 @@ namespace _func908
 void ScoreKeeper::RenderTopScores(const std::vector<TopScore> &topScoreList, Point position, int newHighScore)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, const std::vector<TopScore> &topScoreList_arg, Point position_arg, int newHighScore_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func908::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func909::func;
 	return execfunc(this, topScoreList, position, newHighScore);
 }
 
-namespace _func909
+namespace _func910
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::CheckTypes", typeid(void (ScoreKeeper::*)()), ".4155ba01000000415455534889fb4c8da3880700004883ec18", nullptr, 0, 0, &func);
@@ -11629,11 +11642,11 @@ namespace _func909
 void ScoreKeeper::CheckTypes()
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func909::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func910::func;
 	return execfunc(this);
 }
 
-namespace _func910
+namespace _func911
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::SetupTopShip", typeid(void (ScoreKeeper::*)(int )), ".41545589f5534889fb4883ec40", nullptr, 0, 0, &func);
@@ -11642,30 +11655,17 @@ namespace _func910
 void ScoreKeeper::SetupTopShip(int variant)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int variant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func910::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func911::func;
 	return execfunc(this, variant);
 }
 
-namespace _func911
+namespace _func912
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::CycleLeft", typeid(void (ScoreKeeper::*)()), "!.55bd09000000534889fb4883ec08", nullptr, 0, 0, &func);
 }
 
 void ScoreKeeper::CycleLeft()
-{
-	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func911::func;
-	return execfunc(this);
-}
-
-namespace _func912
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ScoreKeeper::CycleRight", typeid(void (ScoreKeeper::*)()), "!.5531ed534889fb4883ec08", nullptr, 0, 0, &func);
-}
-
-void ScoreKeeper::CycleRight()
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func912::func;
@@ -11675,17 +11675,30 @@ void ScoreKeeper::CycleRight()
 namespace _func913
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ScoreKeeper::CycleRight", typeid(void (ScoreKeeper::*)()), "!.5531ed534889fb4883ec08", nullptr, 0, 0, &func);
+}
+
+void ScoreKeeper::CycleRight()
+{
+	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func913::func;
+	return execfunc(this);
+}
+
+namespace _func914
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::MouseClick", typeid(void (ScoreKeeper::*)(int , int )), ".55534889fb4883ec0880bf280c000000", nullptr, 0, 0, &func);
 }
 
 void ScoreKeeper::MouseClick(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func913::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func914::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func914
+namespace _func915
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::KeyDown", typeid(bool (ScoreKeeper::*)(SDLKey )), ".5589f5534889fb4883ec18", nullptr, 0, 0, &func);
@@ -11694,11 +11707,11 @@ namespace _func914
 bool ScoreKeeper::KeyDown(SDLKey key)
 {
 	typedef bool (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func914::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func915::func;
 	return execfunc(this, key);
 }
 
-namespace _func915
+namespace _func916
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::Open", typeid(void (ScoreKeeper::*)(bool )), ".4157ba0d000000", nullptr, 0, 0, &func);
@@ -11707,11 +11720,11 @@ namespace _func915
 void ScoreKeeper::Open(bool fromGameOver)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool fromGameOver_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func915::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func916::func;
 	return execfunc(this, fromGameOver);
 }
 
-namespace _func916
+namespace _func917
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::OnRender", typeid(void (ScoreKeeper::*)(bool )), ".4157415641554189f5415455534889fb4881ec28020000", nullptr, 0, 0, &func);
@@ -11720,11 +11733,11 @@ namespace _func916
 void ScoreKeeper::OnRender(bool lastPlaythrough)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool lastPlaythrough_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func916::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func917::func;
 	return execfunc(this, lastPlaythrough);
 }
 
-namespace _func917
+namespace _func918
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ScoreKeeper::MouseMove", typeid(void (ScoreKeeper::*)(int , int )), ".4156415541544189d45589f55380bf280c000000", nullptr, 0, 0, &func);
@@ -11733,18 +11746,18 @@ namespace _func917
 void ScoreKeeper::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func917::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func918::func;
 	return execfunc(this, mX, mY);
 }
 
 ScoreKeeper *Global_ScoreKeeper_Keeper;
 
-namespace _var918
+namespace _var919
 {
     static VariableDefinition varObj("Global_ScoreKeeper_Keeper", "!488b3b488b07ff5028488b7b08488b07ff502831f6bf(???????\?)", &Global_ScoreKeeper_Keeper);
 }
 
-namespace _func919
+namespace _func920
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Settings::GetDlcEnabled", typeid(bool (*)()), "31c0803d????????007505c30f1f40004883ec08", nullptr, 0, 0, &func);
@@ -11753,11 +11766,11 @@ namespace _func919
 bool Settings::GetDlcEnabled()
 {
 	typedef bool (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func919::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func920::func;
 	return execfunc();
 }
 
-namespace _func920
+namespace _func921
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Settings::GetHotkeyName", typeid(std::string (*)(const std::string &)), ".415741564155415455534883ec58488d6c2440", nullptr, 0, 0, &func);
@@ -11766,11 +11779,11 @@ namespace _func920
 std::string Settings::GetHotkeyName(const std::string &name)
 {
 	typedef std::string (*custom_arg_funcptr_t)(const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func920::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func921::func;
 	return execfunc(name);
 }
 
-namespace _func921
+namespace _func922
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Settings::GetHotkey", typeid(SDLKey (*)(const std::string &)), ".415741564155415455534883ec2848897c2418", nullptr, 0, 0, &func);
@@ -11779,11 +11792,11 @@ namespace _func921
 SDLKey Settings::GetHotkey(const std::string &hotkeyName)
 {
 	typedef SDLKey (*custom_arg_funcptr_t)(const std::string &hotkeyName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func921::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func922::func;
 	return execfunc(hotkeyName);
 }
 
-namespace _func922
+namespace _func923
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Settings::SetHotkey", typeid(void (*)(const std::string &, SDLKey )), ".415741564155415455534883ec5848897c2420", nullptr, 0, 0, &func);
@@ -11792,11 +11805,11 @@ namespace _func922
 void Settings::SetHotkey(const std::string &hotkeyName, SDLKey key)
 {
 	typedef void (*custom_arg_funcptr_t)(const std::string &hotkeyName_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func922::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func923::func;
 	return execfunc(hotkeyName, key);
 }
 
-namespace _func923
+namespace _func924
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Settings::SaveSettings", typeid(void (*)()), ".415741564155415455534881ecc8010000", nullptr, 0, 0, &func);
@@ -11805,11 +11818,11 @@ namespace _func923
 void Settings::SaveSettings()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func923::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func924::func;
 	return execfunc();
 }
 
-namespace _func924
+namespace _func925
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Settings::GetCommandConsole", typeid(char (*)()), "!.0fb605????????c3", nullptr, 0, 32, &func);
@@ -11818,11 +11831,11 @@ namespace _func924
 char Settings::GetCommandConsole()
 {
 	typedef char (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func924::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func925::func;
 	return execfunc();
 }
 
-namespace _func925
+namespace _func926
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Settings::ResetHotkeys", typeid(void (*)()), ".415641be????????4155415441bc????????55534883ec30", nullptr, 0, 0, &func);
@@ -11831,11 +11844,11 @@ namespace _func925
 void Settings::ResetHotkeys()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func925::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func926::func;
 	return execfunc();
 }
 
-namespace _func926
+namespace _func927
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Settings::LoadSettings", typeid(void (*)()), ".415741564155415455534881ec58020000", nullptr, 0, 0, &func);
@@ -11844,18 +11857,18 @@ namespace _func926
 void Settings::LoadSettings()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func926::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func927::func;
 	return execfunc();
 }
 
 SettingValues *Global_Settings_Settings;
 
-namespace _var927
+namespace _var928
 {
     static VariableDefinition varObj("Global_Settings_Settings", "!4155415441bc(???????\?)55534883ec30", &Global_Settings_Settings);
 }
 
-namespace _func928
+namespace _func929
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Shields::SetHackingLevel", typeid(void (Shields::*)(int )), "83fe017e??83bf20020000017e??89b720020000", nullptr, 0, 0, &func);
@@ -11864,30 +11877,17 @@ namespace _func928
 void Shields::SetHackingLevel(int hackingLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(Shields *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func928::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func929::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func929
+namespace _func930
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Shields::Jump", typeid(void (Shields::*)()), ".534889fb4883ec30e8????????f30f100d", nullptr, 0, 0, &func);
 }
 
 void Shields::Jump()
-{
-	typedef void (*custom_arg_funcptr_t)(Shields *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func929::func;
-	return execfunc(this);
-}
-
-namespace _func930
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Shields::OnLoop", typeid(void (Shields::*)()), ".41564155415455534889fb4c8d6b104883ec30", nullptr, 0, 0, &func);
-}
-
-void Shields::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(Shields *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func930::func;
@@ -11897,17 +11897,30 @@ void Shields::OnLoop()
 namespace _func931
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Shields::OnLoop", typeid(void (Shields::*)()), ".41564155415455534889fb4c8d6b104883ec30", nullptr, 0, 0, &func);
+}
+
+void Shields::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(Shields *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func931::func;
+	return execfunc(this);
+}
+
+namespace _func932
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Shields::constructor", typeid(void (Shields::*)(int , int , int , const std::string &)), ".4154554c89c54189c889d189f231f6534889fb4883ec40", nullptr, 0, 0, &func);
 }
 
 void Shields::constructor(int roomId, int shipId, int startingPower, const std::string &shieldFile)
 {
 	typedef void (*custom_arg_funcptr_t)(Shields *this_arg, int roomId_arg, int shipId_arg, int startingPower_arg, const std::string &shieldFile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func931::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func932::func;
 	return execfunc(this, roomId, shipId, startingPower, shieldFile);
 }
 
-namespace _func932
+namespace _func933
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Shields::AddSuperShield", typeid(void (Shields::*)(Point )), ".55ba050000004889f5534889fb4883ec08", nullptr, 0, 0, &func);
@@ -11916,11 +11929,11 @@ namespace _func932
 void Shields::AddSuperShield(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(Shields *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func932::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func933::func;
 	return execfunc(this, pos);
 }
 
-namespace _func933
+namespace _func934
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Shields::SetBaseEllipse", typeid(void (Shields::*)(Globals::Ellipse )), ".660fd64424f8488b4424f84889b750020000", nullptr, 0, 0, &func);
@@ -11929,11 +11942,11 @@ namespace _func933
 void Shields::SetBaseEllipse(Globals::Ellipse ellipse)
 {
 	typedef void (*custom_arg_funcptr_t)(Shields *this_arg, Globals::Ellipse ellipse_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func933::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func934::func;
 	return execfunc(this, ellipse);
 }
 
-namespace _func934
+namespace _func935
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Shields::InstantCharge", typeid(void (Shields::*)()), ".55534889fb488dabd00200004883ec38", nullptr, 0, 0, &func);
@@ -11942,11 +11955,11 @@ namespace _func934
 void Shields::InstantCharge()
 {
 	typedef void (*custom_arg_funcptr_t)(Shields *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func934::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func935::func;
 	return execfunc(this);
 }
 
-namespace _func935
+namespace _func936
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Shields::RenderBase", typeid(void (Shields::*)(float , float )), ".41550f28f9415455534889fb4883ec68", nullptr, 0, 0, &func);
@@ -11955,11 +11968,11 @@ namespace _func935
 void Shields::RenderBase(float alpha, float superShieldOverwrite)
 {
 	typedef void (*custom_arg_funcptr_t)(Shields *this_arg, float alpha_arg, float superShieldOverwrite_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func935::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func936::func;
 	return execfunc(this, alpha, superShieldOverwrite);
 }
 
-namespace _func936
+namespace _func937
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Shields::CollisionTest", typeid(CollisionResponse (Shields::*)(float , float , Damage )), ".554889f5534889fb488d7f044883ec18", nullptr, 0, 0, &func);
@@ -11968,11 +11981,11 @@ namespace _func936
 CollisionResponse Shields::CollisionTest(float x, float y, Damage damage)
 {
 	typedef CollisionResponse (*custom_arg_funcptr_t)(Shields *this_arg, float x_arg, float y_arg, Damage damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func936::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func937::func;
 	return execfunc(this, x, y, damage);
 }
 
-namespace _func937
+namespace _func938
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Shields::CollisionReal", typeid(CollisionResponse (Shields::*)(float , float , Damage , bool )), ".415741564189d641554989f5415455534889fb488d7f04", nullptr, 0, 0, &func);
@@ -11981,18 +11994,18 @@ namespace _func937
 CollisionResponse Shields::CollisionReal(float x, float y, Damage damage, bool force)
 {
 	typedef CollisionResponse (*custom_arg_funcptr_t)(Shields *this_arg, float x_arg, float y_arg, Damage damage_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func937::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func938::func;
 	return execfunc(this, x, y, damage, force);
 }
 
 GL_Color *Global_COLOR_GREEN;
 
-namespace _var938
+namespace _var939
 {
     static VariableDefinition varObj("Global_COLOR_GREEN", "!f30fc2cf01488bbbf8020000f30f101d(???????\?)f30f5edd", &Global_COLOR_GREEN, true, true);
 }
 
-namespace _func939
+namespace _func940
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::GetBaseEllipse", typeid(Globals::Ellipse (Ship::*)()), "534889fb4883ec20f30f108fc4020000", nullptr, 0, 0, &func);
@@ -12001,11 +12014,11 @@ namespace _func939
 Globals::Ellipse Ship::GetBaseEllipse()
 {
 	typedef Globals::Ellipse (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func939::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func940::func;
 	return execfunc(this);
 }
 
-namespace _func940
+namespace _func941
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::ContainsHullBreach", typeid(std::pair<int, int> (Ship::*)(int )), ".??57??56??89fe??55??545589f553??83ec08", nullptr, 0, 0, &func);
@@ -12014,11 +12027,11 @@ namespace _func940
 std::pair<int, int> Ship::ContainsHullBreach(int roomId)
 {
 	typedef std::pair<int, int> (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func940::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func941::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func941
+namespace _func942
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::RoomLocked", typeid(bool (Ship::*)(int )), ".4c8b8778040000488b8f8004000048b835c2724f232cf7344c29c148c1f903", nullptr, 0, 0, &func);
@@ -12027,11 +12040,11 @@ namespace _func941
 bool Ship::RoomLocked(int roomId)
 {
 	typedef bool (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func941::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func942::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func942
+namespace _func943
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::DestroyedDone", typeid(bool (Ship::*)()), ".0fb687b802000084c0", nullptr, 0, 0, &func);
@@ -12040,11 +12053,11 @@ namespace _func942
 bool Ship::DestroyedDone()
 {
 	typedef bool (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func942::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func943::func;
 	return execfunc(this);
 }
 
-namespace _func943
+namespace _func944
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::OnRenderJump", typeid(void (Ship::*)(float )), ".41564155415455534889fb4883ec208b7f08", nullptr, 0, 0, &func);
@@ -12053,11 +12066,11 @@ namespace _func943
 void Ship::OnRenderJump(float progress)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, float progress_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func943::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func944::func;
 	return execfunc(this, progress);
 }
 
-namespace _func944
+namespace _func945
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::GetShipCorner", typeid(Point (Ship::*)()), ".534889fb4883ec108b7f08e8", nullptr, 0, 0, &func);
@@ -12066,30 +12079,17 @@ namespace _func944
 Point Ship::GetShipCorner()
 {
 	typedef Point (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func944::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func945::func;
 	return execfunc(this);
 }
 
-namespace _func945
+namespace _func946
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::OnRenderBase", typeid(void (Ship::*)(bool )), ".41554189f5415455534889fb4883ec288b7f08", nullptr, 0, 0, &func);
 }
 
 void Ship::OnRenderBase(bool unk)
-{
-	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func945::func;
-	return execfunc(this, unk);
-}
-
-namespace _func946
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Ship::OnRenderFloor", typeid(void (Ship::*)(bool )), ".5589f5534889fb4883ec1880bf7004000000", nullptr, 0, 0, &func);
-}
-
-void Ship::OnRenderFloor(bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func946::func;
@@ -12099,23 +12099,23 @@ void Ship::OnRenderFloor(bool unk)
 namespace _func947
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Ship::OnRenderSparks", typeid(void (Ship::*)()), ".5531c94889fd5331db4883ec08488b5710488b47184829d048c1f8034885c07429", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Ship::OnRenderFloor", typeid(void (Ship::*)(bool )), ".5589f5534889fb4883ec1880bf7004000000", nullptr, 0, 0, &func);
 }
 
-void Ship::OnRenderSparks()
+void Ship::OnRenderFloor(bool unk)
 {
-	typedef void (*custom_arg_funcptr_t)(Ship *this_arg);
+	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func947::func;
-	return execfunc(this);
+	return execfunc(this, unk);
 }
 
 namespace _func948
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Ship::OnRenderBreaches", typeid(void (Ship::*)()), ".41544531e45531ed53488b57404889fb", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Ship::OnRenderSparks", typeid(void (Ship::*)()), ".5531c94889fd5331db4883ec08488b5710488b47184829d048c1f8034885c07429", nullptr, 0, 0, &func);
 }
 
-void Ship::OnRenderBreaches()
+void Ship::OnRenderSparks()
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func948::func;
@@ -12125,17 +12125,30 @@ void Ship::OnRenderBreaches()
 namespace _func949
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Ship::OnRenderBreaches", typeid(void (Ship::*)()), ".41544531e45531ed53488b57404889fb", nullptr, 0, 0, &func);
+}
+
+void Ship::OnRenderBreaches()
+{
+	typedef void (*custom_arg_funcptr_t)(Ship *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func949::func;
+	return execfunc(this);
+}
+
+namespace _func950
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Ship::BreachSpecificHull", typeid(bool (Ship::*)(int , int )), ".41564989fe4155415455534883ec30", nullptr, 0, 0, &func);
 }
 
 bool Ship::BreachSpecificHull(int grid_x, int grid_y)
 {
 	typedef bool (*custom_arg_funcptr_t)(Ship *this_arg, int grid_x_arg, int grid_y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func949::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func950::func;
 	return execfunc(this, grid_x, grid_y);
 }
 
-namespace _func950
+namespace _func951
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::GetSelectedRoomId", typeid(int (Ship::*)(int , int , bool )), "!.41544189cc5589d5538b7f08", nullptr, 0, 0, &func);
@@ -12144,11 +12157,11 @@ namespace _func950
 int Ship::GetSelectedRoomId(int x, int y, bool unk)
 {
 	typedef int (*custom_arg_funcptr_t)(Ship *this_arg, int x_arg, int y_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func950::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func951::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func951
+namespace _func952
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::SetSelectedRoom", typeid(void (Ship::*)(int )), ".415431c94189f4554889fd53488b5710", nullptr, 0, 0, &func);
@@ -12157,11 +12170,11 @@ namespace _func951
 void Ship::SetSelectedRoom(int roomId)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func951::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func952::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func952
+namespace _func953
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::SetRoomBlackout", typeid(void (Ship::*)(int , bool )), "!.4863c60fb6f2", nullptr, 0, 0, &func);
@@ -12170,11 +12183,11 @@ namespace _func952
 void Ship::SetRoomBlackout(int roomId, bool blackout)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool blackout_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func952::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func953::func;
 	return execfunc(this, roomId, blackout);
 }
 
-namespace _func953
+namespace _func954
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::GetAvailableRoomSlot", typeid(int (Ship::*)(int , bool )), "!.4863c60fb6f2", nullptr, 0, 0, &func);
@@ -12183,11 +12196,11 @@ namespace _func953
 int Ship::GetAvailableRoomSlot(int roomId, bool intruder)
 {
 	typedef int (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func953::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func954::func;
 	return execfunc(this, roomId, intruder);
 }
 
-namespace _func954
+namespace _func955
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::EmptySlots", typeid(int (Ship::*)(int )), ".41544863f64c8d24f500000000554889fd", nullptr, 0, 0, &func);
@@ -12196,11 +12209,11 @@ namespace _func954
 int Ship::EmptySlots(int roomId)
 {
 	typedef int (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func954::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func955::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func955
+namespace _func956
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::FullRoom", typeid(bool (Ship::*)(int , bool )), ".488b4f10488b47184829c848c1f80339c6", nullptr, 0, 0, &func);
@@ -12209,11 +12222,11 @@ namespace _func955
 bool Ship::FullRoom(int roomId, bool intruder)
 {
 	typedef bool (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func955::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func956::func;
 	return execfunc(this, roomId, intruder);
 }
 
-namespace _func956
+namespace _func957
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::GetAvailableRoom", typeid(int (Ship::*)(int , bool )), ".41574156440fb6f2415541544189f4554889fd534883ec48", nullptr, 0, 0, &func);
@@ -12222,11 +12235,11 @@ namespace _func956
 int Ship::GetAvailableRoom(int preferred, bool intruder)
 {
 	typedef int (*custom_arg_funcptr_t)(Ship *this_arg, int preferred_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func956::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func957::func;
 	return execfunc(this, preferred, intruder);
 }
 
-namespace _func957
+namespace _func958
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::OnRenderWalls", typeid(void (Ship::*)(bool , bool )), ".41574531ff41564c8db7500400004155440fb6ee41544189d45531ed534889fb4883ec18", nullptr, 0, 0, &func);
@@ -12235,11 +12248,11 @@ namespace _func957
 void Ship::OnRenderWalls(bool forceView, bool doorControlMode)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, bool forceView_arg, bool doorControlMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func957::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func958::func;
 	return execfunc(this, forceView, doorControlMode);
 }
 
-namespace _func958
+namespace _func959
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::OnLoop", typeid(void (Ship::*)(std::vector<float> &)), ".415741564989fe41554154554889f553488d9f500400004883ec68", nullptr, 0, 0, &func);
@@ -12248,11 +12261,11 @@ namespace _func958
 void Ship::OnLoop(std::vector<float> &oxygenLevels)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, std::vector<float> &oxygenLevels_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func958::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func959::func;
 	return execfunc(this, oxygenLevels);
 }
 
-namespace _func959
+namespace _func960
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::BreachRandomHull", typeid(void (Ship::*)(int )), ".4156415541544989fc554863ee534883ec40", nullptr, 0, 0, &func);
@@ -12261,11 +12274,11 @@ namespace _func959
 void Ship::BreachRandomHull(int roomId)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func959::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func960::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func960
+namespace _func961
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::GetHullBreaches", typeid(std::vector<Repairable*> (Ship::*)(bool )), ".41554154554889f5534889fb4883ec18", nullptr, 0, 0, &func);
@@ -12274,11 +12287,11 @@ namespace _func960
 std::vector<Repairable*> Ship::GetHullBreaches(bool onlyDamaged)
 {
 	typedef std::vector<Repairable*> (*custom_arg_funcptr_t)(Ship *this_arg, bool onlyDamaged_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func960::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func961::func;
 	return execfunc(this, onlyDamaged);
 }
 
-namespace _func961
+namespace _func962
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::LockdownRoom", typeid(void (Ship::*)(int , Pointf )), ".41574989ff4156415541545589f5534881ec38010000", nullptr, 0, 0, &func);
@@ -12287,11 +12300,11 @@ namespace _func961
 void Ship::LockdownRoom(int roomId, Pointf pos)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, Pointf pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func961::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func962::func;
 	return execfunc(this, roomId, pos);
 }
 
-namespace _func962
+namespace _func963
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Ship::OnInit", typeid(void (Ship::*)(ShipBlueprint *)), "!.41574989ff41564155415455534889f34881ec28030100", nullptr, 0, 0, &func);
@@ -12300,41 +12313,41 @@ namespace _func962
 void Ship::OnInit(ShipBlueprint *bp)
 {
 	typedef void (*custom_arg_funcptr_t)(Ship *this_arg, ShipBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func962::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func963::func;
 	return execfunc(this, bp);
-}
-
-namespace _noop963
-{
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_4", "!.39c17d03(c60201)");
 }
 
 namespace _noop964
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_1", "!.39c27d03(c60101)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_4", "!.39c17d03(c60201)");
 }
 
 namespace _noop965
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_5", "!.89c67e03(c60201)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_1", "!.39c27d03(c60101)");
 }
 
 namespace _noop966
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_2", "!.89c67d03(c60101)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_5", "!.89c67e03(c60201)");
 }
 
 namespace _noop967
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_3", "!.39c17d0b(c684149000000001)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_2", "!.89c67d03(c60101)");
 }
 
 namespace _noop968
 {
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_3", "!.39c17d0b(c684149000000001)");
+}
+
+namespace _noop969
+{
     static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_0", "!.39c27d0b(c6840cb000000001)");
 }
 
-namespace _func969
+namespace _func970
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipAI::constructor", typeid(void (ShipAI::*)(bool )), "5589f5534889fb488d7f104883ec0848c747f800000000", nullptr, 0, 0, &func);
@@ -12343,11 +12356,11 @@ namespace _func969
 void ShipAI::constructor(bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipAI *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func969::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func970::func;
 	return execfunc(this, unk);
 }
 
-namespace _func970
+namespace _func971
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipAI::SetStalemate", typeid(void (ShipAI::*)(bool )), ".4084f6740980bf9801000000", nullptr, 0, 0, &func);
@@ -12356,11 +12369,11 @@ namespace _func970
 void ShipAI::SetStalemate(bool stalemate)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipAI *this_arg, bool stalemate_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func970::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func971::func;
 	return execfunc(this, stalemate);
 }
 
-namespace _func971
+namespace _func972
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipAI::OnLoop", typeid(void (ShipAI::*)(bool )), ".41545589f5534889fb4883ec304084f6488b07", nullptr, 0, 0, &func);
@@ -12369,11 +12382,11 @@ namespace _func971
 void ShipAI::OnLoop(bool hostile)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipAI *this_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func971::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func972::func;
 	return execfunc(this, hostile);
 }
 
-namespace _func972
+namespace _func973
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipAI::GetTeleportCommand", typeid(std::pair<int, int> (ShipAI::*)()), "5348837f08004889fb", nullptr, 0, 0, &func);
@@ -12382,11 +12395,11 @@ namespace _func972
 std::pair<int, int> ShipAI::GetTeleportCommand()
 {
 	typedef std::pair<int, int> (*custom_arg_funcptr_t)(ShipAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func972::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func973::func;
 	return execfunc(this);
 }
 
-namespace _func973
+namespace _func974
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBlueprint::destructor", typeid(void (ShipBlueprint::*)()), "4154554889fd534883ec10488b874002000048c707", nullptr, 0, 0, &func);
@@ -12395,11 +12408,11 @@ namespace _func973
 void ShipBlueprint::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func973::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func974::func;
 	return execfunc(this);
 }
 
-namespace _func974
+namespace _func975
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::constructor", typeid(void (ShipBuilder::*)()), "534889fb488d7f184883ec30", nullptr, 0, 0, &func);
@@ -12408,11 +12421,11 @@ namespace _func974
 void ShipBuilder::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func974::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func975::func;
 	return execfunc(this);
 }
 
-namespace _func975
+namespace _func976
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::MouseMove", typeid(void (ShipBuilder::*)(int , int )), ".4157488d87201100004989ff41564889c7415541545589d55389f34881ec08010000", nullptr, 0, 0, &func);
@@ -12421,30 +12434,17 @@ namespace _func975
 void ShipBuilder::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func975::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func976::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func976
+namespace _func977
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::ClearShipAchievements", typeid(void (ShipBuilder::*)()), ".488b87f81d0000c787101e0000ffffffff", nullptr, 0, 0, &func);
 }
 
 void ShipBuilder::ClearShipAchievements()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func976::func;
-	return execfunc(this);
-}
-
-namespace _func977
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipBuilder::Close", typeid(void (ShipBuilder::*)()), ".5553??89fb??83ec08??8bb710110000??8b9708110000", nullptr, 0, 0, &func);
-}
-
-void ShipBuilder::Close()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func977::func;
@@ -12454,12 +12454,12 @@ void ShipBuilder::Close()
 namespace _func978
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipBuilder::GetShip", typeid(ShipManager *(ShipBuilder::*)()), ".5331c04889fb4881", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipBuilder::Close", typeid(void (ShipBuilder::*)()), ".5553??89fb??83ec08??8bb710110000??8b9708110000", nullptr, 0, 0, &func);
 }
 
-ShipManager *ShipBuilder::GetShip()
+void ShipBuilder::Close()
 {
-	typedef ShipManager *(*custom_arg_funcptr_t)(ShipBuilder *this_arg);
+	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func978::func;
 	return execfunc(this);
 }
@@ -12467,12 +12467,12 @@ ShipManager *ShipBuilder::GetShip()
 namespace _func979
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipBuilder::SetupShipAchievements", typeid(void (ShipBuilder::*)()), ".4156be????????41554989fd415455534883ec50", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipBuilder::GetShip", typeid(ShipManager *(ShipBuilder::*)()), ".5331c04889fb4881", nullptr, 0, 0, &func);
 }
 
-void ShipBuilder::SetupShipAchievements()
+ShipManager *ShipBuilder::GetShip()
 {
-	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
+	typedef ShipManager *(*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func979::func;
 	return execfunc(this);
 }
@@ -12480,10 +12480,10 @@ void ShipBuilder::SetupShipAchievements()
 namespace _func980
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipBuilder::CreateEquipmentBoxes", typeid(void (ShipBuilder::*)()), ".41574989ff41564155415455534883ec48488bb710110000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipBuilder::SetupShipAchievements", typeid(void (ShipBuilder::*)()), ".4156be????????41554989fd415455534883ec50", nullptr, 0, 0, &func);
 }
 
-void ShipBuilder::CreateEquipmentBoxes()
+void ShipBuilder::SetupShipAchievements()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func980::func;
@@ -12493,10 +12493,10 @@ void ShipBuilder::CreateEquipmentBoxes()
 namespace _func981
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipBuilder::CreateSystemBoxes", typeid(void (ShipBuilder::*)()), ".4157415641554154554889fd534883ec18488bb700120000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CreateEquipmentBoxes", typeid(void (ShipBuilder::*)()), ".41574989ff41564155415455534883ec48488bb710110000", nullptr, 0, 0, &func);
 }
 
-void ShipBuilder::CreateSystemBoxes()
+void ShipBuilder::CreateEquipmentBoxes()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func981::func;
@@ -12506,10 +12506,10 @@ void ShipBuilder::CreateSystemBoxes()
 namespace _func982
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipBuilder::OnRender", typeid(void (ShipBuilder::*)()), ".4155415455534889fb4883ec7880bf5814000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CreateSystemBoxes", typeid(void (ShipBuilder::*)()), ".4157415641554154554889fd534883ec18488bb700120000", nullptr, 0, 0, &func);
 }
 
-void ShipBuilder::OnRender()
+void ShipBuilder::CreateSystemBoxes()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func982::func;
@@ -12519,10 +12519,10 @@ void ShipBuilder::OnRender()
 namespace _func983
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipBuilder::OnLoop", typeid(void (ShipBuilder::*)()), ".415741564155415455534889fb", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipBuilder::OnRender", typeid(void (ShipBuilder::*)()), ".4155415455534889fb4883ec7880bf5814000000", nullptr, 0, 0, &func);
 }
 
-void ShipBuilder::OnLoop()
+void ShipBuilder::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func983::func;
@@ -12532,10 +12532,10 @@ void ShipBuilder::OnLoop()
 namespace _func984
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipBuilder::CheckTypes", typeid(void (ShipBuilder::*)()), ".4155ba01000000415455534889fb4c8da3580b00004883ec18", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipBuilder::OnLoop", typeid(void (ShipBuilder::*)()), ".415741564155415455534889fb", nullptr, 0, 0, &func);
 }
 
-void ShipBuilder::CheckTypes()
+void ShipBuilder::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func984::func;
@@ -12545,17 +12545,30 @@ void ShipBuilder::CheckTypes()
 namespace _func985
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipBuilder::CheckTypes", typeid(void (ShipBuilder::*)()), ".4155ba01000000415455534889fb4c8da3580b00004883ec18", nullptr, 0, 0, &func);
+}
+
+void ShipBuilder::CheckTypes()
+{
+	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func985::func;
+	return execfunc(this);
+}
+
+namespace _func986
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::SwitchShip", typeid(void (ShipBuilder::*)(int , int )), ".41554189f541544c63e255534889fb4883ec28", nullptr, 0, 0, &func);
 }
 
 void ShipBuilder::SwitchShip(int shipType, int shipVariant)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int shipType_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func985::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func986::func;
 	return execfunc(this, shipType, shipVariant);
 }
 
-namespace _func986
+namespace _func987
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::CycleShipNext", typeid(void (ShipBuilder::*)()), "!.41564989fe415541545553488b3f4885ff", nullptr, 0, 0, &func);
@@ -12564,11 +12577,11 @@ namespace _func986
 void ShipBuilder::CycleShipNext()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func986::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func987::func;
 	return execfunc(this);
 }
 
-namespace _func987
+namespace _func988
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::SwapType", typeid(void (ShipBuilder::*)(int )), "!.5589f5534889fb4883ec08488b3f4885ff", nullptr, 0, 0, &func);
@@ -12577,30 +12590,17 @@ namespace _func987
 void ShipBuilder::SwapType(int variant)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int variant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func987::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func988::func;
 	return execfunc(this, variant);
 }
 
-namespace _func988
+namespace _func989
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::CycleTypeNext", typeid(void (ShipBuilder::*)()), ".??54??31e455??89fd538b87841d00008d5801", nullptr, 0, 0, &func);
 }
 
 void ShipBuilder::CycleTypeNext()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func988::func;
-	return execfunc(this);
-}
-
-namespace _func989
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipBuilder::CycleTypePrev", typeid(void (ShipBuilder::*)()), ".??54??bc0200000055??89fd538b87841d00008d58ffeb", nullptr, 0, 0, &func);
-}
-
-void ShipBuilder::CycleTypePrev()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func989::func;
@@ -12610,10 +12610,10 @@ void ShipBuilder::CycleTypePrev()
 namespace _func990
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipBuilder::CycleShipPrevious", typeid(void (ShipBuilder::*)()), "!.41564989fe415541545553488b3f4885ff", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CycleTypePrev", typeid(void (ShipBuilder::*)()), ".??54??bc0200000055??89fd538b87841d00008d58ffeb", nullptr, 0, 0, &func);
 }
 
-void ShipBuilder::CycleShipPrevious()
+void ShipBuilder::CycleTypePrev()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func990::func;
@@ -12623,17 +12623,30 @@ void ShipBuilder::CycleShipPrevious()
 namespace _func991
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipBuilder::CycleShipPrevious", typeid(void (ShipBuilder::*)()), "!.41564989fe415541545553488b3f4885ff", nullptr, 0, 0, &func);
+}
+
+void ShipBuilder::CycleShipPrevious()
+{
+	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func991::func;
+	return execfunc(this);
+}
+
+namespace _func992
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::OnKeyDown", typeid(void (ShipBuilder::*)(SDLKey )), ".5589f5534889fb4883ec0880bf5814000000", nullptr, 0, 0, &func);
 }
 
 void ShipBuilder::OnKeyDown(SDLKey key)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func991::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func992::func;
 	return execfunc(this, key);
 }
 
-namespace _func992
+namespace _func993
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::MouseClick", typeid(void (ShipBuilder::*)(int , int )), ".415455534889fb4883ec3080bf701b000000", nullptr, 0, 0, &func);
@@ -12642,11 +12655,11 @@ namespace _func992
 void ShipBuilder::MouseClick(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func992::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func993::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func993
+namespace _func994
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipBuilder::Open", typeid(void (ShipBuilder::*)()), ".4157415641554154554889fd534881ece8030000", nullptr, 0, 0, &func);
@@ -12655,11 +12668,11 @@ namespace _func993
 void ShipBuilder::Open()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func993::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func994::func;
 	return execfunc(this);
 }
 
-namespace _func994
+namespace _func995
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipButton::constructor", typeid(void (ShipButton::*)(int , int )), "41574156415541544189d45589f5534889fb4881ec38030000", nullptr, 0, 0, &func);
@@ -12668,11 +12681,11 @@ namespace _func994
 void ShipButton::constructor(int shipType, int shipVariant)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipButton *this_arg, int shipType_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func994::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func995::func;
 	return execfunc(this, shipType, shipVariant);
 }
 
-namespace _func995
+namespace _func996
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipButton::OnInit", typeid(void (ShipButton::*)(const std::string &, Point )), ".4889d1534889fb48c1f920", nullptr, 0, 0, &func);
@@ -12681,11 +12694,11 @@ namespace _func995
 void ShipButton::OnInit(const std::string &imgName, Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipButton *this_arg, const std::string &imgName_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func995::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func996::func;
 	return execfunc(this, imgName, pos);
 }
 
-namespace _func996
+namespace _func997
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipButton::MouseMove", typeid(void (ShipButton::*)(int , int )), "!.41554189f5415455534889fb4883ec18", nullptr, 0, 0, &func);
@@ -12694,11 +12707,11 @@ namespace _func996
 void ShipButton::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipButton *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func996::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func997::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func997
+namespace _func998
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipButton::OnRender", typeid(void (ShipButton::*)()), ".55534889fb4883ec4880bf9800000000", nullptr, 0, 0, &func);
@@ -12707,11 +12720,11 @@ namespace _func997
 void ShipButton::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func997::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func998::func;
 	return execfunc(this);
 }
 
-namespace _func998
+namespace _func999
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipEvent::constructor", typeid(void (ShipEvent::*)(const ShipEvent &)), "415641554989f5488d760841544989fc488d7f08", nullptr, 0, 0, &func);
@@ -12720,11 +12733,11 @@ namespace _func998
 void ShipEvent::constructor(const ShipEvent &event)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipEvent *this_arg, const ShipEvent &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func998::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func999::func;
 	return execfunc(this, event);
 }
 
-namespace _func999
+namespace _func1000
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGenerator::UpgradeSystem", typeid(bool (*)(ShipManager *, std::vector<int> &, unsigned int )), "4157415641554189d541544989fc55534883ec38", nullptr, 0, 0, &func);
@@ -12733,11 +12746,11 @@ namespace _func999
 bool ShipGenerator::UpgradeSystem(ShipManager *ship, std::vector<int> &systemMaxes, unsigned int sysId)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, unsigned int sysId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func999::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1000::func;
 	return execfunc(ship, systemMaxes, sysId);
 }
 
-namespace _func1000
+namespace _func1001
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGenerator::GetPossibleCrewList", typeid(std::vector<CrewBlueprint> (*)(ShipManager *, const std::string &, unsigned int )), ".41574156415541544989d4554889fd534881ec88010000", nullptr, 0, 0, &func);
@@ -12746,11 +12759,11 @@ namespace _func1000
 std::vector<CrewBlueprint> ShipGenerator::GetPossibleCrewList(ShipManager *ship, const std::string &crewList, unsigned int flags)
 {
 	typedef std::vector<CrewBlueprint> (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &crewList_arg, unsigned int flags_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1000::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1001::func;
 	return execfunc(ship, crewList, flags);
 }
 
-namespace _func1001
+namespace _func1002
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGenerator::GetPossibleWeaponList", typeid(std::vector<WeaponBlueprint*> (*)(ShipManager *, const std::string &, int , unsigned int )), ".4157415641554589c5415455534889fb4889f74883ec68", nullptr, 0, 0, &func);
@@ -12759,11 +12772,11 @@ namespace _func1001
 std::vector<WeaponBlueprint*> ShipGenerator::GetPossibleWeaponList(ShipManager *ship, const std::string &weaponList, int scrap, unsigned int flags)
 {
 	typedef std::vector<WeaponBlueprint*> (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &weaponList_arg, int scrap_arg, unsigned int flags_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1001::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1002::func;
 	return execfunc(ship, weaponList, scrap, flags);
 }
 
-namespace _func1002
+namespace _func1003
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGenerator::GetPossibleDroneList", typeid(std::vector<DroneBlueprint*> (*)(ShipManager *, const std::string &, int , unsigned int , bool )), ".415741564989d6415541544589c4554889fd4889f7534489cb4881ec88000000", nullptr, 0, 0, &func);
@@ -12772,11 +12785,11 @@ namespace _func1002
 std::vector<DroneBlueprint*> ShipGenerator::GetPossibleDroneList(ShipManager *ship, const std::string &droneList, int scrap, unsigned int flags, bool repeat)
 {
 	typedef std::vector<DroneBlueprint*> (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &droneList_arg, int scrap_arg, unsigned int flags_arg, bool repeat_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1002::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1003::func;
 	return execfunc(ship, droneList, scrap, flags, repeat);
 }
 
-namespace _func1003
+namespace _func1004
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGenerator::GenerateSystemMaxes", typeid(std::vector<int> (*)(const ShipBlueprint &, int )), ".415741564989fe41554c8dae3001000041545589d55331db4883ec28", nullptr, 0, 0, &func);
@@ -12785,30 +12798,17 @@ namespace _func1003
 std::vector<int> ShipGenerator::GenerateSystemMaxes(const ShipBlueprint &ship, int level)
 {
 	typedef std::vector<int> (*custom_arg_funcptr_t)(const ShipBlueprint &ship_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1003::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1004::func;
 	return execfunc(ship, level);
 }
 
-namespace _func1004
+namespace _func1005
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades0", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".41574989ff41564989d64155415455534889f331f64883ec58", nullptr, 0, 0, &func);
 }
 
 std::vector<int> ShipGenerator::GetPossibleSystemUpgrades0(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
-{
-	typedef std::vector<int> (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1004::func;
-	return execfunc(ship, systemMaxes, scrap, type);
-}
-
-namespace _func1005
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades1", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".415741564989fe41554989d54154554889f531f6534883ec58", nullptr, 0, 0, &func);
-}
-
-std::vector<int> ShipGenerator::GetPossibleSystemUpgrades1(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1005::func;
@@ -12818,10 +12818,10 @@ std::vector<int> ShipGenerator::GetPossibleSystemUpgrades1(ShipManager *ship, st
 namespace _func1006
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades2", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".415741564989fe41554989d54154554889f531f6534883ec58", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades1", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".415741564989fe41554989d54154554889f531f6534883ec58", nullptr, 0, 0, &func);
 }
 
-std::vector<int> ShipGenerator::GetPossibleSystemUpgrades2(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
+std::vector<int> ShipGenerator::GetPossibleSystemUpgrades1(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1006::func;
@@ -12831,17 +12831,30 @@ std::vector<int> ShipGenerator::GetPossibleSystemUpgrades2(ShipManager *ship, st
 namespace _func1007
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades2", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".415741564989fe41554989d54154554889f531f6534883ec58", nullptr, 0, 0, &func);
+}
+
+std::vector<int> ShipGenerator::GetPossibleSystemUpgrades2(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
+{
+	typedef std::vector<int> (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1007::func;
+	return execfunc(ship, systemMaxes, scrap, type);
+}
+
+namespace _func1008
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipGenerator::CreateShip", typeid(ShipManager *(*)(const std::string &, int , ShipEvent &)), ".41574156415541544189f4554889d5534881ec18050000", nullptr, 0, 0, &func);
 }
 
 ShipManager *ShipGenerator::CreateShip(const std::string &name, int sector, ShipEvent &event)
 {
 	typedef ShipManager *(*custom_arg_funcptr_t)(const std::string &name_arg, int sector_arg, ShipEvent &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1007::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1008::func;
 	return execfunc(name, sector, event);
 }
 
-namespace _func1008
+namespace _func1009
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), ".41574989ff41564989d641554154554889f531f6534489c34883ec58", nullptr, 0, 0, &func);
@@ -12850,11 +12863,11 @@ namespace _func1008
 std::vector<int> ShipGenerator::GetPossibleSystemUpgrades(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1008::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1009::func;
 	return execfunc(ship, systemMaxes, scrap, type);
 }
 
-namespace _func1009
+namespace _func1010
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetSlotWorldPosition", typeid(Point (ShipGraph::*)(int , int )), "534863d289f34883ec20488b07", nullptr, 0, 0, &func);
@@ -12863,11 +12876,11 @@ namespace _func1009
 Point ShipGraph::GetSlotWorldPosition(int slotId, int roomId)
 {
 	typedef Point (*custom_arg_funcptr_t)(ShipGraph *this_arg, int slotId_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1009::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1010::func;
 	return execfunc(this, slotId, roomId);
 }
 
-namespace _func1010
+namespace _func1011
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetSlotRenderPosition", typeid(Point (ShipGraph::*)(int , int , bool )), ".41554c63ea41544989fc5589cd5389f34883ec28", nullptr, 0, 0, &func);
@@ -12876,11 +12889,11 @@ namespace _func1010
 Point ShipGraph::GetSlotRenderPosition(int slotId, int roomId, bool intruder)
 {
 	typedef Point (*custom_arg_funcptr_t)(ShipGraph *this_arg, int slotId_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1010::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1011::func;
 	return execfunc(this, slotId, roomId, intruder);
 }
 
-namespace _func1011
+namespace _func1012
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::DoorCount", typeid(int (ShipGraph::*)(int )), ".488b4f30488b573831c04829ca48c1fa02", nullptr, 0, 0, &func);
@@ -12889,11 +12902,11 @@ namespace _func1011
 int ShipGraph::DoorCount(int roomId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipGraph *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1011::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1012::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1012
+namespace _func1013
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ConnectingDoor", typeid(Door *(ShipGraph::*)(int , int , int , int )), ".415741564189d641554589c541544189cc5589f5534889fb4883ec68", nullptr, 0, 0, &func);
@@ -12902,11 +12915,11 @@ namespace _func1012
 Door *ShipGraph::ConnectingDoor(int x1, int y1, int x2, int y2)
 {
 	typedef Door *(*custom_arg_funcptr_t)(ShipGraph *this_arg, int x1_arg, int y1_arg, int x2_arg, int y2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1012::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1013::func;
 	return execfunc(this, x1, y1, x2, y2);
 }
 
-namespace _func1013
+namespace _func1014
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ConnectedGridSquares", typeid(int (ShipGraph::*)(int , int , int , int )), ".41574189cf41564589c641b82300000041554531ed41544989fcbf23000000", nullptr, 0, 0, &func);
@@ -12915,11 +12928,11 @@ namespace _func1013
 int ShipGraph::ConnectedGridSquares(int x1, int y1, int x2, int y2)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x1_arg, int y1_arg, int x2_arg, int y2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1013::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1014::func;
 	return execfunc(this, x1, y1, x2, y2);
 }
 
-namespace _func1014
+namespace _func1015
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ConnectedGridSquaresPoint", typeid(int (ShipGraph::*)(Point , Point )), "!.4889d14889f24989c8", nullptr, 0, 0, &func);
@@ -12928,11 +12941,11 @@ namespace _func1014
 int ShipGraph::ConnectedGridSquaresPoint(Point p1, Point p2)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1014::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1015::func;
 	return execfunc(this, p1, p2);
 }
 
-namespace _func1015
+namespace _func1016
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ConnectingDoor", typeid(Door *(ShipGraph::*)(Point , Point )), "!.4889d14889f24989c8", nullptr, 0, 0, &func);
@@ -12941,11 +12954,11 @@ namespace _func1015
 Door *ShipGraph::ConnectingDoor(Point p1, Point p2)
 {
 	typedef Door *(*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1015::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1016::func;
 	return execfunc(this, p1, p2);
 }
 
-namespace _func1016
+namespace _func1017
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetNumSlots", typeid(int (ShipGraph::*)(int )), ".488b074863f6488b04f0", nullptr, 0, 0, &func);
@@ -12954,11 +12967,11 @@ namespace _func1016
 int ShipGraph::GetNumSlots(int room)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1016::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1017::func;
 	return execfunc(this, room);
 }
 
-namespace _func1017
+namespace _func1018
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::PopClosestDoor", typeid(int (ShipGraph::*)(std::vector<int> &, std::vector<float> &)), ".554889f5534883ec08", nullptr, 0, 0, &func);
@@ -12967,30 +12980,17 @@ namespace _func1017
 int ShipGraph::PopClosestDoor(std::vector<int> &doors, std::vector<float> &distances)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipGraph *this_arg, std::vector<int> &doors_arg, std::vector<float> &distances_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1017::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1018::func;
 	return execfunc(this, doors, distances);
 }
 
-namespace _func1018
+namespace _func1019
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ConvertToWorldAngle", typeid(float (ShipGraph::*)(float )), ".f30f584758", nullptr, 0, 0, &func);
 }
 
 float ShipGraph::ConvertToWorldAngle(float ang)
-{
-	typedef float (*custom_arg_funcptr_t)(ShipGraph *this_arg, float ang_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1018::func;
-	return execfunc(this, ang);
-}
-
-namespace _func1019
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipGraph::ConvertToLocalAngle", typeid(float (ShipGraph::*)(float )), ".f30f5c4758", nullptr, 0, 0, &func);
-}
-
-float ShipGraph::ConvertToLocalAngle(float ang)
 {
 	typedef float (*custom_arg_funcptr_t)(ShipGraph *this_arg, float ang_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1019::func;
@@ -13000,17 +13000,30 @@ float ShipGraph::ConvertToLocalAngle(float ang)
 namespace _func1020
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipGraph::ConvertToLocalAngle", typeid(float (ShipGraph::*)(float )), ".f30f5c4758", nullptr, 0, 0, &func);
+}
+
+float ShipGraph::ConvertToLocalAngle(float ang)
+{
+	typedef float (*custom_arg_funcptr_t)(ShipGraph *this_arg, float ang_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1020::func;
+	return execfunc(this, ang);
+}
+
+namespace _func1021
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ConvertToWorldPosition", typeid(Pointf (ShipGraph::*)(Pointf )), ".534889fb4883ec20f30f2a7f48", nullptr, 0, 0, &func);
 }
 
 Pointf ShipGraph::ConvertToWorldPosition(Pointf local)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(ShipGraph *this_arg, Pointf local_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1020::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1021::func;
 	return execfunc(this, local);
 }
 
-namespace _func1021
+namespace _func1022
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ConvertToLocalPosition", typeid(Pointf (ShipGraph::*)(Pointf , bool )), ".4883ec184084f6660fd60424", nullptr, 0, 0, &func);
@@ -13019,11 +13032,11 @@ namespace _func1021
 Pointf ShipGraph::ConvertToLocalPosition(Pointf world, bool past)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(ShipGraph *this_arg, Pointf world_arg, bool past_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1021::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1022::func;
 	return execfunc(this, world, past);
 }
 
-namespace _func1022
+namespace _func1023
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ComputeCenter", typeid(void (ShipGraph::*)()), ".41574989ff41564155415455534883ec18", nullptr, 0, 0, &func);
@@ -13032,11 +13045,11 @@ namespace _func1022
 void ShipGraph::ComputeCenter()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipGraph *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1022::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1023::func;
 	return execfunc(this);
 }
 
-namespace _func1023
+namespace _func1024
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ContainsPoint", typeid(bool (ShipGraph::*)(int , int )), ".8b4f6831c039f1", nullptr, 0, 0, &func);
@@ -13045,11 +13058,11 @@ namespace _func1023
 bool ShipGraph::ContainsPoint(int x, int y)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1023::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1024::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1024
+namespace _func1025
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetSelectedRoom", typeid(int (ShipGraph::*)(int , int , bool )), ".41574531c04989ff41564531f6415541544189f45589d5530fb6d94883ec08", nullptr, 0, 0, &func);
@@ -13058,11 +13071,11 @@ namespace _func1024
 int ShipGraph::GetSelectedRoom(int x, int y, bool unk)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x_arg, int y_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1024::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1025::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func1025
+namespace _func1026
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::RoomCount", typeid(int (ShipGraph::*)()), ".488b4708482b0748c1f803", nullptr, 0, 0, &func);
@@ -13071,11 +13084,11 @@ namespace _func1025
 int ShipGraph::RoomCount()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipGraph *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1025::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1026::func;
 	return execfunc(this);
 }
 
-namespace _func1026
+namespace _func1027
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetRoomOxygen", typeid(float (ShipGraph::*)(int )), ".85f60f57c0", nullptr, 0, 0, &func);
@@ -13084,11 +13097,11 @@ namespace _func1026
 float ShipGraph::GetRoomOxygen(int room)
 {
 	typedef float (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1026::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1027::func;
 	return execfunc(this, room);
 }
 
-namespace _func1027
+namespace _func1028
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetRoomBlackedOut", typeid(bool (ShipGraph::*)(int )), ".85f6b801000000", nullptr, 0, 0, &func);
@@ -13097,11 +13110,11 @@ namespace _func1027
 bool ShipGraph::GetRoomBlackedOut(int room)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1027::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1028::func;
 	return execfunc(this, room);
 }
 
-namespace _func1028
+namespace _func1029
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::Restart", typeid(void (*)()), ".415741564155415455534883ec284c8b25", nullptr, 0, 0, &func);
@@ -13110,11 +13123,11 @@ namespace _func1028
 void ShipGraph::Restart()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1028::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1029::func;
 	return execfunc();
 }
 
-namespace _func1029
+namespace _func1030
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetDoors", typeid(std::vector<Door*> (ShipGraph::*)(int )), ".41564531c04989f6415541544189d4554889fd53", nullptr, 0, 0, &func);
@@ -13123,11 +13136,11 @@ namespace _func1029
 std::vector<Door*> ShipGraph::GetDoors(int roomId)
 {
 	typedef std::vector<Door*> (*custom_arg_funcptr_t)(ShipGraph *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1029::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1030::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1030
+namespace _func1031
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::IsRoomConnected", typeid(bool (ShipGraph::*)(int , int )), ".41564155415441bc010000005589d55389f34883ec20", nullptr, 0, 0, &func);
@@ -13136,11 +13149,11 @@ namespace _func1030
 bool ShipGraph::IsRoomConnected(int room1, int room2)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room1_arg, int room2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1030::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1031::func;
 	return execfunc(this, room1, room2);
 }
 
-namespace _func1031
+namespace _func1032
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetShipInfo", typeid(ShipGraph *(*)(int )), ".5389fb4881ec90000000", nullptr, 0, 0, &func);
@@ -13149,11 +13162,11 @@ namespace _func1031
 ShipGraph *ShipGraph::GetShipInfo(int shipId)
 {
 	typedef ShipGraph *(*custom_arg_funcptr_t)(int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1031::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1032::func;
 	return execfunc(shipId);
 }
 
-namespace _func1032
+namespace _func1033
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::ConnectivityDFS", typeid(std::vector<int> (ShipGraph::*)(int )), ".??56??55??54??89d455??89f553??89fb??83ec40", nullptr, 0, 0, &func);
@@ -13162,11 +13175,11 @@ namespace _func1032
 std::vector<int> ShipGraph::ConnectivityDFS(int roomId)
 {
 	typedef std::vector<int> (*custom_arg_funcptr_t)(ShipGraph *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1032::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1033::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1033
+namespace _func1034
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::Dijkstra", typeid(Path (ShipGraph::*)(Point , Point , int )), ".41574989f741564155415455534889d348c1eb204881ecc8000000", nullptr, 0, 0, &func);
@@ -13175,11 +13188,11 @@ namespace _func1033
 Path ShipGraph::Dijkstra(Point start, Point goal, int shipId)
 {
 	typedef Path (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point start_arg, Point goal_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1033::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1034::func;
 	return execfunc(this, start, goal, shipId);
 }
 
-namespace _func1034
+namespace _func1035
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::FindPath", typeid(Path (ShipGraph::*)(Point , Point , int )), ".415741564989f641554154554889d548c1ed20534889fb4883ec58", nullptr, 0, 0, &func);
@@ -13188,11 +13201,11 @@ namespace _func1034
 Path ShipGraph::FindPath(Point p1, Point p2, int shipId)
 {
 	typedef Path (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1034::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1035::func;
 	return execfunc(this, p1, p2, shipId);
 }
 
-namespace _func1035
+namespace _func1036
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipGraph::GetClosestSlot", typeid(Slot (ShipGraph::*)(Point , int , bool )), ".41574889f04531ff48c1e820415641554189f54154440fb6e1554889fd534889c34881eca8000000", nullptr, 0, 0, &func);
@@ -13201,11 +13214,11 @@ namespace _func1035
 Slot ShipGraph::GetClosestSlot(Point pos, int shipId, bool intruder)
 {
 	typedef Slot (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point pos_arg, int shipId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1035::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1036::func;
 	return execfunc(this, pos, shipId, intruder);
 }
 
-namespace _func1036
+namespace _func1037
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipInfo::AddAugmentation", typeid(char (ShipInfo::*)(const std::string &)), "415731c041564155415455534889fb4883ec48837f6002", nullptr, 0, 0, &func);
@@ -13214,11 +13227,11 @@ namespace _func1036
 char ShipInfo::AddAugmentation(const std::string &augment)
 {
 	typedef char (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1036::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1037::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1037
+namespace _func1038
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipInfo::HasAugmentation", typeid(bool (ShipInfo::*)(const std::string &)), "4157488d47084989f7415641554989fd4154554889c5534883ec28", nullptr, 0, 0, &func);
@@ -13227,11 +13240,11 @@ namespace _func1037
 bool ShipInfo::HasAugmentation(const std::string &augment)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1037::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1038::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1038
+namespace _func1039
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipInfo::GetAugmentationValue", typeid(float (ShipInfo::*)(const std::string &)), ".4157415641554989fd415455534883ec48488d7c2430", nullptr, 0, 0, &func);
@@ -13240,11 +13253,11 @@ namespace _func1038
 float ShipInfo::GetAugmentationValue(const std::string &augment)
 {
 	typedef float (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1038::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1039::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1039
+namespace _func1040
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::IsCloaked", typeid(bool (ShipManager::*)()), "488b8758060000837828ff7413488b4750", nullptr, 0, 0, &func);
@@ -13253,11 +13266,11 @@ namespace _func1039
 bool ShipManager::IsCloaked()
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1039::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1040::func;
 	return execfunc(this);
 }
 
-namespace _func1040
+namespace _func1041
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetShieldPower", typeid(ShieldPower (ShipManager::*)()), ".488b87800000004885c0741c", nullptr, 0, 0, &func);
@@ -13266,11 +13279,11 @@ namespace _func1040
 ShieldPower ShipManager::GetShieldPower()
 {
 	typedef ShieldPower (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1040::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1041::func;
 	return execfunc(this);
 }
 
-namespace _func1041
+namespace _func1042
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CloneHealing", typeid(void (ShipManager::*)()), ".41554154", nullptr, 0, 0, &func);
@@ -13279,11 +13292,11 @@ namespace _func1041
 void ShipManager::CloneHealing()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1041::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1042::func;
 	return execfunc(this);
 }
 
-namespace _func1042
+namespace _func1043
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::IsSystemHacked2", typeid(int (ShipManager::*)(int )), ".83fe1174????8b8758060000??63d6??63149031c083faff75??", nullptr, 0, 0, &func);
@@ -13292,11 +13305,11 @@ namespace _func1042
 int ShipManager::IsSystemHacked2(int systemId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1042::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1043::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1043
+namespace _func1044
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::SaveCrewPositions", typeid(void (ShipManager::*)()), ".5331d2bf??????????83ec20??89e6??c704??00000000", nullptr, 0, 0, &func);
@@ -13305,30 +13318,17 @@ namespace _func1043
 void ShipManager::SaveCrewPositions()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1043::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1044::func;
 	return execfunc(this);
 }
 
-namespace _func1044
+namespace _func1045
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CanFitSystem", typeid(bool (ShipManager::*)(int )), ".415483fe054989fc5553", nullptr, 0, 0, &func);
 }
 
 bool ShipManager::CanFitSystem(int systemId)
-{
-	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1044::func;
-	return execfunc(this, systemId);
-}
-
-namespace _func1045
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::CanFitSubsystem", typeid(bool (ShipManager::*)(int )), ".41544989fc5553488b5728488b47304829d0", nullptr, 0, 0, &func);
-}
-
-bool ShipManager::CanFitSubsystem(int systemId)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1045::func;
@@ -13338,17 +13338,30 @@ bool ShipManager::CanFitSubsystem(int systemId)
 namespace _func1046
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::CanFitSubsystem", typeid(bool (ShipManager::*)(int )), ".41544989fc5553488b5728488b47304829d0", nullptr, 0, 0, &func);
+}
+
+bool ShipManager::CanFitSubsystem(int systemId)
+{
+	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1046::func;
+	return execfunc(this, systemId);
+}
+
+namespace _func1047
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::DamageHull", typeid(int (ShipManager::*)(int , bool )), ".41544189d45589f553488b074889fb", nullptr, 0, 0, &func);
 }
 
 int ShipManager::DamageHull(int dmg, bool force)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int dmg_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1046::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1047::func;
 	return execfunc(this, dmg, force);
 }
 
-namespace _func1047
+namespace _func1048
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ModifyScrapCount", typeid(void (ShipManager::*)(int , bool )), ".41545589f5534889fb4883ec3085f6", nullptr, 0, 0, &func);
@@ -13357,11 +13370,11 @@ namespace _func1047
 void ShipManager::ModifyScrapCount(int scrap, bool income)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int scrap_arg, bool income_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1047::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1048::func;
 	return execfunc(this, scrap, income);
 }
 
-namespace _func1048
+namespace _func1049
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetCrewmember", typeid(CrewMember *(ShipManager::*)(int , bool )), ".4156415541544989fc5589f553488bb7c8000000", nullptr, 0, 0, &func);
@@ -13370,11 +13383,11 @@ namespace _func1048
 CrewMember *ShipManager::GetCrewmember(int slot, bool present)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(ShipManager *this_arg, int slot_arg, bool present_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1048::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1049::func;
 	return execfunc(this, slot, present);
 }
 
-namespace _func1049
+namespace _func1050
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::RemoveCrewmember", typeid(void (ShipManager::*)(CrewMember *)), ".55??89fd53??83ec08??8b87c0000000??8b8fc8000000??29c1??c1f903??85c974??", nullptr, 0, 0, &func);
@@ -13383,11 +13396,11 @@ namespace _func1049
 void ShipManager::RemoveCrewmember(CrewMember *crew)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1049::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1050::func;
 	return execfunc(this, crew);
 }
 
-namespace _func1050
+namespace _func1051
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::FindCrew", typeid(CrewMember *(ShipManager::*)(const CrewBlueprint *)), ".415731c931d2", nullptr, 0, 0, &func);
@@ -13396,11 +13409,11 @@ namespace _func1050
 CrewMember *ShipManager::FindCrew(const CrewBlueprint *bp)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(ShipManager *this_arg, const CrewBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1050::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1051::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1051
+namespace _func1052
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ResetScrapLevel", typeid(void (ShipManager::*)()), ".8b05????????c787700600001e00000083f801", nullptr, 0, 0, &func);
@@ -13409,11 +13422,11 @@ namespace _func1051
 void ShipManager::ResetScrapLevel()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1051::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1052::func;
 	return execfunc(this);
 }
 
-namespace _func1052
+namespace _func1053
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CountPlayerCrew", typeid(int (ShipManager::*)()), ".41564989fe415541545553488b87c800", nullptr, 0, 0, &func);
@@ -13422,11 +13435,11 @@ namespace _func1052
 int ShipManager::CountPlayerCrew()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1052::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1053::func;
 	return execfunc(this);
 }
 
-namespace _func1053
+namespace _func1054
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CountCrew", typeid(int (ShipManager::*)(bool )), ".41574989ff41564155415455534883ec08488b8fc0000000", nullptr, 0, 0, &func);
@@ -13435,11 +13448,11 @@ namespace _func1053
 int ShipManager::CountCrew(bool boarders)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, bool boarders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1053::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1054::func;
 	return execfunc(this, boarders);
 }
 
-namespace _func1054
+namespace _func1055
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CountCrewShipId", typeid(int (ShipManager::*)(int , int )), ".415741564989fe4155415455534883ec18488b87c8000000", nullptr, 0, 0, &func);
@@ -13448,30 +13461,17 @@ namespace _func1054
 int ShipManager::CountCrewShipId(int roomId, int shipId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1054::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1055::func;
 	return execfunc(this, roomId, shipId);
 }
 
-namespace _func1055
+namespace _func1056
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::IsCrewOverFull", typeid(bool (ShipManager::*)()), ".538b470831f64889fb", nullptr, 0, 0, &func);
 }
 
 bool ShipManager::IsCrewOverFull()
-{
-	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1055::func;
-	return execfunc(this);
-}
-
-namespace _func1056
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::IsCrewFull", typeid(bool (ShipManager::*)()), ".538b470831f64889fb", nullptr, 0, 0, &func);
-}
-
-bool ShipManager::IsCrewFull()
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1056::func;
@@ -13481,36 +13481,36 @@ bool ShipManager::IsCrewFull()
 namespace _func1057
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::IsCrewFull", typeid(bool (ShipManager::*)()), ".538b470831f64889fb", nullptr, 0, 0, &func);
+}
+
+bool ShipManager::IsCrewFull()
+{
+	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1057::func;
+	return execfunc(this);
+}
+
+namespace _func1058
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::DoSensorsProvide", typeid(bool (ShipManager::*)(int )), ".4883ec08488b87580600004863401c83f8ff", nullptr, 0, 0, &func);
 }
 
 bool ShipManager::DoSensorsProvide(int vision)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int vision_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1057::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1058::func;
 	return execfunc(this, vision);
 }
 
-namespace _func1058
+namespace _func1059
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::SetDestroyed", typeid(void (ShipManager::*)()), "!.5531c94889fd5331db4883ec08488b5728", nullptr, 0, 0, &func);
 }
 
 void ShipManager::SetDestroyed()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1058::func;
-	return execfunc(this);
-}
-
-namespace _func1059
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::JumpLeave", typeid(void (ShipManager::*)()), ".415431c055534889fb4883ec2083af1006000001", nullptr, 0, 0, &func);
-}
-
-void ShipManager::JumpLeave()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1059::func;
@@ -13520,36 +13520,36 @@ void ShipManager::JumpLeave()
 namespace _func1060
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::JumpLeave", typeid(void (ShipManager::*)()), ".415431c055534889fb4883ec2083af1006000001", nullptr, 0, 0, &func);
+}
+
+void ShipManager::JumpLeave()
+{
+	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1060::func;
+	return execfunc(this);
+}
+
+namespace _func1061
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::DamageCrew", typeid(bool (ShipManager::*)(CrewMember *, Damage )), ".4156415541545553807c245e004889f3", nullptr, 0, 0, &func);
 }
 
 bool ShipManager::DamageCrew(CrewMember *crew, Damage dmg)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, Damage dmg_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1060::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1061::func;
 	return execfunc(this, crew, dmg);
 }
 
-namespace _func1061
+namespace _func1062
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::Wait", typeid(void (ShipManager::*)()), ".55534889fb4883ec08488b875806000083780cff", nullptr, 0, 0, &func);
 }
 
 void ShipManager::Wait()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1061::func;
-	return execfunc(this);
-}
-
-namespace _func1062
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::JumpArrive", typeid(void (ShipManager::*)()), ".55534889fb488dbf200600004883ec28", nullptr, 0, 0, &func);
-}
-
-void ShipManager::JumpArrive()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1062::func;
@@ -13559,10 +13559,10 @@ void ShipManager::JumpArrive()
 namespace _func1063
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::InstantPowerShields", typeid(void (ShipManager::*)()), ".53488b87580600004889fb48630083f8ff", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipManager::JumpArrive", typeid(void (ShipManager::*)()), ".55534889fb488dbf200600004883ec28", nullptr, 0, 0, &func);
 }
 
-void ShipManager::InstantPowerShields()
+void ShipManager::JumpArrive()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1063::func;
@@ -13572,10 +13572,10 @@ void ShipManager::InstantPowerShields()
 namespace _func1064
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::CheckSpreadDamage", typeid(void (ShipManager::*)()), ".41574989ff41564155415455534883ec28488b4f28", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipManager::InstantPowerShields", typeid(void (ShipManager::*)()), ".53488b87580600004889fb48630083f8ff", nullptr, 0, 0, &func);
 }
 
-void ShipManager::CheckSpreadDamage()
+void ShipManager::InstantPowerShields()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1064::func;
@@ -13585,36 +13585,36 @@ void ShipManager::CheckSpreadDamage()
 namespace _func1065
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::CheckSpreadDamage", typeid(void (ShipManager::*)()), ".41574989ff41564155415455534883ec28488b4f28", nullptr, 0, 0, &func);
+}
+
+void ShipManager::CheckSpreadDamage()
+{
+	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1065::func;
+	return execfunc(this);
+}
+
+namespace _func1066
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetSystemPower", typeid(int (ShipManager::*)(int )), ".488b87580600004863f6486304b083f8ff740d", nullptr, 0, 0, &func);
 }
 
 int ShipManager::GetSystemPower(int systemId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1065::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1066::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1066
+namespace _func1067
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CheckVision", typeid(void (ShipManager::*)()), ".415741564155415455534889fb4883ec28488b8758060000", nullptr, 0, 0, &func);
 }
 
 void ShipManager::CheckVision()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1066::func;
-	return execfunc(this);
-}
-
-namespace _func1067
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::ClearStatusAll", typeid(void (ShipManager::*)()), "!.5531c94889fd5331db4883ec08488b5728", nullptr, 0, 0, &func);
-}
-
-void ShipManager::ClearStatusAll()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1067::func;
@@ -13624,17 +13624,30 @@ void ShipManager::ClearStatusAll()
 namespace _func1068
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::ClearStatusAll", typeid(void (ShipManager::*)()), "!.5531c94889fd5331db4883ec08488b5728", nullptr, 0, 0, &func);
+}
+
+void ShipManager::ClearStatusAll()
+{
+	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1068::func;
+	return execfunc(this);
+}
+
+namespace _func1069
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ClearStatusSystem", typeid(void (ShipManager::*)(int )), ".83fe11743383feff7426", nullptr, 0, 0, &func);
 }
 
 void ShipManager::ClearStatusSystem(int system)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int system_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1068::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1069::func;
 	return execfunc(this, system);
 }
 
-namespace _func1069
+namespace _func1070
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::SetSystemPowerLimit", typeid(void (ShipManager::*)(int , int )), ".83fe11743b83feff742e", nullptr, 0, 0, &func);
@@ -13643,11 +13656,11 @@ namespace _func1069
 void ShipManager::SetSystemPowerLimit(int systemId, int limit)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int limit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1069::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1070::func;
 	return execfunc(this, systemId, limit);
 }
 
-namespace _func1070
+namespace _func1071
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::SetSystemPowerLoss", typeid(void (ShipManager::*)(int , int )), ".83fe11743b83feff742e", nullptr, 0, 0, &func);
@@ -13656,11 +13669,11 @@ namespace _func1070
 void ShipManager::SetSystemPowerLoss(int systemId, int powerLoss)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int powerLoss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1070::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1071::func;
 	return execfunc(this, systemId, powerLoss);
 }
 
-namespace _func1071
+namespace _func1072
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::SetSystemDividePower", typeid(void (ShipManager::*)(int , int )), ".83fe11743b83feff742e", nullptr, 0, 0, &func);
@@ -13669,30 +13682,17 @@ namespace _func1071
 void ShipManager::SetSystemDividePower(int systemId, int amount)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1071::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1072::func;
 	return execfunc(this, systemId, amount);
 }
 
-namespace _func1072
+namespace _func1073
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetSystemAvailablePower", typeid(int (ShipManager::*)(int )), ".??54??63f65553??8b8758060000??89fb8b04b083f8ff74??", nullptr, 0, 0, &func);
 }
 
 int ShipManager::GetSystemAvailablePower(int systemId)
-{
-	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1072::func;
-	return execfunc(this, systemId);
-}
-
-namespace _func1073
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::GetSystemDamage", typeid(int (ShipManager::*)(int )), ".??8b8758060000??63f6??6304b083f8ff74????8b5728??8b14c28b8278010000", nullptr, 0, 0, &func);
-}
-
-int ShipManager::GetSystemDamage(int systemId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1073::func;
@@ -13702,10 +13702,10 @@ int ShipManager::GetSystemDamage(int systemId)
 namespace _func1074
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::GetSystemHealth", typeid(int (ShipManager::*)(int )), ".??8b8758060000??63f6??6304b083f8ff74????8b5728??8b04c28b8074010000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipManager::GetSystemDamage", typeid(int (ShipManager::*)(int )), ".??8b8758060000??63f6??6304b083f8ff74????8b5728??8b14c28b8278010000", nullptr, 0, 0, &func);
 }
 
-int ShipManager::GetSystemHealth(int systemId)
+int ShipManager::GetSystemDamage(int systemId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1074::func;
@@ -13715,12 +13715,12 @@ int ShipManager::GetSystemHealth(int systemId)
 namespace _func1075
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::IncreaseSystemPower", typeid(bool (ShipManager::*)(int )), ".??8b8758060000??63f6??6304b083f8ff74????8b5728be01000000??8b3cc231d2e9????????", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipManager::GetSystemHealth", typeid(int (ShipManager::*)(int )), ".??8b8758060000??63f6??6304b083f8ff74????8b5728??8b04c28b8074010000", nullptr, 0, 0, &func);
 }
 
-bool ShipManager::IncreaseSystemPower(int systemId)
+int ShipManager::GetSystemHealth(int systemId)
 {
-	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
+	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1075::func;
 	return execfunc(this, systemId);
 }
@@ -13728,10 +13728,10 @@ bool ShipManager::IncreaseSystemPower(int systemId)
 namespace _func1076
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::ForceIncreaseSystemPower", typeid(bool (ShipManager::*)(int )), ".83feff74????8b8758060000??63f6??6304b083f8ff74????8b5728??8b3cc2??85ff74????8b07", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipManager::IncreaseSystemPower", typeid(bool (ShipManager::*)(int )), ".??8b8758060000??63f6??6304b083f8ff74????8b5728be01000000??8b3cc231d2e9????????", nullptr, 0, 0, &func);
 }
 
-bool ShipManager::ForceIncreaseSystemPower(int systemId)
+bool ShipManager::IncreaseSystemPower(int systemId)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1076::func;
@@ -13741,17 +13741,30 @@ bool ShipManager::ForceIncreaseSystemPower(int systemId)
 namespace _func1077
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::ForceIncreaseSystemPower", typeid(bool (ShipManager::*)(int )), ".83feff74????8b8758060000??63f6??6304b083f8ff74????8b5728??8b3cc2??85ff74????8b07", nullptr, 0, 0, &func);
+}
+
+bool ShipManager::ForceIncreaseSystemPower(int systemId)
+{
+	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1077::func;
+	return execfunc(this, systemId);
+}
+
+namespace _func1078
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ForceDecreaseSystemPower", typeid(bool (ShipManager::*)(int )), ".83feff743b488b87580600004863f6486304b083f8ff7428488b5728488b3cc24885ff741b488b07be01000000488b8008010000", nullptr, 0, 0, &func);
 }
 
 bool ShipManager::ForceDecreaseSystemPower(int sys)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1077::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1078::func;
 	return execfunc(this, sys);
 }
 
-namespace _func1078
+namespace _func1079
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetSystemInRoom", typeid(ShipSystem *(ShipManager::*)(int )), ".415531d24989fd41545589f55331db4883ec08488b4f28", nullptr, 0, 0, &func);
@@ -13760,11 +13773,11 @@ namespace _func1078
 ShipSystem *ShipManager::GetSystemInRoom(int roomId)
 {
 	typedef ShipSystem *(*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1078::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1079::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1079
+namespace _func1080
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetSystemRoom", typeid(int (ShipManager::*)(int )), ".83feff7433488b87580600004863f6", nullptr, 0, 0, &func);
@@ -13773,11 +13786,11 @@ namespace _func1079
 int ShipManager::GetSystemRoom(int sysId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int sysId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1079::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1080::func;
 	return execfunc(this, sysId);
 }
 
-namespace _func1080
+namespace _func1081
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetSystem", typeid(ShipSystem *(ShipManager::*)(int )), ".83feff7423488b87580600004863f6", nullptr, 0, 0, &func);
@@ -13786,11 +13799,11 @@ namespace _func1080
 ShipSystem *ShipManager::GetSystem(int systemId)
 {
 	typedef ShipSystem *(*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1080::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1081::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1081
+namespace _func1082
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::DoorsFunction", typeid(bool (ShipManager::*)()), ".53488b87580600004889fb4863402083f8ff", nullptr, 0, 0, &func);
@@ -13799,30 +13812,17 @@ namespace _func1081
 bool ShipManager::DoorsFunction()
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1081::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1082::func;
 	return execfunc(this);
 }
 
-namespace _func1082
+namespace _func1083
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::SystemLocked", typeid(bool (ShipManager::*)(int )), ".??8b8758060000??63f6??6304b083f8ff74????8b5728??8b3cc2e9????????", nullptr, 0, 0, &func);
 }
 
 bool ShipManager::SystemLocked(int systemId)
-{
-	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1082::func;
-	return execfunc(this, systemId);
-}
-
-namespace _func1083
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::SystemFunctions", typeid(bool (ShipManager::*)(int )), ".488b87580600004863f6486304b083f8ff7415", nullptr, 0, 0, &func);
-}
-
-bool ShipManager::SystemFunctions(int systemId)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1083::func;
@@ -13832,23 +13832,23 @@ bool ShipManager::SystemFunctions(int systemId)
 namespace _func1084
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::GetDodgeFactor", typeid(int (ShipManager::*)()), ".534889fb4883ec10488b9758060000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipManager::SystemFunctions", typeid(bool (ShipManager::*)(int )), ".488b87580600004863f6486304b083f8ff7415", nullptr, 0, 0, &func);
 }
 
-int ShipManager::GetDodgeFactor()
+bool ShipManager::SystemFunctions(int systemId)
 {
-	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1084::func;
-	return execfunc(this);
+	return execfunc(this, systemId);
 }
 
 namespace _func1085
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::GetNetDodgeFactor", typeid(int (ShipManager::*)()), ".554889fd534883ec08", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipManager::GetDodgeFactor", typeid(int (ShipManager::*)()), ".534889fb4883ec10488b9758060000", nullptr, 0, 0, &func);
 }
 
-int ShipManager::GetNetDodgeFactor()
+int ShipManager::GetDodgeFactor()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1085::func;
@@ -13858,17 +13858,30 @@ int ShipManager::GetNetDodgeFactor()
 namespace _func1086
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::GetNetDodgeFactor", typeid(int (ShipManager::*)()), ".554889fd534883ec08", nullptr, 0, 0, &func);
+}
+
+int ShipManager::GetNetDodgeFactor()
+{
+	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1086::func;
+	return execfunc(this);
+}
+
+namespace _func1087
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetDodged", typeid(bool (ShipManager::*)()), ".415455534889fb4883ec20807f1c00", nullptr, 0, 0, &func);
 }
 
 bool ShipManager::GetDodged()
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1086::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1087::func;
 	return execfunc(this);
 }
 
-namespace _func1087
+namespace _func1088
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::HasSystem", typeid(bool (ShipManager::*)(int )), ".83fe11741b488b8758060000", nullptr, 0, 0, &func);
@@ -13877,19 +13890,6 @@ namespace _func1087
 bool ShipManager::HasSystem(int systemId)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1087::func;
-	return execfunc(this, systemId);
-}
-
-namespace _func1088
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::SystemRoom", typeid(int (ShipManager::*)(int )), ".488b87580600004863f6486304b083f8ff74??488b5728488b3cc2488b07488b", nullptr, 0, 0, &func);
-}
-
-int ShipManager::SystemRoom(int systemId)
-{
-	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1088::func;
 	return execfunc(this, systemId);
 }
@@ -13897,10 +13897,10 @@ int ShipManager::SystemRoom(int systemId)
 namespace _func1089
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::GetSystemPowerMax", typeid(int (ShipManager::*)(int )), ".488b87580600004863f6486304b083f8ff740d", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipManager::SystemRoom", typeid(int (ShipManager::*)(int )), ".488b87580600004863f6486304b083f8ff74??488b5728488b3cc2488b07488b", nullptr, 0, 0, &func);
 }
 
-int ShipManager::GetSystemPowerMax(int systemId)
+int ShipManager::SystemRoom(int systemId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1089::func;
@@ -13910,17 +13910,30 @@ int ShipManager::GetSystemPowerMax(int systemId)
 namespace _func1090
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::GetSystemPowerMax", typeid(int (ShipManager::*)(int )), ".488b87580600004863f6486304b083f8ff740d", nullptr, 0, 0, &func);
+}
+
+int ShipManager::GetSystemPowerMax(int systemId)
+{
+	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1090::func;
+	return execfunc(this, systemId);
+}
+
+namespace _func1091
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::UpgradeSystem", typeid(void (ShipManager::*)(int , int )), ".55534889fb4883ec1883fe11", nullptr, 0, 0, &func);
 }
 
 void ShipManager::UpgradeSystem(int id, int amount)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int id_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1090::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1091::func;
 	return execfunc(this, id, amount);
 }
 
-namespace _func1091
+namespace _func1092
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CanUpgrade", typeid(int (ShipManager::*)(int , int )), ".83fe117453", nullptr, 0, 0, &func);
@@ -13929,11 +13942,11 @@ namespace _func1091
 int ShipManager::CanUpgrade(int systemId, int amount)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1091::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1092::func;
 	return execfunc(this, systemId, amount);
 }
 
-namespace _func1092
+namespace _func1093
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CommandCrewMoveRoom", typeid(bool (ShipManager::*)(CrewMember *, int )), "!.4889f731c989d6baffffffff", nullptr, 0, 0, &func);
@@ -13942,11 +13955,11 @@ namespace _func1092
 bool ShipManager::CommandCrewMoveRoom(CrewMember *crew, int roomId)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1092::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1093::func;
 	return execfunc(this, crew, roomId);
 }
 
-namespace _func1093
+namespace _func1094
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetSelectedCrewPoint", typeid(CrewMember *(ShipManager::*)(int , int , bool )), ".415741564989fe41554189d5415455534883ec38", nullptr, 0, 0, &func);
@@ -13955,11 +13968,11 @@ namespace _func1093
 CrewMember *ShipManager::GetSelectedCrewPoint(int x, int y, bool intruder)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(ShipManager *this_arg, int x_arg, int y_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1093::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1094::func;
 	return execfunc(this, x, y, intruder);
 }
 
-namespace _func1094
+namespace _func1095
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetTooltip", typeid(std::string (ShipManager::*)(int , int )), ".415741564989fe41554189cd41544989f4", nullptr, 0, 0, &func);
@@ -13968,11 +13981,11 @@ namespace _func1094
 std::string ShipManager::GetTooltip(int x, int y)
 {
 	typedef std::string (*custom_arg_funcptr_t)(ShipManager *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1094::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1095::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1095
+namespace _func1096
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetWeaponList", typeid(std::vector<ProjectileFactory*> (ShipManager::*)()), ".41545553488b86580600004889fb83780cff", nullptr, 0, 0, &func);
@@ -13981,11 +13994,11 @@ namespace _func1095
 std::vector<ProjectileFactory*> ShipManager::GetWeaponList()
 {
 	typedef std::vector<ProjectileFactory*> (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1095::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1096::func;
 	return execfunc(this);
 }
 
-namespace _func1096
+namespace _func1097
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetDroneCount", typeid(int (ShipManager::*)()), ".488b8758060000837810ff7413", nullptr, 0, 0, &func);
@@ -13994,11 +14007,11 @@ namespace _func1096
 int ShipManager::GetDroneCount()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1096::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1097::func;
 	return execfunc(this);
 }
 
-namespace _func1097
+namespace _func1098
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ModifyDroneCount", typeid(void (ShipManager::*)(int )), ".488b8758060000837810ff7523", nullptr, 0, 0, &func);
@@ -14007,11 +14020,11 @@ namespace _func1097
 void ShipManager::ModifyDroneCount(int drones)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int drones_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1097::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1098::func;
 	return execfunc(this, drones);
 }
 
-namespace _func1098
+namespace _func1099
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetOxygenPercentage", typeid(int (ShipManager::*)()), ".488b8758060000837808ff742b", nullptr, 0, 0, &func);
@@ -14020,11 +14033,11 @@ namespace _func1098
 int ShipManager::GetOxygenPercentage()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1098::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1099::func;
 	return execfunc(this);
 }
 
-namespace _func1099
+namespace _func1100
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetOxygenLevel", typeid(float (ShipManager::*)(int )), ".??8b8758060000837808ff74????8b7f40e9????????", nullptr, 0, 0, &func);
@@ -14033,11 +14046,11 @@ namespace _func1099
 float ShipManager::GetOxygenLevel(int roomId)
 {
 	typedef float (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1099::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1100::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1100
+namespace _func1101
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetOxygenLevels", typeid(std::vector<float> (ShipManager::*)()), ".??545553??8b8658060000??89fb837808ff75??", nullptr, 0, 0, &func);
@@ -14046,11 +14059,11 @@ namespace _func1100
 std::vector<float> ShipManager::GetOxygenLevels()
 {
 	typedef std::vector<float> (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1100::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1101::func;
 	return execfunc(this);
 }
 
-namespace _func1101
+namespace _func1102
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::RemoveItem", typeid(void (ShipManager::*)(const std::string &)), ".41574156415541544989f455534889fb4883ec48", nullptr, 0, 0, &func);
@@ -14059,11 +14072,11 @@ namespace _func1101
 void ShipManager::RemoveItem(const std::string &name)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1101::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1102::func;
 	return execfunc(this, name);
 }
 
-namespace _func1102
+namespace _func1103
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::AddWeapon", typeid(int (ShipManager::*)(const WeaponBlueprint *, int )), ".488b875806000083780cff7413", nullptr, 0, 0, &func);
@@ -14072,11 +14085,11 @@ namespace _func1102
 int ShipManager::AddWeapon(const WeaponBlueprint *bp, int slot)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, const WeaponBlueprint *bp_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1102::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1103::func;
 	return execfunc(this, bp, slot);
 }
 
-namespace _func1103
+namespace _func1104
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ModifyMissileCount", typeid(void (ShipManager::*)(int )), ".488b875806000083780cff7523", nullptr, 0, 0, &func);
@@ -14085,11 +14098,11 @@ namespace _func1103
 void ShipManager::ModifyMissileCount(int missiles)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int missiles_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1103::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1104::func;
 	return execfunc(this, missiles);
 }
 
-namespace _func1104
+namespace _func1105
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetMissileCount", typeid(int (ShipManager::*)()), ".488b875806000083780cff7413", nullptr, 0, 0, &func);
@@ -14098,11 +14111,11 @@ namespace _func1104
 int ShipManager::GetMissileCount()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1104::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1105::func;
 	return execfunc(this);
 }
 
-namespace _func1105
+namespace _func1106
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetDroneList", typeid(std::vector<Drone*> (ShipManager::*)()), ".41545553488b86580600004889fb837810ff", nullptr, 0, 0, &func);
@@ -14111,11 +14124,11 @@ namespace _func1105
 std::vector<Drone*> ShipManager::GetDroneList()
 {
 	typedef std::vector<Drone*> (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1105::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1106::func;
 	return execfunc(this);
 }
 
-namespace _func1106
+namespace _func1107
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::IsSystemHacked", typeid(int (ShipManager::*)(int )), ".83fe11741b488b87580600004863d6", nullptr, 0, 0, &func);
@@ -14124,11 +14137,11 @@ namespace _func1106
 int ShipManager::IsSystemHacked(int systemId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1106::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1107::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1107
+namespace _func1108
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ExportBattleState", typeid(void (ShipManager::*)(int )), ".4157415641554154554889fd5389f34883ec28", nullptr, 0, 0, &func);
@@ -14137,11 +14150,11 @@ namespace _func1107
 void ShipManager::ExportBattleState(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1107::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1108::func;
 	return execfunc(this, file);
 }
 
-namespace _func1108
+namespace _func1109
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::StartFire", typeid(void (ShipManager::*)(int )), "!.4881c7d8000000", nullptr, 0, 0, &func);
@@ -14150,11 +14163,11 @@ namespace _func1108
 void ShipManager::StartFire(int roomId)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1108::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1109::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1109
+namespace _func1110
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetFireCount", typeid(int (ShipManager::*)(int )), "!.4881c7d8000000", nullptr, 0, 0, &func);
@@ -14163,11 +14176,11 @@ namespace _func1109
 int ShipManager::GetFireCount(int roomId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1109::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1110::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1110
+namespace _func1111
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::AddCrewMember", typeid(void (ShipManager::*)(CrewMember *, int )), ".5589d5534889fb4889f74883ec184889742408", nullptr, 0, 0, &func);
@@ -14176,11 +14189,11 @@ namespace _func1110
 void ShipManager::AddCrewMember(CrewMember *crew, int roomId)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1110::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1111::func;
 	return execfunc(this, crew, roomId);
 }
 
-namespace _func1111
+namespace _func1112
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::TeleportCrew", typeid(std::vector<CrewMember*> (ShipManager::*)(int , bool )), ".4157415641554989fd41544989f455534883ec18", nullptr, 0, 0, &func);
@@ -14189,11 +14202,11 @@ namespace _func1111
 std::vector<CrewMember*> ShipManager::TeleportCrew(int roomId, bool intruders)
 {
 	typedef std::vector<CrewMember*> (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1111::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1112::func;
 	return execfunc(this, roomId, intruders);
 }
 
-namespace _func1112
+namespace _func1113
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::GetLeavingCrew", typeid(std::vector<CrewMember*> (ShipManager::*)(bool )), ".415631c941554989f541544989fc5589d553", nullptr, 0, 0, &func);
@@ -14202,11 +14215,11 @@ namespace _func1112
 std::vector<CrewMember*> ShipManager::GetLeavingCrew(bool intruders)
 {
 	typedef std::vector<CrewMember*> (*custom_arg_funcptr_t)(ShipManager *this_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1112::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1113::func;
 	return execfunc(this, intruders);
 }
 
-namespace _func1113
+namespace _func1114
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::AddCrewMemberFromBlueprint", typeid(CrewMember *(ShipManager::*)(CrewBlueprint *, int , bool , int , bool )), ".41574989ff415641554589cd4154554889f5", nullptr, 0, 0, &func);
@@ -14215,11 +14228,11 @@ namespace _func1113
 CrewMember *ShipManager::AddCrewMemberFromBlueprint(CrewBlueprint *bp, int slot, bool init, int roomId, bool intruder)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(ShipManager *this_arg, CrewBlueprint *bp_arg, int slot_arg, bool init_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1113::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1114::func;
 	return execfunc(this, bp, slot, init, roomId, intruder);
 }
 
-namespace _func1114
+namespace _func1115
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::PulsarDamage", typeid(void (ShipManager::*)()), ".41574156415541545553", nullptr, 0, 0, &func);
@@ -14228,11 +14241,11 @@ namespace _func1114
 void ShipManager::PulsarDamage()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1114::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1115::func;
 	return execfunc(this);
 }
 
-namespace _func1115
+namespace _func1116
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::DamageSystem", typeid(void (ShipManager::*)(int , Damage )), ".41574989ff4156415541545589f5534883ec48", nullptr, 0, 0, &func);
@@ -14241,11 +14254,11 @@ namespace _func1115
 void ShipManager::DamageSystem(int systemId, Damage damage)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, Damage damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1115::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1116::func;
 	return execfunc(this, systemId, damage);
 }
 
-namespace _func1116
+namespace _func1117
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CheckCrystalAugment", typeid(void (ShipManager::*)(Pointf )), ".4157be????????4156415541544989fc55534883ec68", nullptr, 0, 0, &func);
@@ -14254,11 +14267,11 @@ namespace _func1116
 void ShipManager::CheckCrystalAugment(Pointf pos)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1116::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1117::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1117
+namespace _func1118
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::PrepareSuperBarrage", typeid(void (ShipManager::*)()), ".415741564155415455534889fb4881ec980000004883bf0006000000", nullptr, 0, 0, &func);
@@ -14267,11 +14280,11 @@ namespace _func1117
 void ShipManager::PrepareSuperBarrage()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1117::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1118::func;
 	return execfunc(this);
 }
 
-namespace _func1118
+namespace _func1119
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::RestoreCrewPositions", typeid(bool (ShipManager::*)()), ".415531d2bf????????415455534883ec684889e6", nullptr, 0, 0, &func);
@@ -14280,11 +14293,11 @@ namespace _func1118
 bool ShipManager::RestoreCrewPositions()
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1118::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1119::func;
 	return execfunc(this);
 }
 
-namespace _func1119
+namespace _func1120
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::UpdateEnvironment", typeid(void (ShipManager::*)()), ".4157488d87d800000041564989fe4889c74155415455534883ec78", nullptr, 0, 0, &func);
@@ -14293,11 +14306,11 @@ namespace _func1119
 void ShipManager::UpdateEnvironment()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1119::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1120::func;
 	return execfunc(this);
 }
 
-namespace _func1120
+namespace _func1121
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::SelectRandomCrew", typeid(CrewBlueprint (ShipManager::*)(int , const std::string &)), ".41574156415541544989fc554889cd534883ec68", nullptr, 0, 0, &func);
@@ -14306,30 +14319,17 @@ namespace _func1120
 CrewBlueprint ShipManager::SelectRandomCrew(int seed, const std::string &racePref)
 {
 	typedef CrewBlueprint (*custom_arg_funcptr_t)(ShipManager *this_arg, int seed_arg, const std::string &racePref_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1120::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1121::func;
 	return execfunc(this, seed, racePref);
 }
 
-namespace _func1121
+namespace _func1122
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CollisionShield", typeid(CollisionResponse (ShipManager::*)(Pointf , Pointf , Damage , bool )), ".415741564189d641554154554889f5534889fb4881ece8000000", nullptr, 0, 0, &func);
 }
 
 CollisionResponse ShipManager::CollisionShield(Pointf start, Pointf finish, Damage damage, bool raytrace)
-{
-	typedef CollisionResponse (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1121::func;
-	return execfunc(this, start, finish, damage, raytrace);
-}
-
-namespace _func1122
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::CollisionMoving", typeid(CollisionResponse (ShipManager::*)(Pointf , Pointf , Damage , bool )), ".41574989ff488d7f044156415541544189d4554889f5534881ec08010000", nullptr, 0, 0, &func);
-}
-
-CollisionResponse ShipManager::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1122::func;
@@ -14339,36 +14339,36 @@ CollisionResponse ShipManager::CollisionMoving(Pointf start, Pointf finish, Dama
 namespace _func1123
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::CollisionMoving", typeid(CollisionResponse (ShipManager::*)(Pointf , Pointf , Damage , bool )), ".41574989ff488d7f044156415541544189d4554889f5534881ec08010000", nullptr, 0, 0, &func);
+}
+
+CollisionResponse ShipManager::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
+{
+	typedef CollisionResponse (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1123::func;
+	return execfunc(this, start, finish, damage, raytrace);
+}
+
+namespace _func1124
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::DamageArea", typeid(bool (ShipManager::*)(Pointf , Damage , bool )), ".4157b901000000415641554189f5415455534889fb4881ecc8000000", nullptr, 0, 0, &func);
 }
 
 bool ShipManager::DamageArea(Pointf location, Damage dmg, bool forceHit)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf location_arg, Damage dmg_arg, bool forceHit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1123::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1124::func;
 	return execfunc(this, location, dmg, forceHit);
 }
 
-namespace _func1124
+namespace _func1125
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::PrepareSuperDrones", typeid(void (ShipManager::*)()), ".415741564155415455534889fb4883ec58488b87b8090000", nullptr, 0, 0, &func);
 }
 
 void ShipManager::PrepareSuperDrones()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1124::func;
-	return execfunc(this);
-}
-
-namespace _func1125
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::RenderChargeBars", typeid(void (ShipManager::*)()), ".4155415455534889fb4883ec388b5708", nullptr, 0, 0, &func);
-}
-
-void ShipManager::RenderChargeBars()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1125::func;
@@ -14378,10 +14378,10 @@ void ShipManager::RenderChargeBars()
 namespace _func1126
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::RenderWeapons", typeid(void (ShipManager::*)()), ".41574156415541544c8da718010000554889fd4c89e7534883ec68", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipManager::RenderChargeBars", typeid(void (ShipManager::*)()), ".4155415455534889fb4883ec388b5708", nullptr, 0, 0, &func);
 }
 
-void ShipManager::RenderWeapons()
+void ShipManager::RenderChargeBars()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1126::func;
@@ -14391,17 +14391,30 @@ void ShipManager::RenderWeapons()
 namespace _func1127
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::RenderWeapons", typeid(void (ShipManager::*)()), ".41574156415541544c8da718010000554889fd4c89e7534883ec68", nullptr, 0, 0, &func);
+}
+
+void ShipManager::RenderWeapons()
+{
+	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1127::func;
+	return execfunc(this);
+}
+
+namespace _func1128
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::OnRender", typeid(void (ShipManager::*)(bool , bool )), ".4157415641554989fd4154555389f34881ec98000000", nullptr, 0, 0, &func);
 }
 
 void ShipManager::OnRender(bool showInterior, bool doorControlMode)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, bool showInterior_arg, bool doorControlMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1127::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1128::func;
 	return execfunc(this, showInterior, doorControlMode);
 }
 
-namespace _func1128
+namespace _func1129
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CreateCrewDrone", typeid(CrewDrone *(ShipManager::*)(const DroneBlueprint *)), ".55534889fb4883ec188b4670", nullptr, 0, 0, &func);
@@ -14410,11 +14423,11 @@ namespace _func1128
 CrewDrone *ShipManager::CreateCrewDrone(const DroneBlueprint *bp)
 {
 	typedef CrewDrone *(*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1128::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1129::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1129
+namespace _func1130
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CreateSpaceDrone", typeid(SpaceDrone *(ShipManager::*)(const DroneBlueprint *)), ".41554154554889f5534883ec38837e7007", nullptr, 0, 0, &func);
@@ -14423,11 +14436,11 @@ namespace _func1129
 SpaceDrone *ShipManager::CreateSpaceDrone(const DroneBlueprint *bp)
 {
 	typedef SpaceDrone *(*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1129::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1130::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1130
+namespace _func1131
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::AddDrone", typeid(Drone *(ShipManager::*)(const DroneBlueprint *, int )), ".4155415455534889fb4883ec18488b8758060000", nullptr, 0, 0, &func);
@@ -14436,11 +14449,11 @@ namespace _func1130
 Drone *ShipManager::AddDrone(const DroneBlueprint *bp, int slot)
 {
 	typedef Drone *(*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1130::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1131::func;
 	return execfunc(this, bp, slot);
 }
 
-namespace _func1131
+namespace _func1132
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::AddEquipmentFromList", typeid(void (ShipManager::*)(std::vector<std::string> *)), ".415641554154554889f5534883ec30", nullptr, 0, 0, &func);
@@ -14449,11 +14462,11 @@ namespace _func1131
 void ShipManager::AddEquipmentFromList(std::vector<std::string> *equipmentList)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, std::vector<std::string> *equipmentList_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1131::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1132::func;
 	return execfunc(this, equipmentList);
 }
 
-namespace _func1132
+namespace _func1133
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::AddSystem", typeid(int (ShipManager::*)(int )), ".415741564155415455534889fb4881ece8000000", nullptr, 0, 0, &func);
@@ -14462,11 +14475,11 @@ namespace _func1132
 int ShipManager::AddSystem(int systemId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1132::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1133::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1133
+namespace _func1134
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CreateSystems", typeid(int (ShipManager::*)()), ".4154488d8fb007000055534889fb4883ec20", nullptr, 0, 0, &func);
@@ -14475,11 +14488,11 @@ namespace _func1133
 int ShipManager::CreateSystems()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1133::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1134::func;
 	return execfunc(this);
 }
 
-namespace _func1134
+namespace _func1135
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::DamageBeam", typeid(bool (ShipManager::*)(Pointf , Pointf , Damage )), ".4157415641554154554889fd534881ece8000000", nullptr, 0, 0, &func);
@@ -14488,11 +14501,11 @@ namespace _func1134
 bool ShipManager::DamageBeam(Pointf location1, Pointf location2, Damage dmg)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf location1_arg, Pointf location2_arg, Damage dmg_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1134::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1135::func;
 	return execfunc(this, location1, location2, dmg);
 }
 
-namespace _func1135
+namespace _func1136
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::UpdateCrewMembers", typeid(void (ShipManager::*)()), ".415731c94156415541544989fc555331db4881ec38010000", nullptr, 0, 0, &func);
@@ -14501,11 +14514,11 @@ namespace _func1135
 void ShipManager::UpdateCrewMembers()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1135::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1136::func;
 	return execfunc(this);
 }
 
-namespace _func1136
+namespace _func1137
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::KillEveryone", typeid(void (ShipManager::*)(bool )), "!.??5431c9??0fb6e655??89fd53", nullptr, 0, 0, &func);
@@ -14514,11 +14527,11 @@ namespace _func1136
 void ShipManager::KillEveryone(bool noClone)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, bool noClone_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1136::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1137::func;
 	return execfunc(this, noClone);
 }
 
-namespace _func1137
+namespace _func1138
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::PowerDrone", typeid(bool (ShipManager::*)(Drone *, int , bool , bool )), ".41554154554889fd534883ec08488b87", nullptr, 0, 0, &func);
@@ -14527,11 +14540,11 @@ namespace _func1137
 bool ShipManager::PowerDrone(Drone *drone, int roomId, bool userDriven, bool force)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipManager *this_arg, Drone *drone_arg, int roomId_arg, bool userDriven_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1137::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1138::func;
 	return execfunc(this, drone, roomId, userDriven, force);
 }
 
-namespace _func1138
+namespace _func1139
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ImportBattleState", typeid(void (ShipManager::*)(int )), "!.4157415641554154554889fd5389f34883ec18", nullptr, 0, 0, &func);
@@ -14540,11 +14553,11 @@ namespace _func1138
 void ShipManager::ImportBattleState(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1138::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1139::func;
 	return execfunc(this, file);
 }
 
-namespace _func1139
+namespace _func1140
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::OnLoop", typeid(void (ShipManager::*)()), ".41574989ffbe????????41564155415455534881ec48010000", nullptr, 0, 0, &func);
@@ -14553,11 +14566,11 @@ namespace _func1139
 void ShipManager::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1139::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1140::func;
 	return execfunc(this);
 }
 
-namespace _func1140
+namespace _func1141
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ExportShip", typeid(void (ShipManager::*)(int )), ".41574989ff415641554154555389f3488db75807000089df4881ec78010000", nullptr, 0, 0, &func);
@@ -14566,11 +14579,11 @@ namespace _func1140
 void ShipManager::ExportShip(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1140::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1141::func;
 	return execfunc(this, file);
 }
 
-namespace _func1141
+namespace _func1142
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::AddCrewMemberFromString", typeid(CrewMember *(ShipManager::*)(const std::string &, const std::string &, bool , int , bool , bool )), ".415741564589c641554154554889fd534881ec58020000", nullptr, 0, 0, &func);
@@ -14579,11 +14592,11 @@ namespace _func1141
 CrewMember *ShipManager::AddCrewMemberFromString(const std::string &name, const std::string &race, bool intruder, int roomId, bool init, bool male)
 {
 	typedef CrewMember *(*custom_arg_funcptr_t)(ShipManager *this_arg, const std::string &name_arg, const std::string &race_arg, bool intruder_arg, int roomId_arg, bool init_arg, bool male_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1141::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1142::func;
 	return execfunc(this, name, race, intruder, roomId, init, male);
 }
 
-namespace _func1142
+namespace _func1143
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::AddInitialCrew", typeid(void (ShipManager::*)(std::vector<CrewBlueprint> &)), ".41574156415541544989f4be????????554889fd534881ec88010000", nullptr, 0, 0, &func);
@@ -14592,11 +14605,11 @@ namespace _func1142
 void ShipManager::AddInitialCrew(std::vector<CrewBlueprint> &blueprints)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, std::vector<CrewBlueprint> &blueprints_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1142::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1143::func;
 	return execfunc(this, blueprints);
 }
 
-namespace _func1143
+namespace _func1144
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::Restart", typeid(void (ShipManager::*)()), ".415641554154554889fd534883ec208b4708", nullptr, 0, 0, &func);
@@ -14605,11 +14618,11 @@ namespace _func1143
 void ShipManager::Restart()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1143::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1144::func;
 	return execfunc(this);
 }
 
-namespace _func1144
+namespace _func1145
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::SaveToBlueprint", typeid(ShipBlueprint (ShipManager::*)(bool )), ".4157415641554189d54154554889f5534889fb4883ec48", nullptr, 0, 0, &func);
@@ -14618,11 +14631,11 @@ namespace _func1144
 ShipBlueprint ShipManager::SaveToBlueprint(bool overwrite)
 {
 	typedef ShipBlueprint (*custom_arg_funcptr_t)(ShipManager *this_arg, bool overwrite_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1144::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1145::func;
 	return execfunc(this, overwrite);
 }
 
-namespace _func1145
+namespace _func1146
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::OnInit", typeid(int (ShipManager::*)(ShipBlueprint *, int )), ".4156415541544c8da7800600005589d5534889fb4c89e74883ec50", nullptr, 0, 0, &func);
@@ -14631,11 +14644,11 @@ namespace _func1145
 int ShipManager::OnInit(ShipBlueprint *bp, int shipLevel)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, ShipBlueprint *bp_arg, int shipLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1145::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1146::func;
 	return execfunc(this, bp, shipLevel);
 }
 
-namespace _func1146
+namespace _func1147
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::ImportShip", typeid(void (ShipManager::*)(int )), ".415741564189f64155415455534889fb4c8dab800600004c8dbb880700004881ec18040000", nullptr, 0, 0, &func);
@@ -14644,11 +14657,11 @@ namespace _func1146
 void ShipManager::ImportShip(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1146::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1147::func;
 	return execfunc(this, file);
 }
 
-namespace _func1147
+namespace _func1148
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::constructor", typeid(int (ShipManager::*)(int )), ".415741564989fe488dbfd800000041554154555389f34881ec98000000", nullptr, 0, 0, &func);
@@ -14657,30 +14670,17 @@ namespace _func1147
 int ShipManager::constructor(int shipId)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipManager *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1147::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1148::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func1148
+namespace _func1149
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::destructor", typeid(void (ShipManager::*)()), ".415641554989fd4154555348c707", nullptr, 0, 0, &func);
 }
 
 void ShipManager::destructor()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1148::func;
-	return execfunc(this);
-}
-
-namespace _func1149
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::destructor2", typeid(void (ShipManager::*)()), "!.534889fb", nullptr, 0, 0, &func);
-}
-
-void ShipManager::destructor2()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1149::func;
@@ -14690,10 +14690,10 @@ void ShipManager::destructor2()
 namespace _func1150
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipManager::CreateArmory", typeid(void (ShipManager::*)()), "415741564155415455534889fb4883ec48488b", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipManager::destructor2", typeid(void (ShipManager::*)()), "!.534889fb", nullptr, 0, 0, &func);
 }
 
-void ShipManager::CreateArmory()
+void ShipManager::destructor2()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1150::func;
@@ -14703,17 +14703,30 @@ void ShipManager::CreateArmory()
 namespace _func1151
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipManager::CreateArmory", typeid(void (ShipManager::*)()), "415741564155415455534889fb4883ec48488b", nullptr, 0, 0, &func);
+}
+
+void ShipManager::CreateArmory()
+{
+	typedef void (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1151::func;
+	return execfunc(this);
+}
+
+namespace _func1152
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipManager::CreateDrone", typeid(Drone *(ShipManager::*)(DroneBlueprint *)), "41544989f455534889fb4883ec108b", nullptr, 0, 0, &func);
 }
 
 Drone *ShipManager::CreateDrone(DroneBlueprint *drone)
 {
 	typedef Drone *(*custom_arg_funcptr_t)(ShipManager *this_arg, DroneBlueprint *drone_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1151::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1152::func;
 	return execfunc(this, drone);
 }
 
-namespace _func1152
+namespace _func1153
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::GetAugmentationCount", typeid(int (ShipObject::*)()), "8b570831c0488b0d????????85d2", nullptr, 0, 0, &func);
@@ -14722,11 +14735,11 @@ namespace _func1152
 int ShipObject::GetAugmentationCount()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1152::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1153::func;
 	return execfunc(this);
 }
 
-namespace _func1153
+namespace _func1154
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::ClearShipInfo", typeid(void (ShipObject::*)()), ".538b570831c085d20f94c0488d14004801c2488d1490", nullptr, 0, 0, &func);
@@ -14735,11 +14748,11 @@ namespace _func1153
 void ShipObject::ClearShipInfo()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1153::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1154::func;
 	return execfunc(this);
 }
 
-namespace _func1154
+namespace _func1155
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::GetAugmentationList", typeid(std::vector<std::string> (ShipObject::*)()), ".415631c04155415455538b56084889fb85d20f94c0488d14004801c2488d1490", nullptr, 0, 0, &func);
@@ -14748,11 +14761,11 @@ namespace _func1154
 std::vector<std::string> ShipObject::GetAugmentationList()
 {
 	typedef std::vector<std::string> (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1154::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1155::func;
 	return execfunc(this);
 }
 
-namespace _func1155
+namespace _func1156
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::HasAugmentation", typeid(int (ShipObject::*)(const std::string &)), ".415741564155415455534889fb4883ec38488d7c2420", nullptr, 0, 0, &func);
@@ -14761,11 +14774,11 @@ namespace _func1155
 int ShipObject::HasAugmentation(const std::string &augment)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1155::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1156::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1156
+namespace _func1157
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::HasEquipment", typeid(int (ShipObject::*)(const std::string &)), ".415741564155415455534889f34883ec68", nullptr, 0, 0, &func);
@@ -14774,11 +14787,11 @@ namespace _func1156
 int ShipObject::HasEquipment(const std::string &equip)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1156::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1157::func;
 	return execfunc(this, equip);
 }
 
-namespace _func1157
+namespace _func1158
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::GetAugmentationValue", typeid(float (ShipObject::*)(const std::string &)), ".415741564155415455534889fb4883ec58488d7c2430", nullptr, 0, 0, &func);
@@ -14787,11 +14800,11 @@ namespace _func1157
 float ShipObject::GetAugmentationValue(const std::string &augment)
 {
 	typedef float (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1157::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1158::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1158
+namespace _func1159
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::AddAugmentation", typeid(bool (ShipObject::*)(const std::string &)), ".415741564155415455534889fb4883ec58488d7c2430", nullptr, 0, 0, &func);
@@ -14800,11 +14813,11 @@ namespace _func1158
 bool ShipObject::AddAugmentation(const std::string &augment)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1158::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1159::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1159
+namespace _func1160
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::RemoveAugmentation", typeid(void (ShipObject::*)(const std::string &)), ".415741564155415455534889fb4883ec48488d7c2420", nullptr, 0, 0, &func);
@@ -14813,11 +14826,11 @@ namespace _func1159
 void ShipObject::RemoveAugmentation(const std::string &augment)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1159::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1160::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1160
+namespace _func1161
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipObject::RemoveEquipment", typeid(void (ShipObject::*)(const std::string &, bool )), ".??57??56??55??545553??89fb??83ec58??8d????308954????e8????????8b530831c0", nullptr, 0, 0, &func);
@@ -14826,37 +14839,24 @@ namespace _func1160
 void ShipObject::RemoveEquipment(const std::string &blueName, bool completely)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &blueName_arg, bool completely_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1160::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1161::func;
 	return execfunc(this, blueName, completely);
 }
 
 ShipInfo **Global_ShipObject_ShipInfoList;
 
-namespace _var1161
+namespace _var1162
 {
     static VariableDefinition varObj("Global_ShipObject_ShipInfoList", "!8b570831c0488b0d(???????\?)85d20f94c0488d14004801c2", &Global_ShipObject_ShipInfoList, true, true);
 }
 
-namespace _func1162
+namespace _func1163
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSelect::constructor", typeid(void (ShipSelect::*)()), "53ba6e0000004889fbbe700000004883ec10", nullptr, 0, 0, &func);
 }
 
 void ShipSelect::constructor()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1162::func;
-	return execfunc(this);
-}
-
-namespace _func1163
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipSelect::ClearShipButtons", typeid(void (ShipSelect::*)()), ".554889fd534883ec08488b4f30488b57284889c84829d048c1f80385c0", nullptr, 0, 0, &func);
-}
-
-void ShipSelect::ClearShipButtons()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1163::func;
@@ -14866,10 +14866,10 @@ void ShipSelect::ClearShipButtons()
 namespace _func1164
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipSelect::OnLoop", typeid(void (ShipSelect::*)()), ".415741564155415455534889fb4881ec0801000080bf5005000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipSelect::ClearShipButtons", typeid(void (ShipSelect::*)()), ".554889fd534883ec08488b4f30488b57284889c84829d048c1f80385c0", nullptr, 0, 0, &func);
 }
 
-void ShipSelect::OnLoop()
+void ShipSelect::ClearShipButtons()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1164::func;
@@ -14879,36 +14879,36 @@ void ShipSelect::OnLoop()
 namespace _func1165
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipSelect::OnLoop", typeid(void (ShipSelect::*)()), ".415741564155415455534889fb4881ec0801000080bf5005000000", nullptr, 0, 0, &func);
+}
+
+void ShipSelect::OnLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1165::func;
+	return execfunc(this);
+}
+
+namespace _func1166
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipSelect::KeyDown", typeid(int (ShipSelect::*)(SDLKey )), "!.4881c748050000", nullptr, 0, 0, &func);
 }
 
 int ShipSelect::KeyDown(SDLKey key)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipSelect *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1165::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1166::func;
 	return execfunc(this, key);
 }
 
-namespace _func1166
+namespace _func1167
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSelect::MouseClick", typeid(void (ShipSelect::*)()), "!.5380bf50050000004889fb", nullptr, 0, 0, &func);
 }
 
 void ShipSelect::MouseClick()
-{
-	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1166::func;
-	return execfunc(this);
-}
-
-namespace _func1167
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipSelect::Close", typeid(void (ShipSelect::*)()), "!.c64758004881c748050000", nullptr, 0, 0, &func);
-}
-
-void ShipSelect::Close()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1167::func;
@@ -14918,12 +14918,12 @@ void ShipSelect::Close()
 namespace _func1168
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipSelect::GetSelectedShip", typeid(int (ShipSelect::*)()), "!.8b475cc3", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipSelect::Close", typeid(void (ShipSelect::*)()), "!.c64758004881c748050000", nullptr, 0, 0, &func);
 }
 
-int ShipSelect::GetSelectedShip()
+void ShipSelect::Close()
 {
-	typedef int (*custom_arg_funcptr_t)(ShipSelect *this_arg);
+	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1168::func;
 	return execfunc(this);
 }
@@ -14931,23 +14931,23 @@ int ShipSelect::GetSelectedShip()
 namespace _func1169
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipSelect::SelectShip", typeid(void (ShipSelect::*)(int )), ".415789f241564989fe4155415455534881eca8020000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipSelect::GetSelectedShip", typeid(int (ShipSelect::*)()), "!.8b475cc3", nullptr, 0, 0, &func);
 }
 
-void ShipSelect::SelectShip(int shipType)
+int ShipSelect::GetSelectedShip()
 {
-	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg, int shipType_arg);
+	typedef int (*custom_arg_funcptr_t)(ShipSelect *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1169::func;
-	return execfunc(this, shipType);
+	return execfunc(this);
 }
 
 namespace _func1170
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ShipSelect::PreSelectShip", typeid(void (ShipSelect::*)(int )), "!.85f6534889fb", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ShipSelect::SelectShip", typeid(void (ShipSelect::*)(int )), ".415789f241564989fe4155415455534881eca8020000", nullptr, 0, 0, &func);
 }
 
-void ShipSelect::PreSelectShip(int shipType)
+void ShipSelect::SelectShip(int shipType)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg, int shipType_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1170::func;
@@ -14957,17 +14957,30 @@ void ShipSelect::PreSelectShip(int shipType)
 namespace _func1171
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipSelect::PreSelectShip", typeid(void (ShipSelect::*)(int )), "!.85f6534889fb", nullptr, 0, 0, &func);
+}
+
+void ShipSelect::PreSelectShip(int shipType)
+{
+	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg, int shipType_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1171::func;
+	return execfunc(this, shipType);
+}
+
+namespace _func1172
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipSelect::MouseMove", typeid(void (ShipSelect::*)(int , int )), ".41574189f74156415541544189d4554889fd534881ec18010000", nullptr, 0, 0, &func);
 }
 
 void ShipSelect::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1171::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1172::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1172
+namespace _func1173
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSelect::Open", typeid(void (ShipSelect::*)(int , int )), ".41574989ff41564155415455534881ecc8010000", nullptr, 0, 0, &func);
@@ -14976,11 +14989,11 @@ namespace _func1172
 void ShipSelect::Open(int currentId, int currentType)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg, int currentId_arg, int currentType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1172::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1173::func;
 	return execfunc(this, currentId, currentType);
 }
 
-namespace _func1173
+namespace _func1174
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSelect::OnRender", typeid(void (ShipSelect::*)()), ".41564155415455534889fb4883ec5080bf5005000000", nullptr, 0, 0, &func);
@@ -14989,11 +15002,11 @@ namespace _func1173
 void ShipSelect::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1173::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1174::func;
 	return execfunc(this);
 }
 
-namespace _func1174
+namespace _func1175
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipStatus::RenderHealth", typeid(void (ShipStatus::*)(bool )), "4155415455534881ec880000004084f6", nullptr, 0, 0, &func);
@@ -15002,11 +15015,11 @@ namespace _func1174
 void ShipStatus::RenderHealth(bool renderText)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool renderText_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1174::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1175::func;
 	return execfunc(this, renderText);
 }
 
-namespace _func1175
+namespace _func1176
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipStatus::OnInit", typeid(void (ShipStatus::*)(Point , float )), "415741564155415455534889fb4881ece8010000f30f114708", nullptr, 0, 0, &func);
@@ -15015,30 +15028,17 @@ namespace _func1175
 void ShipStatus::OnInit(Point location, float size)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipStatus *this_arg, Point location_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1175::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1176::func;
 	return execfunc(this, location, size);
 }
 
-namespace _func1176
+namespace _func1177
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipStatus::RenderResources", typeid(void (ShipStatus::*)(bool )), ".415741564155415455534889fb4881ec58060000", nullptr, 0, 0, &func);
 }
 
 void ShipStatus::RenderResources(bool renderText)
-{
-	typedef void (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool renderText_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1176::func;
-	return execfunc(this, renderText);
-}
-
-namespace _func1177
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipStatus::RenderEvadeOxygen", typeid(void (ShipStatus::*)(bool )), "415741564155415455534889fb4881ec580300004084f6", nullptr, 0, 0, &func);
-}
-
-void ShipStatus::RenderEvadeOxygen(bool renderText)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool renderText_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1177::func;
@@ -15048,17 +15048,30 @@ void ShipStatus::RenderEvadeOxygen(bool renderText)
 namespace _func1178
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipStatus::RenderEvadeOxygen", typeid(void (ShipStatus::*)(bool )), "415741564155415455534889fb4881ec580300004084f6", nullptr, 0, 0, &func);
+}
+
+void ShipStatus::RenderEvadeOxygen(bool renderText)
+{
+	typedef void (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool renderText_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1178::func;
+	return execfunc(this, renderText);
+}
+
+namespace _func1179
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipStatus::OnRender", typeid(void (ShipStatus::*)()), "4155415455534889fb4881ec88000000e8????????f30f2a03", nullptr, 0, 0, &func);
 }
 
 void ShipStatus::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1178::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1179::func;
 	return execfunc(this);
 }
 
-namespace _func1179
+namespace _func1180
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipStatus::RenderShields", typeid(void (ShipStatus::*)(bool )), "41574156415541544989fc55534883ec18488b7f10", nullptr, 0, 0, &func);
@@ -15067,11 +15080,11 @@ namespace _func1179
 void ShipStatus::RenderShields(bool renderText)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool renderText_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1179::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1180::func;
 	return execfunc(this, renderText);
 }
 
-namespace _func1180
+namespace _func1181
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipStatus::OnLoop", typeid(void (ShipStatus::*)()), "415541544531e4554889fd5331db4883ec48", nullptr, 0, 0, &func);
@@ -15080,11 +15093,11 @@ namespace _func1180
 void ShipStatus::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1180::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1181::func;
 	return execfunc(this);
 }
 
-namespace _func1181
+namespace _func1182
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::SetHackingLevel", typeid(void (ShipSystem::*)(int )), "89b720020000", nullptr, 0, 0, &func);
@@ -15093,11 +15106,11 @@ namespace _func1181
 void ShipSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1181::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1182::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func1182
+namespace _func1183
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::ForceDecreasePower", typeid(bool (ShipSystem::*)(int )), ".415641554154554889fd5380bf8c01000000", nullptr, 0, 0, &func);
@@ -15106,11 +15119,11 @@ namespace _func1182
 bool ShipSystem::ForceDecreasePower(int powerLoss)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, int powerLoss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1182::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1183::func;
 	return execfunc(this, powerLoss);
 }
 
-namespace _func1183
+namespace _func1184
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::AddDamage", typeid(void (ShipSystem::*)(int )), ".8b87740100008b977801000029f08b775439d00f4fc231c985c00f48c1", nullptr, 0, 0, &func);
@@ -15119,11 +15132,11 @@ namespace _func1183
 void ShipSystem::AddDamage(int amount)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1183::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1184::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1184
+namespace _func1185
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::Ioned", typeid(bool (ShipSystem::*)(int )), ".8b879c01000083f8ff0f94c285c00f9fc008d0", nullptr, 0, 0, &func);
@@ -15132,11 +15145,11 @@ namespace _func1184
 bool ShipSystem::Ioned(int num)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, int num_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1184::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1185::func;
 	return execfunc(this, num);
 }
 
-namespace _func1185
+namespace _func1186
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::destructor", typeid(void (ShipSystem::*)()), ".415441bc05000000554889fd534889eb4883ec10", nullptr, 0, 0, &func);
@@ -15145,30 +15158,17 @@ namespace _func1185
 void ShipSystem::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1185::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1186::func;
 	return execfunc(this);
 }
 
-namespace _func1186
+namespace _func1187
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::SaveState", typeid(void (ShipSystem::*)(int )), "!.554889fd5389f34883ec088bb790010000", nullptr, 0, 0, &func);
 }
 
 void ShipSystem::SaveState(int file)
-{
-	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1186::func;
-	return execfunc(this, file);
-}
-
-namespace _func1187
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("ShipSystem::LoadState", typeid(void (ShipSystem::*)(int )), ".5589f5534889fb89f74883ec08", nullptr, 0, 0, &func);
-}
-
-void ShipSystem::LoadState(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1187::func;
@@ -15178,17 +15178,30 @@ void ShipSystem::LoadState(int file)
 namespace _func1188
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("ShipSystem::LoadState", typeid(void (ShipSystem::*)(int )), ".5589f5534889fb89f74883ec08", nullptr, 0, 0, &func);
+}
+
+void ShipSystem::LoadState(int file)
+{
+	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1188::func;
+	return execfunc(this, file);
+}
+
+namespace _func1189
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::GetEffectivePower", typeid(int (ShipSystem::*)()), ".8b474831d285c0", nullptr, 0, 0, &func);
 }
 
 int ShipSystem::GetEffectivePower()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1188::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1189::func;
 	return execfunc(this);
 }
 
-namespace _func1189
+namespace _func1190
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::SetBonusPower", typeid(void (ShipSystem::*)(int , int )), ".4154555380bf8c010000004889fb", nullptr, 0, 0, &func);
@@ -15197,11 +15210,11 @@ namespace _func1189
 void ShipSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1189::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1190::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func1190
+namespace _func1191
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::GetPowerCap", typeid(int (ShipSystem::*)()), ".8b979001000031c083fa07", nullptr, 0, 0, &func);
@@ -15210,11 +15223,11 @@ namespace _func1190
 int ShipSystem::GetPowerCap()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1190::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1191::func;
 	return execfunc(this);
 }
 
-namespace _func1191
+namespace _func1192
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::BlockedBoosted", typeid(bool (ShipSystem::*)(bool )), ".4084f6534889fb", nullptr, 0, 0, &func);
@@ -15223,11 +15236,11 @@ namespace _func1191
 bool ShipSystem::BlockedBoosted(bool countLimit)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool countLimit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1191::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1192::func;
 	return execfunc(this, countLimit);
 }
 
-namespace _func1192
+namespace _func1193
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::IsMannedBoost", typeid(int (ShipSystem::*)()), ".8b474885c07e21", nullptr, 0, 0, &func);
@@ -15236,11 +15249,11 @@ namespace _func1192
 int ShipSystem::IsMannedBoost()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1192::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1193::func;
 	return execfunc(this);
 }
 
-namespace _func1193
+namespace _func1194
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::GetLocked", typeid(bool (ShipSystem::*)()), ".8b879c01000083f8ff", nullptr, 0, 0, &func);
@@ -15249,11 +15262,11 @@ namespace _func1193
 bool ShipSystem::GetLocked()
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1193::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1194::func;
 	return execfunc(this);
 }
 
-namespace _func1194
+namespace _func1195
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::GetLockTimer", typeid(TimerHelper (ShipSystem::*)()), ".488b96a0", nullptr, 0, 0, &func);
@@ -15262,11 +15275,11 @@ namespace _func1194
 TimerHelper ShipSystem::GetLockTimer()
 {
 	typedef TimerHelper (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1194::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1195::func;
 	return execfunc(this);
 }
 
-namespace _func1195
+namespace _func1196
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::StopHacking", typeid(void (ShipSystem::*)()), "!.488b07c6872402000000", nullptr, 0, 0, &func);
@@ -15275,11 +15288,11 @@ namespace _func1195
 void ShipSystem::StopHacking()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1195::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1196::func;
 	return execfunc(this);
 }
 
-namespace _func1196
+namespace _func1197
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::UpgradeSystem", typeid(bool (ShipSystem::*)(int )), ".5589f5534889fb4883ec08488b07", nullptr, 0, 0, &func);
@@ -15288,11 +15301,11 @@ namespace _func1196
 bool ShipSystem::UpgradeSystem(int amount)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1196::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1197::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1197
+namespace _func1198
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::GetMaxPower", typeid(int (ShipSystem::*)()), ".8b4f548b877401000031d2", nullptr, 0, 0, &func);
@@ -15301,11 +15314,11 @@ namespace _func1197
 int ShipSystem::GetMaxPower()
 {
 	typedef int (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1197::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1198::func;
 	return execfunc(this);
 }
 
-namespace _func1198
+namespace _func1199
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::CheckMaxPower", typeid(void (ShipSystem::*)()), ".4155415455534889fb4883ec0880bf8c01000000", nullptr, 0, 0, &func);
@@ -15314,11 +15327,11 @@ namespace _func1198
 void ShipSystem::CheckMaxPower()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1198::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1199::func;
 	return execfunc(this);
 }
 
-namespace _func1199
+namespace _func1200
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::RenderSystemSymbol", typeid(void (ShipSystem::*)(bool , int )), ".41545589d5534889fb4883ec", nullptr, 0, 0, &func);
@@ -15327,11 +15340,11 @@ namespace _func1199
 void ShipSystem::RenderSystemSymbol(bool forPowerUI, int forceColor)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool forPowerUI_arg, int forceColor_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1199::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1200::func;
 	return execfunc(this, forPowerUI, forceColor);
 }
 
-namespace _func1200
+namespace _func1201
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::RenderPowerBoxesPlain", typeid(int (*)(int , int , int , int , int , int , int , int )), ".4157b840", nullptr, 0, 0, &func);
@@ -15340,11 +15353,11 @@ namespace _func1200
 int ShipSystem::RenderPowerBoxesPlain(int x, int y, int width, int height, int gap, int current, int temp, int max)
 {
 	typedef int (*custom_arg_funcptr_t)(int x_arg, int y_arg, int width_arg, int height_arg, int gap_arg, int current_arg, int temp_arg, int max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1200::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1201::func;
 	return execfunc(x, y, width, height, gap, current, temp, max);
 }
 
-namespace _func1201
+namespace _func1202
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::IsSubsystem", typeid(bool (*)(int )), ".83ff0c741383ff06", nullptr, 0, 0, &func);
@@ -15353,11 +15366,11 @@ namespace _func1201
 bool ShipSystem::IsSubsystem(int systemType)
 {
 	typedef bool (*custom_arg_funcptr_t)(int systemType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1201::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1202::func;
 	return execfunc(systemType);
 }
 
-namespace _func1202
+namespace _func1203
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::RenderPowerBoxes", typeid(int (ShipSystem::*)(int , int , int , int , int , int , bool )), "!.41574989ff41564189ce41554189f541544589c4554489cd5389d34881ec88000000", nullptr, 0, 0, &func);
@@ -15366,116 +15379,116 @@ namespace _func1202
 int ShipSystem::RenderPowerBoxes(int x, int y, int width, int height, int gap, int heightMod, bool flash)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipSystem *this_arg, int x_arg, int y_arg, int width_arg, int height_arg, int gap_arg, int heightMod_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1202::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1203::func;
 	return execfunc(this, x, y, width, height, gap, heightMod, flash);
 }
 
 GL_Primitive **ShipSystem__glowWhite;
 
-namespace _var1203
+namespace _var1204
 {
     static VariableDefinition varObj("ShipSystem__glowWhite", "!.488b3d(???????\?)", &ShipSystem__glowWhite, true, true);
 }
 
 GL_Primitive **ShipSystem__lockBlue;
 
-namespace _var1204
+namespace _var1205
 {
     static VariableDefinition varObj("ShipSystem__lockBlue", "!.4c8b05(???????\?)", &ShipSystem__lockBlue, true, true);
 }
 
 GL_Primitive **ShipSystem__fireImage;
 
-namespace _var1205
+namespace _var1206
 {
     static VariableDefinition varObj("ShipSystem__fireImage", "!.488b3d(???????\?)", &ShipSystem__fireImage, true, true);
 }
 
 GL_Primitive **ShipSystem__lockHack;
 
-namespace _var1206
+namespace _var1207
 {
     static VariableDefinition varObj("ShipSystem__lockHack", "!.488b3d(???????\?)", &ShipSystem__lockHack, true, true);
 }
 
 GL_Primitive **ShipSystem__manningBarIon;
 
-namespace _var1207
+namespace _var1208
 {
     static VariableDefinition varObj("ShipSystem__manningBarIon", "!.488b3d(???????\?)", &ShipSystem__manningBarIon, true, true);
 }
 
 GL_Primitive **ShipSystem__manningBarOff;
 
-namespace _var1208
+namespace _var1209
 {
     static VariableDefinition varObj("ShipSystem__manningBarOff", "!.480f443d(???????\?)", &ShipSystem__manningBarOff, true, true);
 }
 
 GL_Primitive **ShipSystem__lockWhite;
 
-namespace _var1209
+namespace _var1210
 {
     static VariableDefinition varObj("ShipSystem__lockWhite", "!.4c8b05(???????\?)", &ShipSystem__lockWhite, true, true);
 }
 
 GL_Primitive **ShipSystem__sabotageImage;
 
-namespace _var1210
+namespace _var1211
 {
     static VariableDefinition varObj("ShipSystem__sabotageImage", "!.488b3d(???????\?)", &ShipSystem__sabotageImage, true, true);
 }
 
 GL_Primitive **ShipSystem__manningOutline;
 
-namespace _var1211
+namespace _var1212
 {
     static VariableDefinition varObj("ShipSystem__manningOutline", "!.488b3d(???????\?)", &ShipSystem__manningOutline, true, true);
 }
 
 GL_Primitive **ShipSystem__manningBarOn;
 
-namespace _var1212
+namespace _var1213
 {
     static VariableDefinition varObj("ShipSystem__manningBarOn", "!.488b3d(???????\?)", &ShipSystem__manningBarOn, true, true);
 }
 
 GL_Primitive **ShipSystem__manningWhite;
 
-namespace _var1213
+namespace _var1214
 {
     static VariableDefinition varObj("ShipSystem__manningWhite", "!.488b3d(???????\?)", &ShipSystem__manningWhite, true, true);
 }
 
 GL_Primitive **ShipSystem__manningGreen;
 
-namespace _var1214
+namespace _var1215
 {
     static VariableDefinition varObj("ShipSystem__manningGreen", "!.488b3d(???????\?)", &ShipSystem__manningGreen, true, true);
 }
 
 GL_Primitive **ShipSystem__manningYellow;
 
-namespace _var1215
+namespace _var1216
 {
     static VariableDefinition varObj("ShipSystem__manningYellow", "!.488b3d(???????\?)", &ShipSystem__manningYellow, true, true);
 }
 
 GL_Primitive **ShipSystem__glowBlue;
 
-namespace _var1216
+namespace _var1217
 {
     static VariableDefinition varObj("ShipSystem__glowBlue", "!.488b3d(???????\?)", &ShipSystem__glowBlue, true, true);
 }
 
 GL_Primitive **ShipSystem__glowRed;
 
-namespace _var1217
+namespace _var1218
 {
     static VariableDefinition varObj("ShipSystem__glowRed", "!.488b3d(???????\?)", &ShipSystem__glowRed, true, true);
 }
 
-namespace _func1218
+namespace _func1219
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::RawDecreasePower", typeid(bool (ShipSystem::*)()), "!.5553??89fb??83ec088b6f588b7f18e8????????", nullptr, 0, 0, &func);
@@ -15484,11 +15497,11 @@ namespace _func1218
 bool ShipSystem::RawDecreasePower()
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1218::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1219::func;
 	return execfunc(this);
 }
 
-namespace _func1219
+namespace _func1220
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::IncreasePower", typeid(bool (ShipSystem::*)(int , bool )), ".534889fb4883ec108b879c010000", nullptr, 0, 0, &func);
@@ -15497,11 +15510,11 @@ namespace _func1219
 bool ShipSystem::IncreasePower(int amount, bool force)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1219::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1220::func;
 	return execfunc(this, amount, force);
 }
 
-namespace _func1220
+namespace _func1221
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::DecreasePower", typeid(bool (ShipSystem::*)(bool )), ".55534889fb4883ec080fb6878c010000", nullptr, 0, 0, &func);
@@ -15510,11 +15523,11 @@ namespace _func1220
 bool ShipSystem::DecreasePower(bool force)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1220::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1221::func;
 	return execfunc(this, force);
 }
 
-namespace _func1221
+namespace _func1222
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::DamageOverTime", typeid(bool (ShipSystem::*)(float )), ".55534889fb", nullptr, 0, 0, &func);
@@ -15523,11 +15536,11 @@ namespace _func1221
 bool ShipSystem::DamageOverTime(float unk)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, float unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1221::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1222::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1222
+namespace _func1223
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::CheckForRepower", typeid(void (ShipSystem::*)()), ".415541544531e455534889fb4883ec08", nullptr, 0, 0, &func);
@@ -15536,11 +15549,11 @@ namespace _func1222
 void ShipSystem::CheckForRepower()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1222::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1223::func;
 	return execfunc(this);
 }
 
-namespace _func1223
+namespace _func1224
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::LockSystem", typeid(void (ShipSystem::*)(int )), ".83fe00751b8b879c010000", nullptr, 0, 0, &func);
@@ -15549,11 +15562,11 @@ namespace _func1223
 void ShipSystem::LockSystem(int lock)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1223::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1224::func;
 	return execfunc(this, lock);
 }
 
-namespace _func1224
+namespace _func1225
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::ClearStatus", typeid(void (ShipSystem::*)()), ".83bf9001000007", nullptr, 0, 0, &func);
@@ -15562,11 +15575,11 @@ namespace _func1224
 void ShipSystem::ClearStatus()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1224::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1225::func;
 	return execfunc(this);
 }
 
-namespace _func1225
+namespace _func1226
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::SetPowerCap", typeid(void (ShipSystem::*)(int )), "!.53488b074889fb89b790010000", nullptr, 0, 0, &func);
@@ -15575,11 +15588,11 @@ namespace _func1225
 void ShipSystem::SetPowerCap(int cap)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int cap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1225::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1226::func;
 	return execfunc(this, cap);
 }
 
-namespace _func1226
+namespace _func1227
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::SetPowerLoss", typeid(int (ShipSystem::*)(int )), "!.53488b074889fb89b794010000", nullptr, 0, 0, &func);
@@ -15588,11 +15601,11 @@ namespace _func1226
 int ShipSystem::SetPowerLoss(int power)
 {
 	typedef int (*custom_arg_funcptr_t)(ShipSystem *this_arg, int power_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1226::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1227::func;
 	return execfunc(this, power);
 }
 
-namespace _func1227
+namespace _func1228
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::SetDividePower", typeid(void (ShipSystem::*)(int )), "!.83fe01534889fb89b798010000", nullptr, 0, 0, &func);
@@ -15601,11 +15614,11 @@ namespace _func1227
 void ShipSystem::SetDividePower(int val)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int val_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1227::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1228::func;
 	return execfunc(this, val);
 }
 
-namespace _func1228
+namespace _func1229
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::PartialRepair", typeid(bool (ShipSystem::*)(float , bool )), ".5531c0534889fb4883ec18", nullptr, 0, 0, &func);
@@ -15614,11 +15627,11 @@ namespace _func1228
 bool ShipSystem::PartialRepair(float speed, bool autoRepair)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, float speed_arg, bool autoRepair_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1228::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1229::func;
 	return execfunc(this, speed, autoRepair);
 }
 
-namespace _func1229
+namespace _func1230
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::AddLock", typeid(void (ShipSystem::*)(int )), ".8b879c01000083f8ff", nullptr, 0, 0, &func);
@@ -15627,11 +15640,11 @@ namespace _func1229
 void ShipSystem::AddLock(int lock)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1229::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1230::func;
 	return execfunc(this, lock);
 }
 
-namespace _func1230
+namespace _func1231
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::IonDamage", typeid(void (ShipSystem::*)(int )), ".5589f553??83ec08", nullptr, 0, 0, &func);
@@ -15640,11 +15653,11 @@ namespace _func1230
 void ShipSystem::IonDamage(int amount)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1230::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1231::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1231
+namespace _func1232
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::OnLoop", typeid(void (ShipSystem::*)()), ".415455538b879c0100004889fb85c0", nullptr, 0, 0, &func);
@@ -15653,11 +15666,11 @@ namespace _func1231
 void ShipSystem::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1231::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1232::func;
 	return execfunc(this);
 }
 
-namespace _func1232
+namespace _func1233
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::NameToSystemId", typeid(int (*)(const std::string &)), ".53be????????4889fb", nullptr, 0, 0, &func);
@@ -15666,11 +15679,11 @@ namespace _func1232
 int ShipSystem::NameToSystemId(const std::string &name)
 {
 	typedef int (*custom_arg_funcptr_t)(const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1232::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1233::func;
 	return execfunc(name);
 }
 
-namespace _func1233
+namespace _func1234
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::SystemIdToName", typeid(std::string (*)(int )), ".534889fb4883ec1083fe11488d54240f", nullptr, 0, 0, &func);
@@ -15679,11 +15692,11 @@ namespace _func1233
 std::string ShipSystem::SystemIdToName(int systemId)
 {
 	typedef std::string (*custom_arg_funcptr_t)(int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1233::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1234::func;
 	return execfunc(systemId);
 }
 
-namespace _func1234
+namespace _func1235
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::GetLevelDescription", typeid(std::string (*)(int , int , bool )), ".4156415541544189d455534889fb4881ec10020000", nullptr, 0, 0, &func);
@@ -15692,11 +15705,11 @@ namespace _func1234
 std::string ShipSystem::GetLevelDescription(int systemId, int level, bool tooltip)
 {
 	typedef std::string (*custom_arg_funcptr_t)(int systemId_arg, int level_arg, bool tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1234::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1235::func;
 	return execfunc(systemId, level, tooltip);
 }
 
-namespace _func1235
+namespace _func1236
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::constructor", typeid(void (ShipSystem::*)(int , int , int , int )), ".41574989ff41564189f641554589c54154555389d389ca4881ecd8010000", nullptr, 0, 0, &func);
@@ -15705,11 +15718,11 @@ namespace _func1235
 void ShipSystem::constructor(int systemId, int roomId, int shipId, int startingPower)
 {
 	typedef void (*custom_arg_funcptr_t)(ShipSystem *this_arg, int systemId_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1235::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1236::func;
 	return execfunc(this, systemId, roomId, shipId, startingPower);
 }
 
-namespace _func1236
+namespace _func1237
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("ShipSystem::PartialDamage", typeid(bool (ShipSystem::*)(float )), "55534889fbbf????????4883ec18f30f1144240c", nullptr, 0, 0, &func);
@@ -15718,11 +15731,11 @@ namespace _func1236
 bool ShipSystem::PartialDamage(float amount)
 {
 	typedef bool (*custom_arg_funcptr_t)(ShipSystem *this_arg, float amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1236::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1237::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1237
+namespace _func1238
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SoundControl::StopPlaylist", typeid(void (SoundControl::*)(int )), "415541544989fc55534883ec38803f000f84c8000000", nullptr, 0, 0, &func);
@@ -15731,11 +15744,11 @@ namespace _func1237
 void SoundControl::StopPlaylist(int fadeOut)
 {
 	typedef void (*custom_arg_funcptr_t)(SoundControl *this_arg, int fadeOut_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1237::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1238::func;
 	return execfunc(this, fadeOut);
 }
 
-namespace _func1238
+namespace _func1239
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SoundControl::StopChannel", typeid(void (SoundControl::*)(int , float )), ".4156415541544989fc55534883ec10803f000f84", nullptr, 0, 0, &func);
@@ -15744,11 +15757,11 @@ namespace _func1238
 void SoundControl::StopChannel(int channel, float fade)
 {
 	typedef void (*custom_arg_funcptr_t)(SoundControl *this_arg, int channel_arg, float fade_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1238::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1239::func;
 	return execfunc(this, channel, fade);
 }
 
-namespace _func1239
+namespace _func1240
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SoundControl::StartPlaylist", typeid(void (SoundControl::*)(std::vector<std::string> &)), ".41574156415541544989fc55534883ec58803f004889742420", nullptr, 0, 0, &func);
@@ -15757,11 +15770,11 @@ namespace _func1239
 void SoundControl::StartPlaylist(std::vector<std::string> &playlist)
 {
 	typedef void (*custom_arg_funcptr_t)(SoundControl *this_arg, std::vector<std::string> &playlist_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1239::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1240::func;
 	return execfunc(this, playlist);
 }
 
-namespace _func1240
+namespace _func1241
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SoundControl::PlaySoundMix", typeid(int (SoundControl::*)(const std::string &, float , bool )), ".415731c04156415541544989fc55534883ec48803f00", nullptr, 0, 0, &func);
@@ -15770,11 +15783,11 @@ namespace _func1240
 int SoundControl::PlaySoundMix(const std::string &soundName, float volume, bool loop)
 {
 	typedef int (*custom_arg_funcptr_t)(SoundControl *this_arg, const std::string &soundName_arg, float volume_arg, bool loop_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1240::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1241::func;
 	return execfunc(this, soundName, volume, loop);
 }
 
-namespace _func1241
+namespace _func1242
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SoundControl::UpdateSoundLoop", typeid(void (SoundControl::*)(const std::string &, float )), ".4157415641554154554889fd534883ec38", nullptr, 0, 0, &func);
@@ -15783,18 +15796,18 @@ namespace _func1241
 void SoundControl::UpdateSoundLoop(const std::string &loopId, float count)
 {
 	typedef void (*custom_arg_funcptr_t)(SoundControl *this_arg, const std::string &loopId_arg, float count_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1241::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1242::func;
 	return execfunc(this, loopId, count);
 }
 
 SoundControl *Global_SoundControl_Sounds;
 
-namespace _var1242
+namespace _var1243
 {
     static VariableDefinition varObj("Global_SoundControl_Sounds", "!488b8360020000488378e80074cf4881c36002000031d2bf(???????\?)", &Global_SoundControl_Sounds);
 }
 
-namespace _func1243
+namespace _func1244
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceDrone::SetMovementTarget", typeid(void (SpaceDrone::*)(Targetable *)), "554889f5534889fb4883ec084885f6744f488b06", nullptr, 0, 0, &func);
@@ -15803,11 +15816,11 @@ namespace _func1243
 void SpaceDrone::SetMovementTarget(Targetable *target)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1243::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1244::func;
 	return execfunc(this, target);
 }
 
-namespace _func1244
+namespace _func1245
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceDrone::SetDeployed", typeid(void (SpaceDrone::*)(bool )), ".5589f5534889fb4883ec08488b07ff506084c0743b", nullptr, 0, 0, &func);
@@ -15816,11 +15829,11 @@ namespace _func1244
 void SpaceDrone::SetDeployed(bool deployed)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceDrone *this_arg, bool deployed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1244::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1245::func;
 	return execfunc(this, deployed);
 }
 
-namespace _func1245
+namespace _func1246
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceDrone::CollisionMoving", typeid(CollisionResponse (SpaceDrone::*)(Pointf , Pointf , Damage , bool )), ".41554154554889f5534889fb488d7f044883ec18", nullptr, 0, 0, &func);
@@ -15829,11 +15842,11 @@ namespace _func1245
 CollisionResponse SpaceDrone::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1245::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1246::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func1246
+namespace _func1247
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceDrone::UpdateAimingAngle", typeid(float (SpaceDrone::*)(Pointf , float , float )), ".530f28e14889fb4883ec30660fd60424", nullptr, 0, 0, &func);
@@ -15842,11 +15855,11 @@ namespace _func1246
 float SpaceDrone::UpdateAimingAngle(Pointf location, float percentage, float forceDesired)
 {
 	typedef float (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Pointf location_arg, float percentage_arg, float forceDesired_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1246::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1247::func;
 	return execfunc(this, location, percentage, forceDesired);
 }
 
-namespace _func1247
+namespace _func1248
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceDrone::GetNextProjectile", typeid(Projectile *(SpaceDrone::*)()), ".415741564155415455534889fb4883ec68488b07", nullptr, 0, 0, &func);
@@ -15855,11 +15868,11 @@ namespace _func1247
 Projectile *SpaceDrone::GetNextProjectile()
 {
 	typedef Projectile *(*custom_arg_funcptr_t)(SpaceDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1247::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1248::func;
 	return execfunc(this);
 }
 
-namespace _func1248
+namespace _func1249
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceDrone::constructor", typeid(void (SpaceDrone::*)(int , int , DroneBlueprint *)), "41570f57d24989ff", nullptr, 0, 0, &func);
@@ -15868,11 +15881,11 @@ namespace _func1248
 void SpaceDrone::constructor(int iShipId, int selfId, DroneBlueprint *blueprint)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceDrone *this_arg, int iShipId_arg, int selfId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1248::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1249::func;
 	return execfunc(this, iShipId, selfId, blueprint);
 }
 
-namespace _func1249
+namespace _func1250
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceDrone::destructor", typeid(void (SpaceDrone::*)(int )), "4157415641554154554889fd488dbf80", nullptr, 0, 0, &func);
@@ -15881,11 +15894,11 @@ namespace _func1249
 void SpaceDrone::destructor(int __in_chrg)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceDrone *this_arg, int __in_chrg_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1249::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1250::func;
 	return execfunc(this, __in_chrg);
 }
 
-namespace _func1250
+namespace _func1251
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::constructor", typeid(void (SpaceManager::*)()), "!415455534889fb488d7f18488dabe00100004c8da3700200004883ec10", nullptr, 0, 0, &func);
@@ -15894,11 +15907,11 @@ namespace _func1250
 void SpaceManager::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1250::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1251::func;
 	return execfunc(this);
 }
 
-namespace _func1251
+namespace _func1252
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::GetScreenShake", typeid(int (SpaceManager::*)()), ".0fb687b0040000", nullptr, 0, 0, &func);
@@ -15907,11 +15920,11 @@ namespace _func1251
 int SpaceManager::GetScreenShake()
 {
 	typedef int (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1251::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1252::func;
 	return execfunc(this);
 }
 
-namespace _func1252
+namespace _func1253
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SaveSpace", typeid(void (SpaceManager::*)(int )), ".41544189f455530fb6b7500300004889fb4489e7", nullptr, 0, 0, &func);
@@ -15920,11 +15933,11 @@ namespace _func1252
 void SpaceManager::SaveSpace(int fileHelper)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1252::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1253::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1253
+namespace _func1254
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SwitchBeacon", typeid(ImageDesc (SpaceManager::*)()), ".488b96d80300004889f8", nullptr, 0, 0, &func);
@@ -15933,11 +15946,11 @@ namespace _func1253
 ImageDesc SpaceManager::SwitchBeacon()
 {
 	typedef ImageDesc (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1253::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1254::func;
 	return execfunc(this);
 }
 
-namespace _func1254
+namespace _func1255
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SwitchPlanet", typeid(ImageDesc (SpaceManager::*)(const std::string &)), ".4157415641554989d541544989fc4889d755534889f3", nullptr, 0, 0, &func);
@@ -15946,11 +15959,11 @@ namespace _func1254
 ImageDesc SpaceManager::SwitchPlanet(const std::string &name)
 {
 	typedef ImageDesc (*custom_arg_funcptr_t)(SpaceManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1254::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1255::func;
 	return execfunc(this, name);
 }
 
-namespace _func1255
+namespace _func1256
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::UpdatePlanetImage", typeid(void (SpaceManager::*)()), ".55534889fb4883ec68488bb710010000", nullptr, 0, 0, &func);
@@ -15959,11 +15972,11 @@ namespace _func1255
 void SpaceManager::UpdatePlanetImage()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1255::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1256::func;
 	return execfunc(this);
 }
 
-namespace _func1256
+namespace _func1257
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SwitchImages", typeid(void (SpaceManager::*)(ImageDesc , ImageDesc , ImageDesc )), ".55534889fb4883ec68488b8424a0000000", nullptr, 0, 0, &func);
@@ -15972,11 +15985,11 @@ namespace _func1256
 void SpaceManager::SwitchImages(ImageDesc planet, ImageDesc unk1, ImageDesc unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, ImageDesc planet_arg, ImageDesc unk1_arg, ImageDesc unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1256::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1257::func;
 	return execfunc(this, planet, unk1, unk2);
 }
 
-namespace _func1257
+namespace _func1258
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SwitchBackground", typeid(ImageDesc (SpaceManager::*)(const std::string &)), ".415641be????????41554989d541544989f4554889fd534883ec30", nullptr, 0, 0, &func);
@@ -15985,11 +15998,11 @@ namespace _func1257
 ImageDesc SpaceManager::SwitchBackground(const std::string &name)
 {
 	typedef ImageDesc (*custom_arg_funcptr_t)(SpaceManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1257::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1258::func;
 	return execfunc(this, name);
 }
 
-namespace _func1258
+namespace _func1259
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::StartAsteroids", typeid(void (SpaceManager::*)(int , bool )), ".4883ec28488b87d8000000482b87d00000000fb6ca", nullptr, 0, 0, &func);
@@ -15998,11 +16011,11 @@ namespace _func1258
 void SpaceManager::StartAsteroids(int shieldCount, bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, int shieldCount_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1258::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1259::func;
 	return execfunc(this, shieldCount, unk);
 }
 
-namespace _func1259
+namespace _func1260
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SetFireLevel", typeid(void (SpaceManager::*)(bool )), ".55488dafa0030000bad0840000534889fb4883ec28", nullptr, 0, 0, &func);
@@ -16011,11 +16024,11 @@ namespace _func1259
 void SpaceManager::SetFireLevel(bool state)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1259::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1260::func;
 	return execfunc(this, state);
 }
 
-namespace _func1260
+namespace _func1261
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SetPlanetaryDefense", typeid(void (SpaceManager::*)(char , int )), ".41544189f4be204e000055488dafa0030000534889fb4881ec90000000", nullptr, 0, 0, &func);
@@ -16024,11 +16037,11 @@ namespace _func1260
 void SpaceManager::SetPlanetaryDefense(char state, int target)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, char state_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1260::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1261::func;
 	return execfunc(this, state, target);
 }
 
-namespace _func1261
+namespace _func1262
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SetPulsarLevel", typeid(void (SpaceManager::*)(bool )), ".55488dafa0030000ba50460000534889fb4883ec28", nullptr, 0, 0, &func);
@@ -16037,11 +16050,11 @@ namespace _func1261
 void SpaceManager::SetPulsarLevel(bool pulsarLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool pulsarLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1261::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1262::func;
 	return execfunc(this, pulsarLevel);
 }
 
-namespace _func1262
+namespace _func1263
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::DangerousEnvironment", typeid(bool (SpaceManager::*)()), ".0fb6977003000084d2", nullptr, 0, 0, &func);
@@ -16050,11 +16063,11 @@ namespace _func1262
 bool SpaceManager::DangerousEnvironment()
 {
 	typedef bool (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1262::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1263::func;
 	return execfunc(this);
 }
 
-namespace _func1263
+namespace _func1264
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::MouseMove", typeid(void (SpaceManager::*)(int , int , int )), ".41574989ff41564531f641554189f541544189d45589cd5331db4883ec08", nullptr, 0, 0, &func);
@@ -16063,11 +16076,11 @@ namespace _func1263
 void SpaceManager::MouseMove(int x, int y, int unk)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, int x_arg, int y_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1263::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1264::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func1264
+namespace _func1265
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::GetSelectedDrone", typeid(SpaceDrone *(SpaceManager::*)(int , int , int )), ".41574156415541544989fc55534883ec184c8b87e8000000", nullptr, 0, 0, &func);
@@ -16076,11 +16089,11 @@ namespace _func1264
 SpaceDrone *SpaceManager::GetSelectedDrone(int x, int y, int unk)
 {
 	typedef SpaceDrone *(*custom_arg_funcptr_t)(SpaceManager *this_arg, int x_arg, int y_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1264::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1265::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func1265
+namespace _func1266
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::GetFlashOpacity", typeid(float (SpaceManager::*)()), ".530f57c04883ec10", nullptr, 0, 0, &func);
@@ -16089,11 +16102,11 @@ namespace _func1265
 float SpaceManager::GetFlashOpacity()
 {
 	typedef float (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1265::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1266::func;
 	return execfunc(this);
 }
 
-namespace _func1266
+namespace _func1267
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::GetColorTint", typeid(GL_Color (SpaceManager::*)()), ".80bf7c04000000", nullptr, 0, 0, &func);
@@ -16102,19 +16115,6 @@ namespace _func1266
 GL_Color SpaceManager::GetColorTint()
 {
 	typedef GL_Color (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1266::func;
-	return execfunc(this);
-}
-
-namespace _func1267
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::OnRenderFleet", typeid(void (SpaceManager::*)()), ".41564989fe4155415455534883ec2080bf7c04000000", nullptr, 0, 0, &func);
-}
-
-void SpaceManager::OnRenderFleet()
-{
-	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1267::func;
 	return execfunc(this);
 }
@@ -16122,10 +16122,10 @@ void SpaceManager::OnRenderFleet()
 namespace _func1268
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::OnRenderForeground", typeid(void (SpaceManager::*)()), ".55534889fb4883ec4880bf7c04000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnRenderFleet", typeid(void (SpaceManager::*)()), ".41564989fe4155415455534883ec2080bf7c04000000", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::OnRenderForeground()
+void SpaceManager::OnRenderFleet()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1268::func;
@@ -16135,17 +16135,30 @@ void SpaceManager::OnRenderForeground()
 namespace _func1269
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("SpaceManager::OnRenderForeground", typeid(void (SpaceManager::*)()), ".55534889fb4883ec4880bf7c04000000", nullptr, 0, 0, &func);
+}
+
+void SpaceManager::OnRenderForeground()
+{
+	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1269::func;
+	return execfunc(this);
+}
+
+namespace _func1270
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::SetDangerZone", typeid(void (SpaceManager::*)(int )), ".4157415641554989fd41544189f455534883ec28", nullptr, 0, 0, &func);
 }
 
 void SpaceManager::SetDangerZone(int fleetType)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fleetType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1269::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1270::func;
 	return execfunc(this, fleetType);
 }
 
-namespace _func1270
+namespace _func1271
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::OnRenderAsteroids", typeid(void (SpaceManager::*)(int , float )), ".554889fd534883ec1880bfc800000000", nullptr, 0, 0, &func);
@@ -16154,11 +16167,11 @@ namespace _func1270
 void SpaceManager::OnRenderAsteroids(int fieldLayers, float unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fieldLayers_arg, float unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1270::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1271::func;
 	return execfunc(this, fieldLayers, unk2);
 }
 
-namespace _func1271
+namespace _func1272
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::OnRenderProjectiles", typeid(void (SpaceManager::*)(int , int )), ".415741564189d6415541544189f455534889fb4883ec28", nullptr, 0, 0, &func);
@@ -16167,30 +16180,17 @@ namespace _func1271
 void SpaceManager::OnRenderProjectiles(int iShipId, int layerCommand)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, int iShipId_arg, int layerCommand_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1271::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1272::func;
 	return execfunc(this, iShipId, layerCommand);
 }
 
-namespace _func1272
+namespace _func1273
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::OnInit", typeid(void (SpaceManager::*)()), ".55be????????534889fb4883ec58", nullptr, 0, 0, &func);
 }
 
 void SpaceManager::OnInit()
-{
-	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1272::func;
-	return execfunc(this);
-}
-
-namespace _func1273
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::Restart", typeid(void (SpaceManager::*)()), "!.41545553488b0f4889fb", nullptr, 0, 0, &func);
-}
-
-void SpaceManager::Restart()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1273::func;
@@ -16200,10 +16200,10 @@ void SpaceManager::Restart()
 namespace _func1274
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::ClearEnvironment", typeid(void (SpaceManager::*)()), ".c6875003000000c6875103000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::Restart", typeid(void (SpaceManager::*)()), "!.41545553488b0f4889fb", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::ClearEnvironment()
+void SpaceManager::Restart()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1274::func;
@@ -16213,10 +16213,10 @@ void SpaceManager::ClearEnvironment()
 namespace _func1275
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::Clear", typeid(void (SpaceManager::*)()), "!.41545553488b87d0000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::ClearEnvironment", typeid(void (SpaceManager::*)()), ".c6875003000000c6875103000000", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::Clear()
+void SpaceManager::ClearEnvironment()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1275::func;
@@ -16226,10 +16226,10 @@ void SpaceManager::Clear()
 namespace _func1276
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::ClearProjectiles", typeid(void (SpaceManager::*)()), ".41545553488b0f4889fb", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::Clear", typeid(void (SpaceManager::*)()), "!.41545553488b87d0000000", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::ClearProjectiles()
+void SpaceManager::Clear()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1276::func;
@@ -16239,23 +16239,23 @@ void SpaceManager::ClearProjectiles()
 namespace _func1277
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::UpdateProjectile", typeid(void (SpaceManager::*)(Projectile *)), ".415741564531f641554531ed41544531e4554889fd4889f7534889f34883ec08", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::ClearProjectiles", typeid(void (SpaceManager::*)()), ".41545553488b0f4889fb", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::UpdateProjectile(Projectile *proj)
+void SpaceManager::ClearProjectiles()
 {
-	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
+	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1277::func;
-	return execfunc(this, proj);
+	return execfunc(this);
 }
 
 namespace _func1278
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::TransferProjectile", typeid(void (SpaceManager::*)(Projectile *)), "!.554889f7534889f34883ec08", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::UpdateProjectile", typeid(void (SpaceManager::*)(Projectile *)), ".415741564531f641554531ed41544531e4554889fd4889f7534889f34883ec08", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::TransferProjectile(Projectile *proj)
+void SpaceManager::UpdateProjectile(Projectile *proj)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1278::func;
@@ -16265,17 +16265,30 @@ void SpaceManager::TransferProjectile(Projectile *proj)
 namespace _func1279
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("SpaceManager::TransferProjectile", typeid(void (SpaceManager::*)(Projectile *)), "!.554889f7534889f34883ec08", nullptr, 0, 0, &func);
+}
+
+void SpaceManager::TransferProjectile(Projectile *proj)
+{
+	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1279::func;
+	return execfunc(this, proj);
+}
+
+namespace _func1280
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::OnRenderBackground", typeid(void (SpaceManager::*)()), ".41564989fe4155415455534883ec1080bf7c04000000", nullptr, 0, 0, &func);
 }
 
 void SpaceManager::OnRenderBackground()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1279::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1280::func;
 	return execfunc(this);
 }
 
-namespace _func1280
+namespace _func1281
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::AddProjectile", typeid(void (SpaceManager::*)(Projectile *)), ".4883ec18488b4708483b47104889742408", nullptr, 0, 0, &func);
@@ -16284,11 +16297,11 @@ namespace _func1280
 void SpaceManager::AddProjectile(Projectile *proj)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1280::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1281::func;
 	return execfunc(this, proj);
 }
 
-namespace _func1281
+namespace _func1282
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::LoadSpace", typeid(void (SpaceManager::*)(int )), ".415741564189f64155415455534889fb89f74883ec48", nullptr, 0, 0, &func);
@@ -16297,11 +16310,11 @@ namespace _func1281
 void SpaceManager::LoadSpace(int fileHelper)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1281::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1282::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1282
+namespace _func1283
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::AddShip", typeid(void (SpaceManager::*)(ShipManager *)), ".415455534889fb4883ec30488b87d8000000", nullptr, 0, 0, &func);
@@ -16310,30 +16323,17 @@ namespace _func1282
 void SpaceManager::AddShip(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1282::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1283::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1283
+namespace _func1284
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceManager::UpdatePDS", typeid(void (SpaceManager::*)()), ".415731d241564531f64155415449bcabaaaaaaaaaaaaaa554889fd4c8dad98040000534881ec28010000", nullptr, 0, 0, &func);
 }
 
 void SpaceManager::UpdatePDS()
-{
-	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1283::func;
-	return execfunc(this);
-}
-
-namespace _func1284
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::OnLoopNebulas", typeid(void (SpaceManager::*)()), ".415748ba398ee3388ee3388e415641554989fd415455534881ecc8010000", nullptr, 0, 0, &func);
-}
-
-void SpaceManager::OnLoopNebulas()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1284::func;
@@ -16343,10 +16343,10 @@ void SpaceManager::OnLoopNebulas()
 namespace _func1285
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::OnLoop", typeid(void (SpaceManager::*)()), ".41574156415541544989fc488dbf1804000055534883ec48", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnLoopNebulas", typeid(void (SpaceManager::*)()), ".415748ba398ee3388ee3388e415641554989fd415455534881ecc8010000", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::OnLoop()
+void SpaceManager::OnLoopNebulas()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1285::func;
@@ -16356,23 +16356,23 @@ void SpaceManager::OnLoop()
 namespace _func1286
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::SetNebula", typeid(void (SpaceManager::*)(bool )), ".4157415641554154554889fd534881ec98000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnLoop", typeid(void (SpaceManager::*)()), ".41574156415541544989fc488dbf1804000055534883ec48", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::SetNebula(bool state)
+void SpaceManager::OnLoop()
 {
-	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
+	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1286::func;
-	return execfunc(this, state);
+	return execfunc(this);
 }
 
 namespace _func1287
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("SpaceManager::SetStorm", typeid(void (SpaceManager::*)(bool )), ".4883ec28be01000000c6873a04000001", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("SpaceManager::SetNebula", typeid(void (SpaceManager::*)(bool )), ".4157415641554154554889fd534881ec98000000", nullptr, 0, 0, &func);
 }
 
-void SpaceManager::SetStorm(bool state)
+void SpaceManager::SetNebula(bool state)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1287::func;
@@ -16382,17 +16382,30 @@ void SpaceManager::SetStorm(bool state)
 namespace _func1288
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("SpaceManager::SetStorm", typeid(void (SpaceManager::*)(bool )), ".4883ec28be01000000c6873a04000001", nullptr, 0, 0, &func);
+}
+
+void SpaceManager::SetStorm(bool state)
+{
+	typedef void (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1288::func;
+	return execfunc(this, state);
+}
+
+namespace _func1289
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("SpaceStatus::OnInit", typeid(void (SpaceStatus::*)(SpaceManager *, Point )), "41564889d08d4add48c1e820", nullptr, 0, 0, &func);
 }
 
 void SpaceStatus::OnInit(SpaceManager *space, Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceStatus *this_arg, SpaceManager *space_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1288::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1289::func;
 	return execfunc(this, space, pos);
 }
 
-namespace _func1289
+namespace _func1290
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceStatus::RenderWarningText", typeid(void (SpaceStatus::*)(int , int )), ".415741564155415449bc0000", nullptr, 0, 0, &func);
@@ -16401,11 +16414,11 @@ namespace _func1289
 void SpaceStatus::RenderWarningText(int effect, int textOffset)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceStatus *this_arg, int effect_arg, int textOffset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1289::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1290::func;
 	return execfunc(this, effect, textOffset);
 }
 
-namespace _func1290
+namespace _func1291
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceStatus::OnLoop", typeid(void (SpaceStatus::*)()), ".55534889fb4883ec38488b8788000000", nullptr, 0, 0, &func);
@@ -16414,11 +16427,11 @@ namespace _func1290
 void SpaceStatus::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1290::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1291::func;
 	return execfunc(this);
 }
 
-namespace _func1291
+namespace _func1292
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceStatus::MouseMove", typeid(void (SpaceStatus::*)(int , int )), ".41544189d45589f5534889fb4883ec20", nullptr, 0, 0, &func);
@@ -16427,11 +16440,11 @@ namespace _func1291
 void SpaceStatus::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceStatus *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1291::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1292::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1292
+namespace _func1293
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SpaceStatus::OnRender", typeid(void (SpaceStatus::*)()), ".415455534889fb4883ec10488b7f58e8", nullptr, 0, 0, &func);
@@ -16440,11 +16453,11 @@ namespace _func1292
 void SpaceStatus::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(SpaceStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1292::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1293::func;
 	return execfunc(this);
 }
 
-namespace _func1293
+namespace _func1294
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Spreader_Fire::CounterRoom", typeid(int (Spreader_Fire::*)(int )), "??57??89ff??56??55??54555389f3??83ec388b7f088974", nullptr, 0, 0, &func);
@@ -16453,11 +16466,11 @@ namespace _func1293
 int Spreader_Fire::CounterRoom(int roomId)
 {
 	typedef int (*custom_arg_funcptr_t)(Spreader_Fire *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1293::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1294::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1294
+namespace _func1295
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Spreader_Fire::UpdateSpread", typeid(void (Spreader_Fire::*)()), ".??57??89ff??56??55??545553??83ec588b7f08e8??????????89c7e8", nullptr, 0, 0, &func);
@@ -16466,11 +16479,11 @@ namespace _func1294
 void Spreader_Fire::UpdateSpread()
 {
 	typedef void (*custom_arg_funcptr_t)(Spreader_Fire *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1294::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1295::func;
 	return execfunc(this);
 }
 
-namespace _func1295
+namespace _func1296
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::SetPosition", typeid(void (StarMap::*)(Point )), "4889b7a0000000", nullptr, 0, 0, &func);
@@ -16479,11 +16492,11 @@ namespace _func1295
 void StarMap::SetPosition(Point unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1295::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1296::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1296
+namespace _func1297
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::SetOpen", typeid(void (StarMap::*)(bool )), "!.4084f6488b07", nullptr, 0, 0, &func);
@@ -16492,11 +16505,11 @@ namespace _func1296
 void StarMap::SetOpen(bool unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, bool unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1296::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1297::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1297
+namespace _func1298
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GetNextDangerMove", typeid(int (StarMap::*)()), ".8b8f0805000085c9", nullptr, 0, 0, &func);
@@ -16505,11 +16518,11 @@ namespace _func1297
 int StarMap::GetNextDangerMove()
 {
 	typedef int (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1297::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1298::func;
 	return execfunc(this);
 }
 
-namespace _func1298
+namespace _func1299
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::KeyDown", typeid(void (StarMap::*)(int )), ".80bfb808000000", nullptr, 0, 0, &func);
@@ -16518,30 +16531,17 @@ namespace _func1298
 void StarMap::KeyDown(int unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1298::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1299::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1299
+namespace _func1300
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::Close", typeid(void (StarMap::*)()), ".534889fb4883ec2080bf3c08000000", nullptr, 0, 0, &func);
 }
 
 void StarMap::Close()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1299::func;
-	return execfunc(this);
-}
-
-namespace _func1300
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::Open", typeid(void (StarMap::*)()), ".53807f08004889fb", nullptr, 0, 0, &func);
-}
-
-void StarMap::Open()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1300::func;
@@ -16551,10 +16551,10 @@ void StarMap::Open()
 namespace _func1301
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::InitMapTitle", typeid(void (StarMap::*)()), ".41554154554889fd534883ec68488bbf38050000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::Open", typeid(void (StarMap::*)()), ".53807f08004889fb", nullptr, 0, 0, &func);
 }
 
-void StarMap::InitMapTitle()
+void StarMap::Open()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1301::func;
@@ -16564,10 +16564,10 @@ void StarMap::InitMapTitle()
 namespace _func1302
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::InitNoFuelText", typeid(void (StarMap::*)()), ".41554989fd415455534883ec38488bbf80050000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::InitMapTitle", typeid(void (StarMap::*)()), ".41554154554889fd534883ec68488bbf38050000", nullptr, 0, 0, &func);
 }
 
-void StarMap::InitNoFuelText()
+void StarMap::InitMapTitle()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1302::func;
@@ -16577,10 +16577,10 @@ void StarMap::InitNoFuelText()
 namespace _func1303
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::InitBossMessageBox", typeid(void (StarMap::*)()), ".55534889fb4883ec38488baf78070000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::InitNoFuelText", typeid(void (StarMap::*)()), ".41554989fd415455534883ec38488bbf80050000", nullptr, 0, 0, &func);
 }
 
-void StarMap::InitBossMessageBox()
+void StarMap::InitNoFuelText()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1303::func;
@@ -16590,10 +16590,10 @@ void StarMap::InitBossMessageBox()
 namespace _func1304
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::OnLanguageChange", typeid(void (StarMap::*)()), "!.534889fbe8????????4889dfe8", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::InitBossMessageBox", typeid(void (StarMap::*)()), ".55534889fb4883ec38488baf78070000", nullptr, 0, 0, &func);
 }
 
-void StarMap::OnLanguageChange()
+void StarMap::InitBossMessageBox()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1304::func;
@@ -16603,17 +16603,30 @@ void StarMap::OnLanguageChange()
 namespace _func1305
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::OnLanguageChange", typeid(void (StarMap::*)()), "!.534889fbe8????????4889dfe8", nullptr, 0, 0, &func);
+}
+
+void StarMap::OnLanguageChange()
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1305::func;
+	return execfunc(this);
+}
+
+namespace _func1306
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GetRandomSectorChoice", typeid(int (StarMap::*)()), ".4883ec08803d????????00753b", nullptr, 0, 0, &func);
 }
 
 int StarMap::GetRandomSectorChoice()
 {
 	typedef int (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1305::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1306::func;
 	return execfunc(this);
 }
 
-namespace _func1306
+namespace _func1307
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::NeighboringSector", typeid(bool (StarMap::*)(int )), ".31c085f67867", nullptr, 0, 0, &func);
@@ -16622,11 +16635,11 @@ namespace _func1306
 bool StarMap::NeighboringSector(int potentialSector)
 {
 	typedef bool (*custom_arg_funcptr_t)(StarMap *this_arg, int potentialSector_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1306::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1307::func;
 	return execfunc(this, potentialSector);
 }
 
-namespace _func1307
+namespace _func1308
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GetSelectedSector", typeid(void (StarMap::*)(int , int , int )), ".41554989fd415441bcffffffff5589cd534883ec18", nullptr, 0, 0, &func);
@@ -16635,11 +16648,11 @@ namespace _func1307
 void StarMap::GetSelectedSector(int unk0, int unk1, int unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg, int unk1_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1307::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1308::func;
 	return execfunc(this, unk0, unk1, unk2);
 }
 
-namespace _func1308
+namespace _func1309
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::StartSecretSector", typeid(void (StarMap::*)()), ".4883ec28488b87b0080000c687b908000001", nullptr, 0, 0, &func);
@@ -16648,30 +16661,17 @@ namespace _func1308
 void StarMap::StartSecretSector()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1308::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1309::func;
 	return execfunc(this);
 }
 
-namespace _func1309
+namespace _func1310
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::ReachSector", typeid(void (StarMap::*)(Sector *)), ".41574989ff41564155415455534883ec58488b7e10", nullptr, 0, 0, &func);
 }
 
 void StarMap::ReachSector(Sector *unk0)
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1309::func;
-	return execfunc(this, unk0);
-}
-
-namespace _func1310
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::UpdateSectorMap", typeid(void (StarMap::*)(Sector *)), "!.4885f6743b", nullptr, 0, 0, &func);
-}
-
-void StarMap::UpdateSectorMap(Sector *unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1310::func;
@@ -16681,36 +16681,36 @@ void StarMap::UpdateSectorMap(Sector *unk0)
 namespace _func1311
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::UpdateSectorMap", typeid(void (StarMap::*)(Sector *)), "!.4885f6743b", nullptr, 0, 0, &func);
+}
+
+void StarMap::UpdateSectorMap(Sector *unk0)
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1311::func;
+	return execfunc(this, unk0);
+}
+
+namespace _func1312
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::SaveGame", typeid(void (StarMap::*)(int )), ".415731d24156415541545589f5534889fb4883ec48", nullptr, 0, 0, &func);
 }
 
 void StarMap::SaveGame(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1311::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1312::func;
 	return execfunc(this, file);
 }
 
-namespace _func1312
+namespace _func1313
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::InitStatistics", typeid(void (StarMap::*)()), "!.f3c366666666662e0f1f840000000000", nullptr, 0, 0, &func);
 }
 
 void StarMap::InitStatistics()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1312::func;
-	return execfunc(this);
-}
-
-namespace _func1313
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::PrintStatistics", typeid(void (StarMap::*)()), "!.f3c366666666662e0f1f840000000000", nullptr, 0, 0, &func);
-}
-
-void StarMap::PrintStatistics()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1313::func;
@@ -16720,10 +16720,10 @@ void StarMap::PrintStatistics()
 namespace _func1314
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::AnalyzeMap", typeid(void (StarMap::*)()), "!.f3c366666666662e0f1f840000000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::PrintStatistics", typeid(void (StarMap::*)()), "!.f3c366666666662e0f1f840000000000", nullptr, 0, 0, &func);
 }
 
-void StarMap::AnalyzeMap()
+void StarMap::PrintStatistics()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1314::func;
@@ -16733,36 +16733,36 @@ void StarMap::AnalyzeMap()
 namespace _func1315
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::AnalyzeMap", typeid(void (StarMap::*)()), "!.f3c366666666662e0f1f840000000000", nullptr, 0, 0, &func);
+}
+
+void StarMap::AnalyzeMap()
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1315::func;
+	return execfunc(this);
+}
+
+namespace _func1316
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::ModifyPursuit", typeid(void (StarMap::*)(int )), ".01b708050000", nullptr, 0, 0, &func);
 }
 
 void StarMap::ModifyPursuit(int unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1315::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1316::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1316
+namespace _func1317
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::AtBeacon", typeid(void (StarMap::*)()), ".488b87880000000fb64020", nullptr, 0, 0, &func);
 }
 
 void StarMap::AtBeacon()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1316::func;
-	return execfunc(this);
-}
-
-namespace _func1317
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::GetWaitLocation", typeid(void (StarMap::*)()), ".80bfc0000000007427", nullptr, 0, 0, &func);
-}
-
-void StarMap::GetWaitLocation()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1317::func;
@@ -16772,10 +16772,10 @@ void StarMap::GetWaitLocation()
 namespace _func1318
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::StartBeacon", typeid(void (StarMap::*)()), ".8b970005000031c085d2", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::GetWaitLocation", typeid(void (StarMap::*)()), ".80bfc0000000007427", nullptr, 0, 0, &func);
 }
 
-void StarMap::StartBeacon()
+void StarMap::GetWaitLocation()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1318::func;
@@ -16785,17 +16785,30 @@ void StarMap::StartBeacon()
 namespace _func1319
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::StartBeacon", typeid(void (StarMap::*)()), ".8b970005000031c085d2", nullptr, 0, 0, &func);
+}
+
+void StarMap::StartBeacon()
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1319::func;
+	return execfunc(this);
+}
+
+namespace _func1320
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::LocationsConnected", typeid(bool (StarMap::*)(Location *, Location *)), ".488b7e08488b76104829fe48c1fe034885f6", nullptr, 0, 0, &func);
 }
 
 bool StarMap::LocationsConnected(Location *unk0, Location *unk1)
 {
 	typedef bool (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg, Location *unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1319::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1320::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1320
+namespace _func1321
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::PointToGrid", typeid(Point (StarMap::*)(float , float )), ".4883ec280f28d90f28e0488d7c2410", nullptr, 0, 0, &func);
@@ -16804,11 +16817,11 @@ namespace _func1320
 Point StarMap::PointToGrid(float x, float y)
 {
 	typedef Point (*custom_arg_funcptr_t)(StarMap *this_arg, float x_arg, float y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1320::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1321::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1321
+namespace _func1322
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::TravelToLocation", typeid(void (StarMap::*)(Location *)), ".80bea0000000004889b788000000", nullptr, 0, 0, &func);
@@ -16817,30 +16830,17 @@ namespace _func1321
 void StarMap::TravelToLocation(Location *unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1321::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1322::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1322
+namespace _func1323
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::ForceExitBeacon", typeid(void (StarMap::*)()), ".488b8788000000c6402001", nullptr, 0, 0, &func);
 }
 
 void StarMap::ForceExitBeacon()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1322::func;
-	return execfunc(this);
-}
-
-namespace _func1323
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::OnRenderFogEffect", typeid(void (StarMap::*)()), "!.f3c366666666662e0f1f840000000000", nullptr, 0, 0, &func);
-}
-
-void StarMap::OnRenderFogEffect()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1323::func;
@@ -16850,23 +16850,23 @@ void StarMap::OnRenderFogEffect()
 namespace _func1324
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::LocationHasBoss", typeid(void (StarMap::*)(Location *)), ".48638fa00a0000488b97b00a0000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::OnRenderFogEffect", typeid(void (StarMap::*)()), "!.f3c366666666662e0f1f840000000000", nullptr, 0, 0, &func);
 }
 
-void StarMap::LocationHasBoss(Location *unk0)
+void StarMap::OnRenderFogEffect()
 {
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1324::func;
-	return execfunc(this, unk0);
+	return execfunc(this);
 }
 
 namespace _func1325
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::LocationHasStore", typeid(void (StarMap::*)(Location *)), ".488b46304885c0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::LocationHasBoss", typeid(void (StarMap::*)(Location *)), ".48638fa00a0000488b97b00a0000", nullptr, 0, 0, &func);
 }
 
-void StarMap::LocationHasStore(Location *unk0)
+void StarMap::LocationHasBoss(Location *unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1325::func;
@@ -16876,10 +16876,10 @@ void StarMap::LocationHasStore(Location *unk0)
 namespace _func1326
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::LocationHasShip", typeid(void (StarMap::*)(Location *)), ".488b46304885c0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::LocationHasStore", typeid(void (StarMap::*)(Location *)), ".488b46304885c0", nullptr, 0, 0, &func);
 }
 
-void StarMap::LocationHasShip(Location *unk0)
+void StarMap::LocationHasStore(Location *unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1326::func;
@@ -16889,17 +16889,30 @@ void StarMap::LocationHasShip(Location *unk0)
 namespace _func1327
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::LocationHasShip", typeid(void (StarMap::*)(Location *)), ".488b46304885c0", nullptr, 0, 0, &func);
+}
+
+void StarMap::LocationHasShip(Location *unk0)
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1327::func;
+	return execfunc(this, unk0);
+}
+
+namespace _func1328
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::AdvanceWorldLevel", typeid(void (StarMap::*)()), ".55534889fb4883ec488b8700050000", nullptr, 0, 0, &func);
 }
 
 void StarMap::AdvanceWorldLevel()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1327::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1328::func;
 	return execfunc(this);
 }
 
-namespace _func1328
+namespace _func1329
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GetLocationText", typeid(std::string (StarMap::*)(const Location *)), ".41554154554889fd534889f3", nullptr, 0, 0, &func);
@@ -16908,30 +16921,17 @@ namespace _func1328
 std::string StarMap::GetLocationText(const Location *loc)
 {
 	typedef std::string (*custom_arg_funcptr_t)(StarMap *this_arg, const Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1328::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1329::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1329
+namespace _func1330
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::ReverseBossPath", typeid(void (StarMap::*)()), ".488b8fb80a0000488b87b00a0000", nullptr, 0, 0, &func);
 }
 
 void StarMap::ReverseBossPath()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1329::func;
-	return execfunc(this);
-}
-
-namespace _func1330
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::ForceBossJump", typeid(void (StarMap::*)()), ".80bfa80a000000c687a90a000001", nullptr, 0, 0, &func);
-}
-
-void StarMap::ForceBossJump()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1330::func;
@@ -16941,10 +16941,10 @@ void StarMap::ForceBossJump()
 namespace _func1331
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::ClearBoss", typeid(void (StarMap::*)()), ".41544989fc5531ed53488b572831db488b4730c687c80a000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::ForceBossJump", typeid(void (StarMap::*)()), ".80bfa80a000000c687a90a000001", nullptr, 0, 0, &func);
 }
 
-void StarMap::ClearBoss()
+void StarMap::ForceBossJump()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1331::func;
@@ -16954,17 +16954,30 @@ void StarMap::ClearBoss()
 namespace _func1332
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::ClearBoss", typeid(void (StarMap::*)()), ".41544989fc5531ed53488b572831db488b4730c687c80a000000", nullptr, 0, 0, &func);
+}
+
+void StarMap::ClearBoss()
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1332::func;
+	return execfunc(this);
+}
+
+namespace _func1333
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::SetBossStage", typeid(void (StarMap::*)(int )), ".89b7500c0000", nullptr, 0, 0, &func);
 }
 
 void StarMap::SetBossStage(int stage)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int stage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1332::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1333::func;
 	return execfunc(this, stage);
 }
 
-namespace _func1333
+namespace _func1334
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::CheckGameOver", typeid(void (StarMap::*)()), ".31c083bfa40a000004", nullptr, 0, 0, &func);
@@ -16973,11 +16986,11 @@ namespace _func1333
 void StarMap::CheckGameOver()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1333::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1334::func;
 	return execfunc(this);
 }
 
-namespace _func1334
+namespace _func1335
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GetPotentialSectorChoiceName", typeid(std::string (StarMap::*)()), ".55??89f553??89fb??83ec38??6386b00c000083f8ff0f84????????", nullptr, 0, 0, &func);
@@ -16986,19 +16999,6 @@ namespace _func1334
 std::string StarMap::GetPotentialSectorChoiceName()
 {
 	typedef std::string (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1334::func;
-	return execfunc(this);
-}
-
-namespace _func1335
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::RenderLabels", typeid(void (StarMap::*)()), ".415741564155415455534889fb4881ec98000000", nullptr, 0, 0, &func);
-}
-
-void StarMap::RenderLabels()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1335::func;
 	return execfunc(this);
 }
@@ -17006,10 +17006,10 @@ void StarMap::RenderLabels()
 namespace _func1336
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::DeleteMap", typeid(void (StarMap::*)()), ".41554154554889fd534883ec184c8baf380c0000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StarMap::RenderLabels", typeid(void (StarMap::*)()), ".415741564155415455534889fb4881ec98000000", nullptr, 0, 0, &func);
 }
 
-void StarMap::DeleteMap()
+void StarMap::RenderLabels()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1336::func;
@@ -17019,36 +17019,36 @@ void StarMap::DeleteMap()
 namespace _func1337
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::DeleteMap", typeid(void (StarMap::*)()), ".41554154554889fd534883ec184c8baf380c0000", nullptr, 0, 0, &func);
+}
+
+void StarMap::DeleteMap()
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1337::func;
+	return execfunc(this);
+}
+
+namespace _func1338
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::MouseClick", typeid(void (StarMap::*)(int , int )), ".55534889fb4883ec2880bfc006000000", nullptr, 0, 0, &func);
 }
 
 void StarMap::MouseClick(int unk0, int unk1)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg, int unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1337::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1338::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1338
+namespace _func1339
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::AddSectorColumn", typeid(void (StarMap::*)()), ".415741564155415455bd56555555534889fb4881ec48010000", nullptr, 0, 0, &func);
 }
 
 void StarMap::AddSectorColumn()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1338::func;
-	return execfunc(this);
-}
-
-namespace _func1339
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::PushSectorColumn", typeid(void (StarMap::*)()), "!.41544989fc31d25531ed53", nullptr, 0, 0, &func);
-}
-
-void StarMap::PushSectorColumn()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1339::func;
@@ -17058,17 +17058,30 @@ void StarMap::PushSectorColumn()
 namespace _func1340
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::PushSectorColumn", typeid(void (StarMap::*)()), "!.41544989fc31d25531ed53", nullptr, 0, 0, &func);
+}
+
+void StarMap::PushSectorColumn()
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1340::func;
+	return execfunc(this);
+}
+
+namespace _func1341
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::SelectNewSector", typeid(void (StarMap::*)(int )), "!.534c8b87900800004889fb488b8f980800004c29c148c1f903", nullptr, 0, 0, &func);
 }
 
 void StarMap::SelectNewSector(int unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1340::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1341::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1341
+namespace _func1342
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GenerateSectorMap", typeid(void (StarMap::*)()), ".415741564155415455534889fb4881ec18010000488bb798080000", nullptr, 0, 0, &func);
@@ -17077,11 +17090,11 @@ namespace _func1341
 void StarMap::GenerateSectorMap()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1341::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1342::func;
 	return execfunc(this);
 }
 
-namespace _func1342
+namespace _func1343
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::DrawConnection", typeid(void (StarMap::*)(const Pointf &, const Pointf &, const GL_Color *)), ".4157415641554989d541544989f4554889fd4889d7534889cb4881ec98000000", nullptr, 0, 0, &func);
@@ -17090,11 +17103,11 @@ namespace _func1342
 void StarMap::DrawConnection(const Pointf &pos1, const Pointf &pos2, const GL_Color *color)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, const Pointf &pos1_arg, const Pointf &pos2_arg, const GL_Color *color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1342::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1343::func;
 	return execfunc(this, pos1, pos2, color);
 }
 
-namespace _func1343
+namespace _func1344
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::SetupNoFuel", typeid(void (StarMap::*)(int , const std::string &)), ".415741564989fe41554154554889d5534881ecb8000000", nullptr, 0, 0, &func);
@@ -17103,11 +17116,11 @@ namespace _func1343
 void StarMap::SetupNoFuel(int seed, const std::string &forceEscape)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int seed_arg, const std::string &forceEscape_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1343::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1344::func;
 	return execfunc(this, seed, forceEscape);
 }
 
-namespace _func1344
+namespace _func1345
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::TurnIntoFleetLocation", typeid(void (StarMap::*)(Location *)), ".41554154554889fd534889f34883ec38488b7e30", nullptr, 0, 0, &func);
@@ -17116,30 +17129,17 @@ namespace _func1344
 void StarMap::TurnIntoFleetLocation(Location *loc)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1344::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1345::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1345
+namespace _func1346
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::UpdateBoss", typeid(void (StarMap::*)()), ".554889fd534883ec288b87a00a0000", nullptr, 0, 0, &func);
 }
 
 void StarMap::UpdateBoss()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1345::func;
-	return execfunc(this);
-}
-
-namespace _func1346
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::UpdateDangerZone", typeid(void (StarMap::*)()), ".415455534889fb4883ec4080bf3c08000000", nullptr, 0, 0, &func);
-}
-
-void StarMap::UpdateDangerZone()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1346::func;
@@ -17149,17 +17149,30 @@ void StarMap::UpdateDangerZone()
 namespace _func1347
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::UpdateDangerZone", typeid(void (StarMap::*)()), ".415455534889fb4883ec4080bf3c08000000", nullptr, 0, 0, &func);
+}
+
+void StarMap::UpdateDangerZone()
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1347::func;
+	return execfunc(this);
+}
+
+namespace _func1348
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GetNewLocation", typeid(Location *(StarMap::*)()), ".5331c080bfc0000000004889fb", nullptr, 0, 0, &func);
 }
 
 Location *StarMap::GetNewLocation()
 {
 	typedef Location *(*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1347::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1348::func;
 	return execfunc(this);
 }
 
-namespace _func1348
+namespace _func1349
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::OnLoop", typeid(void (StarMap::*)()), ".41564155415455534889fb4883ec20807f0800", nullptr, 0, 0, &func);
@@ -17168,11 +17181,11 @@ namespace _func1348
 void StarMap::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1348::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1349::func;
 	return execfunc(this);
 }
 
-namespace _func1349
+namespace _func1350
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GenerateNebulas", typeid(void (StarMap::*)(const std::vector<std::string> &)), ".41574156415541544989f455534881ecb8000000", nullptr, 0, 0, &func);
@@ -17181,11 +17194,11 @@ namespace _func1349
 void StarMap::GenerateNebulas(const std::vector<std::string> &names)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, const std::vector<std::string> &names_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1349::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1350::func;
 	return execfunc(this, names);
 }
 
-namespace _func1350
+namespace _func1351
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GenerateEvents", typeid(void (StarMap::*)(bool )), ".4157415641554989fd41545589f55348bbabaaaaaaaaaaaaaa4881ec58010000", nullptr, 0, 0, &func);
@@ -17194,11 +17207,11 @@ namespace _func1350
 void StarMap::GenerateEvents(bool tutorial)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, bool tutorial_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1350::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1351::func;
 	return execfunc(this, tutorial);
 }
 
-namespace _func1351
+namespace _func1352
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::AddConnections", typeid(void (StarMap::*)(Location *)), ".415641554989fd41544c8da7800c0000554889f5534c89e34883ec10", nullptr, 0, 0, &func);
@@ -17207,11 +17220,11 @@ namespace _func1351
 void StarMap::AddConnections(Location *unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1351::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1352::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1352
+namespace _func1353
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::MapConnected", typeid(bool (StarMap::*)()), ".53488bb7880c00004889fb488dbf780c0000", nullptr, 0, 0, &func);
@@ -17220,11 +17233,11 @@ namespace _func1352
 bool StarMap::MapConnected()
 {
 	typedef bool (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1352::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1353::func;
 	return execfunc(this);
 }
 
-namespace _func1353
+namespace _func1354
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::ConnectLocations", typeid(void (StarMap::*)(Point , Point )), ".415741564155415455488d6f4853488d5f404883ec38", nullptr, 0, 0, &func);
@@ -17233,11 +17246,11 @@ namespace _func1353
 void StarMap::ConnectLocations(Point unk0, Point unk1)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg, Point unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1353::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1354::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1354
+namespace _func1355
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::PopulateGrid", typeid(void (StarMap::*)(Point )), ".415541544989fc5553488d5f404883ec38", nullptr, 0, 0, &func);
@@ -17246,11 +17259,11 @@ namespace _func1354
 void StarMap::PopulateGrid(Point unk0)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1354::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1355::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1355
+namespace _func1356
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::PopClosestLoc", typeid(Location *(StarMap::*)(std::vector<Location*> &, std::map<Location*, int> &)), ".4157415641554989f541544989d455534883ec28488b4e08", nullptr, 0, 0, &func);
@@ -17259,11 +17272,11 @@ namespace _func1355
 Location *StarMap::PopClosestLoc(std::vector<Location*> &vec, std::map<Location*, int> &map)
 {
 	typedef Location *(*custom_arg_funcptr_t)(StarMap *this_arg, std::vector<Location*> &vec_arg, std::map<Location*, int> &map_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1355::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1356::func;
 	return execfunc(this, vec, map);
 }
 
-namespace _func1356
+namespace _func1357
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::AddQuest", typeid(bool (StarMap::*)(const std::string &, bool )), ".415731c941b8ffffffff415641554989fd4154554889f5534883ec78", nullptr, 0, 0, &func);
@@ -17272,11 +17285,11 @@ namespace _func1356
 bool StarMap::AddQuest(const std::string &questEvent, bool force)
 {
 	typedef bool (*custom_arg_funcptr_t)(StarMap *this_arg, const std::string &questEvent_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1356::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1357::func;
 	return execfunc(this, questEvent, force);
 }
 
-namespace _func1357
+namespace _func1358
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::GenerateMap", typeid(Location *(StarMap::*)(bool , bool )), ".41574156415541544189f455534889fb4881ec38010000", nullptr, 0, 0, &func);
@@ -17285,11 +17298,11 @@ namespace _func1357
 Location *StarMap::GenerateMap(bool tutorial, bool seed)
 {
 	typedef Location *(*custom_arg_funcptr_t)(StarMap *this_arg, bool tutorial_arg, bool seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1357::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1358::func;
 	return execfunc(this, tutorial, seed);
 }
 
-namespace _func1358
+namespace _func1359
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::NewGame", typeid(Location *(StarMap::*)(bool )), ".415741564989fe41554189f5415455534883ec78", nullptr, 0, 0, &func);
@@ -17298,11 +17311,11 @@ namespace _func1358
 Location *StarMap::NewGame(bool unk0)
 {
 	typedef Location *(*custom_arg_funcptr_t)(StarMap *this_arg, bool unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1358::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1359::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1359
+namespace _func1360
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::Dijkstra", typeid(std::vector<Location*> (StarMap::*)(Location *, Location *, bool )), ".415741564155415455534881ecf8000000", nullptr, 0, 0, &func);
@@ -17311,11 +17324,11 @@ namespace _func1359
 std::vector<Location*> StarMap::Dijkstra(Location *start, Location *finish, bool include_unknown)
 {
 	typedef std::vector<Location*> (*custom_arg_funcptr_t)(StarMap *this_arg, Location *start_arg, Location *finish_arg, bool include_unknown_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1359::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1360::func;
 	return execfunc(this, start, finish, include_unknown);
 }
 
-namespace _func1360
+namespace _func1361
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::OnTouch", typeid(void (StarMap::*)(TouchAction , int , int , int , int , int )), ".41574989ff41564189ce41554589cd41544589c45589d55389f34881ec98000000", nullptr, 0, 0, &func);
@@ -17324,11 +17337,11 @@ namespace _func1360
 void StarMap::OnTouch(TouchAction unk0, int unk1, int unk2, int unk3, int unk4, int unk5)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, TouchAction unk0_arg, int unk1_arg, int unk2_arg, int unk3_arg, int unk4_arg, int unk5_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1360::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1361::func;
 	return execfunc(this, unk0, unk1, unk2, unk3, unk4, unk5);
 }
 
-namespace _func1361
+namespace _func1362
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::MouseMove", typeid(void (StarMap::*)(int , int )), ".415741564989fe41554189d541544189f455534881ec88000000", nullptr, 0, 0, &func);
@@ -17337,11 +17350,11 @@ namespace _func1361
 void StarMap::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1361::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1362::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1362
+namespace _func1363
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::RenderSectorName", typeid(void (StarMap::*)(Sector *, GL_Color )), ".4157415641554989f541544989fc55534881ecf8010000", nullptr, 0, 0, &func);
@@ -17350,11 +17363,11 @@ namespace _func1362
 void StarMap::RenderSectorName(Sector *unk0, GL_Color unk1)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg, GL_Color unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1362::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1363::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1363
+namespace _func1364
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::constructor", typeid(void (StarMap::*)()), ".41574989ff41564d8db7d80100004155", nullptr, 0, 0, &func);
@@ -17363,11 +17376,11 @@ namespace _func1363
 void StarMap::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1363::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1364::func;
 	return execfunc(this);
 }
 
-namespace _func1364
+namespace _func1365
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::LoadGame", typeid(Location *(StarMap::*)(int )), ".415741564189f64155415455534889fb89f74881ecf8030000", nullptr, 0, 0, &func);
@@ -17376,11 +17389,11 @@ namespace _func1364
 Location *StarMap::LoadGame(int fileHelper)
 {
 	typedef Location *(*custom_arg_funcptr_t)(StarMap *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1364::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1365::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1365
+namespace _func1366
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::RenderLeftInsetButton", typeid(void (StarMap::*)(float , float , bool )), ".41544189f455534889fb4883ec50", nullptr, 0, 0, &func);
@@ -17389,30 +17402,17 @@ namespace _func1365
 void StarMap::RenderLeftInsetButton(float unk0, float unk1, bool unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg, float unk0_arg, float unk1_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1365::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1366::func;
 	return execfunc(this, unk0, unk1, unk2);
 }
 
-namespace _func1366
+namespace _func1367
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StarMap::RenderDistressButtons", typeid(void (StarMap::*)()), ".4156be????????41554154554889fd", nullptr, 0, 0, &func);
 }
 
 void StarMap::RenderDistressButtons()
-{
-	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1366::func;
-	return execfunc(this);
-}
-
-namespace _func1367
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StarMap::OnRender", typeid(void (StarMap::*)()), ".415741564155415455534889fb4881ec78010000", nullptr, 0, 0, &func);
-}
-
-void StarMap::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1367::func;
@@ -17422,17 +17422,30 @@ void StarMap::OnRender()
 namespace _func1368
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StarMap::OnRender", typeid(void (StarMap::*)()), ".415741564155415455534889fb4881ec78010000", nullptr, 0, 0, &func);
+}
+
+void StarMap::OnRender()
+{
+	typedef void (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1368::func;
+	return execfunc(this);
+}
+
+namespace _func1369
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StatusEffect::GetNebulaEffect", typeid(StatusEffect (*)()), "4883ec08803d????????007433660f6f05????????48b8020000000700000048ba0000000002000000", nullptr, 0, 0, &func);
 }
 
 StatusEffect StatusEffect::GetNebulaEffect()
 {
 	typedef StatusEffect (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1368::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1369::func;
 	return execfunc();
 }
 
-namespace _func1369
+namespace _func1370
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::KeyDown", typeid(bool (Store::*)(SDLKey )), "5383bf2c060000024889fb", nullptr, 0, 0, &func);
@@ -17441,30 +17454,17 @@ namespace _func1369
 bool Store::KeyDown(SDLKey key)
 {
 	typedef bool (*custom_arg_funcptr_t)(Store *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1369::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1370::func;
 	return execfunc(this, key);
 }
 
-namespace _func1370
+namespace _func1371
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::OnLoop", typeid(void (Store::*)()), ".5531c94889fd5331db4883ec08488b9778040000", nullptr, 0, 0, &func);
 }
 
 void Store::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1370::func;
-	return execfunc(this);
-}
-
-namespace _func1371
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Store::Close", typeid(void (Store::*)()), "!.534889fbc6470800488bbf48060000", nullptr, 0, 0, &func);
-}
-
-void Store::Close()
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1371::func;
@@ -17474,10 +17474,10 @@ void Store::Close()
 namespace _func1372
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Store::constructor", typeid(void (Store::*)()), ".415455534889fb488d6b284c8d63684883ec10", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Store::Close", typeid(void (Store::*)()), "!.534889fbc6470800488bbf48060000", nullptr, 0, 0, &func);
 }
 
-void Store::constructor()
+void Store::Close()
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1372::func;
@@ -17487,17 +17487,30 @@ void Store::constructor()
 namespace _func1373
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Store::constructor", typeid(void (Store::*)()), ".415455534889fb488d6b284c8d63684883ec10", nullptr, 0, 0, &func);
+}
+
+void Store::constructor()
+{
+	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1373::func;
+	return execfunc(this);
+}
+
+namespace _func1374
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Store::SaveStore", typeid(void (Store::*)(int )), ".41574156415541545589f5534889fb4883ec18", nullptr, 0, 0, &func);
 }
 
 void Store::SaveStore(int file)
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1373::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1374::func;
 	return execfunc(this, file);
 }
 
-namespace _func1374
+namespace _func1375
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::RelinkShip", typeid(void (Store::*)(ShipManager *, Equipment *)), ".41554989fd4531c041544989d4554889f55331db4883ec08", nullptr, 0, 0, &func);
@@ -17506,11 +17519,11 @@ namespace _func1374
 void Store::RelinkShip(ShipManager *ship, Equipment *equip)
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg, ShipManager *ship_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1374::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1375::func;
 	return execfunc(this, ship, equip);
 }
 
-namespace _func1375
+namespace _func1376
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::HasType", typeid(bool (Store::*)(int )), ".39b730060000", nullptr, 0, 0, &func);
@@ -17519,11 +17532,11 @@ namespace _func1375
 bool Store::HasType(int type)
 {
 	typedef bool (*custom_arg_funcptr_t)(Store *this_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1375::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1376::func;
 	return execfunc(this, type);
 }
 
-namespace _func1376
+namespace _func1377
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::Clear", typeid(void (Store::*)()), ".554889fd534883ec08488bb780040000", nullptr, 0, 0, &func);
@@ -17532,11 +17545,11 @@ namespace _func1376
 void Store::Clear()
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1376::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1377::func;
 	return execfunc(this);
 }
 
-namespace _func1377
+namespace _func1378
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::InitHeading", typeid(void (Store::*)(int , Point )), ".554863ee", nullptr, 0, 0, &func);
@@ -17545,11 +17558,11 @@ namespace _func1377
 void Store::InitHeading(int index, Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg, int index_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1377::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1378::func;
 	return execfunc(this, index, pos);
 }
 
-namespace _func1378
+namespace _func1379
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::DrawBuySellTabText", typeid(void (*)()), ".55be????????534883ec58488d54241f488d7c2440", nullptr, 0, 0, &func);
@@ -17558,11 +17571,11 @@ namespace _func1378
 void Store::DrawBuySellTabText()
 {
 	typedef void (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1378::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1379::func;
 	return execfunc();
 }
 
-namespace _func1379
+namespace _func1380
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::SetPositions", typeid(void (Store::*)()), ".4157ba2a000000bec60000004156415541545531ed534889fb4883ec78", nullptr, 0, 0, &func);
@@ -17571,11 +17584,11 @@ namespace _func1379
 void Store::SetPositions()
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1379::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1380::func;
 	return execfunc(this);
 }
 
-namespace _func1380
+namespace _func1381
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::LoadStore", typeid(void (Store::*)(int , int )), ".4157415641554189f5415455534889fb4883ec68", nullptr, 0, 0, &func);
@@ -17584,11 +17597,11 @@ namespace _func1380
 void Store::LoadStore(int file, int worldLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg, int file_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1380::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1381::func;
 	return execfunc(this, file, worldLevel);
 }
 
-namespace _func1381
+namespace _func1382
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::SetPosition", typeid(void (Store::*)(Point )), "!.534889fb", nullptr, 0, 0, &func);
@@ -17597,11 +17610,11 @@ namespace _func1381
 void Store::SetPosition(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1381::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1382::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1382
+namespace _func1383
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::CreateStoreBoxes", typeid(void (Store::*)(int , Equipment *)), ".4157415641554189f541544989fc55534881ec88000000", nullptr, 0, 0, &func);
@@ -17610,11 +17623,11 @@ namespace _func1382
 void Store::CreateStoreBoxes(int type, Equipment *equip)
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg, int type_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1382::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1383::func;
 	return execfunc(this, type, equip);
 }
 
-namespace _func1383
+namespace _func1384
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::OnInit", typeid(void (Store::*)(ShipManager *, Equipment *, int )), "!.415641554989d541544189cc554889f553", nullptr, 0, 0, &func);
@@ -17623,30 +17636,17 @@ namespace _func1383
 void Store::OnInit(ShipManager *shopper, Equipment *equip, int worldLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg, ShipManager *shopper_arg, Equipment *equip_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1383::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1384::func;
 	return execfunc(this, shopper, equip, worldLevel);
 }
 
-namespace _func1384
+namespace _func1385
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Store::MouseMove", typeid(void (Store::*)(int , int )), ".415741564189d641554189f5415455534889fb4883ec78", nullptr, 0, 0, &func);
 }
 
 void Store::MouseMove(int x, int y)
-{
-	typedef void (*custom_arg_funcptr_t)(Store *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1384::func;
-	return execfunc(this, x, y);
-}
-
-namespace _func1385
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Store::MouseClick", typeid(void (Store::*)(int , int )), ".41564189d641554189f5415455534889fb4883ec40", nullptr, 0, 0, &func);
-}
-
-void Store::MouseClick(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg, int x_arg, int y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1385::func;
@@ -17656,23 +17656,23 @@ void Store::MouseClick(int x, int y)
 namespace _func1386
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Store::OnRender", typeid(void (Store::*)()), ".415741564989fe4155415455534881ecd8010000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Store::MouseClick", typeid(void (Store::*)(int , int )), ".41564189d641554189f5415455534889fb4883ec40", nullptr, 0, 0, &func);
 }
 
-void Store::OnRender()
+void Store::MouseClick(int x, int y)
 {
-	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
+	typedef void (*custom_arg_funcptr_t)(Store *this_arg, int x_arg, int y_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1386::func;
-	return execfunc(this);
+	return execfunc(this, x, y);
 }
 
 namespace _func1387
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Store::destructor", typeid(void (Store::*)()), ".415531c94154554889fd5331db4883ec18", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Store::OnRender", typeid(void (Store::*)()), ".415741564989fe4155415455534881ecd8010000", nullptr, 0, 0, &func);
 }
 
-void Store::destructor()
+void Store::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1387::func;
@@ -17682,17 +17682,30 @@ void Store::destructor()
 namespace _func1388
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Store::destructor", typeid(void (Store::*)()), ".415531c94154554889fd5331db4883ec18", nullptr, 0, 0, &func);
+}
+
+void Store::destructor()
+{
+	typedef void (*custom_arg_funcptr_t)(Store *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1388::func;
+	return execfunc(this);
+}
+
+namespace _func1389
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("StoreBox::MouseClick", typeid(void (StoreBox::*)(int , int )), "807f60007412807f6100740c", nullptr, 0, 0, &func);
 }
 
 void StoreBox::MouseClick(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1388::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1389::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1389
+namespace _func1390
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StoreBox::Activate", typeid(void (StoreBox::*)()), ".4883ec28488b8718010000", nullptr, 0, 0, &func);
@@ -17701,11 +17714,11 @@ namespace _func1389
 void StoreBox::Activate()
 {
 	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1389::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1390::func;
 	return execfunc(this);
 }
 
-namespace _func1390
+namespace _func1391
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StoreBox::SetPosition", typeid(void (StoreBox::*)(Point )), ".554889f248c1fa2053488d5f184883ec18", nullptr, 0, 0, &func);
@@ -17714,11 +17727,11 @@ namespace _func1390
 void StoreBox::SetPosition(Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1390::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1391::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1391
+namespace _func1392
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StoreBox::InitBlueprint", typeid(void (StoreBox::*)(Blueprint *)), ".554889f5488d7610534889fb488dbfb0000000", nullptr, 0, 0, &func);
@@ -17727,11 +17740,11 @@ namespace _func1391
 void StoreBox::InitBlueprint(Blueprint *bp)
 {
 	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg, Blueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1391::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1392::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1392
+namespace _func1393
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StoreBox::constructor", typeid(void (StoreBox::*)(const std::string &, ShipManager *, Equipment *)), ".41574989d7415641554989f5415455534889fb", nullptr, 0, 0, &func);
@@ -17740,30 +17753,17 @@ namespace _func1392
 void StoreBox::constructor(const std::string &buttonImage, ShipManager *shopper, Equipment *equip)
 {
 	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg, const std::string &buttonImage_arg, ShipManager *shopper_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1392::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1393::func;
 	return execfunc(this, buttonImage, shopper, equip);
 }
 
-namespace _func1393
+namespace _func1394
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("StoreBox::OnLoop", typeid(void (StoreBox::*)()), "!.538b871001000031f64889fb85c0", nullptr, 0, 0, &func);
 }
 
 void StoreBox::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1393::func;
-	return execfunc(this);
-}
-
-namespace _func1394
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("StoreBox::Purchase", typeid(void (StoreBox::*)()), ".534889fbbe", nullptr, 0, 0, &func);
-}
-
-void StoreBox::Purchase()
 {
 	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1394::func;
@@ -17773,10 +17773,10 @@ void StoreBox::Purchase()
 namespace _func1395
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("StoreBox::OnRender", typeid(void (StoreBox::*)()), ".415741564155415455534889fb488d7f184881ecc8040000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("StoreBox::Purchase", typeid(void (StoreBox::*)()), ".534889fbbe", nullptr, 0, 0, &func);
 }
 
-void StoreBox::OnRender()
+void StoreBox::Purchase()
 {
 	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1395::func;
@@ -17786,17 +17786,30 @@ void StoreBox::OnRender()
 namespace _func1396
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("StoreBox::OnRender", typeid(void (StoreBox::*)()), ".415741564155415455534889fb488d7f184881ecc8040000", nullptr, 0, 0, &func);
+}
+
+void StoreBox::OnRender()
+{
+	typedef void (*custom_arg_funcptr_t)(StoreBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1396::func;
+	return execfunc(this);
+}
+
+namespace _func1397
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("SuperShieldDrone::GetWeaponCooldown", typeid(float (SuperShieldDrone::*)()), "??8bbf58010000f30f1005??????????85ff74????83ec08??8b07ff5030b804000000", nullptr, 0, 0, &func);
 }
 
 float SuperShieldDrone::GetWeaponCooldown()
 {
 	typedef float (*custom_arg_funcptr_t)(SuperShieldDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1396::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1397::func;
 	return execfunc(this);
 }
 
-namespace _func1397
+namespace _func1398
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SuperShieldDrone::OnLoop", typeid(void (SuperShieldDrone::*)()), ".534889fb4883ec30e813fdff", nullptr, 0, 0, &func);
@@ -17805,11 +17818,11 @@ namespace _func1397
 void SuperShieldDrone::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(SuperShieldDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1397::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1398::func;
 	return execfunc(this);
 }
 
-namespace _func1398
+namespace _func1399
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SuperShieldDrone::constructor", typeid(void (SuperShieldDrone::*)(int , int , DroneBlueprint *)), ".53??89fb??83ec??e8??????????8d????0e??8d????10????????????c703??????????c74340??????????c74350????????e8??????????8dbbc8040000", nullptr, 0, 0, &func);
@@ -17818,11 +17831,11 @@ namespace _func1398
 void SuperShieldDrone::constructor(int iShipId, int selfId, DroneBlueprint *blueprint)
 {
 	typedef void (*custom_arg_funcptr_t)(SuperShieldDrone *this_arg, int iShipId_arg, int selfId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1398::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1399::func;
 	return execfunc(this, iShipId, selfId, blueprint);
 }
 
-namespace _func1399
+namespace _func1400
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemBox::OnRender", typeid(void (SystemBox::*)(bool )), "4157b8010000004156415541545589f5534889fb4883ec58", nullptr, 0, 0, &func);
@@ -17831,11 +17844,11 @@ namespace _func1399
 void SystemBox::OnRender(bool ignoreStatus)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemBox *this_arg, bool ignoreStatus_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1399::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1400::func;
 	return execfunc(this, ignoreStatus);
 }
 
-namespace _func1400
+namespace _func1401
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemBox::MouseClick", typeid(bool (SystemBox::*)(bool )), ".41544189f4554889fd5331db4883ec20", nullptr, 0, 0, &func);
@@ -17844,11 +17857,11 @@ namespace _func1400
 bool SystemBox::MouseClick(bool shift)
 {
 	typedef bool (*custom_arg_funcptr_t)(SystemBox *this_arg, bool shift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1400::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1401::func;
 	return execfunc(this, shift);
 }
 
-namespace _func1401
+namespace _func1402
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemBox::MouseRightClick", typeid(void (SystemBox::*)(bool )), ".5589f553??89fb??83ec28??8bbf90000000e8????????84c075??80bba000000000", nullptr, 0, 0, &func);
@@ -17857,11 +17870,11 @@ namespace _func1401
 void SystemBox::MouseRightClick(bool force)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemBox *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1401::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1402::func;
 	return execfunc(this, force);
 }
 
-namespace _func1402
+namespace _func1403
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemBox::destructor", typeid(void (SystemBox::*)()), ".55??89fd5331db??83ec18??c707????????660f1f440000", nullptr, 0, 0, &func);
@@ -17870,11 +17883,11 @@ namespace _func1402
 void SystemBox::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(SystemBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1402::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1403::func;
 	return execfunc(this);
 }
 
-namespace _func1403
+namespace _func1404
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemBox::constructor", typeid(void (SystemBox::*)(Point , ShipSystem *, bool )), ".4157415641be01000000415541544189cc55534889fb", nullptr, 0, 0, &func);
@@ -17883,11 +17896,11 @@ namespace _func1403
 void SystemBox::constructor(Point pos, ShipSystem *sys, bool playerUI)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, bool playerUI_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1403::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1404::func;
 	return execfunc(this, pos, sys, playerUI);
 }
 
-namespace _func1404
+namespace _func1405
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemBox::KeyDown", typeid(void (SystemBox::*)(SDLKey , bool )), ".415541544189d45589f5534889fb4883ec38", nullptr, 0, 0, &func);
@@ -17896,11 +17909,11 @@ namespace _func1404
 void SystemBox::KeyDown(SDLKey key, bool shift)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemBox *this_arg, SDLKey key_arg, bool shift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1404::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1405::func;
 	return execfunc(this, key, shift);
 }
 
-namespace _func1405
+namespace _func1406
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemBox::MouseMove", typeid(void (SystemBox::*)(int , int )), ".5589f5534889fb4883ec388b87ac010000", nullptr, 0, 0, &func);
@@ -17909,11 +17922,11 @@ namespace _func1405
 void SystemBox::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1405::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1406::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1406
+namespace _func1407
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemControl::GetSystemBox", typeid(SystemBox *(SystemControl::*)(int )), "415531d24989fd41545589f55331db4883ec08488b4f10488b47184829c848c1f8034885c07522eb57", nullptr, 0, 0, &func);
@@ -17922,11 +17935,11 @@ namespace _func1406
 SystemBox *SystemControl::GetSystemBox(int systemId)
 {
 	typedef SystemBox *(*custom_arg_funcptr_t)(SystemControl *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1406::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1407::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1407
+namespace _func1408
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemControl::GetPowerBars", typeid(SystemControl::PowerBars *(*)(int , int , int , bool )), ".41574189f24189d34189cf415641554c63ee41545589fd534863df4989d84889d84881ec88000000", nullptr, 0, 0, &func);
@@ -17935,11 +17948,11 @@ namespace _func1407
 SystemControl::PowerBars *SystemControl::GetPowerBars(int width, int height, int gap, bool useShieldGap)
 {
 	typedef SystemControl::PowerBars *(*custom_arg_funcptr_t)(int width_arg, int height_arg, int gap_arg, bool useShieldGap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1407::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1408::func;
 	return execfunc(width, height, gap, useShieldGap);
 }
 
-namespace _func1408
+namespace _func1409
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemControl::RenderPowerBar", typeid(void (SystemControl::*)()), ".415741564989fe4155415455534883ec28488b3f", nullptr, 0, 0, &func);
@@ -17948,11 +17961,11 @@ namespace _func1408
 void SystemControl::RenderPowerBar()
 {
 	typedef void (*custom_arg_funcptr_t)(SystemControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1408::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1409::func;
 	return execfunc(this);
 }
 
-namespace _func1409
+namespace _func1410
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemControl::OnRender", typeid(void (SystemControl::*)(bool )), ".??54??89fc5589f55389f3??83ec50e8????????", nullptr, 0, 0, &func);
@@ -17961,11 +17974,11 @@ namespace _func1409
 void SystemControl::OnRender(bool front)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemControl *this_arg, bool front_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1409::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1410::func;
 	return execfunc(this, front);
 }
 
-namespace _func1410
+namespace _func1411
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemControl::CreateSystemBoxes", typeid(void (SystemControl::*)()), ".415731d231f641564155415455534889fb4883ec58488d7c2430", nullptr, 0, 0, &func);
@@ -17974,11 +17987,11 @@ namespace _func1410
 void SystemControl::CreateSystemBoxes()
 {
 	typedef void (*custom_arg_funcptr_t)(SystemControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1410::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1411::func;
 	return execfunc(this);
 }
 
-namespace _func1411
+namespace _func1412
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemControl::UpdateSubSystemBox", typeid(void (SystemControl::*)()), ".55be????????53??89fb??83ec68??8d????2f??8d????40", nullptr, 0, 0, &func);
@@ -17987,25 +18000,25 @@ namespace _func1411
 void SystemControl::UpdateSubSystemBox()
 {
 	typedef void (*custom_arg_funcptr_t)(SystemControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1411::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1412::func;
 	return execfunc(this);
 }
 
 Point *Global_SystemControl_weapon_position;
 
-namespace _var1412
+namespace _var1413
 {
     static VariableDefinition varObj("Global_SystemControl_weapon_position", "!488b442430488d7c243031d231f6488905(???????\?)e8????????488b442430488b7318488b5310488905(???????\?)", &Global_SystemControl_weapon_position, true, true);
 }
 
 Point *Global_SystemControl_drone_position;
 
-namespace _var1413
+namespace _var1414
 {
     static VariableDefinition varObj("Global_SystemControl_drone_position", "", &Global_SystemControl_drone_position, true, true);
 }
 
-namespace _func1414
+namespace _func1415
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemCustomBox::constructor", typeid(void (SystemCustomBox::*)(Point , ShipSystem *, ShipManager *)), "41544989cc31c9554889f5534889fb4883ec40", nullptr, 0, 0, &func);
@@ -18014,11 +18027,11 @@ namespace _func1414
 void SystemCustomBox::constructor(Point pos, ShipSystem *sys, ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemCustomBox *this_arg, Point pos_arg, ShipSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1414::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1415::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func1415
+namespace _func1416
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemStoreBox::CanHold", typeid(bool (SystemStoreBox::*)()), "534883bf18010000004889fb", nullptr, 0, 0, &func);
@@ -18027,11 +18040,11 @@ namespace _func1415
 bool SystemStoreBox::CanHold()
 {
 	typedef bool (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1415::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1416::func;
 	return execfunc(this);
 }
 
-namespace _func1416
+namespace _func1417
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemStoreBox::SetExtraData", typeid(void (SystemStoreBox::*)(int )), ".55534889fb4883ec38837f0804", nullptr, 0, 0, &func);
@@ -18040,11 +18053,11 @@ namespace _func1416
 void SystemStoreBox::SetExtraData(int droneChoice)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, int droneChoice_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1416::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1417::func;
 	return execfunc(this, droneChoice);
 }
 
-namespace _func1417
+namespace _func1418
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemStoreBox::Activate", typeid(void (SystemStoreBox::*)()), ".534889fb4883ec20488bbf180100008b83e0000000", nullptr, 0, 0, &func);
@@ -18053,11 +18066,11 @@ namespace _func1417
 void SystemStoreBox::Activate()
 {
 	typedef void (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1417::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1418::func;
 	return execfunc(this);
 }
 
-namespace _func1418
+namespace _func1419
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemStoreBox::SetInfoBox", typeid(int (SystemStoreBox::*)(InfoBox *, int )), ".41554189d54154554889f5534889fb4881ec", nullptr, 0, 0, &func);
@@ -18066,11 +18079,11 @@ namespace _func1418
 int SystemStoreBox::SetInfoBox(InfoBox *box, int forceSystemInfoWidth)
 {
 	typedef int (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, InfoBox *box_arg, int forceSystemInfoWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1418::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1419::func;
 	return execfunc(this, box, forceSystemInfoWidth);
 }
 
-namespace _func1419
+namespace _func1420
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemStoreBox::constructor", typeid(void (SystemStoreBox::*)(ShipManager *, Equipment *, int )), ".41568d41fa41554989d541544989f45589cd534889fb4883ec5083f802", nullptr, 0, 0, &func);
@@ -18079,11 +18092,11 @@ namespace _func1419
 void SystemStoreBox::constructor(ShipManager *shopper, Equipment *equip, int sys)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, ShipManager *shopper_arg, Equipment *equip_arg, int sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1419::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1420::func;
 	return execfunc(this, shopper, equip, sys);
 }
 
-namespace _func1420
+namespace _func1421
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemStoreBox::Purchase", typeid(void (SystemStoreBox::*)()), ".534889fb4883ec30e8????????8b7308", nullptr, 0, 0, &func);
@@ -18092,11 +18105,11 @@ namespace _func1420
 void SystemStoreBox::Purchase()
 {
 	typedef void (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1420::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1421::func;
 	return execfunc(this);
 }
 
-namespace _func1421
+namespace _func1422
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemStoreBox::MouseMove", typeid(void (SystemStoreBox::*)(int , int )), ".41544189d45589f5534889fb4883ec308b8710010000", nullptr, 0, 0, &func);
@@ -18105,11 +18118,11 @@ namespace _func1421
 void SystemStoreBox::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1421::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1422::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1422
+namespace _func1423
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("SystemStoreBox::GetConfirmText", typeid(TextString (SystemStoreBox::*)()), ".53??81c650010000??89fbe8????????", nullptr, 0, 0, &func);
@@ -18118,11 +18131,11 @@ namespace _func1422
 TextString SystemStoreBox::GetConfirmText()
 {
 	typedef TextString (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1422::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1423::func;
 	return execfunc(this);
 }
 
-namespace _func1423
+namespace _func1424
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TabbedWindow::Close", typeid(void (TabbedWindow::*)()), "!538b57684889fb488b4738", nullptr, 0, 0, &func);
@@ -18131,11 +18144,11 @@ namespace _func1423
 void TabbedWindow::Close()
 {
 	typedef void (*custom_arg_funcptr_t)(TabbedWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1423::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1424::func;
 	return execfunc(this);
 }
 
-namespace _func1424
+namespace _func1425
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TabbedWindow::SetTab", typeid(void (TabbedWindow::*)(unsigned int )), ".41554189f541544989fc5531ed534883", nullptr, 0, 0, &func);
@@ -18144,11 +18157,11 @@ namespace _func1424
 void TabbedWindow::SetTab(unsigned int tab)
 {
 	typedef void (*custom_arg_funcptr_t)(TabbedWindow *this_arg, unsigned int tab_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1424::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1425::func;
 	return execfunc(this, tab);
 }
 
-namespace _func1425
+namespace _func1426
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TabbedWindow::AddWindow", typeid(void (TabbedWindow::*)(const std::string &, Button *, FocusWindow *)), ".4154554889f5534889fb4889cf", nullptr, 0, 0, &func);
@@ -18157,11 +18170,11 @@ namespace _func1425
 void TabbedWindow::AddWindow(const std::string &name, Button *button, FocusWindow *window)
 {
 	typedef void (*custom_arg_funcptr_t)(TabbedWindow *this_arg, const std::string &name_arg, Button *button_arg, FocusWindow *window_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1425::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1426::func;
 	return execfunc(this, name, button, window);
 }
 
-namespace _func1426
+namespace _func1427
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TabbedWindow::OnRender", typeid(void (TabbedWindow::*)()), "!.554889fd534883ec18e8????????f30f2a", nullptr, 0, 0, &func);
@@ -18170,11 +18183,11 @@ namespace _func1426
 void TabbedWindow::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(TabbedWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1426::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1427::func;
 	return execfunc(this);
 }
 
-namespace _func1427
+namespace _func1428
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TabbedWindow::MouseMove", typeid(void (TabbedWindow::*)(int , int )), ".41554189d541544189f4554889fd534883", nullptr, 0, 0, &func);
@@ -18183,11 +18196,11 @@ namespace _func1427
 void TabbedWindow::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(TabbedWindow *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1427::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1428::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1428
+namespace _func1429
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportBox::constructor", typeid(void (TeleportBox::*)(Point , TeleportSystem *)), "4155b9010000004989d5415455534889fb4c8da370020000488dab000300004883ec58", nullptr, 0, 0, &func);
@@ -18196,11 +18209,11 @@ namespace _func1428
 void TeleportBox::constructor(Point pos, TeleportSystem *sys)
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportBox *this_arg, Point pos_arg, TeleportSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1428::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1429::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func1429
+namespace _func1430
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::Jump", typeid(void (TeleportSystem::*)()), "534889fbe8????????c78344020000000000005b", nullptr, 0, 0, &func);
@@ -18209,11 +18222,11 @@ namespace _func1429
 void TeleportSystem::Jump()
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1429::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1430::func;
 	return execfunc(this);
 }
 
-namespace _func1430
+namespace _func1431
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::SetHackingLevel", typeid(void (TeleportSystem::*)(int )), ".5589f5534889fb4883ec0883fe017e09", nullptr, 0, 0, &func);
@@ -18222,11 +18235,11 @@ namespace _func1430
 void TeleportSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1430::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1431::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func1431
+namespace _func1432
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::OnRenderFloor", typeid(void (TeleportSystem::*)()), ".415741564155415455534889fb4883ec38", nullptr, 0, 0, &func);
@@ -18235,11 +18248,11 @@ namespace _func1431
 void TeleportSystem::OnRenderFloor()
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1431::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1432::func;
 	return execfunc(this);
 }
 
-namespace _func1432
+namespace _func1433
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::constructor", typeid(void (TeleportSystem::*)(int , int , int , int )), ".5589d5534889fb4883ec08", nullptr, 0, 0, &func);
@@ -18248,11 +18261,11 @@ namespace _func1432
 void TeleportSystem::constructor(int systemId, int roomId, int shipId, int startingPower)
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int systemId_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1432::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1433::func;
 	return execfunc(this, systemId, roomId, shipId, startingPower);
 }
 
-namespace _func1433
+namespace _func1434
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::GetChargedPercent", typeid(float (TeleportSystem::*)()), ".f30f108744020000", nullptr, 0, 0, &func);
@@ -18261,11 +18274,11 @@ namespace _func1433
 float TeleportSystem::GetChargedPercent()
 {
 	typedef float (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1433::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1434::func;
 	return execfunc(this);
 }
 
-namespace _func1434
+namespace _func1435
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::Charged", typeid(bool (TeleportSystem::*)()), ".534889fb", nullptr, 0, 0, &func);
@@ -18274,11 +18287,11 @@ namespace _func1434
 bool TeleportSystem::Charged()
 {
 	typedef bool (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1434::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1435::func;
 	return execfunc(this);
 }
 
-namespace _func1435
+namespace _func1436
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::ClearCrewLocations", typeid(void (TeleportSystem::*)()), ".41564155415455534c63a77c0200004889fb", nullptr, 0, 0, &func);
@@ -18287,11 +18300,11 @@ namespace _func1435
 void TeleportSystem::ClearCrewLocations()
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1435::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1436::func;
 	return execfunc(this);
 }
 
-namespace _func1436
+namespace _func1437
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::UpdateCrewLocation", typeid(void (TeleportSystem::*)(int )), ".488b97500200004863c689f148c1e806488d14c2b801000000", nullptr, 0, 0, &func);
@@ -18300,11 +18313,11 @@ namespace _func1436
 void TeleportSystem::UpdateCrewLocation(int unk)
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1436::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1437::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1437
+namespace _func1438
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::SetArmed", typeid(void (TeleportSystem::*)(int )), ".534889fb4883ec3083fe01", nullptr, 0, 0, &func);
@@ -18313,11 +18326,11 @@ namespace _func1437
 void TeleportSystem::SetArmed(int armed)
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int armed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1437::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1438::func;
 	return execfunc(this, armed);
 }
 
-namespace _func1438
+namespace _func1439
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TeleportSystem::ForceReady", typeid(void (TeleportSystem::*)()), "!.c787440200000000c84231f6", nullptr, 0, 0, &func);
@@ -18326,19 +18339,6 @@ namespace _func1438
 void TeleportSystem::ForceReady()
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1438::func;
-	return execfunc(this);
-}
-
-namespace _func1439
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("TeleportSystem::CanSend", typeid(bool (TeleportSystem::*)()), ".534889fb4883ec308b4f1885c9", nullptr, 0, 0, &func);
-}
-
-bool TeleportSystem::CanSend()
-{
-	typedef bool (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1439::func;
 	return execfunc(this);
 }
@@ -18346,10 +18346,10 @@ bool TeleportSystem::CanSend()
 namespace _func1440
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TeleportSystem::CanReceive", typeid(bool (TeleportSystem::*)()), ".5589f5534889fb4883ec0880bf4902000000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TeleportSystem::CanSend", typeid(bool (TeleportSystem::*)()), ".534889fb4883ec308b4f1885c9", nullptr, 0, 0, &func);
 }
 
-bool TeleportSystem::CanReceive()
+bool TeleportSystem::CanSend()
 {
 	typedef bool (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1440::func;
@@ -18359,12 +18359,12 @@ bool TeleportSystem::CanReceive()
 namespace _func1441
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TeleportSystem::OnLoop", typeid(void (TeleportSystem::*)()), ".534889fb4883ec30", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TeleportSystem::CanReceive", typeid(bool (TeleportSystem::*)()), ".5589f5534889fb4883ec0880bf4902000000", nullptr, 0, 0, &func);
 }
 
-void TeleportSystem::OnLoop()
+bool TeleportSystem::CanReceive()
 {
-	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
+	typedef bool (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1441::func;
 	return execfunc(this);
 }
@@ -18372,10 +18372,10 @@ void TeleportSystem::OnLoop()
 namespace _func1442
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TeleportSystem::InitiateTeleport", typeid(void (TeleportSystem::*)()), ".534889fb4883ec20", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TeleportSystem::OnLoop", typeid(void (TeleportSystem::*)()), ".534889fb4883ec30", nullptr, 0, 0, &func);
 }
 
-void TeleportSystem::InitiateTeleport()
+void TeleportSystem::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1442::func;
@@ -18385,17 +18385,30 @@ void TeleportSystem::InitiateTeleport()
 namespace _func1443
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("TeleportSystem::InitiateTeleport", typeid(void (TeleportSystem::*)()), ".534889fb4883ec20", nullptr, 0, 0, &func);
+}
+
+void TeleportSystem::InitiateTeleport()
+{
+	typedef void (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1443::func;
+	return execfunc(this);
+}
+
+namespace _func1444
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::ResetPrimitives", typeid(void (TextButton::*)()), "554889fd5331db4883ec08488b7c1d50", nullptr, 0, 0, &func);
 }
 
 void TextButton::ResetPrimitives()
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1443::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1444::func;
 	return execfunc(this);
 }
 
-namespace _func1444
+namespace _func1445
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::GetIdealButtonWidth", typeid(int (TextButton::*)()), "55534889fb4883ec3880bfe800000000", nullptr, 0, 0, &func);
@@ -18404,11 +18417,11 @@ namespace _func1444
 int TextButton::GetIdealButtonWidth()
 {
 	typedef int (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1444::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1445::func;
 	return execfunc(this);
 }
 
-namespace _func1445
+namespace _func1446
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::OnInit", typeid(void (TextButton::*)(Point , Point , int , TextString *, int )), "415741564d89c641554989d541544989f44c89c6554489cd534889fb488dbfe0000000", nullptr, 0, 0, &func);
@@ -18417,30 +18430,17 @@ namespace _func1445
 void TextButton::OnInit(Point pos, Point size, int cornerInset, TextString *buttonLabel, int font)
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, Point pos_arg, Point size_arg, int cornerInset_arg, TextString *buttonLabel_arg, int font_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1445::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1446::func;
 	return execfunc(this, pos, size, cornerInset, buttonLabel, font);
 }
 
-namespace _func1446
+namespace _func1447
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::OnRender", typeid(void (TextButton::*)()), "4157415641554989fd415455534883ec5880bfd000000000", nullptr, 0, 0, &func);
 }
 
 void TextButton::OnRender()
-{
-	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1446::func;
-	return execfunc(this);
-}
-
-namespace _func1447
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("TextButton::destructor", typeid(void (TextButton::*)()), "534889fb4883ec1048c707????????488b7f50", nullptr, 0, 0, &func);
-}
-
-void TextButton::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1447::func;
@@ -18450,17 +18450,30 @@ void TextButton::destructor()
 namespace _func1448
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("TextButton::destructor", typeid(void (TextButton::*)()), "534889fb4883ec1048c707????????488b7f50", nullptr, 0, 0, &func);
+}
+
+void TextButton::destructor()
+{
+	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1448::func;
+	return execfunc(this);
+}
+
+namespace _func1449
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::GetSize", typeid(Point (TextButton::*)()), "4155415455534889fb4883ec1880bfd000000000751a", nullptr, 0, 0, &func);
 }
 
 Point TextButton::GetSize()
 {
 	typedef Point (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1448::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1449::func;
 	return execfunc(this);
 }
 
-namespace _func1449
+namespace _func1450
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::OnInitRect", typeid(void (TextButton::*)(Globals::Rect &, int , TextString &, int )), "41574156415541544989cc554889f5534889fb4883ec488954240c", nullptr, 0, 0, &func);
@@ -18469,11 +18482,11 @@ namespace _func1449
 void TextButton::OnInitRect(Globals::Rect &rect, int cornerInset, TextString &buttonLabel, int font)
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, Globals::Rect &rect_arg, int cornerInset_arg, TextString &buttonLabel_arg, int font_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1449::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1450::func;
 	return execfunc(this, rect, cornerInset, buttonLabel, font);
 }
 
-namespace _func1450
+namespace _func1451
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::SetBaseImage", typeid(void (TextButton::*)(const std::string &, Point , int )), "4154488b065553488378e800", nullptr, 0, 0, &func);
@@ -18482,11 +18495,11 @@ namespace _func1450
 void TextButton::SetBaseImage(const std::string &name, Point pos, int autoWidthMin)
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, const std::string &name_arg, Point pos_arg, int autoWidthMin_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1450::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1451::func;
 	return execfunc(this, name, pos, autoWidthMin);
 }
 
-namespace _func1451
+namespace _func1452
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::SetAutoWidth", typeid(void (TextButton::*)(bool , bool , int , int )), "4585c04088b7d0000000", nullptr, 0, 0, &func);
@@ -18495,30 +18508,17 @@ namespace _func1451
 void TextButton::SetAutoWidth(bool autoWidth, bool autoRightAlign, int margin, int min)
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, bool autoWidth_arg, bool autoRightAlign_arg, int margin_arg, int min_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1451::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1452::func;
 	return execfunc(this, autoWidth, autoRightAlign, margin, min);
 }
 
-namespace _func1452
+namespace _func1453
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::UpdateAutoWidth", typeid(void (TextButton::*)()), ".4155415455534889fb4883ec1880bfd000000000", nullptr, 0, 0, &func);
 }
 
 void TextButton::UpdateAutoWidth()
-{
-	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1452::func;
-	return execfunc(this);
-}
-
-namespace _func1453
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("TextButton::constructor", typeid(void (TextButton::*)()), "55534889fb488d7f08488d6b284883ec28", nullptr, 0, 0, &func);
-}
-
-void TextButton::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1453::func;
@@ -18528,23 +18528,23 @@ void TextButton::constructor()
 namespace _func1454
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TextButton::SetInactiveColor", typeid(void (TextButton::*)(GL_Color )), ".!80bf8000000000660fd64c24f0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TextButton::constructor", typeid(void (TextButton::*)()), "55534889fb488d7f08488d6b284883ec28", nullptr, 0, 0, &func);
 }
 
-void TextButton::SetInactiveColor(GL_Color color)
+void TextButton::constructor()
 {
-	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
+	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1454::func;
-	return execfunc(this, color);
+	return execfunc(this);
 }
 
 namespace _func1455
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TextButton::SetActiveColor", typeid(void (TextButton::*)(GL_Color )), ".!80bf8000000000660fd64c24f0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TextButton::SetInactiveColor", typeid(void (TextButton::*)(GL_Color )), ".!80bf8000000000660fd64c24f0", nullptr, 0, 0, &func);
 }
 
-void TextButton::SetActiveColor(GL_Color color)
+void TextButton::SetInactiveColor(GL_Color color)
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1455::func;
@@ -18554,10 +18554,10 @@ void TextButton::SetActiveColor(GL_Color color)
 namespace _func1456
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TextButton::SetSelectedColor", typeid(void (TextButton::*)(GL_Color )), ".!80bf8000000000660fd64c24f0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TextButton::SetActiveColor", typeid(void (TextButton::*)(GL_Color )), ".!80bf8000000000660fd64c24f0", nullptr, 0, 0, &func);
 }
 
-void TextButton::SetSelectedColor(GL_Color color)
+void TextButton::SetActiveColor(GL_Color color)
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1456::func;
@@ -18567,10 +18567,10 @@ void TextButton::SetSelectedColor(GL_Color color)
 namespace _func1457
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TextButton::SetTextColor", typeid(void (TextButton::*)(GL_Color )), ".80bf8000000000660fd64c24f8", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TextButton::SetSelectedColor", typeid(void (TextButton::*)(GL_Color )), ".!80bf8000000000660fd64c24f0", nullptr, 0, 0, &func);
 }
 
-void TextButton::SetTextColor(GL_Color color)
+void TextButton::SetSelectedColor(GL_Color color)
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1457::func;
@@ -18580,17 +18580,30 @@ void TextButton::SetTextColor(GL_Color color)
 namespace _func1458
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("TextButton::SetTextColor", typeid(void (TextButton::*)(GL_Color )), ".80bf8000000000660fd64c24f8", nullptr, 0, 0, &func);
+}
+
+void TextButton::SetTextColor(GL_Color color)
+{
+	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1458::func;
+	return execfunc(this, color);
+}
+
+namespace _func1459
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("TextButton::InitPrimitives", typeid(void (TextButton::*)()), "415741564989fe4155415455534881ecb800000080bf8000000000", nullptr, 0, 0, &func);
 }
 
 void TextButton::InitPrimitives()
 {
 	typedef void (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1458::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1459::func;
 	return execfunc(this);
 }
 
-namespace _func1459
+namespace _func1460
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextInput::constructor", typeid(void (TextInput::*)(int , TextInput::AllowedCharType , const std::string &)), "!41544189d45589f54889ce534889fb", nullptr, 0, 0, &func);
@@ -18599,11 +18612,11 @@ namespace _func1459
 void TextInput::constructor(int maxChars, TextInput::AllowedCharType allowedCharType, const std::string &prompt)
 {
 	typedef void (*custom_arg_funcptr_t)(TextInput *this_arg, int maxChars_arg, TextInput::AllowedCharType allowedCharType_arg, const std::string &prompt_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1459::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1460::func;
 	return execfunc(this, maxChars, allowedCharType, prompt);
 }
 
-namespace _func1460
+namespace _func1461
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextInput::OnRender", typeid(void (TextInput::*)(int , Point )), ".4156b9ffffffff41554189f54889fe41544989d431d255534889fb4883ec70", nullptr, 0, 0, &func);
@@ -18612,11 +18625,11 @@ namespace _func1460
 void TextInput::OnRender(int font, Point pos)
 {
 	typedef void (*custom_arg_funcptr_t)(TextInput *this_arg, int font_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1460::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1461::func;
 	return execfunc(this, font, pos);
 }
 
-namespace _func1461
+namespace _func1462
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextInput::OnLoop", typeid(void (TextInput::*)()), ".!538b473839473c", nullptr, 0, 0, &func);
@@ -18625,11 +18638,11 @@ namespace _func1461
 void TextInput::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1461::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1462::func;
 	return execfunc(this);
 }
 
-namespace _func1462
+namespace _func1463
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextInput::OnTextEvent", typeid(void (TextInput::*)(CEvent::TextEvent )), ".53807f40004889fb", nullptr, 0, 0, &func);
@@ -18638,11 +18651,11 @@ namespace _func1462
 void TextInput::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void (*custom_arg_funcptr_t)(TextInput *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1462::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1463::func;
 	return execfunc(this, event);
 }
 
-namespace _func1463
+namespace _func1464
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextInput::GetActive", typeid(bool (TextInput::*)()), ".!0fb64740c3", nullptr, 0, 0, &func);
@@ -18651,11 +18664,11 @@ namespace _func1463
 bool TextInput::GetActive()
 {
 	typedef bool (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1463::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1464::func;
 	return execfunc(this);
 }
 
-namespace _func1464
+namespace _func1465
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextInput::GetText", typeid(std::string (TextInput::*)()), ".53b9ffffffff4889fb31d2", nullptr, 0, 0, &func);
@@ -18664,19 +18677,6 @@ namespace _func1464
 std::string TextInput::GetText()
 {
 	typedef std::string (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1464::func;
-	return execfunc(this);
-}
-
-namespace _func1465
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("TextInput::Start", typeid(void (TextInput::*)()), ".534883ec30488b4710482b4708", nullptr, 0, 0, &func);
-}
-
-void TextInput::Start()
-{
-	typedef void (*custom_arg_funcptr_t)(TextInput *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1465::func;
 	return execfunc(this);
 }
@@ -18684,10 +18684,10 @@ void TextInput::Start()
 namespace _func1466
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TextInput::Stop", typeid(void (TextInput::*)()), ".!c6474000", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TextInput::Start", typeid(void (TextInput::*)()), ".534883ec30488b4710482b4708", nullptr, 0, 0, &func);
 }
 
-void TextInput::Stop()
+void TextInput::Start()
 {
 	typedef void (*custom_arg_funcptr_t)(TextInput *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1466::func;
@@ -18697,17 +18697,30 @@ void TextInput::Stop()
 namespace _func1467
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("TextInput::Stop", typeid(void (TextInput::*)()), ".!c6474000", nullptr, 0, 0, &func);
+}
+
+void TextInput::Stop()
+{
+	typedef void (*custom_arg_funcptr_t)(TextInput *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1467::func;
+	return execfunc(this);
+}
+
+namespace _func1468
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("TextInput::SetText", typeid(int (TextInput::*)(const std::string &)), ".55488d6f08534889fb4883ec28", nullptr, 0, 0, &func);
 }
 
 int TextInput::SetText(const std::string &text)
 {
 	typedef int (*custom_arg_funcptr_t)(TextInput *this_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1467::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1468::func;
 	return execfunc(this, text);
 }
 
-namespace _func1468
+namespace _func1469
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextInput::OnTextInput", typeid(void (TextInput::*)(int )), ".41564155415455534889fb4883ec30807f4000", nullptr, 0, 0, &func);
@@ -18716,11 +18729,11 @@ namespace _func1468
 void TextInput::OnTextInput(int asciiChar)
 {
 	typedef void (*custom_arg_funcptr_t)(TextInput *this_arg, int asciiChar_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1468::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1469::func;
 	return execfunc(this, asciiChar);
 }
 
-namespace _func1469
+namespace _func1470
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextLibrary::GetText", typeid(std::string (TextLibrary::*)(const std::string &, const std::string &)), "41574156415541544989fc5553488d5e384883ec48", nullptr, 0, 0, &func);
@@ -18729,11 +18742,11 @@ namespace _func1469
 std::string TextLibrary::GetText(const std::string &name, const std::string &lang)
 {
 	typedef std::string (*custom_arg_funcptr_t)(TextLibrary *this_arg, const std::string &name_arg, const std::string &lang_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1469::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1470::func;
 	return execfunc(this, name, lang);
 }
 
-namespace _func1470
+namespace _func1471
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TextString::GetText", typeid(std::string (TextString::*)()), "53807e08004889fb", nullptr, 0, 0, &func);
@@ -18742,11 +18755,11 @@ namespace _func1470
 std::string TextString::GetText()
 {
 	typedef std::string (*custom_arg_funcptr_t)(TextString *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1470::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1471::func;
 	return execfunc(this);
 }
 
-namespace _func1471
+namespace _func1472
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TimerHelper::Start", typeid(void (TimerHelper::*)(int )), "83feffc6471101c7470800000000", nullptr, 0, 0, &func);
@@ -18755,11 +18768,11 @@ namespace _func1471
 void TimerHelper::Start(int goal)
 {
 	typedef void (*custom_arg_funcptr_t)(TimerHelper *this_arg, int goal_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1471::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1472::func;
 	return execfunc(this, goal);
 }
 
-namespace _func1472
+namespace _func1473
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TimerHelper::Running", typeid(bool (TimerHelper::*)()), "!.0fb64711c3", nullptr, 0, 0, &func);
@@ -18768,11 +18781,11 @@ namespace _func1472
 bool TimerHelper::Running()
 {
 	typedef bool (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1472::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1473::func;
 	return execfunc(this);
 }
 
-namespace _func1473
+namespace _func1474
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TimerHelper::ResetMinMax", typeid(void (TimerHelper::*)(int , int )), ".8917897704", nullptr, 0, 0, &func);
@@ -18781,11 +18794,11 @@ namespace _func1473
 void TimerHelper::ResetMinMax(int min, int max)
 {
 	typedef void (*custom_arg_funcptr_t)(TimerHelper *this_arg, int min_arg, int max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1473::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1474::func;
 	return execfunc(this, min, max);
 }
 
-namespace _func1474
+namespace _func1475
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TimerHelper::SetMaxTime", typeid(void (TimerHelper::*)(float )), ".f30f104f08f30f5e4f0c", nullptr, 0, 0, &func);
@@ -18794,30 +18807,17 @@ namespace _func1474
 void TimerHelper::SetMaxTime(float max)
 {
 	typedef void (*custom_arg_funcptr_t)(TimerHelper *this_arg, float max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1474::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1475::func;
 	return execfunc(this, max);
 }
 
-namespace _func1475
+namespace _func1476
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TimerHelper::Stop", typeid(void (TimerHelper::*)()), "!.c6471100c3", nullptr, 0, 0, &func);
 }
 
 void TimerHelper::Stop()
-{
-	typedef void (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1475::func;
-	return execfunc(this);
-}
-
-namespace _func1476
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("TimerHelper::Update", typeid(void (TimerHelper::*)()), ".53807f11004889fb", nullptr, 0, 0, &func);
-}
-
-void TimerHelper::Update()
 {
 	typedef void (*custom_arg_funcptr_t)(TimerHelper *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1476::func;
@@ -18827,17 +18827,30 @@ void TimerHelper::Update()
 namespace _func1477
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("TimerHelper::Update", typeid(void (TimerHelper::*)()), ".53807f11004889fb", nullptr, 0, 0, &func);
+}
+
+void TimerHelper::Update()
+{
+	typedef void (*custom_arg_funcptr_t)(TimerHelper *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1477::func;
+	return execfunc(this);
+}
+
+namespace _func1478
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("TimerHelper::Done", typeid(bool (TimerHelper::*)()), ".0fb6471184c0", nullptr, 0, 0, &func);
 }
 
 bool TimerHelper::Done()
 {
 	typedef bool (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1477::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1478::func;
 	return execfunc(this);
 }
 
-namespace _func1478
+namespace _func1479
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TutorialManager::constructor", typeid(void (TutorialManager::*)()), "!534889fb488d7f084883ec10c647f800", nullptr, 0, 0, &func);
@@ -18846,19 +18859,6 @@ namespace _func1478
 void TutorialManager::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1478::func;
-	return execfunc(this);
-}
-
-namespace _func1479
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("TutorialManager::Running", typeid(bool (TutorialManager::*)()), "!.0fb607c3", nullptr, 0, 0, &func);
-}
-
-bool TutorialManager::Running()
-{
-	typedef bool (*custom_arg_funcptr_t)(TutorialManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1479::func;
 	return execfunc(this);
 }
@@ -18866,10 +18866,10 @@ bool TutorialManager::Running()
 namespace _func1480
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TutorialManager::AllowJumping", typeid(bool (TutorialManager::*)()), ".554889fdbe", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TutorialManager::Running", typeid(bool (TutorialManager::*)()), "!.0fb607c3", nullptr, 0, 0, &func);
 }
 
-bool TutorialManager::AllowJumping()
+bool TutorialManager::Running()
 {
 	typedef bool (*custom_arg_funcptr_t)(TutorialManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1480::func;
@@ -18879,10 +18879,10 @@ bool TutorialManager::AllowJumping()
 namespace _func1481
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TutorialManager::AllowUpgrades", typeid(bool (TutorialManager::*)()), ".55bd01000000534889fb4883ec38", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TutorialManager::AllowJumping", typeid(bool (TutorialManager::*)()), ".554889fdbe", nullptr, 0, 0, &func);
 }
 
-bool TutorialManager::AllowUpgrades()
+bool TutorialManager::AllowJumping()
 {
 	typedef bool (*custom_arg_funcptr_t)(TutorialManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1481::func;
@@ -18892,17 +18892,30 @@ bool TutorialManager::AllowUpgrades()
 namespace _func1482
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("TutorialManager::AllowUpgrades", typeid(bool (TutorialManager::*)()), ".55bd01000000534889fb4883ec38", nullptr, 0, 0, &func);
+}
+
+bool TutorialManager::AllowUpgrades()
+{
+	typedef bool (*custom_arg_funcptr_t)(TutorialManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1482::func;
+	return execfunc(this);
+}
+
+namespace _func1483
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("TutorialManager::MouseMove", typeid(void (TutorialManager::*)(int , int )), ".41574156415541544989fc55534883ec38803f", nullptr, 0, 0, &func);
 }
 
 void TutorialManager::MouseMove(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(TutorialManager *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1482::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1483::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1483
+namespace _func1484
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TutorialManager::MouseClick", typeid(bool (TutorialManager::*)()), ".41574156415541544989fc55534883ec380fb607", nullptr, 0, 0, &func);
@@ -18911,19 +18924,6 @@ namespace _func1483
 bool TutorialManager::MouseClick()
 {
 	typedef bool (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1483::func;
-	return execfunc(this);
-}
-
-namespace _func1484
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("TutorialManager::OnLoop", typeid(void (TutorialManager::*)()), ".415741564155415455534889fb4881ec88000000803f", nullptr, 0, 0, &func);
-}
-
-void TutorialManager::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(TutorialManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1484::func;
 	return execfunc(this);
 }
@@ -18931,10 +18931,10 @@ void TutorialManager::OnLoop()
 namespace _func1485
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("TutorialManager::LoadTutorial", typeid(void (TutorialManager::*)()), ".415741564155415455534889fb4881ecc8010100", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("TutorialManager::OnLoop", typeid(void (TutorialManager::*)()), ".415741564155415455534889fb4881ec88000000803f", nullptr, 0, 0, &func);
 }
 
-void TutorialManager::LoadTutorial()
+void TutorialManager::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(TutorialManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1485::func;
@@ -18944,17 +18944,30 @@ void TutorialManager::LoadTutorial()
 namespace _func1486
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("TutorialManager::LoadTutorial", typeid(void (TutorialManager::*)()), ".415741564155415455534889fb4881ecc8010100", nullptr, 0, 0, &func);
+}
+
+void TutorialManager::LoadTutorial()
+{
+	typedef void (*custom_arg_funcptr_t)(TutorialManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1486::func;
+	return execfunc(this);
+}
+
+namespace _func1487
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("TutorialManager::OnInit", typeid(void (TutorialManager::*)(ShipManager *, CommandGui *, CrewControl *, Upgrades *, CombatControl *, SystemControl *, TabbedWindow *)), ".415455534889fb4883ec404889b790010000", nullptr, 0, 0, &func);
 }
 
 void TutorialManager::OnInit(ShipManager *ship, CommandGui *gui, CrewControl *crewControl, Upgrades *upgradesScreen, CombatControl *combatControl, SystemControl *sysControl, TabbedWindow *unk)
 {
 	typedef void (*custom_arg_funcptr_t)(TutorialManager *this_arg, ShipManager *ship_arg, CommandGui *gui_arg, CrewControl *crewControl_arg, Upgrades *upgradesScreen_arg, CombatControl *combatControl_arg, SystemControl *sysControl_arg, TabbedWindow *unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1486::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1487::func;
 	return execfunc(this, ship, gui, crewControl, upgradesScreen, combatControl, sysControl, unk);
 }
 
-namespace _func1487
+namespace _func1488
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("TutorialManager::OnRender", typeid(void (TutorialManager::*)()), ".41574156415541544989fc55534881ec88000000", nullptr, 0, 0, &func);
@@ -18963,18 +18976,18 @@ namespace _func1487
 void TutorialManager::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1487::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1488::func;
 	return execfunc(this);
 }
 
 TutorialManager *Global_TutorialManager_Tutorial;
 
-namespace _var1488
+namespace _var1489
 {
     static VariableDefinition varObj("Global_TutorialManager_Tutorial", "!498b07488b7810488b07ff908000000084c00f84????????bf(???????\?)", &Global_TutorialManager_Tutorial);
 }
 
-namespace _func1489
+namespace _func1490
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("UnlockArrow::constructor", typeid(void (UnlockArrow::*)(Point , int , int )), "554889f5534889fb4883ec28803d????????00", nullptr, 0, 0, &func);
@@ -18983,11 +18996,11 @@ namespace _func1489
 void UnlockArrow::constructor(Point pos, int unk1, int unk2)
 {
 	typedef void (*custom_arg_funcptr_t)(UnlockArrow *this_arg, Point pos_arg, int unk1_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1489::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1490::func;
 	return execfunc(this, pos, unk1, unk2);
 }
 
-namespace _func1490
+namespace _func1491
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("UnlockArrow::MouseMove", typeid(bool (UnlockArrow::*)(int , int )), ".837f0403", nullptr, 0, 0, &func);
@@ -18996,11 +19009,11 @@ namespace _func1490
 bool UnlockArrow::MouseMove(int x, int y)
 {
 	typedef bool (*custom_arg_funcptr_t)(UnlockArrow *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1490::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1491::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1491
+namespace _func1492
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("UnlockArrow::OnRender", typeid(void (UnlockArrow::*)()), ".534889fb4883ec308b0785c0", nullptr, 0, 0, &func);
@@ -19009,11 +19022,11 @@ namespace _func1491
 void UnlockArrow::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(UnlockArrow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1491::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1492::func;
 	return execfunc(this);
 }
 
-namespace _func1492
+namespace _func1493
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("UpgradeBox::OnRender", typeid(void (UpgradeBox::*)()), "415741564989fe4155415455534881ecd801000080bf5901000000", nullptr, 0, 0, &func);
@@ -19022,30 +19035,17 @@ namespace _func1492
 void UpgradeBox::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1492::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1493::func;
 	return execfunc(this);
 }
 
-namespace _func1493
+namespace _func1494
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("UpgradeBox::MouseMove", typeid(void (UpgradeBox::*)(int , int )), ".48833f007412", nullptr, 0, 0, &func);
 }
 
 void UpgradeBox::MouseMove(int mX, int mY)
-{
-	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1493::func;
-	return execfunc(this, mX, mY);
-}
-
-namespace _func1494
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("UpgradeBox::MouseClick", typeid(void (UpgradeBox::*)(int , int )), ".534889fb4883ec20488b074885c0", nullptr, 0, 0, &func);
-}
-
-void UpgradeBox::MouseClick(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1494::func;
@@ -19055,10 +19055,10 @@ void UpgradeBox::MouseClick(int mX, int mY)
 namespace _func1495
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("UpgradeBox::MouseRightClick", typeid(void (UpgradeBox::*)(int , int )), ".534889fb4883ec20488b074885c0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("UpgradeBox::MouseClick", typeid(void (UpgradeBox::*)(int , int )), ".534889fb4883ec20488b074885c0", nullptr, 0, 0, &func);
 }
 
-void UpgradeBox::MouseRightClick(int mX, int mY)
+void UpgradeBox::MouseClick(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1495::func;
@@ -19068,23 +19068,23 @@ void UpgradeBox::MouseRightClick(int mX, int mY)
 namespace _func1496
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("UpgradeBox::Undo", typeid(void (UpgradeBox::*)()), ".538b47204889fb85c0", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("UpgradeBox::MouseRightClick", typeid(void (UpgradeBox::*)(int , int )), ".534889fb4883ec20488b074885c0", nullptr, 0, 0, &func);
 }
 
-void UpgradeBox::Undo()
+void UpgradeBox::MouseRightClick(int mX, int mY)
 {
-	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
+	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1496::func;
-	return execfunc(this);
+	return execfunc(this, mX, mY);
 }
 
 namespace _func1497
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("UpgradeBox::Accept", typeid(void (UpgradeBox::*)()), ".534889fb4883ec20488b3f4885ff", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("UpgradeBox::Undo", typeid(void (UpgradeBox::*)()), ".538b47204889fb85c0", nullptr, 0, 0, &func);
 }
 
-void UpgradeBox::Accept()
+void UpgradeBox::Undo()
 {
 	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1497::func;
@@ -19094,17 +19094,30 @@ void UpgradeBox::Accept()
 namespace _func1498
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("UpgradeBox::Accept", typeid(void (UpgradeBox::*)()), ".534889fb4883ec20488b3f4885ff", nullptr, 0, 0, &func);
+}
+
+void UpgradeBox::Accept()
+{
+	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1498::func;
+	return execfunc(this);
+}
+
+namespace _func1499
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("UpgradeBox::constructorEmpty", typeid(void (UpgradeBox::*)(Point , bool )), ".41554189d541544989f449c1fc20554889f5534889fb488d7f384883ec38", nullptr, 0, 0, &func);
 }
 
 void UpgradeBox::constructorEmpty(Point pos, bool subsystem)
 {
 	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg, Point pos_arg, bool subsystem_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1498::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1499::func;
 	return execfunc(this, pos, subsystem);
 }
 
-namespace _func1499
+namespace _func1500
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("UpgradeBox::constructorSystem", typeid(void (UpgradeBox::*)(ShipManager *, ShipSystem *, Point , bool )), ".41574589c741564c8d773841554989cd41544989d455488dafc8000000534889fb4883ec38", nullptr, 0, 0, &func);
@@ -19113,11 +19126,11 @@ namespace _func1499
 void UpgradeBox::constructorSystem(ShipManager *ship, ShipSystem *sys, Point pos, bool subsystem)
 {
 	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg, ShipManager *ship_arg, ShipSystem *sys_arg, Point pos_arg, bool subsystem_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1499::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1500::func;
 	return execfunc(this, ship, sys, pos, subsystem);
 }
 
-namespace _func1500
+namespace _func1501
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("UpgradeBox::destructor", typeid(void (UpgradeBox::*)()), ".534889fb4883ec10488bbf60010000", nullptr, 0, 0, &func);
@@ -19126,30 +19139,17 @@ namespace _func1500
 void UpgradeBox::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1500::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1501::func;
 	return execfunc(this);
 }
 
-namespace _func1501
+namespace _func1502
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Upgrades::MouseMove", typeid(void (Upgrades::*)(int , int )), "!41554989fd41544189d45589f55331db4883ec08", nullptr, 0, 0, &func);
 }
 
 void Upgrades::MouseMove(int mX, int mY)
-{
-	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1501::func;
-	return execfunc(this, mX, mY);
-}
-
-namespace _func1502
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Upgrades::MouseRightClick", typeid(void (Upgrades::*)(int , int )), ".415431c94989fc5531ed534883ec20", nullptr, 0, 0, &func);
-}
-
-void Upgrades::MouseRightClick(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1502::func;
@@ -19159,23 +19159,23 @@ void Upgrades::MouseRightClick(int mX, int mY)
 namespace _func1503
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Upgrades::Close", typeid(void (Upgrades::*)()), ".41554154554889fd534883ec28807f0800", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Upgrades::MouseRightClick", typeid(void (Upgrades::*)(int , int )), ".415431c94989fc5531ed534883ec20", nullptr, 0, 0, &func);
 }
 
-void Upgrades::Close()
+void Upgrades::MouseRightClick(int mX, int mY)
 {
-	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg);
+	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1503::func;
-	return execfunc(this);
+	return execfunc(this, mX, mY);
 }
 
 namespace _func1504
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Upgrades::OnLoop", typeid(void (Upgrades::*)()), ".4155415455534889fb4883ec68807f0800", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Upgrades::Close", typeid(void (Upgrades::*)()), ".41554154554889fd534883ec28807f0800", nullptr, 0, 0, &func);
 }
 
-void Upgrades::OnLoop()
+void Upgrades::Close()
 {
 	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1504::func;
@@ -19185,10 +19185,10 @@ void Upgrades::OnLoop()
 namespace _func1505
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("Upgrades::ConfirmUpgrades", typeid(void (Upgrades::*)()), ".415531c941bd????????41544989fc5531ed534883ec28", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("Upgrades::OnLoop", typeid(void (Upgrades::*)()), ".4155415455534889fb4883ec68807f0800", nullptr, 0, 0, &func);
 }
 
-void Upgrades::ConfirmUpgrades()
+void Upgrades::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1505::func;
@@ -19198,17 +19198,30 @@ void Upgrades::ConfirmUpgrades()
 namespace _func1506
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Upgrades::ConfirmUpgrades", typeid(void (Upgrades::*)()), ".415531c941bd????????41544989fc5531ed534883ec28", nullptr, 0, 0, &func);
+}
+
+void Upgrades::ConfirmUpgrades()
+{
+	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1506::func;
+	return execfunc(this);
+}
+
+namespace _func1507
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("Upgrades::MouseClick", typeid(void (Upgrades::*)(int , int )), ".41554189d541544189f4554889fd5331db4883ec28", nullptr, 0, 0, &func);
 }
 
 void Upgrades::MouseClick(int mX, int mY)
 {
 	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1506::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1507::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1507
+namespace _func1508
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Upgrades::ClearUpgradeBoxes", typeid(void (Upgrades::*)()), ".41544989fc55534883ec10488b4f30488b57284889c84829d048c1f80385c0", nullptr, 0, 0, &func);
@@ -19217,11 +19230,11 @@ namespace _func1507
 void Upgrades::ClearUpgradeBoxes()
 {
 	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1507::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1508::func;
 	return execfunc(this);
 }
 
-namespace _func1508
+namespace _func1509
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Upgrades::OnInit", typeid(void (Upgrades::*)(ShipManager *)), ".41574989ff41564155415455534881ecb8000000", nullptr, 0, 0, &func);
@@ -19230,30 +19243,17 @@ namespace _func1508
 void Upgrades::OnInit(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1508::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1509::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1509
+namespace _func1510
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("Upgrades::Open", typeid(void (Upgrades::*)()), "!.534889fbe8????????488b", nullptr, 0, 0, &func);
 }
 
 void Upgrades::Open()
-{
-	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1509::func;
-	return execfunc(this);
-}
-
-namespace _func1510
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("Upgrades::OnRender", typeid(void (Upgrades::*)()), ".415455534889fb4883ec50488b7f20", nullptr, 0, 0, &func);
-}
-
-void Upgrades::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1510::func;
@@ -19263,17 +19263,30 @@ void Upgrades::OnRender()
 namespace _func1511
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("Upgrades::OnRender", typeid(void (Upgrades::*)()), ".415455534889fb4883ec50488b7f20", nullptr, 0, 0, &func);
+}
+
+void Upgrades::OnRender()
+{
+	typedef void (*custom_arg_funcptr_t)(Upgrades *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1511::func;
+	return execfunc(this);
+}
+
+namespace _func1512
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::RenderWithAlpha", typeid(void (WarningMessage::*)(float )), "41570f28f041564155415455534889fb4883ec48", nullptr, 0, 0, &func);
 }
 
 void WarningMessage::RenderWithAlpha(float alpha)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1511::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1512::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func1512
+namespace _func1513
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::constructor", typeid(void (WarningMessage::*)()), ".0f57c0534889fb488d7f2831d24883ec20", nullptr, 0, 0, &func);
@@ -19282,11 +19295,11 @@ namespace _func1512
 void WarningMessage::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1512::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1513::func;
 	return execfunc(this);
 }
 
-namespace _func1513
+namespace _func1514
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::InitImage", typeid(void (WarningMessage::*)(const std::string &, Point , float , bool )), ".41564189ce415541544989f4554889d5534889fb488dbfa80000004c8d6b604883ec10", nullptr, 0, 0, &func);
@@ -19295,11 +19308,11 @@ namespace _func1513
 void WarningMessage::InitImage(const std::string &imageName, Point position, float time, bool flash)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &imageName_arg, Point position_arg, float time_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1513::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1514::func;
 	return execfunc(this, imageName, position, time, flash);
 }
 
-namespace _func1514
+namespace _func1515
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::InitText", typeid(void (WarningMessage::*)(const TextString &, Point , float , GL_Color , bool , bool )), ".41574589c741564189ce41554154554889f5534889fb488d7f384883ec28", nullptr, 0, 0, &func);
@@ -19308,30 +19321,17 @@ namespace _func1514
 void WarningMessage::InitText(const TextString &text, Point position, float time, GL_Color textColor, bool centerText, bool flash)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg, Point position_arg, float time_arg, GL_Color textColor_arg, bool centerText_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1514::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1515::func;
 	return execfunc(this, text, position, time, textColor, centerText, flash);
 }
 
-namespace _func1515
+namespace _func1516
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::OnLoop", typeid(void (WarningMessage::*)()), ".55488d6f08534889fb4889ef4883ec08", nullptr, 0, 0, &func);
 }
 
 void WarningMessage::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1515::func;
-	return execfunc(this);
-}
-
-namespace _func1516
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("WarningMessage::OnRender", typeid(void (WarningMessage::*)()), ".53807f1e004889fb", nullptr, 0, 0, &func);
-}
-
-void WarningMessage::OnRender()
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1516::func;
@@ -19341,17 +19341,30 @@ void WarningMessage::OnRender()
 namespace _func1517
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("WarningMessage::OnRender", typeid(void (WarningMessage::*)()), ".53807f1e004889fb", nullptr, 0, 0, &func);
+}
+
+void WarningMessage::OnRender()
+{
+	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1517::func;
+	return execfunc(this);
+}
+
+namespace _func1518
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::SetImage", typeid(void (WarningMessage::*)(const std::string &)), ".4155415455534889fb4883ec08807f3000", nullptr, 0, 0, &func);
 }
 
 void WarningMessage::SetImage(const std::string &imageName)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &imageName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1517::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1518::func;
 	return execfunc(this, imageName);
 }
 
-namespace _func1518
+namespace _func1519
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::SetText", typeid(void (WarningMessage::*)(const TextString &)), ".4155415455534889fb4883ec08807f3000", nullptr, 0, 0, &func);
@@ -19360,11 +19373,11 @@ namespace _func1518
 void WarningMessage::SetText(const TextString &text)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1518::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1519::func;
 	return execfunc(this, text);
 }
 
-namespace _func1519
+namespace _func1520
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::SetText", typeid(void (WarningMessage::*)(const TextString &, GL_Color )), ".415741564155415455534889fb4883ec18807f3000", nullptr, 0, 0, &func);
@@ -19373,11 +19386,11 @@ namespace _func1519
 void WarningMessage::SetText(const TextString &text, GL_Color textColor)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg, GL_Color textColor_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1519::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1520::func;
 	return execfunc(this, text, textColor);
 }
 
-namespace _func1520
+namespace _func1521
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::SetPosition", typeid(void (WarningMessage::*)(Point )), ".807f300048897728", nullptr, 0, 0, &func);
@@ -19386,11 +19399,11 @@ namespace _func1520
 void WarningMessage::SetPosition(Point position)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, Point position_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1520::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1521::func;
 	return execfunc(this, position);
 }
 
-namespace _func1521
+namespace _func1522
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::SetLoop", typeid(void (WarningMessage::*)(bool )), "!.0f57c0400fb6f64883c708", nullptr, 0, 0, &func);
@@ -19399,11 +19412,11 @@ namespace _func1521
 void WarningMessage::SetLoop(bool loop)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, bool loop_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1521::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1522::func;
 	return execfunc(this, loop);
 }
 
-namespace _func1522
+namespace _func1523
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::SetSound", typeid(void (WarningMessage::*)(const std::string &)), "!.4881c7b8000000", nullptr, 0, 0, &func);
@@ -19412,11 +19425,11 @@ namespace _func1522
 void WarningMessage::SetSound(const std::string &sound)
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &sound_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1522::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1523::func;
 	return execfunc(this, sound);
 }
 
-namespace _func1523
+namespace _func1524
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WarningMessage::Start", typeid(void (WarningMessage::*)()), ".53807f1c004889fb", nullptr, 0, 0, &func);
@@ -19425,11 +19438,11 @@ namespace _func1523
 void WarningMessage::Start()
 {
 	typedef void (*custom_arg_funcptr_t)(WarningMessage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1523::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1524::func;
 	return execfunc(this);
 }
 
-namespace _func1524
+namespace _func1525
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponAnimation::SaveState", typeid(void (WeaponAnimation::*)(int )), "554889fd5389f34883ec08e8??????????8d", nullptr, 0, 0, &func);
@@ -19438,11 +19451,11 @@ namespace _func1524
 void WeaponAnimation::SaveState(int fd)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1524::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1525::func;
 	return execfunc(this, fd);
 }
 
-namespace _func1525
+namespace _func1526
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponAnimation::SetBoostLevel", typeid(void (WeaponAnimation::*)(int )), ".!80bfc10000000074??f3c3", nullptr, 0, 0, &func);
@@ -19451,11 +19464,11 @@ namespace _func1525
 void WeaponAnimation::SetBoostLevel(int value)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, int value_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1525::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1526::func;
 	return execfunc(this, value);
 }
 
-namespace _func1526
+namespace _func1527
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponAnimation::StartFire", typeid(bool (WeaponAnimation::*)()), "530fb687c10000004889fb84c0", nullptr, 0, 0, &func);
@@ -19464,11 +19477,11 @@ namespace _func1526
 bool WeaponAnimation::StartFire()
 {
 	typedef bool (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1526::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1527::func;
 	return execfunc(this);
 }
 
-namespace _func1527
+namespace _func1528
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponAnimation::SetFireTime", typeid(void (WeaponAnimation::*)(float )), "8b470889c22b97c8000000", nullptr, 0, 0, &func);
@@ -19477,11 +19490,11 @@ namespace _func1527
 void WeaponAnimation::SetFireTime(float time)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float time_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1527::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1528::func;
 	return execfunc(this, time);
 }
 
-namespace _func1528
+namespace _func1529
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponAnimation::GetSlide", typeid(Pointf (WeaponAnimation::*)()), "534889fb488dbff8", nullptr, 0, 0, &func);
@@ -19490,11 +19503,11 @@ namespace _func1528
 Pointf WeaponAnimation::GetSlide()
 {
 	typedef Pointf (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1528::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1529::func;
 	return execfunc(this);
 }
 
-namespace _func1529
+namespace _func1530
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponAnimation::SetPowered", typeid(void (WeaponAnimation::*)(bool )), ".5589f553??89fb??83ec0880bfdc0000000074????84f6", nullptr, 0, 0, &func);
@@ -19503,11 +19516,11 @@ namespace _func1529
 void WeaponAnimation::SetPowered(bool powered)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, bool powered_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1529::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1530::func;
 	return execfunc(this, powered);
 }
 
-namespace _func1530
+namespace _func1531
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponAnimation::SetChargedLevel", typeid(void (WeaponAnimation::*)(float )), ".f30f101d????????80bfc1000000000f28c8", nullptr, 0, 0, &func);
@@ -19516,11 +19529,11 @@ namespace _func1530
 void WeaponAnimation::SetChargedLevel(float charged)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float charged_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1530::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1531::func;
 	return execfunc(this, charged);
 }
 
-namespace _func1531
+namespace _func1532
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponAnimation::Update", typeid(void (WeaponAnimation::*)()), "415455534889fb4883ec1080bfc100000000", nullptr, 0, 0, &func);
@@ -19529,11 +19542,11 @@ namespace _func1531
 void WeaponAnimation::Update()
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1531::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1532::func;
 	return execfunc(this);
 }
 
-namespace _func1532
+namespace _func1533
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponAnimation::GetFireLocation", typeid(Point (WeaponAnimation::*)()), ".??83ec188b97f40000008bb7f0000000", nullptr, 0, 0, &func);
@@ -19542,30 +19555,17 @@ namespace _func1532
 Point WeaponAnimation::GetFireLocation()
 {
 	typedef Point (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1532::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1533::func;
 	return execfunc(this);
 }
 
-namespace _func1533
+namespace _func1534
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponAnimation::OnRender", typeid(void (WeaponAnimation::*)(float )), ".??57??56??55??545553??89fb??83ec38", nullptr, 0, 0, &func);
 }
 
 void WeaponAnimation::OnRender(float alpha)
-{
-	typedef void (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1533::func;
-	return execfunc(this, alpha);
-}
-
-namespace _func1534
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("WeaponAnimation::RenderChargeBar", typeid(void (WeaponAnimation::*)(float )), ".41564155415455534889fb4883ec20e8", nullptr, 0, 0, &func);
-}
-
-void WeaponAnimation::RenderChargeBar(float alpha)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float alpha_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1534::func;
@@ -19575,17 +19575,30 @@ void WeaponAnimation::RenderChargeBar(float alpha)
 namespace _func1535
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("WeaponAnimation::RenderChargeBar", typeid(void (WeaponAnimation::*)(float )), ".41564155415455534889fb4883ec20e8", nullptr, 0, 0, &func);
+}
+
+void WeaponAnimation::RenderChargeBar(float alpha)
+{
+	typedef void (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float alpha_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1535::func;
+	return execfunc(this, alpha);
+}
+
+namespace _func1536
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("WeaponBlueprint::RenderIcon", typeid(void (WeaponBlueprint::*)(float )), "!488db738010000", nullptr, 0, 0, &func);
 }
 
 void WeaponBlueprint::RenderIcon(float scale)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg, float scale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1535::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1536::func;
 	return execfunc(this, scale);
 }
 
-namespace _func1536
+namespace _func1537
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponBlueprint::GetDimensions", typeid(Point (WeaponBlueprint::*)()), ".53??8d9738010000", nullptr, 0, 0, &func);
@@ -19594,11 +19607,11 @@ namespace _func1536
 Point WeaponBlueprint::GetDimensions()
 {
 	typedef Point (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1536::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1537::func;
 	return execfunc(this);
 }
 
-namespace _func1537
+namespace _func1538
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponBlueprint::GetDescription", typeid(std::string (WeaponBlueprint::*)(bool )), ".4157415641554989fd4154554889f5534881ec08010000", nullptr, 0, 0, &func);
@@ -19607,30 +19620,17 @@ namespace _func1537
 std::string WeaponBlueprint::GetDescription(bool tooltip)
 {
 	typedef std::string (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg, bool tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1537::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1538::func;
 	return execfunc(this, tooltip);
 }
 
-namespace _func1538
+namespace _func1539
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponBlueprint::constructor", typeid(void (WeaponBlueprint::*)()), ".534889fb488d7f08be????????4883ec20", nullptr, 0, 0, &func);
 }
 
 void WeaponBlueprint::constructor()
-{
-	typedef void (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1538::func;
-	return execfunc(this);
-}
-
-namespace _func1539
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("WeaponBlueprint::destructor", typeid(void (WeaponBlueprint::*)()), ".4154554889fd534883ec10488b8788010000", nullptr, 0, 0, &func);
-}
-
-void WeaponBlueprint::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1539::func;
@@ -19640,17 +19640,30 @@ void WeaponBlueprint::destructor()
 namespace _func1540
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("WeaponBlueprint::destructor", typeid(void (WeaponBlueprint::*)()), ".4154554889fd534883ec10488b8788010000", nullptr, 0, 0, &func);
+}
+
+void WeaponBlueprint::destructor()
+{
+	typedef void (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1540::func;
+	return execfunc(this);
+}
+
+namespace _func1541
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("WeaponBox::RenderBox", typeid(void (WeaponBox::*)(bool , bool )), "41570fb6d2400fb6f641564155415455534889fb4881ec68030000", nullptr, 0, 0, &func);
 }
 
 void WeaponBox::RenderBox(bool dragging, bool flashPowerBox)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponBox *this_arg, bool dragging_arg, bool flashPowerBox_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1540::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1541::func;
 	return execfunc(this, dragging, flashPowerBox);
 }
 
-namespace _func1541
+namespace _func1542
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponBox::GenerateTooltip", typeid(std::string (WeaponBox::*)()), "554889f5534889fb4889f74883ec38488b06", nullptr, 0, 0, &func);
@@ -19659,11 +19672,11 @@ namespace _func1541
 std::string WeaponBox::GenerateTooltip()
 {
 	typedef std::string (*custom_arg_funcptr_t)(WeaponBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1541::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1542::func;
 	return execfunc(this);
 }
 
-namespace _func1542
+namespace _func1543
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::RenderWarnings", typeid(void (WeaponControl::*)()), "!53??89fbe8????????f30f2a4338f30f2a4b3c0f57d2e8??????????8dbb38020000e8????????", nullptr, 0, 0, &func);
@@ -19672,11 +19685,11 @@ namespace _func1542
 void WeaponControl::RenderWarnings()
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1542::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1543::func;
 	return execfunc(this);
 }
 
-namespace _func1543
+namespace _func1544
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::HolderLabel", typeid(TextString (WeaponControl::*)()), ".534889fbbe", nullptr, 0, 0, &func);
@@ -19685,11 +19698,11 @@ namespace _func1543
 TextString WeaponControl::HolderLabel()
 {
 	typedef TextString (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1543::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1544::func;
 	return execfunc(this);
 }
 
-namespace _func1544
+namespace _func1545
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::SelectArmament", typeid(void (WeaponControl::*)(unsigned int )), ".415641554154554863ee4189ec53", nullptr, 0, 0, &func);
@@ -19698,11 +19711,11 @@ namespace _func1544
 void WeaponControl::SelectArmament(unsigned int armamentSlot)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg, unsigned int armamentSlot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1544::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1545::func;
 	return execfunc(this, armamentSlot);
 }
 
-namespace _func1545
+namespace _func1546
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::constructor", typeid(void (WeaponControl::*)()), ".4157be03000000415641554989fd415455498dad3802000053498d9d180300004881ec58030000", nullptr, 0, 0, &func);
@@ -19711,11 +19724,11 @@ namespace _func1545
 void WeaponControl::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1545::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1546::func;
 	return execfunc(this);
 }
 
-namespace _func1546
+namespace _func1547
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::RenderBeamAiming", typeid(void (*)(Pointf , Pointf , bool )), ".41545589fd534883ec40", nullptr, 0, 0, &func);
@@ -19724,30 +19737,17 @@ namespace _func1546
 void WeaponControl::RenderBeamAiming(Pointf one, Pointf two, bool bAutoFire)
 {
 	typedef void (*custom_arg_funcptr_t)(Pointf one_arg, Pointf two_arg, bool bAutoFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1546::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1547::func;
 	return execfunc(one, two, bAutoFire);
 }
 
-namespace _func1547
+namespace _func1548
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::RenderAiming", typeid(void (WeaponControl::*)()), ".41574989ff415641554531ed4154555331db4883ec38", nullptr, 0, 0, &func);
 }
 
 void WeaponControl::RenderAiming()
-{
-	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1547::func;
-	return execfunc(this);
-}
-
-namespace _func1548
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("WeaponControl::RenderSelfAiming", typeid(void (WeaponControl::*)()), ".4157415641554531ed41544989fc555331db4883ec18", nullptr, 0, 0, &func);
-}
-
-void WeaponControl::RenderSelfAiming()
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1548::func;
@@ -19757,17 +19757,30 @@ void WeaponControl::RenderSelfAiming()
 namespace _func1549
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("WeaponControl::RenderSelfAiming", typeid(void (WeaponControl::*)()), ".4157415641554531ed41544989fc555331db4883ec18", nullptr, 0, 0, &func);
+}
+
+void WeaponControl::RenderSelfAiming()
+{
+	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1549::func;
+	return execfunc(this);
+}
+
+namespace _func1550
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::SetAutofiring", typeid(void (WeaponControl::*)(bool , bool )), ".41554189d54154554889fd534883ec484084f64088b7e0000000", nullptr, 0, 0, &func);
 }
 
 void WeaponControl::SetAutofiring(bool on, bool simple)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg, bool on_arg, bool simple_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1549::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1550::func;
 	return execfunc(this, on, simple);
 }
 
-namespace _func1550
+namespace _func1551
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::Fire", typeid(void (WeaponControl::*)(std::vector<Pointf> &, int , bool )), ".4155415455534889fb4883ec28488bbfd80000004885ff", nullptr, 0, 0, &func);
@@ -19776,11 +19789,11 @@ namespace _func1550
 void WeaponControl::Fire(std::vector<Pointf> &points, int target, bool autoFire)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg, std::vector<Pointf> &points_arg, int target_arg, bool autoFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1550::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1551::func;
 	return execfunc(this, points, target, autoFire);
 }
 
-namespace _func1551
+namespace _func1552
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::ArmamentHotkey", typeid(SDLKey (WeaponControl::*)(unsigned int )), ".4883ec5883c60189742420488d7c2430", nullptr, 0, 0, &func);
@@ -19789,30 +19802,17 @@ namespace _func1551
 SDLKey WeaponControl::ArmamentHotkey(unsigned int i)
 {
 	typedef SDLKey (*custom_arg_funcptr_t)(WeaponControl *this_arg, unsigned int i_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1551::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1552::func;
 	return execfunc(this, i);
 }
 
-namespace _func1552
+namespace _func1553
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::OnLoop", typeid(void (WeaponControl::*)()), ".??57be03000000??56??55??545553??89fb??81ec18010000??8b7f18e8????????", nullptr, 0, 0, &func);
 }
 
 void WeaponControl::OnLoop()
-{
-	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1552::func;
-	return execfunc(this);
-}
-
-namespace _func1553
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("WeaponControl::OnLanguageChange", typeid(void (WeaponControl::*)()), ".41564155415455534889fb4883ec70", nullptr, 0, 0, &func);
-}
-
-void WeaponControl::OnLanguageChange()
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1553::func;
@@ -19822,17 +19822,30 @@ void WeaponControl::OnLanguageChange()
 namespace _func1554
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("WeaponControl::OnLanguageChange", typeid(void (WeaponControl::*)()), ".41564155415455534889fb4883ec70", nullptr, 0, 0, &func);
+}
+
+void WeaponControl::OnLanguageChange()
+{
+	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1554::func;
+	return execfunc(this);
+}
+
+namespace _func1555
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::OnRender", typeid(void (WeaponControl::*)(bool )), ".41545589f5be03000000534889fb4883ec10488b7f18", nullptr, 0, 0, &func);
 }
 
 void WeaponControl::OnRender(bool unk)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1554::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1555::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1555
+namespace _func1556
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::LButton", typeid(bool (WeaponControl::*)(int , int , bool )), ".80bf30010000007427530fb69f3101000084db", nullptr, 0, 0, &func);
@@ -19841,11 +19854,11 @@ namespace _func1555
 bool WeaponControl::LButton(int x, int y, bool holdingShift)
 {
 	typedef bool (*custom_arg_funcptr_t)(WeaponControl *this_arg, int x_arg, int y_arg, bool holdingShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1555::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1556::func;
 	return execfunc(this, x, y, holdingShift);
 }
 
-namespace _func1556
+namespace _func1557
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::MouseMove", typeid(void (WeaponControl::*)(int , int )), ".41544189d45589f5534889fb", nullptr, 0, 0, &func);
@@ -19854,11 +19867,11 @@ namespace _func1556
 void WeaponControl::MouseMove(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1556::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1557::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1557
+namespace _func1558
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::KeyDown", typeid(bool (WeaponControl::*)(SDLKey )), ".4155415441bc010000005589f5534889fb4883ec28", nullptr, 0, 0, &func);
@@ -19867,11 +19880,11 @@ namespace _func1557
 bool WeaponControl::KeyDown(SDLKey key)
 {
 	typedef bool (*custom_arg_funcptr_t)(WeaponControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1557::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1558::func;
 	return execfunc(this, key);
 }
 
-namespace _func1558
+namespace _func1559
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponControl::LinkShip", typeid(void (WeaponControl::*)(ShipManager *)), ".55534889fb4883ec28", nullptr, 0, 0, &func);
@@ -19880,11 +19893,11 @@ namespace _func1558
 void WeaponControl::LinkShip(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponControl *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1558::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1559::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1559
+namespace _func1560
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponEquipBox::constructor", typeid(void (WeaponEquipBox::*)(Point , WeaponSystem *, int )), "4154554889d5534889fb4889", nullptr, 0, 0, &func);
@@ -19893,11 +19906,11 @@ namespace _func1559
 void WeaponEquipBox::constructor(Point location, WeaponSystem *sys, int slot)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponEquipBox *this_arg, Point location_arg, WeaponSystem *sys_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1559::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1560::func;
 	return execfunc(this, location, sys, slot);
 }
 
-namespace _func1560
+namespace _func1561
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneEquipBox::constructor", typeid(void (DroneEquipBox::*)(Point , DroneSystem *, int )), ".4154554889d5534889fb4889", nullptr, 0, 0, &func);
@@ -19906,17 +19919,17 @@ namespace _func1560
 void DroneEquipBox::constructor(Point location, DroneSystem *sys, int slot)
 {
 	typedef void (*custom_arg_funcptr_t)(DroneEquipBox *this_arg, Point location_arg, DroneSystem *sys_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1560::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1561::func;
 	return execfunc(this, location, sys, slot);
 }
 
-namespace _func1561
+namespace _func1562
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponStoreBox::__DO_NOT_HOOK", typeid(void (WeaponStoreBox::*)()), "41554989d541544989f4be", nullptr, 0, 0, &func);
 }
 
-namespace _func1562
+namespace _func1563
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponStoreBox::constructor", typeid(void (WeaponStoreBox::*)(ShipManager *, Equipment *, const WeaponBlueprint *)), ".41554989d541544989f4be", nullptr, 0, 0, &func);
@@ -19925,11 +19938,11 @@ namespace _func1562
 void WeaponStoreBox::constructor(ShipManager *ship, Equipment *equip, const WeaponBlueprint *weaponBp)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponStoreBox *this_arg, ShipManager *ship_arg, Equipment *equip_arg, const WeaponBlueprint *weaponBp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1562::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1563::func;
 	return execfunc(this, ship, equip, weaponBp);
 }
 
-namespace _func1563
+namespace _func1564
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponStoreBox::Purchase", typeid(void (WeaponStoreBox::*)()), ".534889fbbe????????4883ec20488d54240e488d7c2410e8????????488d74241031d2bf????????f30f1005????????e8????????488b442410488d78e84881ff????????0f85????????488d54240e488d7c2410be????????e8????????488d742410bf????????e8????????488b442410488d78e84881ff????????0f85????????8bb3e0000000488bbb1801000031d2f7dee8????????8b8310010000488d7b18", nullptr, 0, 0, &func);
@@ -19938,11 +19951,11 @@ namespace _func1563
 void WeaponStoreBox::Purchase()
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1563::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1564::func;
 	return execfunc(this);
 }
 
-namespace _func1564
+namespace _func1565
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("DroneStoreBox::Purchase", typeid(void (DroneStoreBox::*)()), ".534889fbbe????????4883ec20488d54240e488d7c2410e8????????488d74241031d2bf????????f30f1005????????e8????????488b442410488d78e84881ff????????0f85????????488d54240e488d7c2410be????????e8????????488d742410bf????????e8????????488b442410488d78e84881ff????????0f85????????8bb3e0000000488bbb1801000031d2f7dee8????????8b8310010000488d7b18", nullptr, 0, 0, &func);
@@ -19951,11 +19964,11 @@ namespace _func1564
 void DroneStoreBox::Purchase()
 {
 	typedef void (*custom_arg_funcptr_t)(DroneStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1564::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1565::func;
 	return execfunc(this);
 }
 
-namespace _func1565
+namespace _func1566
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponSystem::ForceIncreasePower", typeid(bool (WeaponSystem::*)(int )), ".??5531c9??54??89fc555331db??83ec08??8bb758020000", nullptr, 0, 0, &func);
@@ -19964,11 +19977,11 @@ namespace _func1565
 bool WeaponSystem::ForceIncreasePower(int amount)
 {
 	typedef bool (*custom_arg_funcptr_t)(WeaponSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1565::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1566::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1566
+namespace _func1567
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponSystem::RemoveWeapon", typeid(ProjectileFactory *(WeaponSystem::*)(int )), "31c085f60f88d800000041564155415455534889fb4883ec20", nullptr, 0, 0, &func);
@@ -19977,11 +19990,11 @@ namespace _func1566
 ProjectileFactory *WeaponSystem::RemoveWeapon(int slot)
 {
 	typedef ProjectileFactory *(*custom_arg_funcptr_t)(WeaponSystem *this_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1566::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1567::func;
 	return execfunc(this, slot);
 }
 
-namespace _func1567
+namespace _func1568
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponSystem::SetBonusPower", typeid(void (WeaponSystem::*)(int , int )), "!.5589f5534889fb4883ec08e8????????39e8", nullptr, 0, 0, &func);
@@ -19990,11 +20003,11 @@ namespace _func1567
 void WeaponSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1567::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1568::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func1568
+namespace _func1569
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponSystem::OnLoop", typeid(void (WeaponSystem::*)()), ".415741564155415455534889fb4883ec38e8????????488b9350020000", nullptr, 0, 0, &func);
@@ -20003,11 +20016,11 @@ namespace _func1568
 void WeaponSystem::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1568::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1569::func;
 	return execfunc(this);
 }
 
-namespace _func1569
+namespace _func1570
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponSystem::PowerWeapon", typeid(bool (WeaponSystem::*)(ProjectileFactory *, bool , bool )), ".??55??89d5??54??89cc55??89fd53??89f3??83ec08e8????????", nullptr, 0, 0, &func);
@@ -20016,11 +20029,11 @@ namespace _func1569
 bool WeaponSystem::PowerWeapon(ProjectileFactory *weapon, bool userDriven, bool force)
 {
 	typedef bool (*custom_arg_funcptr_t)(WeaponSystem *this_arg, ProjectileFactory *weapon_arg, bool userDriven_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1569::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1570::func;
 	return execfunc(this, weapon, userDriven, force);
 }
 
-namespace _func1570
+namespace _func1571
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponSystem::DePowerWeapon", typeid(bool (WeaponSystem::*)(ProjectileFactory *, bool )), ".??55??54??89f45553??83ec08??0fb6aef2000000", nullptr, 0, 0, &func);
@@ -20029,11 +20042,11 @@ namespace _func1570
 bool WeaponSystem::DePowerWeapon(ProjectileFactory *weapon, bool userDriven)
 {
 	typedef bool (*custom_arg_funcptr_t)(WeaponSystem *this_arg, ProjectileFactory *weapon_arg, bool userDriven_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1570::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1571::func;
 	return execfunc(this, weapon, userDriven);
 }
 
-namespace _func1571
+namespace _func1572
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WeaponSystemBox::constructor", typeid(void (WeaponSystemBox::*)(Point , ShipSystem *, WeaponControl *)), "554889cdb901000000534889fb4883ec08e8????????488dbb70020000", nullptr, 0, 0, &func);
@@ -20042,11 +20055,11 @@ namespace _func1571
 void WeaponSystemBox::constructor(Point pos, ShipSystem *sys, WeaponControl *weapCtrl)
 {
 	typedef void (*custom_arg_funcptr_t)(WeaponSystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, WeaponControl *weapCtrl_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1571::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1572::func;
 	return execfunc(this, pos, sys, weapCtrl);
 }
 
-namespace _func1572
+namespace _func1573
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WindowFrame::constructor", typeid(void (WindowFrame::*)(int , int , int , int )), "41574156415541545589d55389f34881ecc8000000", nullptr, 0, 0, &func);
@@ -20055,11 +20068,11 @@ namespace _func1572
 void WindowFrame::constructor(int x, int y, int w, int h)
 {
 	typedef void (*custom_arg_funcptr_t)(WindowFrame *this_arg, int x_arg, int y_arg, int w_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1572::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1573::func;
 	return execfunc(this, x, y, w, h);
 }
 
-namespace _func1573
+namespace _func1574
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WindowFrame::destructor", typeid(void (WindowFrame::*)()), "!.534889fb488b7f10", nullptr, 0, 0, &func);
@@ -20068,11 +20081,11 @@ namespace _func1573
 void WindowFrame::destructor()
 {
 	typedef void (*custom_arg_funcptr_t)(WindowFrame *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1573::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1574::func;
 	return execfunc(this);
 }
 
-namespace _func1574
+namespace _func1575
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WindowFrame::Draw", typeid(void (WindowFrame::*)(int , int )), "!.41544189d45589f5534889fb", nullptr, 0, 0, &func);
@@ -20081,11 +20094,11 @@ namespace _func1574
 void WindowFrame::Draw(int x, int y)
 {
 	typedef void (*custom_arg_funcptr_t)(WindowFrame *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1574::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1575::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1575
+namespace _func1576
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WindowFrame::DrawMask", typeid(void (WindowFrame::*)(int )), "!.5389f24889fbbf01000000", nullptr, 0, 0, &func);
@@ -20094,11 +20107,11 @@ namespace _func1575
 void WindowFrame::DrawMask(int unk)
 {
 	typedef void (*custom_arg_funcptr_t)(WindowFrame *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1575::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1576::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1576
+namespace _func1577
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::constructor", typeid(void (WorldManager::*)()), "534889fb488d7f104883ec10", nullptr, 0, 0, &func);
@@ -20107,11 +20120,11 @@ namespace _func1576
 void WorldManager::constructor()
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1576::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1577::func;
 	return execfunc(this);
 }
 
-namespace _func1577
+namespace _func1578
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::OnInit", typeid(int (WorldManager::*)()), ".415455488d6f10534889fb4889ef", nullptr, 0, 0, &func);
@@ -20120,11 +20133,11 @@ namespace _func1577
 int WorldManager::OnInit()
 {
 	typedef int (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1577::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1578::func;
 	return execfunc(this);
 }
 
-namespace _func1578
+namespace _func1579
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::CreateStore", typeid(void (WorldManager::*)(LocationEvent *)), ".554889f5534889fb4883ec08488bb6d0040000", nullptr, 0, 0, &func);
@@ -20133,11 +20146,11 @@ namespace _func1578
 void WorldManager::CreateStore(LocationEvent *event)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1578::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1579::func;
 	return execfunc(this, event);
 }
 
-namespace _func1579
+namespace _func1580
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::CheckRequirements", typeid(bool (WorldManager::*)(LocationEvent *, bool )), ".415455534889f34883ec204885f6", nullptr, 0, 0, &func);
@@ -20146,11 +20159,11 @@ namespace _func1579
 bool WorldManager::CheckRequirements(LocationEvent *event, bool hidden)
 {
 	typedef bool (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg, bool hidden_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1579::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1580::func;
 	return execfunc(this, event, hidden);
 }
 
-namespace _func1580
+namespace _func1581
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::AddBoarders", typeid(bool (WorldManager::*)(BoardingEvent &)), ".4154554889fd534883ec20488b07488b5010", nullptr, 0, 0, &func);
@@ -20159,11 +20172,11 @@ namespace _func1580
 bool WorldManager::AddBoarders(BoardingEvent &boardingEvent)
 {
 	typedef bool (*custom_arg_funcptr_t)(WorldManager *this_arg, BoardingEvent &boardingEvent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1580::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1581::func;
 	return execfunc(this, boardingEvent);
 }
 
-namespace _func1581
+namespace _func1582
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::HostileEnvironment", typeid(bool (WorldManager::*)()), ".534889fb488d7f10", nullptr, 0, 0, &func);
@@ -20172,11 +20185,11 @@ namespace _func1581
 bool WorldManager::HostileEnvironment()
 {
 	typedef bool (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1581::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1582::func;
 	return execfunc(this);
 }
 
-namespace _func1582
+namespace _func1583
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::ModifyEnvironment", typeid(void (WorldManager::*)(int , int )), ".83fe01534889fb", nullptr, 0, 0, &func);
@@ -20185,11 +20198,11 @@ namespace _func1582
 void WorldManager::ModifyEnvironment(int envFlag, int envTarget)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, int envFlag_arg, int envTarget_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1582::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1583::func;
 	return execfunc(this, envFlag, envTarget);
 }
 
-namespace _func1583
+namespace _func1584
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::ModifyStatusEffect", typeid(void (WorldManager::*)(StatusEffect , ShipManager *, int )), ".41554889d04989fd48c1f82041544989cc4889f148c1f920", nullptr, 0, 0, &func);
@@ -20198,11 +20211,11 @@ namespace _func1583
 void WorldManager::ModifyStatusEffect(StatusEffect effect, ShipManager *target, int targetType)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, StatusEffect effect_arg, ShipManager *target_arg, int targetType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1583::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1584::func;
 	return execfunc(this, effect, target, targetType);
 }
 
-namespace _func1584
+namespace _func1585
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::ModifyResources", typeid(LocationEvent *(WorldManager::*)(LocationEvent *)), ".41574989f7488db65803000041564d8db78803000041554154554889fd534881ecd8020000", nullptr, 0, 0, &func);
@@ -20211,11 +20224,11 @@ namespace _func1584
 LocationEvent *WorldManager::ModifyResources(LocationEvent *event)
 {
 	typedef LocationEvent *(*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1584::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1585::func;
 	return execfunc(this, event);
 }
 
-namespace _func1585
+namespace _func1586
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::CheckStatusEffects", typeid(void (WorldManager::*)(std::vector<StatusEffect> &)), "!.415741564989fe41554531ed41544c8da7001500005531ed534889f34883ec08", nullptr, 0, 0, &func);
@@ -20224,30 +20237,17 @@ namespace _func1585
 void WorldManager::CheckStatusEffects(std::vector<StatusEffect> &vec)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, std::vector<StatusEffect> &vec_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1585::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1586::func;
 	return execfunc(this, vec);
 }
 
-namespace _func1586
+namespace _func1587
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::CreateChoiceBox", typeid(void (WorldManager::*)(LocationEvent *)), ".4157488d87501500004989ff41564889c741554154554889f5534889c34881ec08030000", nullptr, 0, 0, &func);
 }
 
 void WorldManager::CreateChoiceBox(LocationEvent *event)
-{
-	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1586::func;
-	return execfunc(this, event);
-}
-
-namespace _func1587
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("WorldManager::CreateChoiceBox0", typeid(void (WorldManager::*)(LocationEvent *)), ".554889f5534889fb4883ec08488b07488b7810488b17", nullptr, 0, 0, &func);
-}
-
-void WorldManager::CreateChoiceBox0(LocationEvent *event)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1587::func;
@@ -20257,17 +20257,30 @@ void WorldManager::CreateChoiceBox0(LocationEvent *event)
 namespace _func1588
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("WorldManager::CreateChoiceBox0", typeid(void (WorldManager::*)(LocationEvent *)), ".554889f5534889fb4883ec08488b07488b7810488b17", nullptr, 0, 0, &func);
+}
+
+void WorldManager::CreateChoiceBox0(LocationEvent *event)
+{
+	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1588::func;
+	return execfunc(this, event);
+}
+
+namespace _func1589
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::CreateShip", typeid(CompleteShip *(WorldManager::*)(ShipEvent *, bool )), ".4156415541544989fc55534881ec60030000", nullptr, 0, 0, &func);
 }
 
 CompleteShip *WorldManager::CreateShip(ShipEvent *shipEvent, bool boss)
 {
 	typedef CompleteShip *(*custom_arg_funcptr_t)(WorldManager *this_arg, ShipEvent *shipEvent_arg, bool boss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1588::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1589::func;
 	return execfunc(this, shipEvent, boss);
 }
 
-namespace _func1589
+namespace _func1590
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::CreateLocation", typeid(void (WorldManager::*)(Location *)), ".41574156415541544989f455534889fb4881ecf8030000", nullptr, 0, 0, &func);
@@ -20276,30 +20289,17 @@ namespace _func1589
 void WorldManager::CreateLocation(Location *loc)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1589::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1590::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1590
+namespace _func1591
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::UpdateLocation", typeid(void (WorldManager::*)(LocationEvent *)), ".4157415641554154554889fd534889f34881ec88030000", nullptr, 0, 0, &func);
 }
 
 void WorldManager::UpdateLocation(LocationEvent *event)
-{
-	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1590::func;
-	return execfunc(this, event);
-}
-
-namespace _func1591
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("WorldManager::UpdateLocation0", typeid(void (WorldManager::*)(LocationEvent *)), ".554889f5534889fb4883ec08488b07488b7810488b17", nullptr, 0, 0, &func);
-}
-
-void WorldManager::UpdateLocation0(LocationEvent *event)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1591::func;
@@ -20309,17 +20309,30 @@ void WorldManager::UpdateLocation0(LocationEvent *event)
 namespace _func1592
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("WorldManager::UpdateLocation0", typeid(void (WorldManager::*)(LocationEvent *)), ".554889f5534889fb4883ec08488b07488b7810488b17", nullptr, 0, 0, &func);
+}
+
+void WorldManager::UpdateLocation0(LocationEvent *event)
+{
+	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1592::func;
+	return execfunc(this, event);
+}
+
+namespace _func1593
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::ClearLocation", typeid(void (WorldManager::*)()), ".415741564155415455534889fb488d7f104881ec68020000", nullptr, 0, 0, &func);
 }
 
 void WorldManager::ClearLocation()
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1592::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1593::func;
 	return execfunc(this);
 }
 
-namespace _func1593
+namespace _func1594
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::LoadGame", typeid(void (WorldManager::*)(const std::string &)), ".415741564155415455534889fb4881ece8010000", nullptr, 0, 0, &func);
@@ -20328,30 +20341,17 @@ namespace _func1593
 void WorldManager::LoadGame(const std::string &fileName)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1593::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1594::func;
 	return execfunc(this, fileName);
 }
 
-namespace _func1594
+namespace _func1595
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::SaveGame", typeid(void (WorldManager::*)()), ".415455534889fb4883ec20488bbfb8110000", nullptr, 0, 0, &func);
 }
 
 void WorldManager::SaveGame()
-{
-	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1594::func;
-	return execfunc(this);
-}
-
-namespace _func1595
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("WorldManager::CreateNewGame", typeid(void (WorldManager::*)()), ".554889fd5331db4883ec28488b07488b78104881c718010000", nullptr, 0, 0, &func);
-}
-
-void WorldManager::CreateNewGame()
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1595::func;
@@ -20361,36 +20361,36 @@ void WorldManager::CreateNewGame()
 namespace _func1596
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("WorldManager::CreateNewGame", typeid(void (WorldManager::*)()), ".554889fd5331db4883ec28488b07488b78104881c718010000", nullptr, 0, 0, &func);
+}
+
+void WorldManager::CreateNewGame()
+{
+	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1596::func;
+	return execfunc(this);
+}
+
+namespace _func1597
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::StartGame", typeid(void (WorldManager::*)(ShipManager *)), ".4154554889f5534889fb4883ec20", nullptr, 0, 0, &func);
 }
 
 void WorldManager::StartGame(ShipManager *ship)
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1596::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1597::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1597
+namespace _func1598
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("WorldManager::Restart", typeid(void (WorldManager::*)()), "!.534889fbe8????????e8????????e8", nullptr, 0, 0, &func);
 }
 
 void WorldManager::Restart()
-{
-	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1597::func;
-	return execfunc(this);
-}
-
-namespace _func1598
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("WorldManager::OnLoop", typeid(void (WorldManager::*)()), ".415731f64989ff41564155415455534881ecf8000000", nullptr, 0, 0, &func);
-}
-
-void WorldManager::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1598::func;
@@ -20400,10 +20400,10 @@ void WorldManager::OnLoop()
 namespace _func1599
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("WorldManager::PauseLoop", typeid(void (WorldManager::*)()), ".41554154554889fd534883ec28488b3f", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("WorldManager::OnLoop", typeid(void (WorldManager::*)()), ".415731f64989ff41564155415455534881ecf8000000", nullptr, 0, 0, &func);
 }
 
-void WorldManager::PauseLoop()
+void WorldManager::OnLoop()
 {
 	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1599::func;
@@ -20413,17 +20413,30 @@ void WorldManager::PauseLoop()
 namespace _func1600
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("WorldManager::PauseLoop", typeid(void (WorldManager::*)()), ".41554154554889fd534883ec28488b3f", nullptr, 0, 0, &func);
+}
+
+void WorldManager::PauseLoop()
+{
+	typedef void (*custom_arg_funcptr_t)(WorldManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1600::func;
+	return execfunc(this);
+}
+
+namespace _func1601
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("freetype::font_data::init", typeid(void (freetype::font_data::*)(const void *, int , unsigned int , bool )), "89c9534889fbf3480f2ac14889f731c989d631d2", nullptr, 0, 0, &func);
 }
 
 void freetype::font_data::init(const void *buffer, int bufferSize, unsigned int h, bool glow)
 {
 	typedef void (*custom_arg_funcptr_t)(freetype::font_data *this_arg, const void *buffer_arg, int bufferSize_arg, unsigned int h_arg, bool glow_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1600::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1601::func;
 	return execfunc(this, buffer, bufferSize, h, glow);
 }
 
-namespace _func1601
+namespace _func1602
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("freetype::font_data::init_bitmap", typeid(void (freetype::font_data::*)(const void *, int , int , int )), ".41544189cc31c955", nullptr, 0, 0, &func);
@@ -20432,11 +20445,11 @@ namespace _func1601
 void freetype::font_data::init_bitmap(const void *buffer, int bufferSize, int size, int h)
 {
 	typedef void (*custom_arg_funcptr_t)(freetype::font_data *this_arg, const void *buffer_arg, int bufferSize_arg, int size_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1601::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1602::func;
 	return execfunc(this, buffer, bufferSize, size, h);
 }
 
-namespace _func1602
+namespace _func1603
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("freetype::font_data::clean", typeid(void (freetype::font_data::*)()), "!.8b7f04e9", nullptr, 0, 0, &func);
@@ -20445,11 +20458,11 @@ namespace _func1602
 void freetype::font_data::clean()
 {
 	typedef void (*custom_arg_funcptr_t)(freetype::font_data *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1602::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1603::func;
 	return execfunc(this);
 }
 
-namespace _func1603
+namespace _func1604
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("freetype::easy_measurePrintLines", typeid(Pointf (*)(int , float , float , int , const std::string &)), ".554889d089fd5389f34883ec38", nullptr, 0, 0, &func);
@@ -20458,11 +20471,11 @@ namespace _func1603
 Pointf freetype::easy_measurePrintLines(int fontSize, float x, float y, int line_length, const std::string &text)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1603::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1604::func;
 	return execfunc(fontSize, x, y, line_length, text);
 }
 
-namespace _func1604
+namespace _func1605
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("freetype::easy_measureWidth", typeid(int (*)(int , const std::string &)), ".5389fb4883ec30488b36488d54241e", nullptr, 0, 0, &func);
@@ -20471,30 +20484,17 @@ namespace _func1604
 int freetype::easy_measureWidth(int fontSize, const std::string &text)
 {
 	typedef int (*custom_arg_funcptr_t)(int fontSize_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1604::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1605::func;
 	return execfunc(fontSize, text);
 }
 
-namespace _func1605
+namespace _func1606
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("freetype::easy_print", typeid(Pointf (*)(int , float , float , const std::string &)), ".5389fb4883ec30488b36488d54241e", nullptr, 0, 0, &func);
 }
 
 Pointf freetype::easy_print(int fontSize, float x, float y, const std::string &text)
-{
-	typedef Pointf (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1605::func;
-	return execfunc(fontSize, x, y, text);
-}
-
-namespace _func1606
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("freetype::easy_printRightAlign", typeid(Pointf (*)(int , float , float , const std::string &)), ".5389fb4883ec30488b36488d54241e", nullptr, 0, 0, &func);
-}
-
-Pointf freetype::easy_printRightAlign(int fontSize, float x, float y, const std::string &text)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1606::func;
@@ -20504,23 +20504,23 @@ Pointf freetype::easy_printRightAlign(int fontSize, float x, float y, const std:
 namespace _func1607
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("freetype::easy_printNewlinesCentered", typeid(Pointf (*)(int , float , float , int , const std::string &)), ".554889d089fd5389f34883ec38", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("freetype::easy_printRightAlign", typeid(Pointf (*)(int , float , float , const std::string &)), ".5389fb4883ec30488b36488d54241e", nullptr, 0, 0, &func);
 }
 
-Pointf freetype::easy_printNewlinesCentered(int fontSize, float x, float y, int line_length, const std::string &text)
+Pointf freetype::easy_printRightAlign(int fontSize, float x, float y, const std::string &text)
 {
-	typedef Pointf (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
+	typedef Pointf (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1607::func;
-	return execfunc(fontSize, x, y, line_length, text);
+	return execfunc(fontSize, x, y, text);
 }
 
 namespace _func1608
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("freetype::easy_printAutoNewlines", typeid(Pointf (*)(int , float , float , int , const std::string &)), ".554889d089fd5389f34883ec38", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("freetype::easy_printNewlinesCentered", typeid(Pointf (*)(int , float , float , int , const std::string &)), ".554889d089fd5389f34883ec38", nullptr, 0, 0, &func);
 }
 
-Pointf freetype::easy_printAutoNewlines(int fontSize, float x, float y, int line_length, const std::string &text)
+Pointf freetype::easy_printNewlinesCentered(int fontSize, float x, float y, int line_length, const std::string &text)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1608::func;
@@ -20530,17 +20530,30 @@ Pointf freetype::easy_printAutoNewlines(int fontSize, float x, float y, int line
 namespace _func1609
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("freetype::easy_printAutoNewlines", typeid(Pointf (*)(int , float , float , int , const std::string &)), ".554889d089fd5389f34883ec38", nullptr, 0, 0, &func);
+}
+
+Pointf freetype::easy_printAutoNewlines(int fontSize, float x, float y, int line_length, const std::string &text)
+{
+	typedef Pointf (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1609::func;
+	return execfunc(fontSize, x, y, line_length, text);
+}
+
+namespace _func1610
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("freetype::easy_printCenter", typeid(Pointf (*)(int , float , float , const std::string &)), ".5389fb4883ec30488b36488d54241e", nullptr, 0, 0, &func);
 }
 
 Pointf freetype::easy_printCenter(int fontSize, float x, float y, const std::string &text)
 {
 	typedef Pointf (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1609::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1610::func;
 	return execfunc(fontSize, x, y, text);
 }
 
-namespace _func1610
+namespace _func1611
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("freetype::easy_printAutoShrink", typeid(void (*)(int , float , float , int , bool , const std::string &)), ".41578d47cc415641554989cd4154555389fb4883ec5883f801", nullptr, 0, 0, &func);
@@ -20549,11 +20562,11 @@ namespace _func1610
 void freetype::easy_printAutoShrink(int fontId, float x, float y, int maxWidth, bool centered, const std::string &text)
 {
 	typedef void (*custom_arg_funcptr_t)(int fontId_arg, float x_arg, float y_arg, int maxWidth_arg, bool centered_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1610::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1611::func;
 	return execfunc(fontId, x, y, maxWidth, centered, text);
 }
 
-namespace _func1611
+namespace _func1612
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("font_height", typeid(float (*)(int , float )), ".85ff530f8e", nullptr, 0, 0, &func);
@@ -20562,11 +20575,11 @@ namespace _func1611
 float __stdcall font_height(int font_id, float size)
 {
 	typedef float (*custom_arg_funcptr_t)(int font_id_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1611::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1612::func;
 	return execfunc(font_id, size);
 }
 
-namespace _func1612
+namespace _func1613
 {
     static void *func = 0;
 	static FunctionDefinition funcObj("font_baseline", typeid(float (*)(int , float )), ".85ff530f8e", nullptr, 0, 0, &func);
@@ -20575,13 +20588,13 @@ namespace _func1612
 float __stdcall font_baseline(int font_id, float size)
 {
 	typedef float (*custom_arg_funcptr_t)(int font_id_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1612::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1613::func;
 	return execfunc(font_id, size);
 }
 
 float *Global_freetype_sil_freetype_outline;
 
-namespace _var1613
+namespace _var1614
 {
     static VariableDefinition varObj("Global_freetype_sil_freetype_outline", "!.f30f5905(???????\?)4531c031c9f30f2df0", &Global_freetype_sil_freetype_outline, true, true);
 }

--- a/FTLGameELF64.h
+++ b/FTLGameELF64.h
@@ -4710,6 +4710,7 @@ struct CommandGui
 {
 	LIBZHL_API void AddEnemyShip(CompleteShip *ship);
 	LIBZHL_API void CheckGameover();
+	LIBZHL_API void ClearLocation();
 	LIBZHL_API Store *CreateNewStore(int sectorNumber);
 	LIBZHL_API Point GetWorldCoordinates(Point point, bool fromTarget);
 	LIBZHL_API bool IsGameOver();

--- a/FTLGameWin32.cpp
+++ b/FTLGameWin32.cpp
@@ -4182,12 +4182,12 @@ namespace _func300
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CompleteShip::PauseLoop", typeid(void (CompleteShip::*)()), "558b490889e583e4f0e8????????c9c3578d7c240883e4f0ff77fc", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CommandGui::ClearLocation", typeid(void (CommandGui::*)()), "5589e5538b8108170000c781541700005e01000089cb8d89c803000083e4f0", argdata, 1, 5, &func);
 }
 
-void CompleteShip::PauseLoop()
+void CommandGui::ClearLocation()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CommandGui *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func300::func;
 	return execfunc(this);
 }
@@ -4196,10 +4196,10 @@ namespace _func301
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CompleteShip::Restart", typeid(void (CompleteShip::*)()), ".578d7c240883e4f0ff77fc5589e5575389cb83ec108b4908e8????????8b43088d4b18c744240400000000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CompleteShip::PauseLoop", typeid(void (CompleteShip::*)()), "558b490889e583e4f0e8????????c9c3578d7c240883e4f0ff77fc", argdata, 1, 5, &func);
 }
 
-void CompleteShip::Restart()
+void CompleteShip::PauseLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func301::func;
@@ -4209,6 +4209,20 @@ void CompleteShip::Restart()
 namespace _func302
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CompleteShip::Restart", typeid(void (CompleteShip::*)()), ".578d7c240883e4f0ff77fc5589e5575389cb83ec108b4908e8????????8b43088d4b18c744240400000000", argdata, 1, 5, &func);
+}
+
+void CompleteShip::Restart()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func302::func;
+	return execfunc(this);
+}
+
+namespace _func303
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CompleteShip::constructor", typeid(void (CompleteShip::*)(SpaceManager *, bool , int )), ".578d7c240883e4f0ff77fc5589e5575389cb83ec108b47048b4f088b17c703????????c7430800000000", argdata, 4, 5, &func);
 }
@@ -4216,11 +4230,11 @@ namespace _func302
 void CompleteShip::constructor(SpaceManager *space, bool unk, int unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, SpaceManager *space_arg, bool unk_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func302::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func303::func;
 	return execfunc(this, space, unk, unk2);
 }
 
-namespace _func303
+namespace _func304
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4230,11 +4244,11 @@ namespace _func303
 void CompleteShip::SetShip(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func303::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func304::func;
 	return execfunc(this, ship);
 }
 
-namespace _func304
+namespace _func305
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -4244,11 +4258,11 @@ namespace _func304
 void CompleteShip::OnInit(const ShipBlueprint *blueprint, int unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, const ShipBlueprint *blueprint_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func304::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func305::func;
 	return execfunc(this, blueprint, unk);
 }
 
-namespace _func305
+namespace _func306
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -4258,11 +4272,11 @@ namespace _func305
 void CompleteShip::AddBoarders(int amount, const std::string &race, bool unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int amount_arg, const std::string &race_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func305::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func306::func;
 	return execfunc(this, amount, race, unk2);
 }
 
-namespace _func306
+namespace _func307
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -4272,11 +4286,11 @@ namespace _func306
 CrewMember *CompleteShip::AddCrewMember(const CrewBlueprint *blueprint, bool hostile)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, const CrewBlueprint *blueprint_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func306::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func307::func;
 	return execfunc(this, blueprint, hostile);
 }
 
-namespace _func307
+namespace _func308
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -4286,11 +4300,11 @@ namespace _func307
 CrewMember *CompleteShip::AddCrewMember1(const std::string &race, const std::string &name, bool hostile)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, const std::string &race_arg, const std::string &name_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func307::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func308::func;
 	return execfunc(this, race, name, hostile);
 }
 
-namespace _func308
+namespace _func309
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -4300,11 +4314,11 @@ namespace _func308
 Drone *CompleteShip::AddDrone(const DroneBlueprint *blueprint, int unk)
 {
 	typedef Drone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, const DroneBlueprint *blueprint_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func308::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func309::func;
 	return execfunc(this, blueprint, unk);
 }
 
-namespace _func309
+namespace _func310
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -4314,11 +4328,11 @@ namespace _func309
 CrewMember *CompleteShip::AddCrewMember2(CrewMember *member, int unk)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, CrewMember *member_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func309::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func310::func;
 	return execfunc(this, member, unk);
 }
 
-namespace _func310
+namespace _func311
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4328,11 +4342,11 @@ namespace _func310
 void CompleteShip::SaveState(int unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func310::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func311::func;
 	return execfunc(this, unk);
 }
 
-namespace _func311
+namespace _func312
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4342,11 +4356,11 @@ namespace _func311
 void CompleteShip::LoadState(int unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func311::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func312::func;
 	return execfunc(this, unk);
 }
 
-namespace _func312
+namespace _func313
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -4356,11 +4370,11 @@ namespace _func312
 void CompleteShip::InitiateTeleport(int targetRoom, int command)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int targetRoom_arg, int command_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func312::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func313::func;
 	return execfunc(this, targetRoom, command);
 }
 
-namespace _func313
+namespace _func314
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4370,11 +4384,11 @@ namespace _func313
 void CompleteShip::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func313::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func314::func;
 	return execfunc(this);
 }
 
-namespace _func314
+namespace _func315
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4384,11 +4398,11 @@ namespace _func314
 std::vector<CrewMember*> CompleteShip::GetTeleportingParty()
 {
 	typedef std::vector<CrewMember*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func314::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func315::func;
 	return execfunc(this);
 }
 
-namespace _func315
+namespace _func316
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4398,11 +4412,11 @@ namespace _func315
 void CompleteShip::KillRandomCrew()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func315::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func316::func;
 	return execfunc(this);
 }
 
-namespace _func316
+namespace _func317
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4412,11 +4426,11 @@ namespace _func316
 int CompleteShip::CountCrew(bool boarders)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, bool boarders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func316::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func317::func;
 	return execfunc(this, boarders);
 }
 
-namespace _func317
+namespace _func318
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4426,11 +4440,11 @@ namespace _func317
 void CompleteShip::Jump()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func317::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func318::func;
 	return execfunc(this);
 }
 
-namespace _func318
+namespace _func319
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4440,11 +4454,11 @@ namespace _func318
 void CompleteShip::SetEnemyShip(CompleteShip *other)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, CompleteShip *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func318::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func319::func;
 	return execfunc(this, other);
 }
 
-namespace _func319
+namespace _func320
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4454,11 +4468,11 @@ namespace _func319
 bool CompleteShip::DeadCrew()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func319::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func320::func;
 	return execfunc(this);
 }
 
-namespace _func320
+namespace _func321
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -4468,11 +4482,11 @@ namespace _func320
 std::vector<CrewMember*> CompleteShip::TeleportCrew(int roomId, bool intruders)
 {
 	typedef std::vector<CrewMember*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, int roomId_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func320::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func321::func;
 	return execfunc(this, roomId, intruders);
 }
 
-namespace _func321
+namespace _func322
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4482,11 +4496,11 @@ namespace _func321
 void CompleteShip::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func321::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func322::func;
 	return execfunc(this);
 }
 
-namespace _func322
+namespace _func323
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4496,11 +4510,11 @@ namespace _func322
 void CompleteShip::OnRenderSpace()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func322::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func323::func;
 	return execfunc(this);
 }
 
-namespace _func323
+namespace _func324
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -4510,11 +4524,11 @@ namespace _func323
 void CompleteShip::OnRenderShip(bool unk1, bool unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CompleteShip *this_arg, bool unk1_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func323::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func324::func;
 	return execfunc(this, unk1, unk2);
 }
 
-namespace _func324
+namespace _func325
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -4524,11 +4538,11 @@ namespace _func324
 void ConfirmWindow::SetText(const TextString &text_, int minWidth, bool autoCenter, const TextString &yesText_, const TextString &noText_)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, const TextString &text__arg, int minWidth_arg, bool autoCenter_arg, const TextString &yesText__arg, const TextString &noText__arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func324::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func325::func;
 	return execfunc(this, text_, minWidth, autoCenter, yesText_, noText_);
 }
 
-namespace _func325
+namespace _func326
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4538,11 +4552,11 @@ namespace _func325
 void ConfirmWindow::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func325::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func326::func;
 	return execfunc(this);
 }
 
-namespace _func326
+namespace _func327
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -4552,11 +4566,11 @@ namespace _func326
 void ConfirmWindow::SetPosition(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func326::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func327::func;
 	return execfunc(this, pos);
 }
 
-namespace _func327
+namespace _func328
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4566,11 +4580,11 @@ namespace _func327
 void ConfirmWindow::Open()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func327::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func328::func;
 	return execfunc(this);
 }
 
-namespace _func328
+namespace _func329
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -4580,11 +4594,11 @@ namespace _func328
 void ConfirmWindow::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func328::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func329::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func329
+namespace _func330
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -4594,11 +4608,11 @@ namespace _func329
 void ConfirmWindow::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func329::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func330::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func330
+namespace _func331
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4606,20 +4620,6 @@ namespace _func330
 }
 
 void ConfirmWindow::constructor()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func330::func;
-	return execfunc(this);
-}
-
-namespace _func331
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ConfirmWindow::Close", typeid(void (ConfirmWindow::*)()), "5589e55389cb83e4f083ec108b8184000000890424e8????????c783840000000000000089d9e8????????8b5dfc", argdata, 1, 5, &func);
-}
-
-void ConfirmWindow::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func331::func;
@@ -4630,12 +4630,12 @@ namespace _func332
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ControlButton::OnRender", typeid(void (ControlButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cb81ec????????8b415c83f8010f84????????f30f102d????????83f802f30f1035????????f30f103d????????f30f116da0f30f1175a4", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ConfirmWindow::Close", typeid(void (ConfirmWindow::*)()), "5589e55389cb83e4f083ec108b8184000000890424e8????????c783840000000000000089d9e8????????8b5dfc", argdata, 1, 5, &func);
 }
 
-void ControlButton::OnRender()
+void ConfirmWindow::Close()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ControlButton *this_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ConfirmWindow *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func332::func;
 	return execfunc(this);
 }
@@ -4644,12 +4644,12 @@ namespace _func333
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ControlsScreen::OnInit", typeid(void (ControlsScreen::*)()), "578d7c240883e4f0ff77fc5589e557565381ec????????8b8144050000898d74feffff85c00f84????????8d8570ffffffbf????????8d8d4cffffff6689bd7cffffff", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ControlButton::OnRender", typeid(void (ControlButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cb81ec????????8b415c83f8010f84????????f30f102d????????83f802f30f1035????????f30f103d????????f30f116da0f30f1175a4", argdata, 1, 5, &func);
 }
 
-void ControlsScreen::OnInit()
+void ControlButton::OnRender()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ControlButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func333::func;
 	return execfunc(this);
 }
@@ -4658,10 +4658,10 @@ namespace _func334
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ControlsScreen::OnLoop", typeid(void (ControlsScreen::*)()), "578d7c240883e4f0ff77fc5589e55756538d45a889ce83ec7c8b79108b59148945a089f801d874??85ff", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ControlsScreen::OnInit", typeid(void (ControlsScreen::*)()), "578d7c240883e4f0ff77fc5589e557565381ec????????8b8144050000898d74feffff85c00f84????????8d8570ffffffbf????????8d8d4cffffff6689bd7cffffff", argdata, 1, 5, &func);
 }
 
-void ControlsScreen::OnLoop()
+void ControlsScreen::OnInit()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func334::func;
@@ -4672,10 +4672,10 @@ namespace _func335
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ControlsScreen::OnRender", typeid(void (ControlsScreen::*)()), "578d7c240883e4f0ff77fc5589e557565389cf81ec????????80b928010000000f85????????8d8520ffffff8d8d18ffffffc744240400000000c78500ffffff1d000000898518ffffff8d8500ffffff890424e8????????8b9500ffffff", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ControlsScreen::OnLoop", typeid(void (ControlsScreen::*)()), "578d7c240883e4f0ff77fc5589e55756538d45a889ce83ec7c8b79108b59148945a089f801d874??85ff", argdata, 1, 5, &func);
 }
 
-void ControlsScreen::OnRender()
+void ControlsScreen::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func335::func;
@@ -4685,6 +4685,20 @@ void ControlsScreen::OnRender()
 namespace _func336
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ControlsScreen::OnRender", typeid(void (ControlsScreen::*)()), "578d7c240883e4f0ff77fc5589e557565389cf81ec????????80b928010000000f85????????8d8520ffffff8d8d18ffffffc744240400000000c78500ffffff1d000000898518ffffff8d8500ffffff890424e8????????8b9500ffffff", argdata, 1, 5, &func);
+}
+
+void ControlsScreen::OnRender()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ControlsScreen *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func336::func;
+	return execfunc(this);
+}
+
+namespace _func337
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CooldownSystemBox::constructor", typeid(void (CooldownSystemBox::*)(Point , ShipSystem *, bool )), "578d7c240883e4f0ff77fc5589e557565381ec????????8b1f8b77048b47088b7f0cc744240c01000000898db0fdffff891c248974240483c324", argdata, 4, 5, &func);
 }
@@ -4692,11 +4706,11 @@ namespace _func336
 void CooldownSystemBox::constructor(Point pos, ShipSystem *sys, bool roundDown)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CooldownSystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, bool roundDown_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func336::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func337::func;
 	return execfunc(this, pos, sys, roundDown);
 }
 
-namespace _func337
+namespace _func338
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4706,11 +4720,11 @@ namespace _func337
 void CooldownSystemBox::OnRender(bool ignoreStatus)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CooldownSystemBox *this_arg, bool ignoreStatus_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func337::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func338::func;
 	return execfunc(this, ignoreStatus);
 }
 
-namespace _func338
+namespace _func339
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4720,11 +4734,11 @@ namespace _func338
 void CreditScreen::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CreditScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func338::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func339::func;
 	return execfunc(this);
 }
 
-namespace _func339
+namespace _func340
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4734,11 +4748,11 @@ namespace _func339
 void CreditScreen::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CreditScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func339::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func340::func;
 	return execfunc(this);
 }
 
-namespace _func340
+namespace _func341
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -4748,11 +4762,11 @@ namespace _func340
 void CreditScreen::Start(const std::string &shipName, const std::vector<std::string> &crewNames)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CreditScreen *this_arg, const std::string &shipName_arg, const std::vector<std::string> &crewNames_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func340::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func341::func;
 	return execfunc(this, shipName, crewNames);
 }
 
-namespace _func341
+namespace _func342
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4762,11 +4776,11 @@ namespace _func341
 bool CreditScreen::Done()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CreditScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func341::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func342::func;
 	return execfunc(this);
 }
 
-namespace _func342
+namespace _func343
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4776,11 +4790,11 @@ namespace _func342
 void CrewAI::UpdateDrones()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func342::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func343::func;
 	return execfunc(this);
 }
 
-namespace _func343
+namespace _func344
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4790,11 +4804,11 @@ namespace _func343
 void CrewAI::AssignCrewmembers()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func343::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func344::func;
 	return execfunc(this);
 }
 
-namespace _func344
+namespace _func345
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x3ff, 0x1ff};
@@ -4804,11 +4818,11 @@ namespace _func344
 int CrewAI::PrioritizeTask(CrewTask task, int crewId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg, CrewTask task_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func344::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func345::func;
 	return execfunc(this, task, crewId);
 }
 
-namespace _func345
+namespace _func346
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4818,11 +4832,11 @@ namespace _func345
 void CrewAI::UpdateIntruders()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func345::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func346::func;
 	return execfunc(this);
 }
 
-namespace _func346
+namespace _func347
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -4832,11 +4846,11 @@ namespace _func346
 int CrewAI::PrioritizeIntruderRoom(CrewMember *crew, int roomId, int target)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg, CrewMember *crew_arg, int roomId_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func346::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func347::func;
 	return execfunc(this, crew, roomId, target);
 }
 
-namespace _func347
+namespace _func348
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4846,11 +4860,11 @@ namespace _func347
 void CrewAI::UpdateCrewMember(int crewId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func347::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func348::func;
 	return execfunc(this, crewId);
 }
 
-namespace _func348
+namespace _func349
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4858,20 +4872,6 @@ namespace _func348
 }
 
 void CrewAI::CheckForHealing()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func348::func;
-	return execfunc(this);
-}
-
-namespace _func349
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewAI::OnLoop", typeid(void (CrewAI::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec6c8b018d4dd0890424e8????????8b55d08b460c", argdata, 1, 5, &func);
-}
-
-void CrewAI::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func349::func;
@@ -4882,10 +4882,10 @@ namespace _func350
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewAI::CheckForProblems", typeid(void (CrewAI::*)()), "578d7c240883e4f0ff77fc5589e557565389cf83ec7c8b01c64108018b4004890424", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewAI::OnLoop", typeid(void (CrewAI::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec6c8b018d4dd0890424e8????????8b55d08b460c", argdata, 1, 5, &func);
 }
 
-void CrewAI::CheckForProblems()
+void CrewAI::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func350::func;
@@ -4895,6 +4895,20 @@ void CrewAI::CheckForProblems()
 namespace _func351
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewAI::CheckForProblems", typeid(void (CrewAI::*)()), "578d7c240883e4f0ff77fc5589e557565389cf83ec7c8b01c64108018b4004890424", argdata, 1, 5, &func);
+}
+
+void CrewAI::CheckForProblems()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func351::func;
+	return execfunc(this);
+}
+
+namespace _func352
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("CrewAI::DangerRating", typeid(int (CrewAI::*)(int , int )), "578d7c240883e4f0ff77fc5589e557565389ce83ec5c8b47048b1f89c18945a88b460c8b0488f30f105028", argdata, 3, 1, &func);
 }
@@ -4902,11 +4916,11 @@ namespace _func351
 int CrewAI::DangerRating(int roomId, int crewId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAI *this_arg, int roomId_arg, int crewId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func351::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func352::func;
 	return execfunc(this, roomId, crewId);
 }
 
-namespace _func352
+namespace _func353
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -4916,11 +4930,11 @@ namespace _func352
 void CrewAnimation::constructor(int shipId, const std::string &race, Pointf unk, bool hostile)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, int shipId_arg, const std::string &race_arg, Pointf unk_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func352::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func353::func;
 	return execfunc(this, shipId, race, unk, hostile);
 }
 
-namespace _func353
+namespace _func354
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4930,11 +4944,11 @@ namespace _func353
 std::string CrewAnimation::GetDeathSound()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func353::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func354::func;
 	return execfunc(this);
 }
 
-namespace _func354
+namespace _func355
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -4944,11 +4958,11 @@ namespace _func354
 std::string CrewAnimation::GetShootingSound()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func354::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func355::func;
 	return execfunc(this);
 }
 
-namespace _func355
+namespace _func356
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -4958,11 +4972,11 @@ namespace _func355
 void CrewAnimation::OnRender(float scale, int selectedState, bool outlineOnly)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, float scale_arg, int selectedState_arg, bool outlineOnly_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func355::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func356::func;
 	return execfunc(this, scale, selectedState, outlineOnly);
 }
 
-namespace _func356
+namespace _func357
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -4972,11 +4986,11 @@ namespace _func356
 void CrewAnimation::OnRenderProps()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func356::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func357::func;
 	return execfunc(this);
 }
 
-namespace _func357
+namespace _func358
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x1ff};
@@ -4986,11 +5000,11 @@ namespace _func357
 void CrewAnimation::OnInit(const std::string &name, Pointf position, bool enemy)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, const std::string &name_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func357::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func358::func;
 	return execfunc(this, name, position, enemy);
 }
 
-namespace _func358
+namespace _func359
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5000,11 +5014,11 @@ namespace _func358
 void CrewAnimation::SetupStrips()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func358::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func359::func;
 	return execfunc(this);
 }
 
-namespace _func359
+namespace _func360
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5014,11 +5028,11 @@ namespace _func359
 void CrewAnimation::OnUpdate(Pointf position, bool moving, bool fighting, bool repairing, bool dying, bool onFire)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, Pointf position_arg, bool moving_arg, bool fighting_arg, bool repairing_arg, bool dying_arg, bool onFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func359::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func360::func;
 	return execfunc(this, position, moving, fighting, repairing, dying, onFire);
 }
 
-namespace _func360
+namespace _func361
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5028,11 +5042,11 @@ namespace _func360
 void CrewAnimation::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func360::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func361::func;
 	return execfunc(this);
 }
 
-namespace _func361
+namespace _func362
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5042,11 +5056,11 @@ namespace _func361
 bool CrewAnimation::FireShot()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func361::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func362::func;
 	return execfunc(this);
 }
 
-namespace _func362
+namespace _func363
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5056,11 +5070,11 @@ namespace _func362
 int CrewAnimation::GetFiringFrame()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func362::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func363::func;
 	return execfunc(this);
 }
 
-namespace _func363
+namespace _func364
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5070,11 +5084,11 @@ namespace _func363
 void CrewAnimation::RenderIcon(bool border)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg, bool border_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func363::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func364::func;
 	return execfunc(this, border);
 }
 
-namespace _func364
+namespace _func365
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5084,11 +5098,11 @@ namespace _func364
 void CrewAnimation::OnUpdateEffects()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func364::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func365::func;
 	return execfunc(this);
 }
 
-namespace _func365
+namespace _func366
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5098,11 +5112,11 @@ namespace _func365
 void CrewBlueprint::RandomSkills(int worldLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func365::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func366::func;
 	return execfunc(this, worldLevel);
 }
 
-namespace _func366
+namespace _func367
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5112,11 +5126,11 @@ namespace _func366
 void CrewBlueprint::RenderSkill(int x, int y, int length, int height, int skill)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int x_arg, int y_arg, int length_arg, int height_arg, int skill_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func366::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func367::func;
 	return execfunc(this, x, y, length, height, skill);
 }
 
-namespace _func367
+namespace _func368
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5126,11 +5140,11 @@ namespace _func367
 void CrewBlueprint::RenderIcon(float opacity)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, float opacity_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func367::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func368::func;
 	return execfunc(this, opacity);
 }
 
-namespace _func368
+namespace _func369
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5140,11 +5154,11 @@ namespace _func368
 void CrewBlueprint::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func368::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func369::func;
 	return execfunc(this);
 }
 
-namespace _func369
+namespace _func370
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5154,11 +5168,11 @@ namespace _func369
 std::string CrewBlueprint::GetNameShort()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func369::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func370::func;
 	return execfunc(this);
 }
 
-namespace _func370
+namespace _func371
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -5168,11 +5182,11 @@ namespace _func370
 GL_Color CrewBlueprint::GetCurrentSkillColor(int skill)
 {
 	typedef GL_Color __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBlueprint *this_arg, int skill_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func370::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func371::func;
 	return execfunc(this, skill);
 }
 
-namespace _func371
+namespace _func372
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -5182,11 +5196,11 @@ namespace _func371
 void CrewBox::constructor(Point pos, CrewMember *crew, int number)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg, Point pos_arg, CrewMember *crew_arg, int number_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func371::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func372::func;
 	return execfunc(this, pos, crew, number);
 }
 
-namespace _func372
+namespace _func373
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5196,11 +5210,11 @@ namespace _func372
 void CrewBox::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func372::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func373::func;
 	return execfunc(this);
 }
 
-namespace _func373
+namespace _func374
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -5210,11 +5224,11 @@ namespace _func373
 CrewMember *CrewBox::GetSelected(int mouseX, int mouseY)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg, int mouseX_arg, int mouseY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func373::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func374::func;
 	return execfunc(this, mouseX, mouseY);
 }
 
-namespace _func374
+namespace _func375
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5224,11 +5238,11 @@ namespace _func374
 void CrewBox::OnLoop(bool selected)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg, bool selected_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func374::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func375::func;
 	return execfunc(this, selected);
 }
 
-namespace _func375
+namespace _func376
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5236,20 +5250,6 @@ namespace _func375
 }
 
 void CrewBox::OnRenderSkillLevel()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func375::func;
-	return execfunc(this);
-}
-
-namespace _func376
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewBox::destructor", typeid(void (CrewBox::*)()), "5589e557565389ce83e4f083ec208b813c010000894c2418890424e8????????8b8640010000890424e8????????8b8644010000890424e8????????8b8648010000890424", argdata, 1, 5, &func);
-}
-
-void CrewBox::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func376::func;
@@ -5260,12 +5260,12 @@ namespace _func377
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewBox::MouseClick", typeid(bool (CrewBox::*)()), "5589e5530fb6596883e4f084db74130fb6596984db740b8b49208b01ff90c400000089d88b5dfcc9", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("CrewBox::destructor", typeid(void (CrewBox::*)()), "5589e557565389ce83e4f083ec208b813c010000894c2418890424e8????????8b8640010000890424e8????????8b8644010000890424e8????????8b8648010000890424", argdata, 1, 5, &func);
 }
 
-bool CrewBox::MouseClick()
+void CrewBox::destructor()
 {
-	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func377::func;
 	return execfunc(this);
 }
@@ -5274,12 +5274,12 @@ namespace _func378
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewBox::RenderIcon", typeid(void (CrewBox::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b49208b01ff90c80000003c0119f6", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewBox::MouseClick", typeid(bool (CrewBox::*)()), "5589e5530fb6596883e4f084db74130fb6596984db740b8b49208b01ff90c400000089d88b5dfcc9", argdata, 1, 1, &func);
 }
 
-void CrewBox::RenderIcon()
+bool CrewBox::MouseClick()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
+	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func378::func;
 	return execfunc(this);
 }
@@ -5288,10 +5288,10 @@ namespace _func379
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewBox::RenderLabels", typeid(void (CrewBox::*)()), "578d7c240883e4f0ff77fc5589e55756538d5dd089ce83ec6c8b412089d9890424", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewBox::RenderIcon", typeid(void (CrewBox::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b49208b01ff90c80000003c0119f6", argdata, 1, 5, &func);
 }
 
-void CrewBox::RenderLabels()
+void CrewBox::RenderIcon()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func379::func;
@@ -5302,10 +5302,10 @@ namespace _func380
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewBox::RenderCloneDying", typeid(void (CrewBox::*)()), "80b91c010000000f859b0000008b4120f30f1080f00600000f2e05????????0f868300000055660fefd2660fefc989e583e4f083ec308b4108", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewBox::RenderLabels", typeid(void (CrewBox::*)()), "578d7c240883e4f0ff77fc5589e55756538d5dd089ce83ec6c8b412089d9890424", argdata, 1, 5, &func);
 }
 
-void CrewBox::RenderCloneDying()
+void CrewBox::RenderLabels()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func380::func;
@@ -5316,12 +5316,12 @@ namespace _func381
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewControl::OnRender", typeid(void (CrewControl::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec7c8b793c8b414029f8c1f80285c0", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewBox::RenderCloneDying", typeid(void (CrewBox::*)()), "80b91c010000000f859b0000008b4120f30f1080f00600000f2e05????????0f868300000055660fefd2660fefc989e583e4f083ec308b4108", argdata, 1, 5, &func);
 }
 
-void CrewControl::OnRender()
+void CrewBox::RenderCloneDying()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func381::func;
 	return execfunc(this);
 }
@@ -5330,10 +5330,10 @@ namespace _func382
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewControl::OnLoop", typeid(void (CrewControl::*)()), "578d7c240883e4f0ff77fc5589e557568db18c0000005389cb83ec6c89f1e8????????80bb9e000000000f85????????89d9", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewControl::OnRender", typeid(void (CrewControl::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec7c8b793c8b414029f8c1f80285c0", argdata, 1, 5, &func);
 }
 
-void CrewControl::OnLoop()
+void CrewControl::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func382::func;
@@ -5344,10 +5344,10 @@ namespace _func383
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewControl::UpdateCrewBoxes", typeid(void (CrewControl::*)()), "578d7c240883e4f0ff77fc5589e55756538d45dc89cbb9????????83ec5cc745dc00000000c745e000000000890424c744240400000000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewControl::OnLoop", typeid(void (CrewControl::*)()), "578d7c240883e4f0ff77fc5589e557568db18c0000005389cb83ec6c89f1e8????????80bb9e000000000f85????????89d9", argdata, 1, 5, &func);
 }
 
-void CrewControl::UpdateCrewBoxes()
+void CrewControl::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func383::func;
@@ -5357,6 +5357,20 @@ void CrewControl::UpdateCrewBoxes()
 namespace _func384
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewControl::UpdateCrewBoxes", typeid(void (CrewControl::*)()), "578d7c240883e4f0ff77fc5589e55756538d45dc89cbb9????????83ec5cc745dc00000000c745e000000000890424c744240400000000", argdata, 1, 5, &func);
+}
+
+void CrewControl::UpdateCrewBoxes()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func384::func;
+	return execfunc(this);
+}
+
+namespace _func385
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("CrewControl::LinkShip", typeid(void (CrewControl::*)(ShipManager *)), "5589e55389cb8b450883e4f08901e8????????c7432000000000c7431c000000008b5dfc", argdata, 2, 5, &func);
 }
@@ -5364,11 +5378,11 @@ namespace _func384
 void CrewControl::LinkShip(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func384::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func385::func;
 	return execfunc(this, ship);
 }
 
-namespace _func385
+namespace _func386
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5378,11 +5392,11 @@ namespace _func385
 void CrewControl::MouseMove(int mX, int mY, int wX, int wY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, int wX_arg, int wY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func385::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func386::func;
 	return execfunc(this, mX, mY, wX, wY);
 }
 
-namespace _func386
+namespace _func387
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5392,11 +5406,11 @@ namespace _func386
 void CrewControl::LButton(int mX, int mY, int wX, int wY, bool shiftHeld)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, int wX_arg, int wY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func386::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func387::func;
 	return execfunc(this, mX, mY, wX, wY, shiftHeld);
 }
 
-namespace _func387
+namespace _func388
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5406,11 +5420,11 @@ namespace _func387
 void CrewControl::ClearDeadCrew(std::vector<CrewMember*> *crew)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg, std::vector<CrewMember*> *crew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func387::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func388::func;
 	return execfunc(this, crew);
 }
 
-namespace _func388
+namespace _func389
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5420,11 +5434,11 @@ namespace _func388
 void CrewControl::ClearCrewBoxes()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func388::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func389::func;
 	return execfunc(this);
 }
 
-namespace _func389
+namespace _func390
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -5434,11 +5448,11 @@ namespace _func389
 void CrewControl::SelectPotentialCrew(CrewMember *crew, bool allowTeleportLeaving)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg, CrewMember *crew_arg, bool allowTeleportLeaving_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func389::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func390::func;
 	return execfunc(this, crew, allowTeleportLeaving);
 }
 
-namespace _func390
+namespace _func391
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5448,11 +5462,11 @@ namespace _func390
 void CrewControl::KeyDown(SDLKey key)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func390::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func391::func;
 	return execfunc(this, key);
 }
 
-namespace _func391
+namespace _func392
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -5462,11 +5476,11 @@ namespace _func391
 void CrewControl::RButton(int mX, int mY, bool shiftHeld)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg, int mX_arg, int mY_arg, bool shiftHeld_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func391::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func392::func;
 	return execfunc(this, mX, mY, shiftHeld);
 }
 
-namespace _func392
+namespace _func393
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5476,11 +5490,11 @@ namespace _func392
 void CrewControl::SelectCrew(bool keep_current)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewControl *this_arg, bool keep_current_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func392::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func393::func;
 	return execfunc(this, keep_current);
 }
 
-namespace _func393
+namespace _func394
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5490,11 +5504,11 @@ namespace _func393
 void CrewCustomizeBox::CheckContents()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewCustomizeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func393::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func394::func;
 	return execfunc(this);
 }
 
-namespace _func394
+namespace _func395
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -5504,11 +5518,11 @@ namespace _func394
 void CrewCustomizeBox::constructor(Point location, ShipManager *shipManager, int slot)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewCustomizeBox *this_arg, Point location_arg, ShipManager *shipManager_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func394::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func395::func;
 	return execfunc(this, location, shipManager, slot);
 }
 
-namespace _func395
+namespace _func396
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5518,11 +5532,11 @@ namespace _func395
 void CrewDrone::constructor(const std::string &type, const std::string &name, int shipId, const DroneBlueprint *blueprint, CrewAnimation *anim)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewDrone *this_arg, const std::string &type_arg, const std::string &name_arg, int shipId_arg, const DroneBlueprint *blueprint_arg, CrewAnimation *anim_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func395::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func396::func;
 	return execfunc(this, type, name, shipId, blueprint, anim);
 }
 
-namespace _func396
+namespace _func397
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5532,11 +5546,11 @@ namespace _func396
 void CrewDrone::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func396::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func397::func;
 	return execfunc(this);
 }
 
-namespace _func397
+namespace _func398
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5546,11 +5560,11 @@ namespace _func397
 bool CrewDrone::ProvidesVision()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func397::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func398::func;
 	return execfunc(this);
 }
 
-namespace _func398
+namespace _func399
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5560,11 +5574,11 @@ namespace _func398
 void CrewDrone::SetCurrentShip(int shipId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewDrone *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func398::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func399::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func399
+namespace _func400
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5574,11 +5588,11 @@ namespace _func399
 void CrewDrone::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func399::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func400::func;
 	return execfunc(this);
 }
 
-namespace _func400
+namespace _func401
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5588,11 +5602,11 @@ namespace _func400
 void CrewEquipBox::RemoveItem()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func400::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func401::func;
 	return execfunc(this);
 }
 
-namespace _func401
+namespace _func402
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -5602,11 +5616,11 @@ namespace _func401
 void CrewEquipBox::constructor(Point pos, ShipManager *ship, int slot)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, Point pos_arg, ShipManager *ship_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func401::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func402::func;
 	return execfunc(this, pos, ship, slot);
 }
 
-namespace _func402
+namespace _func403
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5616,11 +5630,11 @@ namespace _func402
 bool CrewEquipBox::GetConfirmDelete()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func402::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func403::func;
 	return execfunc(this);
 }
 
-namespace _func403
+namespace _func404
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -5630,11 +5644,11 @@ namespace _func403
 void CrewEquipBox::RenderLabels(bool dragging, bool isNew)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, bool dragging_arg, bool isNew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func403::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func404::func;
 	return execfunc(this, dragging, isNew);
 }
 
-namespace _func404
+namespace _func405
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5644,11 +5658,11 @@ namespace _func404
 void CrewEquipBox::OnRender(bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func404::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func405::func;
 	return execfunc(this, unk);
 }
 
-namespace _func405
+namespace _func406
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5658,11 +5672,11 @@ namespace _func405
 void CrewEquipBox::OnTextInput(SDLKey key)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func405::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func406::func;
 	return execfunc(this, key);
 }
 
-namespace _func406
+namespace _func407
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5672,11 +5686,11 @@ namespace _func406
 void CrewEquipBox::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func406::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func407::func;
 	return execfunc(this, event);
 }
 
-namespace _func407
+namespace _func408
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5686,11 +5700,11 @@ namespace _func407
 void CrewEquipBox::MouseClick()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func407::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func408::func;
 	return execfunc(this);
 }
 
-namespace _func408
+namespace _func409
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5700,11 +5714,11 @@ namespace _func408
 void CrewEquipBox::CloseRename()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewEquipBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func408::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func409::func;
 	return execfunc(this);
 }
 
-namespace _func409
+namespace _func410
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5714,11 +5728,11 @@ namespace _func409
 void CrewManifest::OnInit(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func409::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func410::func;
 	return execfunc(this, ship);
 }
 
-namespace _func410
+namespace _func411
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5726,20 +5740,6 @@ namespace _func410
 }
 
 void CrewManifest::OnRender()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func410::func;
-	return execfunc(this);
-}
-
-namespace _func411
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewManifest::constructor", typeid(void (CrewManifest::*)()), "578d7c240883e4f0ff77fc5589e557565389cb8d7d948d75d481ec????????e8????????8d4320c703????????89c1898554ffffff", argdata, 1, 5, &func);
-}
-
-void CrewManifest::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func411::func;
@@ -5750,10 +5750,10 @@ namespace _func412
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewManifest::Update", typeid(void (CrewManifest::*)()), "578d7c240883e4f0ff77fc5589e55756538d45cc89ceb9????????83ec3cc745cc00000000c745d000000000890424c744240800000000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewManifest::constructor", typeid(void (CrewManifest::*)()), "578d7c240883e4f0ff77fc5589e557565389cb8d7d948d75d481ec????????e8????????8d4320c703????????89c1898554ffffff", argdata, 1, 5, &func);
 }
 
-void CrewManifest::Update()
+void CrewManifest::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func412::func;
@@ -5763,25 +5763,25 @@ void CrewManifest::Update()
 namespace _func413
 {
     static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("CrewManifest::OnKeyDown", typeid(void (CrewManifest::*)(SDLKey )), "578d7c240883e4f0ff77fc5589e557565383ec1c8b91d40000008b81d80000008b3729d0c1f80285c074??89cf31db", argdata, 2, 5, &func);
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewManifest::Update", typeid(void (CrewManifest::*)()), "578d7c240883e4f0ff77fc5589e55756538d45cc89ceb9????????83ec3cc745cc00000000c745d000000000890424c744240800000000", argdata, 1, 5, &func);
 }
 
-void CrewManifest::OnKeyDown(SDLKey key)
+void CrewManifest::Update()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func413::func;
-	return execfunc(this, key);
+	return execfunc(this);
 }
 
 namespace _func414
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("CrewManifest::OnKeyUp", typeid(void (CrewManifest::*)(SDLKey )), ".578d7c240883e4f0ff77fc5589e557565383ec1c8b91d40000008b81d80000008b3729d0c1f80285c074??", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("CrewManifest::OnKeyDown", typeid(void (CrewManifest::*)(SDLKey )), "578d7c240883e4f0ff77fc5589e557565383ec1c8b91d40000008b81d80000008b3729d0c1f80285c074??89cf31db", argdata, 2, 5, &func);
 }
 
-void CrewManifest::OnKeyUp(SDLKey key)
+void CrewManifest::OnKeyDown(SDLKey key)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func414::func;
@@ -5792,10 +5792,10 @@ namespace _func415
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("CrewManifest::OnTextInput", typeid(void (CrewManifest::*)(SDLKey )), ".578d7c240883e4f0ff77fc5589e557565383ec1c8b91d40000008b81d80000008b3729d0c1f80285c074??89cf31db", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("CrewManifest::OnKeyUp", typeid(void (CrewManifest::*)(SDLKey )), ".578d7c240883e4f0ff77fc5589e557565383ec1c8b91d40000008b81d80000008b3729d0c1f80285c074??", argdata, 2, 5, &func);
 }
 
-void CrewManifest::OnTextInput(SDLKey key)
+void CrewManifest::OnKeyUp(SDLKey key)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func415::func;
@@ -5806,17 +5806,31 @@ namespace _func416
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("CrewManifest::OnTextInput", typeid(void (CrewManifest::*)(SDLKey )), ".578d7c240883e4f0ff77fc5589e557565383ec1c8b91d40000008b81d80000008b3729d0c1f80285c074??89cf31db", argdata, 2, 5, &func);
+}
+
+void CrewManifest::OnTextInput(SDLKey key)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, SDLKey key_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func416::func;
+	return execfunc(this, key);
+}
+
+namespace _func417
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("CrewManifest::OnTextEvent", typeid(void (CrewManifest::*)(CEvent::TextEvent )), ".578d7c240883e4f0ff77fc5589e557565383ec1c8b91d40000008b81d80000008b3729d0c1f80285c074??89cf31db", argdata, 2, 5, &func);
 }
 
 void CrewManifest::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func416::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func417::func;
 	return execfunc(this, event);
 }
 
-namespace _func417
+namespace _func418
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5826,11 +5840,11 @@ namespace _func417
 void CrewManifest::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func417::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func418::func;
 	return execfunc(this);
 }
 
-namespace _func418
+namespace _func419
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -5840,11 +5854,11 @@ namespace _func418
 void CrewManifest::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func418::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func419::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func419
+namespace _func420
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -5854,11 +5868,11 @@ namespace _func419
 void CrewManifest::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func419::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func420::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func420
+namespace _func421
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5868,20 +5882,6 @@ namespace _func420
 void CrewManifest::Open()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewManifest *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func420::func;
-	return execfunc(this);
-}
-
-namespace _func421
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::CanSabotage", typeid(bool (CrewMember::*)()), ".0fb68198000000", argdata, 1, 1, &func);
-}
-
-bool CrewMember::CanSabotage()
-{
-	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func421::func;
 	return execfunc(this);
 }
@@ -5890,10 +5890,10 @@ namespace _func422
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::CanRepair", typeid(bool (CrewMember::*)()), "80b9980000000074??31c0c38d7426008b015589e55389cb8b8088000000", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("CrewMember::CanSabotage", typeid(bool (CrewMember::*)()), ".0fb68198000000", argdata, 1, 1, &func);
 }
 
-bool CrewMember::CanRepair()
+bool CrewMember::CanSabotage()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func422::func;
@@ -5904,10 +5904,10 @@ namespace _func423
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::CanMan", typeid(bool (CrewMember::*)()), "0fb6819800000084c075??f30f1081080700000f2e05????????76??f3c3", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("CrewMember::CanRepair", typeid(bool (CrewMember::*)()), "80b9980000000074??31c0c38d7426008b015589e55389cb8b8088000000", argdata, 1, 1, &func);
 }
 
-bool CrewMember::CanMan()
+bool CrewMember::CanRepair()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func423::func;
@@ -5918,10 +5918,10 @@ namespace _func424
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::CanHeal", typeid(bool (CrewMember::*)()), "f30f1041280f2e412c7a??75??5589e55389cb83e4f080796c0075??8b8300020000", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("CrewMember::CanMan", typeid(bool (CrewMember::*)()), "0fb6819800000084c075??f30f1081080700000f2e05????????76??f3c3", argdata, 1, 1, &func);
 }
 
-bool CrewMember::CanHeal()
+bool CrewMember::CanMan()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func424::func;
@@ -5931,6 +5931,20 @@ bool CrewMember::CanHeal()
 namespace _func425
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewMember::CanHeal", typeid(bool (CrewMember::*)()), "f30f1041280f2e412c7a??75??5589e55389cb83e4f080796c0075??8b8300020000", argdata, 1, 1, &func);
+}
+
+bool CrewMember::CanHeal()
+{
+	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func425::func;
+	return execfunc(this);
+}
+
+namespace _func426
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("CrewMember::OnRender", typeid(void (CrewMember::*)(bool )), ".578d7c240883e4f0ff77fc5589e5575383ec3080b9fc010000008b3f74??8d65f85b5f5d8d67f8", argdata, 2, 5, &func);
 }
@@ -5938,11 +5952,11 @@ namespace _func425
 void CrewMember::OnRender(bool outlineOnly)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool outlineOnly_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func425::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func426::func;
 	return execfunc(this, outlineOnly);
 }
 
-namespace _func426
+namespace _func427
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -5952,11 +5966,11 @@ namespace _func426
 Damage CrewMember::GetRoomDamage()
 {
 	typedef Damage __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func426::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func427::func;
 	return execfunc(this);
 }
 
-namespace _func427
+namespace _func428
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -5966,11 +5980,11 @@ namespace _func427
 void CrewMember::constructor(CrewBlueprint &blueprint, int shipId, bool intruder, CrewAnimation *animation)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewBlueprint &blueprint_arg, int shipId_arg, bool intruder_arg, CrewAnimation *animation_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func427::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func428::func;
 	return execfunc(this, blueprint, shipId, intruder, animation);
 }
 
-namespace _func428
+namespace _func429
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5980,11 +5994,11 @@ namespace _func428
 void CrewMember::Jump()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func428::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func429::func;
 	return execfunc(this);
 }
 
-namespace _func429
+namespace _func430
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -5994,11 +6008,11 @@ namespace _func429
 bool CrewMember::GetIntruder()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func429::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func430::func;
 	return execfunc(this);
 }
 
-namespace _func430
+namespace _func431
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6008,11 +6022,11 @@ namespace _func430
 void CrewMember::SetOutOfGame()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func430::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func431::func;
 	return execfunc(this);
 }
 
-namespace _func431
+namespace _func432
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6022,11 +6036,11 @@ namespace _func431
 float CrewMember::PositionShift()
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func431::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func432::func;
 	return execfunc(this);
 }
 
-namespace _func432
+namespace _func433
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6036,11 +6050,11 @@ namespace _func432
 void CrewMember::SaveState(int fileHelper)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func432::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func433::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func433
+namespace _func434
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6050,11 +6064,11 @@ namespace _func433
 bool CrewMember::CanTeleport()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func433::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func434::func;
 	return execfunc(this);
 }
 
-namespace _func434
+namespace _func435
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6064,11 +6078,11 @@ namespace _func434
 void CrewMember::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func434::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func435::func;
 	return execfunc(this);
 }
 
-namespace _func435
+namespace _func436
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6078,11 +6092,11 @@ namespace _func435
 void CrewMember::Cleanup()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func435::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func436::func;
 	return execfunc(this);
 }
 
-namespace _func436
+namespace _func437
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6092,11 +6106,11 @@ namespace _func436
 void CrewMember::LoadState(int fileHelper)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func436::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func437::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func437
+namespace _func438
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6106,11 +6120,11 @@ namespace _func437
 void CrewMember::SetCurrentSystem(ShipSystem *sys)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, ShipSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func437::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func438::func;
 	return execfunc(this, sys);
 }
 
-namespace _func438
+namespace _func439
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6120,11 +6134,11 @@ namespace _func438
 bool CrewMember::IsManningArtillery()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func438::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func439::func;
 	return execfunc(this);
 }
 
-namespace _func439
+namespace _func440
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6134,11 +6148,11 @@ namespace _func439
 void CrewMember::IncreaseSkill(int skillId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func439::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func440::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func440
+namespace _func441
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6148,11 +6162,11 @@ namespace _func440
 void CrewMember::CheckSkills()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func440::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func441::func;
 	return execfunc(this);
 }
 
-namespace _func441
+namespace _func442
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6162,11 +6176,11 @@ namespace _func441
 void CrewMember::MasterSkill(int skillId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func441::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func442::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func442
+namespace _func443
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -6176,11 +6190,11 @@ namespace _func442
 int CrewMember::GetSkillFromSystem(int systemId)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func442::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func443::func;
 	return execfunc(systemId);
 }
 
-namespace _func443
+namespace _func444
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6190,11 +6204,11 @@ namespace _func443
 void CrewMember::SetResisted(bool resisted)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool resisted_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func443::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func444::func;
 	return execfunc(this, resisted);
 }
 
-namespace _func444
+namespace _func445
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6204,11 +6218,11 @@ namespace _func444
 bool CrewMember::GetResisted()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func444::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func445::func;
 	return execfunc(this);
 }
 
-namespace _func445
+namespace _func446
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -6218,11 +6232,11 @@ namespace _func445
 void CrewMember::SetSkillProgress(int skillId, int skillLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg, int skillLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func445::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func446::func;
 	return execfunc(this, skillId, skillLevel);
 }
 
-namespace _func446
+namespace _func447
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6232,11 +6246,11 @@ namespace _func446
 int CrewMember::GetSkillLevel(int skillId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func446::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func447::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func447
+namespace _func448
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6246,11 +6260,11 @@ namespace _func447
 std::pair<int, int> CrewMember::GetSkillProgress(int skillId)
 {
 	typedef std::pair<int, int> __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func447::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func448::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func448
+namespace _func449
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6260,11 +6274,11 @@ namespace _func448
 float CrewMember::GetSkillModifier(int skillId)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int skillId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func448::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func449::func;
 	return execfunc(this, skillId);
 }
 
-namespace _func449
+namespace _func450
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6274,11 +6288,11 @@ namespace _func449
 bool CrewMember::BadAtCombat()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func449::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func450::func;
 	return execfunc(this);
 }
 
-namespace _func450
+namespace _func451
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6288,11 +6302,11 @@ namespace _func450
 void CrewMember::EmptySlot()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func450::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func451::func;
 	return execfunc(this);
 }
 
-namespace _func451
+namespace _func452
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6302,11 +6316,11 @@ namespace _func451
 bool CrewMember::NeedsSlot()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func451::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func452::func;
 	return execfunc(this);
 }
 
-namespace _func452
+namespace _func453
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6316,11 +6330,11 @@ namespace _func452
 bool CrewMember::DirectModifyHealth(float health)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func452::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func453::func;
 	return execfunc(this, health);
 }
 
-namespace _func453
+namespace _func454
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6330,11 +6344,11 @@ namespace _func453
 void CrewMember::ModifyHealth(float health)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func453::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func454::func;
 	return execfunc(this, health);
 }
 
-namespace _func454
+namespace _func455
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6344,11 +6358,11 @@ namespace _func454
 bool CrewMember::ApplyDamage(float damage)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func454::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func455::func;
 	return execfunc(this, damage);
 }
 
-namespace _func455
+namespace _func456
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6356,20 +6370,6 @@ namespace _func455
 }
 
 bool CrewMember::RepairingSystem()
-{
-	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func455::func;
-	return execfunc(this);
-}
-
-namespace _func456
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::Sabotaging", typeid(bool (CrewMember::*)()), ".8b416885c074??5589e5538b10", argdata, 1, 1, &func);
-}
-
-bool CrewMember::Sabotaging()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func456::func;
@@ -6380,10 +6380,10 @@ namespace _func457
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::RepairingFire", typeid(bool (CrewMember::*)()), ".8b516831c085d274??8b9100020000", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("CrewMember::Sabotaging", typeid(bool (CrewMember::*)()), ".8b416885c074??5589e5538b10", argdata, 1, 1, &func);
 }
 
-bool CrewMember::RepairingFire()
+bool CrewMember::Sabotaging()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func457::func;
@@ -6394,17 +6394,31 @@ namespace _func458
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewMember::RepairingFire", typeid(bool (CrewMember::*)()), ".8b516831c085d274??8b9100020000", argdata, 1, 1, &func);
+}
+
+bool CrewMember::RepairingFire()
+{
+	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func458::func;
+	return execfunc(this);
+}
+
+namespace _func459
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("CrewMember::SelectSabotageTarget", typeid(Pointf (CrewMember::*)()), ".578d7c240883e4f0ff77fc5589e5", argdata, 1, 9, &func);
 }
 
 Pointf CrewMember::SelectSabotageTarget()
 {
 	typedef Pointf __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func458::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func459::func;
 	return execfunc(this);
 }
 
-namespace _func459
+namespace _func460
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6414,11 +6428,11 @@ namespace _func459
 void CrewMember::SavePosition()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func459::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func460::func;
 	return execfunc(this);
 }
 
-namespace _func460
+namespace _func461
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6428,11 +6442,11 @@ namespace _func460
 void CrewMember::ClearPosition()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func460::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func461::func;
 	return execfunc(this);
 }
 
-namespace _func461
+namespace _func462
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6442,11 +6456,11 @@ namespace _func461
 Slot CrewMember::GetSavedPosition()
 {
 	typedef Slot __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func461::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func462::func;
 	return execfunc(this);
 }
 
-namespace _func462
+namespace _func463
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x4ff};
@@ -6456,11 +6470,11 @@ namespace _func462
 void CrewMember::SetSavePosition(Slot position)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Slot position_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func462::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func463::func;
 	return execfunc(this, position);
 }
 
-namespace _func463
+namespace _func464
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6470,11 +6484,11 @@ namespace _func463
 void CrewMember::StopRepairing()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func463::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func464::func;
 	return execfunc(this);
 }
 
-namespace _func464
+namespace _func465
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6484,11 +6498,11 @@ namespace _func464
 bool CrewMember::Repairing()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func464::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func465::func;
 	return execfunc(this);
 }
 
-namespace _func465
+namespace _func466
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6498,11 +6512,11 @@ namespace _func465
 void CrewMember::SetFrozen(bool frozen)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool frozen_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func465::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func466::func;
 	return execfunc(this, frozen);
 }
 
-namespace _func466
+namespace _func467
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6512,11 +6526,11 @@ namespace _func466
 void CrewMember::SetFrozenLocation(bool frozenLocation)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool frozenLocation_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func466::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func467::func;
 	return execfunc(this, frozenLocation);
 }
 
-namespace _func467
+namespace _func468
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x3ff};
@@ -6526,11 +6540,11 @@ namespace _func467
 void CrewMember::SetTask(CrewTask task)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewTask task_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func467::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func468::func;
 	return execfunc(this, task);
 }
 
-namespace _func468
+namespace _func469
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -6540,11 +6554,11 @@ namespace _func468
 Slot CrewMember::FindSlot(int roomId, int slotId, bool closeEnough)
 {
 	typedef Slot __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg, int slotId_arg, bool closeEnough_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func468::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func469::func;
 	return execfunc(this, roomId, slotId, closeEnough);
 }
 
-namespace _func469
+namespace _func470
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6554,11 +6568,11 @@ namespace _func469
 bool CrewMember::CheckRoomPath(int roomId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func469::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func470::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func470
+namespace _func471
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -6568,11 +6582,11 @@ namespace _func470
 void CrewMember::SetPosition(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func470::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func471::func;
 	return execfunc(this, pos);
 }
 
-namespace _func471
+namespace _func472
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6582,11 +6596,11 @@ namespace _func471
 void CrewMember::ClearTask()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func471::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func472::func;
 	return execfunc(this);
 }
 
-namespace _func472
+namespace _func473
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6596,11 +6610,11 @@ namespace _func472
 void CrewMember::ClearPath()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func472::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func473::func;
 	return execfunc(this);
 }
 
-namespace _func473
+namespace _func474
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6610,11 +6624,11 @@ namespace _func473
 void CrewMember::SetRoom(int roomId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func473::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func474::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func474
+namespace _func475
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6622,20 +6636,6 @@ namespace _func474
 }
 
 bool CrewMember::IsBusy()
-{
-	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func474::func;
-	return execfunc(this);
-}
-
-namespace _func475
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::OnInit", typeid(bool (CrewMember::*)()), ".c741201e000000c7416400000000b8????????", argdata, 1, 1, &func);
-}
-
-bool CrewMember::OnInit()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func475::func;
@@ -6646,12 +6646,12 @@ namespace _func476
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::GetFinalGoal", typeid(Point (CrewMember::*)()), ".f30f1005????????0f2e41547a??74??8b414c8b5150", argdata, 1, 9, &func);
+	static FunctionDefinition funcObj("CrewMember::OnInit", typeid(bool (CrewMember::*)()), ".c741201e000000c7416400000000b8????????", argdata, 1, 1, &func);
 }
 
-Point CrewMember::GetFinalGoal()
+bool CrewMember::OnInit()
 {
-	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func476::func;
 	return execfunc(this);
 }
@@ -6660,10 +6660,10 @@ namespace _func477
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::GetNextGoal", typeid(Point (CrewMember::*)()), ".578d7c240883e4f0ff77fc5589e55753", argdata, 1, 9, &func);
+	static FunctionDefinition funcObj("CrewMember::GetFinalGoal", typeid(Point (CrewMember::*)()), ".f30f1005????????0f2e41547a??74??8b414c8b5150", argdata, 1, 9, &func);
 }
 
-Point CrewMember::GetNextGoal()
+Point CrewMember::GetFinalGoal()
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func477::func;
@@ -6673,6 +6673,20 @@ Point CrewMember::GetNextGoal()
 namespace _func478
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewMember::GetNextGoal", typeid(Point (CrewMember::*)()), ".578d7c240883e4f0ff77fc5589e55753", argdata, 1, 9, &func);
+}
+
+Point CrewMember::GetNextGoal()
+{
+	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func478::func;
+	return execfunc(this);
+}
+
+namespace _func479
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("CrewMember::CloseDoorBehind", typeid(void (CrewMember::*)(Door *)), ".8b442404894164", argdata, 2, 5, &func);
 }
@@ -6680,11 +6694,11 @@ namespace _func478
 void CrewMember::CloseDoorBehind(Door *door)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Door *door_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func478::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func479::func;
 	return execfunc(this, door);
 }
 
-namespace _func479
+namespace _func480
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6694,11 +6708,11 @@ namespace _func479
 float CrewMember::GetMoveSpeed()
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func479::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func480::func;
 	return execfunc(this);
 }
 
-namespace _func480
+namespace _func481
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6708,11 +6722,11 @@ namespace _func480
 void CrewMember::Restart()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func480::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func481::func;
 	return execfunc(this);
 }
 
-namespace _func481
+namespace _func482
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6722,11 +6736,11 @@ namespace _func481
 void CrewMember::SetDamageBoost(float damageBoost)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float damageBoost_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func481::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func482::func;
 	return execfunc(this, damageBoost);
 }
 
-namespace _func482
+namespace _func483
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6736,11 +6750,11 @@ namespace _func482
 void CrewMember::SetHealthBoost(int healthBoost)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int healthBoost_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func482::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func483::func;
 	return execfunc(this, healthBoost);
 }
 
-namespace _func483
+namespace _func484
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6750,11 +6764,11 @@ namespace _func483
 void CrewMember::InitializeSkills()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func483::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func484::func;
 	return execfunc(this);
 }
 
-namespace _func484
+namespace _func485
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6764,11 +6778,11 @@ namespace _func484
 void CrewMember::SetCloneReady(bool cloneReady)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool cloneReady_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func484::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func485::func;
 	return execfunc(this, cloneReady);
 }
 
-namespace _func485
+namespace _func486
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6778,11 +6792,11 @@ namespace _func485
 void CrewMember::Kill(bool noClone)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool noClone_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func485::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func486::func;
 	return execfunc(this, noClone);
 }
 
-namespace _func486
+namespace _func487
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6792,11 +6806,11 @@ namespace _func486
 bool CrewMember::NeedFrozenLocation()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func486::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func487::func;
 	return execfunc(this);
 }
 
-namespace _func487
+namespace _func488
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6806,11 +6820,11 @@ namespace _func487
 void CrewMember::SetCurrentShip(int shipId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func487::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func488::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func488
+namespace _func489
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6820,11 +6834,11 @@ namespace _func488
 void CrewMember::CheckFighting()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func488::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func489::func;
 	return execfunc(this);
 }
 
-namespace _func489
+namespace _func490
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6834,11 +6848,11 @@ namespace _func489
 void CrewMember::SetDeathNumber(int deathNum)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int deathNum_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func489::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func490::func;
 	return execfunc(this, deathNum);
 }
 
-namespace _func490
+namespace _func491
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -6848,11 +6862,11 @@ namespace _func490
 void CrewMember::ForceMindControl(bool force)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func490::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func491::func;
 	return execfunc(this, force);
 }
 
-namespace _func491
+namespace _func492
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -6862,11 +6876,11 @@ namespace _func491
 void CrewMember::RenderSkillUpAnimation(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func491::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func492::func;
 	return execfunc(this, pos);
 }
 
-namespace _func492
+namespace _func493
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6874,20 +6888,6 @@ namespace _func492
 }
 
 void CrewMember::Clone()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func492::func;
-	return execfunc(this);
-}
-
-namespace _func493
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::UpdateHealth", typeid(void (CrewMember::*)()), ".578d7c240883e4f0ff77fc55", argdata, 1, 5, &func);
-}
-
-void CrewMember::UpdateHealth()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func493::func;
@@ -6898,10 +6898,10 @@ namespace _func494
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::OnRenderPath", typeid(void (CrewMember::*)()), ".8b410485c00f85????????660fefc9f30f104108f30f1015????????", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewMember::UpdateHealth", typeid(void (CrewMember::*)()), ".578d7c240883e4f0ff77fc55", argdata, 1, 5, &func);
 }
 
-void CrewMember::OnRenderPath()
+void CrewMember::UpdateHealth()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func494::func;
@@ -6911,6 +6911,20 @@ void CrewMember::OnRenderPath()
 namespace _func495
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewMember::OnRenderPath", typeid(void (CrewMember::*)()), ".8b410485c00f85????????660fefc9f30f104108f30f1015????????", argdata, 1, 5, &func);
+}
+
+void CrewMember::OnRenderPath()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func495::func;
+	return execfunc(this);
+}
+
+namespace _func496
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("CrewMember::SetPath", typeid(bool (CrewMember::*)(Path *)), ".578d7c240883e4f0ff77fc5589e557565389cb", argdata, 2, 1, &func);
 }
@@ -6918,11 +6932,11 @@ namespace _func495
 bool CrewMember::SetPath(Path *path)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Path *path_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func495::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func496::func;
 	return execfunc(this, path);
 }
 
-namespace _func496
+namespace _func497
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -6932,11 +6946,11 @@ namespace _func496
 void CrewMember::SetRoomPath(int slotId, int roomId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int slotId_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func496::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func497::func;
 	return execfunc(this, slotId, roomId);
 }
 
-namespace _func497
+namespace _func498
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -6946,20 +6960,6 @@ namespace _func497
 Point CrewMember::GetLocation()
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func497::func;
-	return execfunc(this);
-}
-
-namespace _func498
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::AtGoal", typeid(bool (CrewMember::*)()), ".f30f104918f30f101d????????f30f10410855f30f5cc1f30f1015????????", argdata, 1, 1, &func);
-}
-
-bool CrewMember::AtGoal()
-{
-	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func498::func;
 	return execfunc(this);
 }
@@ -6968,10 +6968,10 @@ namespace _func499
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::AtFinalGoal", typeid(bool (CrewMember::*)()), ".660fefc9f30f1015????????f30f10410831c055f30f2a899000000089e5", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("CrewMember::AtGoal", typeid(bool (CrewMember::*)()), ".f30f104918f30f101d????????f30f10410855f30f5cc1f30f1015????????", argdata, 1, 1, &func);
 }
 
-bool CrewMember::AtFinalGoal()
+bool CrewMember::AtGoal()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func499::func;
@@ -6982,17 +6982,31 @@ namespace _func500
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewMember::AtFinalGoal", typeid(bool (CrewMember::*)()), ".660fefc9f30f1015????????f30f10410831c055f30f2a899000000089e5", argdata, 1, 1, &func);
+}
+
+bool CrewMember::AtFinalGoal()
+{
+	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func500::func;
+	return execfunc(this);
+}
+
+namespace _func501
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("CrewMember::OnRenderHealth", typeid(void (CrewMember::*)()), ".80b9fc0100000074??f3c3908d7426008b819c000000837838030f84????????57", argdata, 1, 5, &func);
 }
 
 void CrewMember::OnRenderHealth()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func500::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func501::func;
 	return execfunc(this);
 }
 
-namespace _func501
+namespace _func502
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7002,11 +7016,11 @@ namespace _func501
 int CrewMember::GetIntegerHealth()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func501::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func502::func;
 	return execfunc(this);
 }
 
-namespace _func502
+namespace _func503
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7016,11 +7030,11 @@ namespace _func502
 int CrewMember::GetRepairingId()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func502::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func503::func;
 	return execfunc(this);
 }
 
-namespace _func503
+namespace _func504
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -7030,11 +7044,11 @@ namespace _func503
 bool CrewMember::WithinRect(int x, int y, int w, int h)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int x_arg, int y_arg, int w_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func503::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func504::func;
 	return execfunc(this, x, y, w, h);
 }
 
-namespace _func504
+namespace _func505
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7044,11 +7058,11 @@ namespace _func504
 std::string CrewMember::GetLongName()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func504::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func505::func;
 	return execfunc(this);
 }
 
-namespace _func505
+namespace _func506
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7058,11 +7072,11 @@ namespace _func505
 void CrewMember::SetName(TextString *name, bool force)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, TextString *name_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func505::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func506::func;
 	return execfunc(this, name, force);
 }
 
-namespace _func506
+namespace _func507
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7072,11 +7086,11 @@ namespace _func506
 std::string CrewMember::GetName()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func506::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func507::func;
 	return execfunc(this);
 }
 
-namespace _func507
+namespace _func508
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7086,11 +7100,11 @@ namespace _func507
 void CrewMember::SetCurrentTarget(CrewTarget *target, bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, CrewTarget *target_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func507::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func508::func;
 	return execfunc(this, target, unk);
 }
 
-namespace _func508
+namespace _func509
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7100,11 +7114,11 @@ namespace _func508
 void CrewMember::CheckForTeleport()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func508::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func509::func;
 	return execfunc(this);
 }
 
-namespace _func509
+namespace _func510
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7114,11 +7128,11 @@ namespace _func509
 bool CrewMember::GetNewGoal()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func509::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func510::func;
 	return execfunc(this);
 }
 
-namespace _func510
+namespace _func511
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -7128,11 +7142,11 @@ namespace _func510
 bool CrewMember::MoveToRoom(int roomId, int slotId, bool forceMove)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg, int slotId_arg, bool forceMove_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func510::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func511::func;
 	return execfunc(this, roomId, slotId, forceMove);
 }
 
-namespace _func511
+namespace _func512
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7142,11 +7156,11 @@ namespace _func511
 void CrewMember::SetMindControl(bool controlled)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool controlled_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func511::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func512::func;
 	return execfunc(this, controlled);
 }
 
-namespace _func512
+namespace _func513
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7156,11 +7170,11 @@ namespace _func512
 bool CrewMember::RestorePosition()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func512::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func513::func;
 	return execfunc(this);
 }
 
-namespace _func513
+namespace _func514
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7170,11 +7184,11 @@ namespace _func513
 bool CrewMember::ContainsPoint(int x, int y)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func513::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func514::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func514
+namespace _func515
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7184,11 +7198,11 @@ namespace _func514
 void CrewMember::SetMedbay(float health)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, float health_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func514::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func515::func;
 	return execfunc(this, health);
 }
 
-namespace _func515
+namespace _func516
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7198,11 +7212,11 @@ namespace _func515
 void CrewMember::StartTeleport()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func515::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func516::func;
 	return execfunc(this);
 }
 
-namespace _func516
+namespace _func517
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7212,11 +7226,11 @@ namespace _func516
 void CrewMember::StartTeleportArrive()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func516::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func517::func;
 	return execfunc(this);
 }
 
-namespace _func517
+namespace _func518
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7226,11 +7240,11 @@ namespace _func517
 void CrewMember::StartRepair(Repairable *toRepair)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, Repairable *toRepair_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func517::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func518::func;
 	return execfunc(this, toRepair);
 }
 
-namespace _func518
+namespace _func519
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7238,20 +7252,6 @@ namespace _func518
 }
 
 void CrewMember::UpdateRepair()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func518::func;
-	return execfunc(this);
-}
-
-namespace _func519
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::UpdateMovement", typeid(void (CrewMember::*)()), ".8b819c0000008b403883f8060f84????????660fefc00f2e41280f83????????578d7c2408", argdata, 1, 5, &func);
-}
-
-void CrewMember::UpdateMovement()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func519::func;
@@ -7262,10 +7262,10 @@ namespace _func520
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("CrewMember::OnLoop", typeid(void (CrewMember::*)()), ".578d7c240883e4f0ff77fc5589e55756", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("CrewMember::UpdateMovement", typeid(void (CrewMember::*)()), ".8b819c0000008b403883f8060f84????????660fefc00f2e41280f83????????578d7c2408", argdata, 1, 5, &func);
 }
 
-void CrewMember::OnLoop()
+void CrewMember::UpdateMovement()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func520::func;
@@ -7275,6 +7275,20 @@ void CrewMember::OnLoop()
 namespace _func521
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("CrewMember::OnLoop", typeid(void (CrewMember::*)()), ".578d7c240883e4f0ff77fc5589e55756", argdata, 1, 5, &func);
+}
+
+void CrewMember::OnLoop()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func521::func;
+	return execfunc(this);
+}
+
+namespace _func522
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("CrewMember::SetSex", typeid(void (CrewMember::*)(bool )), ".5589e556538b750889cb8b899c00000083e4f089f08881c4090000e8????????89f08883100300008d65f85b", argdata, 2, 5, &func);
 }
@@ -7282,11 +7296,11 @@ namespace _func521
 void CrewMember::SetSex(bool male)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, bool male_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func521::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func522::func;
 	return execfunc(this, male);
 }
 
-namespace _func522
+namespace _func523
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7296,11 +7310,11 @@ namespace _func522
 void CrewMember::CycleColorLayer(int unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func522::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func523::func;
 	return execfunc(this, unk);
 }
 
-namespace _func523
+namespace _func524
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7310,11 +7324,11 @@ namespace _func523
 bool CrewMember::Functional()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func523::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func524::func;
 	return execfunc(this);
 }
 
-namespace _func524
+namespace _func525
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7324,11 +7338,11 @@ namespace _func524
 bool CrewMember::InsideRoom(int roomId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func524::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func525::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func525
+namespace _func526
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7338,11 +7352,11 @@ namespace _func525
 bool CrewMember::GetControllable()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func525::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func526::func;
 	return execfunc(this);
 }
 
-namespace _func526
+namespace _func527
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7352,11 +7366,11 @@ namespace _func526
 std::string CrewMember::GetUniqueRepairing()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func526::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func527::func;
 	return execfunc(this);
 }
 
-namespace _func527
+namespace _func528
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7366,11 +7380,11 @@ namespace _func527
 std::string CrewMember::GetTooltip()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func527::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func528::func;
 	return execfunc(this);
 }
 
-namespace _func528
+namespace _func529
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -7380,11 +7394,11 @@ namespace _func528
 std::string CrewMember::GetSkillTooltip(int skillId, int skillLevel, std::pair<int, int> progress, bool infoScreen)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(int skillId_arg, int skillLevel_arg, std::pair<int, int> progress_arg, bool infoScreen_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func528::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func529::func;
 	return execfunc(skillId, skillLevel, progress, infoScreen);
 }
 
-namespace _func529
+namespace _func530
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7394,11 +7408,11 @@ namespace _func529
 bool CrewMember::CountForVictory()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMember *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func529::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func530::func;
 	return execfunc(this);
 }
 
-namespace _func530
+namespace _func531
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7408,11 +7422,11 @@ namespace _func530
 void CrewMemberFactory::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func530::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func531::func;
 	return execfunc(this);
 }
 
-namespace _func531
+namespace _func532
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7422,11 +7436,11 @@ namespace _func531
 void CrewMemberFactory::Restart()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func531::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func532::func;
 	return execfunc(this);
 }
 
-namespace _func532
+namespace _func533
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7436,11 +7450,11 @@ namespace _func532
 int CrewMemberFactory::CountCloneReadyCrew(bool player)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, bool player_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func532::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func533::func;
 	return execfunc(this, player);
 }
 
-namespace _func533
+namespace _func534
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7450,11 +7464,11 @@ namespace _func533
 int CrewMemberFactory::GetPlayerCrewCount()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func533::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func534::func;
 	return execfunc(this);
 }
 
-namespace _func534
+namespace _func535
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7464,11 +7478,11 @@ namespace _func534
 int CrewMemberFactory::GetEnemyCloneCount()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func534::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func535::func;
 	return execfunc(this);
 }
 
-namespace _func535
+namespace _func536
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7478,11 +7492,11 @@ namespace _func535
 int CrewMemberFactory::GetCrewCount(bool enemy)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func535::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func536::func;
 	return execfunc(this, enemy);
 }
 
-namespace _func536
+namespace _func537
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7492,11 +7506,11 @@ namespace _func536
 int CrewMemberFactory::GetEnemyCrewCount()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func536::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func537::func;
 	return execfunc(this);
 }
 
-namespace _func537
+namespace _func538
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7506,11 +7520,11 @@ namespace _func537
 bool CrewMemberFactory::IsRace(const std::string &species)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &species_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func537::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func538::func;
 	return execfunc(species);
 }
 
-namespace _func538
+namespace _func539
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7520,11 +7534,11 @@ namespace _func538
 std::pair<std::string, bool> CrewMemberFactory::GetRandomFriendlyName(const std::string &race)
 {
 	typedef std::pair<std::string, bool> __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, const std::string &race_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func538::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func539::func;
 	return execfunc(this, race);
 }
 
-namespace _func539
+namespace _func540
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7534,11 +7548,11 @@ namespace _func539
 std::vector<std::string> CrewMemberFactory::GetCrewNames()
 {
 	typedef std::vector<std::string> __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func539::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func540::func;
 	return execfunc(this);
 }
 
-namespace _func540
+namespace _func541
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7548,11 +7562,11 @@ namespace _func540
 RepairDrone *CrewMemberFactory::CreateRepairDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef RepairDrone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func540::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func541::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func541
+namespace _func542
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7562,11 +7576,11 @@ namespace _func541
 void CrewMemberFactory::GetCrewPortraitList(std::vector<CrewMember*> *vec, int teamId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> *vec_arg, int teamId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func541::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func542::func;
 	return execfunc(this, vec, teamId);
 }
 
-namespace _func542
+namespace _func543
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7576,11 +7590,11 @@ namespace _func542
 void CrewMemberFactory::GetCloneReadyList(std::vector<CrewMember*> &vec, bool player)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> &vec_arg, bool player_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func542::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func543::func;
 	return execfunc(this, vec, player);
 }
 
-namespace _func543
+namespace _func544
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7590,11 +7604,11 @@ namespace _func543
 BattleDrone *CrewMemberFactory::CreateBattleDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef BattleDrone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func543::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func544::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func544
+namespace _func545
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -7604,11 +7618,11 @@ namespace _func544
 void CrewMemberFactory::GetCrewList(std::vector<CrewMember*> *vec, int unk, bool unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, std::vector<CrewMember*> *vec_arg, int unk_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func544::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func545::func;
 	return execfunc(this, vec, unk, unk2);
 }
 
-namespace _func545
+namespace _func546
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7618,11 +7632,11 @@ namespace _func545
 BoarderDrone *CrewMemberFactory::CreateBoarderDrone(int shipId, const DroneBlueprint *bp)
 {
 	typedef BoarderDrone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, int shipId_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func545::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func546::func;
 	return execfunc(this, shipId, bp);
 }
 
-namespace _func546
+namespace _func547
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7632,11 +7646,11 @@ namespace _func546
 void CrewMemberFactory::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func546::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func547::func;
 	return execfunc(this);
 }
 
-namespace _func547
+namespace _func548
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7646,11 +7660,11 @@ namespace _func547
 void CrewMemberFactory::RemoveExcessCrew()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func547::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func548::func;
 	return execfunc(this);
 }
 
-namespace _func548
+namespace _func549
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -7660,18 +7674,18 @@ namespace _func548
 CrewMember *CrewMemberFactory::CreateCrewMember(CrewBlueprint *bp, int shipId, bool intruder)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewMemberFactory *this_arg, CrewBlueprint *bp_arg, int shipId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func548::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func549::func;
 	return execfunc(this, bp, shipId, intruder);
 }
 
 CrewMemberFactory *Global_CrewMemberFactory_Factory;
 
-namespace _var549
+namespace _var550
 {
     static VariableDefinition varObj("Global_CrewMemberFactory_Factory", "!b9(???????\?)e8????????29c6", &Global_CrewMemberFactory_Factory);
 }
 
-namespace _func550
+namespace _func551
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7681,11 +7695,11 @@ namespace _func550
 bool CrewStoreBox::CanHold()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func550::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func551::func;
 	return execfunc(this);
 }
 
-namespace _func551
+namespace _func552
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -7695,11 +7709,11 @@ namespace _func551
 void CrewStoreBox::constructor(ShipManager *ship, int worldLevel, const std::string &type)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewStoreBox *this_arg, ShipManager *ship_arg, int worldLevel_arg, const std::string &type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func551::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func552::func;
 	return execfunc(this, ship, worldLevel, type);
 }
 
-namespace _func552
+namespace _func553
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7709,11 +7723,11 @@ namespace _func552
 void CrewStoreBox::Purchase()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func552::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func553::func;
 	return execfunc(this);
 }
 
-namespace _func553
+namespace _func554
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -7723,11 +7737,11 @@ namespace _func553
 void CrewStoreBox::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(CrewStoreBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func553::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func554::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func554
+namespace _func555
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x1ff};
@@ -7737,11 +7751,11 @@ namespace _func554
 void DamageMessage::constructor(float length, Pointf pos, DamageMessage::MessageType type)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DamageMessage *this_arg, float length_arg, Pointf pos_arg, DamageMessage::MessageType type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func554::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func555::func;
 	return execfunc(this, length, pos, type);
 }
 
-namespace _func555
+namespace _func556
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -7751,11 +7765,11 @@ namespace _func555
 void DamageMessage::constructor2(float length, int amount, Pointf pos, bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DamageMessage *this_arg, float length_arg, int amount_arg, Pointf pos_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func555::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func556::func;
 	return execfunc(this, length, amount, pos, unk);
 }
 
-namespace _func556
+namespace _func557
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -7765,11 +7779,11 @@ namespace _func556
 int DebugHelper::CrashCatcher(void *exception_pointers)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(void *exception_pointers_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func556::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func557::func;
 	return execfunc(exception_pointers);
 }
 
-namespace _func557
+namespace _func558
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7779,11 +7793,11 @@ namespace _func557
 bool DefenseDrone::ValidTargetObject(Targetable *target)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func557::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func558::func;
 	return execfunc(this, target);
 }
 
-namespace _func558
+namespace _func559
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7793,11 +7807,11 @@ namespace _func558
 void DefenseDrone::SetWeaponTarget(Targetable *target)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func558::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func559::func;
 	return execfunc(this, target);
 }
 
-namespace _func559
+namespace _func560
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7807,11 +7821,11 @@ namespace _func559
 void DefenseDrone::PickTarget()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func559::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func560::func;
 	return execfunc(this);
 }
 
-namespace _func560
+namespace _func561
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7821,11 +7835,11 @@ namespace _func560
 std::string DefenseDrone::GetTooltip()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func560::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func561::func;
 	return execfunc(this);
 }
 
-namespace _func561
+namespace _func562
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7835,11 +7849,11 @@ namespace _func561
 void DefenseDrone::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DefenseDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func561::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func562::func;
 	return execfunc(this);
 }
 
-namespace _func562
+namespace _func563
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7849,11 +7863,11 @@ namespace _func562
 void Description::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Description *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func562::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func563::func;
 	return execfunc(this);
 }
 
-namespace _func563
+namespace _func564
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7863,11 +7877,11 @@ namespace _func563
 Description &Description::copy_assign_1(Description &other)
 {
 	typedef Description &__attribute__((thiscall)) (*custom_arg_funcptr_t)(Description *this_arg, Description &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func563::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func564::func;
 	return execfunc(this, other);
 }
 
-namespace _func564
+namespace _func565
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7877,11 +7891,11 @@ namespace _func564
 Description &Description::copy_assign_2(const Description &other)
 {
 	typedef Description &__attribute__((thiscall)) (*custom_arg_funcptr_t)(Description *this_arg, const Description &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func564::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func565::func;
 	return execfunc(this, other);
 }
 
-namespace _func565
+namespace _func566
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7891,11 +7905,11 @@ namespace _func565
 void Description::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Description *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func565::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func566::func;
 	return execfunc(this);
 }
 
-namespace _func566
+namespace _func567
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7905,11 +7919,11 @@ namespace _func566
 void Door::FakeClose()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func566::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func567::func;
 	return execfunc(this);
 }
 
-namespace _func567
+namespace _func568
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7919,11 +7933,11 @@ namespace _func567
 bool Door::IsSealed(int shipId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Door *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func567::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func568::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func568
+namespace _func569
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -7931,20 +7945,6 @@ namespace _func568
 }
 
 void Door::FakeOpen()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func568::func;
-	return execfunc(this);
-}
-
-namespace _func569
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("Door::OnLoop", typeid(void (Door::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec2c8b813c02000085c0", argdata, 1, 5, &func);
-}
-
-void Door::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Door *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func569::func;
@@ -7955,17 +7955,31 @@ namespace _func570
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("Door::OnLoop", typeid(void (Door::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec2c8b813c02000085c0", argdata, 1, 5, &func);
+}
+
+void Door::OnLoop()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Door *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func570::func;
+	return execfunc(this);
+}
+
+namespace _func571
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("Door::GetPosition", typeid(Point (Door::*)()), "578d7c240883e4f0ff77fc5589e55783ec248b8144020000894424048b81400200008d4df0890424e8????????8b45f483ec088d4df083c008894424048b45f0890424", argdata, 1, 9, &func);
 }
 
 Point Door::GetPosition()
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(Door *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func570::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func571::func;
 	return execfunc(this);
 }
 
-namespace _func571
+namespace _func572
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7975,11 +7989,11 @@ namespace _func571
 bool Door::ApplyDamage(float amount)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Door *this_arg, float amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func571::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func572::func;
 	return execfunc(this, amount);
 }
 
-namespace _func572
+namespace _func573
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -7989,11 +8003,11 @@ namespace _func572
 void Door::SaveState(int fd)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Door *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func572::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func573::func;
 	return execfunc(this, fd);
 }
 
-namespace _func573
+namespace _func574
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8003,11 +8017,11 @@ namespace _func573
 void Door::LoadState(int fd)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Door *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func573::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func574::func;
 	return execfunc(this, fd);
 }
 
-namespace _func574
+namespace _func575
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -8017,11 +8031,11 @@ namespace _func574
 void DoorBox::constructor(Point pos, ShipSystem *sys, ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DoorBox *this_arg, Point pos_arg, ShipSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func574::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func575::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func575
+namespace _func576
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8031,11 +8045,11 @@ namespace _func575
 void DroneBlueprint::RenderIcon(float scale)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneBlueprint *this_arg, float scale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func575::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func576::func;
 	return execfunc(this, scale);
 }
 
-namespace _func576
+namespace _func577
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8045,11 +8059,11 @@ namespace _func576
 TextString DroneControl::HolderLabel()
 {
 	typedef TextString __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func576::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func577::func;
 	return execfunc(this);
 }
 
-namespace _func577
+namespace _func578
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8059,11 +8073,11 @@ namespace _func577
 SDLKey DroneControl::ArmamentHotkey(unsigned int i)
 {
 	typedef SDLKey __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneControl *this_arg, unsigned int i_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func577::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func578::func;
 	return execfunc(this, i);
 }
 
-namespace _func578
+namespace _func579
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8073,11 +8087,11 @@ namespace _func578
 void DroneControl::SelectArmament(unsigned int i)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneControl *this_arg, unsigned int i_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func578::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func579::func;
 	return execfunc(this, i);
 }
 
-namespace _func579
+namespace _func580
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8087,11 +8101,11 @@ namespace _func579
 void DroneControl::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func579::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func580::func;
 	return execfunc(this);
 }
 
-namespace _func580
+namespace _func581
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -8101,11 +8115,11 @@ namespace _func580
 void DroneStoreBox::constructor(ShipManager *ship, Equipment *equip, const DroneBlueprint *bp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneStoreBox *this_arg, ShipManager *ship_arg, Equipment *equip_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func580::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func581::func;
 	return execfunc(this, ship, equip, bp);
 }
 
-namespace _func581
+namespace _func582
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8115,11 +8129,11 @@ namespace _func581
 void DroneStoreBox::Purchase()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func581::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func582::func;
 	return execfunc(this);
 }
 
-namespace _func582
+namespace _func583
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8129,11 +8143,11 @@ namespace _func582
 void WeaponStoreBox::Purchase()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func582::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func583::func;
 	return execfunc(this);
 }
 
-namespace _func583
+namespace _func584
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8143,11 +8157,11 @@ namespace _func583
 Drone *DroneSystem::RemoveDrone(int slot)
 {
 	typedef Drone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneSystem *this_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func583::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func584::func;
 	return execfunc(this, slot);
 }
 
-namespace _func584
+namespace _func585
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8157,11 +8171,11 @@ namespace _func584
 void DroneSystem::UpdateBonusPower()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func584::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func585::func;
 	return execfunc(this);
 }
 
-namespace _func585
+namespace _func586
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8171,11 +8185,11 @@ namespace _func585
 void DroneSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func585::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func586::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func586
+namespace _func587
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8185,11 +8199,11 @@ namespace _func586
 void DroneSystem::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func586::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func587::func;
 	return execfunc(this);
 }
 
-namespace _func587
+namespace _func588
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8199,11 +8213,11 @@ namespace _func587
 bool DroneSystem::DePowerDrone(Drone *drone, bool unk)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneSystem *this_arg, Drone *drone_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func587::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func588::func;
 	return execfunc(this, drone, unk);
 }
 
-namespace _func588
+namespace _func589
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8213,11 +8227,11 @@ namespace _func588
 void DroneSystem::Jump()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func588::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func589::func;
 	return execfunc(this);
 }
 
-namespace _func589
+namespace _func590
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -8227,11 +8241,11 @@ namespace _func589
 int DroneSystem::StringToDrone(std::string &name)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func589::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func590::func;
 	return execfunc(name);
 }
 
-namespace _func590
+namespace _func591
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8241,11 +8255,11 @@ namespace _func590
 int DropBox::GetHeight()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(DropBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func590::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func591::func;
 	return execfunc(this);
 }
 
-namespace _func591
+namespace _func592
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8255,11 +8269,11 @@ namespace _func591
 int DropBox::GetBodySpaceOffset()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(DropBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func591::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func592::func;
 	return execfunc(this);
 }
 
-namespace _func592
+namespace _func593
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8269,11 +8283,11 @@ namespace _func592
 bool DropBox::Contains(int x, int y)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(DropBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func592::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func593::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func593
+namespace _func594
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8283,11 +8297,11 @@ namespace _func593
 void DropBox::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DropBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func593::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func594::func;
 	return execfunc(this);
 }
 
-namespace _func594
+namespace _func595
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8297,11 +8311,11 @@ namespace _func594
 void DropBox::OnInit(Point p, bool isSellBox_, TextString *titleText_, TextString *bodyText_, int bodySpace_, TextString *lowerText_)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DropBox *this_arg, Point p_arg, bool isSellBox__arg, TextString *titleText__arg, TextString *bodyText__arg, int bodySpace__arg, TextString *lowerText__arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func594::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func595::func;
 	return execfunc(this, p, isSellBox_, titleText_, bodyText_, bodySpace_, lowerText_);
 }
 
-namespace _func595
+namespace _func596
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8311,11 +8325,11 @@ namespace _func595
 void EnergyAlien::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EnergyAlien *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func595::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func596::func;
 	return execfunc(this);
 }
 
-namespace _func596
+namespace _func597
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8325,11 +8339,11 @@ namespace _func596
 Damage EnergyAlien::GetRoomDamage()
 {
 	typedef Damage __attribute__((thiscall)) (*custom_arg_funcptr_t)(EnergyAlien *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func596::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func597::func;
 	return execfunc(this);
 }
 
-namespace _func597
+namespace _func598
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8339,11 +8353,11 @@ namespace _func597
 void Equipment::Open()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func597::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func598::func;
 	return execfunc(this);
 }
 
-namespace _func598
+namespace _func599
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8353,11 +8367,11 @@ namespace _func598
 void Equipment::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func598::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func599::func;
 	return execfunc(this);
 }
 
-namespace _func599
+namespace _func600
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8367,11 +8381,11 @@ namespace _func599
 void Equipment::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func599::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func600::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func600
+namespace _func601
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -8381,11 +8395,11 @@ namespace _func600
 void Equipment::SetPosition(Point p)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, Point p_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func600::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func601::func;
 	return execfunc(this, p);
 }
 
-namespace _func601
+namespace _func602
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8395,11 +8409,11 @@ namespace _func601
 void Equipment::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func601::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func602::func;
 	return execfunc(this);
 }
 
-namespace _func602
+namespace _func603
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8409,11 +8423,11 @@ namespace _func602
 void Equipment::MouseUp(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func602::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func603::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func603
+namespace _func604
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8423,11 +8437,11 @@ namespace _func603
 void Equipment::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func603::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func604::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func604
+namespace _func605
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8435,20 +8449,6 @@ namespace _func604
 }
 
 void Equipment::OnRender()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func604::func;
-	return execfunc(this);
-}
-
-namespace _func605
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("Equipment::constructor", typeid(void (Equipment::*)()), ".578d7c240883e4f0ff77fc5589e5575389cb83ec10e8????????8d4b24", argdata, 1, 5, &func);
-}
-
-void Equipment::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func605::func;
@@ -8459,10 +8459,10 @@ namespace _func606
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("Equipment::Jump", typeid(void (Equipment::*)()), ".5589e55389cb8b8954020000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("Equipment::constructor", typeid(void (Equipment::*)()), ".578d7c240883e4f0ff77fc5589e5575389cb83ec10e8????????8d4b24", argdata, 1, 5, &func);
 }
 
-void Equipment::Jump()
+void Equipment::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func606::func;
@@ -8472,6 +8472,20 @@ void Equipment::Jump()
 namespace _func607
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("Equipment::Jump", typeid(void (Equipment::*)()), ".5589e55389cb8b8954020000", argdata, 1, 5, &func);
+}
+
+void Equipment::Jump()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func607::func;
+	return execfunc(this);
+}
+
+namespace _func608
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("Equipment::IsCompletelyFull", typeid(bool (Equipment::*)(int )), ".5589e557565389cf83e4f083ec108b89", argdata, 2, 1, &func);
 }
@@ -8479,11 +8493,11 @@ namespace _func607
 bool Equipment::IsCompletelyFull(int type)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func607::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func608::func;
 	return execfunc(this, type);
 }
 
-namespace _func608
+namespace _func609
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -8493,11 +8507,11 @@ namespace _func608
 void Equipment::AddDrone(DroneBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, DroneBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func608::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func609::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func609
+namespace _func610
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -8507,11 +8521,11 @@ namespace _func609
 void Equipment::AddAugment(AugmentBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, AugmentBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func609::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func610::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func610
+namespace _func611
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8521,11 +8535,11 @@ namespace _func610
 std::vector<std::string> Equipment::GetCargoHold()
 {
 	typedef std::vector<std::string> __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func610::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func611::func;
 	return execfunc(this);
 }
 
-namespace _func611
+namespace _func612
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -8535,11 +8549,11 @@ namespace _func611
 void Equipment::AddWeapon(WeaponBlueprint *bp, bool free, bool forceCargo)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, WeaponBlueprint *bp_arg, bool free_arg, bool forceCargo_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func611::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func612::func;
 	return execfunc(this, bp, free, forceCargo);
 }
 
-namespace _func612
+namespace _func613
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8549,11 +8563,11 @@ namespace _func612
 void Equipment::AddToCargo(const std::string &name)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func612::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func613::func;
 	return execfunc(this, name);
 }
 
-namespace _func613
+namespace _func614
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8563,11 +8577,11 @@ namespace _func613
 void Equipment::OnInit(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func613::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func614::func;
 	return execfunc(this, ship);
 }
 
-namespace _func614
+namespace _func615
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8577,11 +8591,11 @@ namespace _func614
 void Equipment::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Equipment *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func614::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func615::func;
 	return execfunc(this);
 }
 
-namespace _func615
+namespace _func616
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -8591,11 +8605,11 @@ namespace _func615
 void EquipmentBox::constructor(Point pos, int slot)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, Point pos_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func615::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func616::func;
 	return execfunc(this, pos, slot);
 }
 
-namespace _func616
+namespace _func617
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8605,11 +8619,11 @@ namespace _func616
 Blueprint *EquipmentBox::GetBlueprint()
 {
 	typedef Blueprint *__attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func616::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func617::func;
 	return execfunc(this);
 }
 
-namespace _func617
+namespace _func618
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8619,11 +8633,11 @@ namespace _func617
 void EquipmentBox::SetBlueprint(InfoBox *infoBox, bool detailedBox)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, InfoBox *infoBox_arg, bool detailedBox_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func617::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func618::func;
 	return execfunc(this, infoBox, detailedBox);
 }
 
-namespace _func618
+namespace _func619
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8633,11 +8647,11 @@ namespace _func618
 void EquipmentBox::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func618::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func619::func;
 	return execfunc(this);
 }
 
-namespace _func619
+namespace _func620
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8647,11 +8661,11 @@ namespace _func619
 bool EquipmentBox::CanHoldWeapon()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func619::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func620::func;
 	return execfunc(this);
 }
 
-namespace _func620
+namespace _func621
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8661,11 +8675,11 @@ namespace _func620
 bool EquipmentBox::CanHoldDrone()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func620::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func621::func;
 	return execfunc(this);
 }
 
-namespace _func621
+namespace _func622
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8675,11 +8689,11 @@ namespace _func621
 int EquipmentBox::GetType(bool forcedEmpty)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool forcedEmpty_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func621::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func622::func;
 	return execfunc(this, forcedEmpty);
 }
 
-namespace _func622
+namespace _func623
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8689,11 +8703,11 @@ namespace _func622
 void EquipmentBox::OnRender(bool isEmpty)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool isEmpty_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func622::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func623::func;
 	return execfunc(this, isEmpty);
 }
 
-namespace _func623
+namespace _func624
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8703,11 +8717,11 @@ namespace _func623
 void EquipmentBox::UpdateBoxImage(bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func623::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func624::func;
 	return execfunc(this, unk);
 }
 
-namespace _func624
+namespace _func625
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8717,11 +8731,11 @@ namespace _func624
 void EquipmentBox::RenderLabels(bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func624::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func625::func;
 	return execfunc(this, unk);
 }
 
-namespace _func625
+namespace _func626
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8731,11 +8745,11 @@ namespace _func625
 void EquipmentBox::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func625::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func626::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func626
+namespace _func627
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x4ff};
@@ -8745,11 +8759,11 @@ namespace _func626
 void EquipmentBox::AddItem(EquipmentBoxItem item)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, EquipmentBoxItem item_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func626::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func627::func;
 	return execfunc(this, item);
 }
 
-namespace _func627
+namespace _func628
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8759,11 +8773,11 @@ namespace _func627
 void EquipmentBox::Restart()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func627::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func628::func;
 	return execfunc(this);
 }
 
-namespace _func628
+namespace _func629
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -8773,11 +8787,11 @@ namespace _func628
 void EquipmentBox::SetPosition(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func628::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func629::func;
 	return execfunc(this, pos);
 }
 
-namespace _func629
+namespace _func630
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8787,11 +8801,11 @@ namespace _func629
 void EquipmentBox::RenderIcon()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func629::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func630::func;
 	return execfunc(this);
 }
 
-namespace _func630
+namespace _func631
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8801,11 +8815,11 @@ namespace _func630
 void EquipmentBox::ForceHitBox(Globals::Rect *newBox)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg, Globals::Rect *newBox_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func630::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func631::func;
 	return execfunc(this, newBox);
 }
 
-namespace _func631
+namespace _func632
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8815,11 +8829,11 @@ namespace _func631
 int EquipmentBox::GetItemValue()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(EquipmentBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func631::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func632::func;
 	return execfunc(this);
 }
 
-namespace _func632
+namespace _func633
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -8829,11 +8843,11 @@ namespace _func632
 LocationEvent *EventGenerator::GetBaseEvent(const std::string &name, int worldLevel, bool ignoreUnique, int seed)
 {
 	typedef LocationEvent *__attribute__((thiscall)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg, int worldLevel_arg, bool ignoreUnique_arg, int seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func632::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func633::func;
 	return execfunc(this, name, worldLevel, ignoreUnique, seed);
 }
 
-namespace _func633
+namespace _func634
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -8843,11 +8857,11 @@ namespace _func633
 LocationEvent *EventGenerator::CreateEvent(const std::string &name, int worldLevel, bool ignoreUnique)
 {
 	typedef LocationEvent *__attribute__((thiscall)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg, int worldLevel_arg, bool ignoreUnique_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func633::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func634::func;
 	return execfunc(this, name, worldLevel, ignoreUnique);
 }
 
-namespace _func634
+namespace _func635
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8857,11 +8871,11 @@ namespace _func634
 SectorDescription EventGenerator::GetSpecificSector(const std::string &name)
 {
 	typedef SectorDescription __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func634::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func635::func;
 	return execfunc(this, name);
 }
 
-namespace _func635
+namespace _func636
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8871,11 +8885,11 @@ namespace _func635
 std::string EventGenerator::GetImageFromList(const std::string &listName)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &listName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func635::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func636::func;
 	return execfunc(this, listName);
 }
 
-namespace _func636
+namespace _func637
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -8885,11 +8899,11 @@ namespace _func636
 SectorDescription EventGenerator::GetSectorDescription(const std::string &type, int level)
 {
 	typedef SectorDescription __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &type_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func636::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func637::func;
 	return execfunc(this, type, level);
 }
 
-namespace _func637
+namespace _func638
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8899,11 +8913,11 @@ namespace _func637
 ShipEvent EventGenerator::GetShipEvent(const std::string &event)
 {
 	typedef ShipEvent __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventGenerator *this_arg, const std::string &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func637::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func638::func;
 	return execfunc(this, event);
 }
 
-namespace _func638
+namespace _func639
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -8913,18 +8927,18 @@ namespace _func638
 void EventGenerator::Clear()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventGenerator *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func638::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func639::func;
 	return execfunc(this);
 }
 
 EventGenerator *Global_EventGenerator_Generator;
 
-namespace _var639
+namespace _var640
 {
     static VariableDefinition varObj("Global_EventGenerator_Generator", "!8b8318120000c744240800000000b9(???????\?)8944240c8b8334080000", &Global_EventGenerator_Generator);
 }
 
-namespace _func640
+namespace _func641
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8934,11 +8948,11 @@ namespace _func640
 void EventSystem::AddEvent(int id)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventSystem *this_arg, int id_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func640::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func641::func;
 	return execfunc(this, id);
 }
 
-namespace _func641
+namespace _func642
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -8948,18 +8962,18 @@ namespace _func641
 bool EventSystem::PollEvent(int id)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventSystem *this_arg, int id_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func641::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func642::func;
 	return execfunc(this, id);
 }
 
 EventSystem *Global_EventSystem_EventManager;
 
-namespace _var642
+namespace _var643
 {
     static VariableDefinition varObj("Global_EventSystem_EventManager", "!c704240c000000b9(???????\?)e8????????31c0", &Global_EventSystem_EventManager);
 }
 
-namespace _func643
+namespace _func644
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -8969,11 +8983,11 @@ namespace _func643
 RandomAmount EventsParser::PullMinMax(rapidxml::xml_node<char> *node, const std::string &name)
 {
 	typedef RandomAmount __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func643::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func644::func;
 	return execfunc(this, node, name);
 }
 
-namespace _func644
+namespace _func645
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -8983,11 +8997,11 @@ namespace _func644
 std::string EventsParser::ProcessEvent(rapidxml::xml_node<char> *node, const std::string &eventName)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &eventName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func644::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func645::func;
 	return execfunc(this, node, eventName);
 }
 
-namespace _func645
+namespace _func646
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -8997,11 +9011,11 @@ namespace _func645
 ShipTemplate EventsParser::ProcessShipEvent(rapidxml::xml_node<char> *node)
 {
 	typedef ShipTemplate __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func645::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func646::func;
 	return execfunc(this, node);
 }
 
-namespace _func646
+namespace _func647
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9011,11 +9025,11 @@ namespace _func646
 ResourcesTemplate EventsParser::ProcessModifyItem(ResourcesTemplate &resources, rapidxml::xml_node<char> *node, const std::string &unk)
 {
 	typedef ResourcesTemplate __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg, ResourcesTemplate &resources_arg, rapidxml::xml_node<char> *node_arg, const std::string &unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func646::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func647::func;
 	return execfunc(this, resources, node, unk);
 }
 
-namespace _func647
+namespace _func648
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9025,11 +9039,11 @@ namespace _func647
 void EventsParser::AddAllEvents()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func647::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func648::func;
 	return execfunc(this);
 }
 
-namespace _func648
+namespace _func649
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -9039,11 +9053,11 @@ namespace _func648
 void EventsParser::AddEvents(EventGenerator &generator, char *file, const std::string &fileName)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg, EventGenerator &generator_arg, char *file_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func648::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func649::func;
 	return execfunc(this, generator, file, fileName);
 }
 
-namespace _func649
+namespace _func650
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -9053,11 +9067,11 @@ namespace _func649
 std::vector<std::string> EventsParser::ProcessEventList(rapidxml::xml_node<char> *node, const std::string &listName)
 {
 	typedef std::vector<std::string> __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &listName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func649::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func650::func;
 	return execfunc(this, node, listName);
 }
 
-namespace _func650
+namespace _func651
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -9067,11 +9081,11 @@ namespace _func650
 void EventsParser::ProcessChoice(EventTemplate *event, rapidxml::xml_node<char> *node, const std::string &eventName)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg, EventTemplate *event_arg, rapidxml::xml_node<char> *node_arg, const std::string &eventName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func650::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func651::func;
 	return execfunc(this, event, node, eventName);
 }
 
-namespace _func651
+namespace _func652
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -9081,18 +9095,18 @@ namespace _func651
 void EventsParser::ProcessBaseNode(rapidxml::xml_node<char> *node, EventGenerator &generator)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(EventsParser *this_arg, rapidxml::xml_node<char> *node_arg, EventGenerator &generator_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func651::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func652::func;
 	return execfunc(this, node, generator);
 }
 
 EventsParser *Global_EventsParser_Parser;
 
-namespace _var652
+namespace _var653
 {
     static VariableDefinition varObj("Global_EventsParser_Parser", "!b9(???????\?)8974240889442404", &Global_EventsParser_Parser);
 }
 
-namespace _func653
+namespace _func654
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x2ff};
@@ -9102,11 +9116,11 @@ namespace _func653
 void ExplosionAnimation::OnInit(rapidxml::xml_node<char> *node, const std::string &name, Point glowOffset)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg, rapidxml::xml_node<char> *node_arg, const std::string &name_arg, Point glowOffset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func653::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func654::func;
 	return execfunc(this, node, name, glowOffset);
 }
 
-namespace _func654
+namespace _func655
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x7ff, 0x1ff};
@@ -9116,11 +9130,11 @@ namespace _func654
 void ExplosionAnimation::OnRender(Globals::Rect *shipRect, ImageDesc shipImage, GL_Primitive *shipImagePrimitive)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg, Globals::Rect *shipRect_arg, ImageDesc shipImage_arg, GL_Primitive *shipImagePrimitive_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func654::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func655::func;
 	return execfunc(this, shipRect, shipImage, shipImagePrimitive);
 }
 
-namespace _func655
+namespace _func656
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9130,11 +9144,11 @@ namespace _func655
 void ExplosionAnimation::LoadGibs()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ExplosionAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func655::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func656::func;
 	return execfunc(this);
 }
 
-namespace _func656
+namespace _func657
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9144,11 +9158,11 @@ namespace _func656
 void FTLButton::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(FTLButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func656::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func657::func;
 	return execfunc(this);
 }
 
-namespace _func657
+namespace _func658
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -9158,11 +9172,11 @@ namespace _func657
 void FTLButton::MouseMove(int mX, int mY, bool silent)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(FTLButton *this_arg, int mX_arg, int mY_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func657::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func658::func;
 	return execfunc(this, mX, mY, silent);
 }
 
-namespace _func658
+namespace _func659
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -9172,11 +9186,11 @@ namespace _func658
 std::string FTLButton::GetPilotTooltip()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(FTLButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func658::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func659::func;
 	return execfunc(this);
 }
 
-namespace _func659
+namespace _func660
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9186,11 +9200,11 @@ namespace _func659
 void FileHelper::deleteFile(const std::string &fileName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func659::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func660::func;
 	return execfunc(fileName);
 }
 
-namespace _func660
+namespace _func661
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9198,20 +9212,6 @@ namespace _func660
 }
 
 std::string FileHelper::getResourceFile()
-{
-	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func660::func;
-	return execfunc();
-}
-
-namespace _func661
-{
-    static void *func = 0;
-	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("FileHelper::getUserFolder", typeid(std::string (*)()), ".8d4c240483e4f0ff71fc5589e5575653", argdata, 1, 2, &func);
-}
-
-std::string FileHelper::getUserFolder()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func661::func;
@@ -9222,10 +9222,10 @@ namespace _func662
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("FileHelper::getSaveFile", typeid(std::string (*)()), ".8d4c240483e4f0ff71fc5589e557565351", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("FileHelper::getUserFolder", typeid(std::string (*)()), ".8d4c240483e4f0ff71fc5589e5575653", argdata, 1, 2, &func);
 }
 
-std::string FileHelper::getSaveFile()
+std::string FileHelper::getUserFolder()
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func662::func;
@@ -9235,6 +9235,20 @@ std::string FileHelper::getSaveFile()
 namespace _func663
 {
     static void *func = 0;
+	static short argdata[] = {0x1ff};
+	static FunctionDefinition funcObj("FileHelper::getSaveFile", typeid(std::string (*)()), ".8d4c240483e4f0ff71fc5589e557565351", argdata, 1, 2, &func);
+}
+
+std::string FileHelper::getSaveFile()
+{
+	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func663::func;
+	return execfunc();
+}
+
+namespace _func664
+{
+    static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("FileHelper::initFileHelper", typeid(void (*)()), ".8d4c240483e4f0ff71fc5589e5575653", argdata, 0, 6, &func);
 }
@@ -9242,11 +9256,11 @@ namespace _func663
 void FileHelper::initFileHelper()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func663::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func664::func;
 	return execfunc();
 }
 
-namespace _func664
+namespace _func665
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9256,11 +9270,11 @@ namespace _func664
 int FileHelper::fileLength(int file)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func664::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func665::func;
 	return execfunc(file);
 }
 
-namespace _func665
+namespace _func666
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9270,11 +9284,11 @@ namespace _func665
 bool FileHelper::fileExists(const std::string &fileName)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func665::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func666::func;
 	return execfunc(fileName);
 }
 
-namespace _func666
+namespace _func667
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9284,11 +9298,11 @@ namespace _func666
 void FileHelper::renameFile(const std::string &fileName, const std::string &newName)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg, const std::string &newName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func666::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func667::func;
 	return execfunc(fileName, newName);
 }
 
-namespace _func667
+namespace _func668
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9298,11 +9312,11 @@ namespace _func667
 int FileHelper::createBinaryFile(const std::string &fileName)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func667::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func668::func;
 	return execfunc(fileName);
 }
 
-namespace _func668
+namespace _func669
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -9310,20 +9324,6 @@ namespace _func668
 }
 
 int FileHelper::createSaveFile()
-{
-	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func668::func;
-	return execfunc();
-}
-
-namespace _func669
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::createStatsFile", typeid(int (*)()), ".a1????????a3????????b8????????", argdata, 0, 2, &func);
-}
-
-int FileHelper::createStatsFile()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func669::func;
@@ -9334,12 +9334,12 @@ namespace _func670
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::deleteSaveFile", typeid(void (*)()), ".5589e55383e4f083ec10c70424????????e8????????", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("FileHelper::createStatsFile", typeid(int (*)()), ".a1????????a3????????b8????????", argdata, 0, 2, &func);
 }
 
-void FileHelper::deleteSaveFile()
+int FileHelper::createStatsFile()
 {
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func670::func;
 	return execfunc();
 }
@@ -9348,10 +9348,10 @@ namespace _func671
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::deleteAllSaveFiles", typeid(void (*)()), ".8d4c240483e4f0ff71fc5589e5575653518d45b8", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("FileHelper::deleteSaveFile", typeid(void (*)()), ".5589e55383e4f083ec10c70424????????e8????????", argdata, 0, 6, &func);
 }
 
-void FileHelper::deleteAllSaveFiles()
+void FileHelper::deleteSaveFile()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func671::func;
@@ -9361,6 +9361,20 @@ void FileHelper::deleteAllSaveFiles()
 namespace _func672
 {
     static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("FileHelper::deleteAllSaveFiles", typeid(void (*)()), ".8d4c240483e4f0ff71fc5589e5575653518d45b8", argdata, 0, 6, &func);
+}
+
+void FileHelper::deleteAllSaveFiles()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func672::func;
+	return execfunc();
+}
+
+namespace _func673
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("FileHelper::getPosition", typeid(int (*)(int )), ".8d4c240483e4f0ff71fc5589e55183ec14", argdata, 1, 2, &func);
 }
@@ -9368,11 +9382,11 @@ namespace _func672
 int FileHelper::getPosition(int file)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func672::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func673::func;
 	return execfunc(file);
 }
 
-namespace _func673
+namespace _func674
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9382,11 +9396,11 @@ namespace _func673
 int FileHelper::readBinaryFile(const std::string &fileName)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func673::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func674::func;
 	return execfunc(fileName);
 }
 
-namespace _func674
+namespace _func675
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9396,11 +9410,11 @@ namespace _func674
 void FileHelper::closeBinaryFile(int file)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func674::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func675::func;
 	return execfunc(file);
 }
 
-namespace _func675
+namespace _func676
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9410,11 +9424,11 @@ namespace _func675
 std::string FileHelper::readString(int file)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func675::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func676::func;
 	return execfunc(file);
 }
 
-namespace _func676
+namespace _func677
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9424,11 +9438,11 @@ namespace _func676
 float FileHelper::readFloat(int file)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func676::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func677::func;
 	return execfunc(file);
 }
 
-namespace _func677
+namespace _func678
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9438,11 +9452,11 @@ namespace _func677
 int FileHelper::readInteger(int file)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func677::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func678::func;
 	return execfunc(file);
 }
 
-namespace _func678
+namespace _func679
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9452,11 +9466,11 @@ namespace _func678
 bool FileHelper::seekPosition(int file, int pos)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, int pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func678::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func679::func;
 	return execfunc(file, pos);
 }
 
-namespace _func679
+namespace _func680
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9466,11 +9480,11 @@ namespace _func679
 char *FileHelper::readBuffer(int file, int len, bool nullTerminate)
 {
 	typedef char *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, int len_arg, bool nullTerminate_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func679::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func680::func;
 	return execfunc(file, len, nullTerminate);
 }
 
-namespace _func680
+namespace _func681
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9480,11 +9494,11 @@ namespace _func680
 void FileHelper::readData(int file, void *data, int len)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, void *data_arg, int len_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func680::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func681::func;
 	return execfunc(file, data, len);
 }
 
-namespace _func681
+namespace _func682
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9494,11 +9508,11 @@ namespace _func681
 bool FileHelper::writeData(int file, void *data, int len)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, void *data_arg, int len_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func681::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func682::func;
 	return execfunc(file, data, len);
 }
 
-namespace _func682
+namespace _func683
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -9506,20 +9520,6 @@ namespace _func682
 }
 
 int FileHelper::readSaveFile()
-{
-	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func682::func;
-	return execfunc();
-}
-
-namespace _func683
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("FileHelper::readStatsFile", typeid(int (*)()), ".8d4c240483e4f0ff71fc5589e553518d45f483ec20", argdata, 0, 2, &func);
-}
-
-int FileHelper::readStatsFile()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func683::func;
@@ -9530,17 +9530,31 @@ namespace _func684
 {
     static void *func = 0;
 	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("FileHelper::readStatsFile", typeid(int (*)()), ".8d4c240483e4f0ff71fc5589e553518d45f483ec20", argdata, 0, 2, &func);
+}
+
+int FileHelper::readStatsFile()
+{
+	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func684::func;
+	return execfunc();
+}
+
+namespace _func685
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("FileHelper::saveFileExists", typeid(bool (*)()), ".8d4c240483e4f0ff71fc5589e553518d45f483ec2089442408", argdata, 0, 2, &func);
 }
 
 bool FileHelper::saveFileExists()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func684::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func685::func;
 	return execfunc();
 }
 
-namespace _func685
+namespace _func686
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9550,11 +9564,11 @@ namespace _func685
 bool FileHelper::writeFloat(int file, float data)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, float data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func685::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func686::func;
 	return execfunc(file, data);
 }
 
-namespace _func686
+namespace _func687
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9564,11 +9578,11 @@ namespace _func686
 bool FileHelper::writeString(int file, const std::string &data)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, const std::string &data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func686::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func687::func;
 	return execfunc(file, data);
 }
 
-namespace _func687
+namespace _func688
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9578,11 +9592,11 @@ namespace _func687
 bool FileHelper::writeInt(int file, int data)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int file_arg, int data_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func687::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func688::func;
 	return execfunc(file, data);
 }
 
-namespace _func688
+namespace _func689
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9592,11 +9606,11 @@ namespace _func688
 void Fire::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Fire *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func688::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func689::func;
 	return execfunc(this);
 }
 
-namespace _func689
+namespace _func690
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -9606,11 +9620,11 @@ namespace _func689
 void Fire::UpdateStartTimer(int doorLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Fire *this_arg, int doorLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func689::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func690::func;
 	return execfunc(this, doorLevel);
 }
 
-namespace _func690
+namespace _func691
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -9620,11 +9634,11 @@ namespace _func690
 void Fire::UpdateDeathTimer(int connectedFires)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Fire *this_arg, int connectedFires_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func690::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func691::func;
 	return execfunc(this, connectedFires);
 }
 
-namespace _func691
+namespace _func692
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -9634,11 +9648,11 @@ namespace _func691
 void FocusWindow::MouseClick(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(FocusWindow *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func691::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func692::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func692
+namespace _func693
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -9648,11 +9662,11 @@ namespace _func692
 void FocusWindow::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(FocusWindow *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func692::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func693::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func693
+namespace _func694
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9662,11 +9676,11 @@ namespace _func693
 void FocusWindow::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(FocusWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func693::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func694::func;
 	return execfunc(this);
 }
 
-namespace _func694
+namespace _func695
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -9676,11 +9690,11 @@ namespace _func694
 void FocusWindow::SetPosition(Point p)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(FocusWindow *this_arg, Point p_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func694::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func695::func;
 	return execfunc(this, p);
 }
 
-namespace _func695
+namespace _func696
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9690,11 +9704,11 @@ namespace _func695
 void FocusWindow::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(FocusWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func695::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func696::func;
 	return execfunc(this);
 }
 
-namespace _func696
+namespace _func697
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9704,11 +9718,11 @@ namespace _func696
 void FocusWindow::Open()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(FocusWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func696::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func697::func;
 	return execfunc(this);
 }
 
-namespace _func697
+namespace _func698
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -9718,11 +9732,11 @@ namespace _func697
 void GameOver::OpenText(const std::string &text)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GameOver *this_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func697::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func698::func;
 	return execfunc(this, text);
 }
 
-namespace _func698
+namespace _func699
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9732,11 +9746,11 @@ namespace _func698
 void GameOver::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GameOver *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func698::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func699::func;
 	return execfunc(this);
 }
 
-namespace _func699
+namespace _func700
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9746,11 +9760,11 @@ namespace _func699
 void GameOver::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GameOver *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func699::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func700::func;
 	return execfunc(this);
 }
 
-namespace _func700
+namespace _func701
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -9760,11 +9774,11 @@ namespace _func700
 void GenericButton::SetLocation(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GenericButton *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func700::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func701::func;
 	return execfunc(this, pos);
 }
 
-namespace _func701
+namespace _func702
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -9774,11 +9788,11 @@ namespace _func701
 void GenericButton::SetActive(bool active)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GenericButton *this_arg, bool active_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func701::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func702::func;
 	return execfunc(this, active);
 }
 
-namespace _func702
+namespace _func703
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -9788,11 +9802,11 @@ namespace _func702
 void GenericButton::MouseMove(int x, int y, bool silent)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GenericButton *this_arg, int x_arg, int y_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func702::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func703::func;
 	return execfunc(this, x, y, silent);
 }
 
-namespace _func703
+namespace _func704
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -9800,20 +9814,6 @@ namespace _func703
 }
 
 void GenericButton::OnRightClick()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GenericButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func703::func;
-	return execfunc(this);
-}
-
-namespace _func704
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("GenericButton::ResetPrimitives", typeid(void (GenericButton::*)()), ".f3c39090909090909090909090909090", argdata, 1, 5, &func);
-}
-
-void GenericButton::ResetPrimitives()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GenericButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func704::func;
@@ -9824,10 +9824,10 @@ namespace _func705
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("GenericButton::OnClick", typeid(void (GenericButton::*)()), ".f3c39090909090909090909090909090", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("GenericButton::ResetPrimitives", typeid(void (GenericButton::*)()), ".f3c39090909090909090909090909090", argdata, 1, 5, &func);
 }
 
-void GenericButton::OnClick()
+void GenericButton::ResetPrimitives()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GenericButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func705::func;
@@ -9837,6 +9837,20 @@ void GenericButton::OnClick()
 namespace _func706
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("GenericButton::OnClick", typeid(void (GenericButton::*)()), ".f3c39090909090909090909090909090", argdata, 1, 5, &func);
+}
+
+void GenericButton::OnClick()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(GenericButton *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func706::func;
+	return execfunc(this);
+}
+
+namespace _func707
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("font_text_width", typeid(float (*)(freetype::font_data &, const char *, float )), "5589e557565383e4f083ec408b4d088b750c85c9", argdata, 3, 2, &func);
 }
@@ -9844,11 +9858,11 @@ namespace _func706
 float __stdcall font_text_width(freetype::font_data &fontData, const char *str, float size)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(freetype::font_data &fontData_arg, const char *str_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func706::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func707::func;
 	return execfunc(fontData, str, size);
 }
 
-namespace _func707
+namespace _func708
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -9858,11 +9872,11 @@ namespace _func707
 int __stdcall random32()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func707::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func708::func;
 	return execfunc();
 }
 
-namespace _func708
+namespace _func709
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9872,11 +9886,11 @@ namespace _func708
 void __stdcall srandom32(unsigned int seed)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(unsigned int seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func708::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func709::func;
 	return execfunc(seed);
 }
 
-namespace _func709
+namespace _func710
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -9886,11 +9900,11 @@ namespace _func709
 float __stdcall getSkillBonus(int skill, int level)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(int skill_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func709::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func710::func;
 	return execfunc(skill, level);
 }
 
-namespace _func710
+namespace _func711
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -9900,11 +9914,11 @@ namespace _func710
 void __stdcall GenerateReward(ResourceEvent &ref, RewardDesc &reward, int worldLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceEvent &ref_arg, RewardDesc &reward_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func710::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func711::func;
 	return execfunc(ref, reward, worldLevel);
 }
 
-namespace _func711
+namespace _func712
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9914,11 +9928,11 @@ namespace _func711
 void __stdcall GetValue(ResourceEvent &ref, const std::string &type, int level, int worldLevel)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(ResourceEvent &ref_arg, const std::string &type_arg, int level_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func711::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func712::func;
 	return execfunc(ref, type, level, worldLevel);
 }
 
-namespace _func712
+namespace _func713
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -9928,11 +9942,11 @@ namespace _func712
 void __stdcall sys_graphics_set_window_title(char *title)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(char *title_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func712::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func713::func;
 	return execfunc(title);
 }
 
-namespace _func713
+namespace _func714
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -9942,11 +9956,11 @@ namespace _func713
 void __stdcall graphics_clear(float r, float g, float b, float a, float depth, unsigned int stencil)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(float r_arg, float g_arg, float b_arg, float a_arg, float depth_arg, unsigned int stencil_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func713::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func714::func;
 	return execfunc(r, g, b, a, depth, stencil);
 }
 
-namespace _func714
+namespace _func715
 {
     static void *func = 0;
 	static short argdata[] = {0x2ff, 0x2ff, 0x1ff};
@@ -9956,11 +9970,11 @@ namespace _func714
 float Globals::AimAhead(Pointf delta, Pointf vr, float muzzleV)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf delta_arg, Pointf vr_arg, float muzzleV_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func714::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func715::func;
 	return execfunc(delta, vr, muzzleV);
 }
 
-namespace _func715
+namespace _func716
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -9970,11 +9984,11 @@ namespace _func715
 int Globals::GetNextSpaceId()
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func715::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func716::func;
 	return execfunc();
 }
 
-namespace _func716
+namespace _func717
 {
     static void *func = 0;
 	static short argdata[] = {0x2ff, 0x1ff, 0x1ff};
@@ -9984,11 +9998,11 @@ namespace _func716
 Pointf Globals::GetNextPoint(Pointf current, float mag_speed, float heading)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf current_arg, float mag_speed_arg, float heading_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func716::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func717::func;
 	return execfunc(current, mag_speed, heading);
 }
 
-namespace _func717
+namespace _func718
 {
     static void *func = 0;
 	static short argdata[] = {0x2ff, 0x1ff, 0x2ff};
@@ -9998,39 +10012,39 @@ namespace _func717
 Pointf Globals::GetNextPoint(Pointf current, float mag_speed, Pointf dest)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf current_arg, float mag_speed_arg, Pointf dest_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func717::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func718::func;
 	return execfunc(current, mag_speed, dest);
 }
 
 TextLibrary *Global_Globals_Library;
 
-namespace _var718
+namespace _var719
 {
     static VariableDefinition varObj("Global_Globals_Library", "!899d8ccaffffc6041800b9(???????\?)", &Global_Globals_Library);
 }
 
 int *Globals_GetNextSpaceId_id;
 
-namespace _var719
+namespace _var720
 {
     static VariableDefinition varObj("Globals_GetNextSpaceId_id", "8b15(???????\?)8d420185d2ba650000000f44c2a3????????c3", &Globals_GetNextSpaceId_id);
 }
 
 bool *Globals_RNG;
 
-namespace _var720
+namespace _var721
 {
     static VariableDefinition varObj("Globals_RNG", "!578d7c240883e4f0ff77fc5589e557565389cb83ec4cc7042400000000e8????????803d(???????\?)00890424", &Globals_RNG);
 }
 
 FILE *ftl_log_logfile;
 
-namespace _var721
+namespace _var722
 {
     static VariableDefinition varObj("ftl_log_logfile", "5589e556538d750c83e4f083ec108b5d0889742404891c24e8????????a1(???????\?)85c0", &ftl_log_logfile);
 }
 
-namespace _func722
+namespace _func723
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -10040,11 +10054,11 @@ namespace _func722
 void HackBox::constructor(Point pos, HackingSystem *sys, ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(HackBox *this_arg, Point pos_arg, HackingSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func722::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func723::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func723
+namespace _func724
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10054,11 +10068,11 @@ namespace _func723
 void HackingDrone::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(HackingDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func723::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func724::func;
 	return execfunc(this);
 }
 
-namespace _func724
+namespace _func725
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10068,11 +10082,11 @@ namespace _func724
 void HackingDrone::SetMovementTarget(Targetable *target)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(HackingDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func724::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func725::func;
 	return execfunc(this, target);
 }
 
-namespace _func725
+namespace _func726
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -10082,11 +10096,11 @@ namespace _func725
 CollisionResponse HackingDrone::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((thiscall)) (*custom_arg_funcptr_t)(HackingDrone *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func725::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func726::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func726
+namespace _func727
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10094,20 +10108,6 @@ namespace _func726
 }
 
 void HackingSystem::BlowHackingDrone()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(HackingSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func726::func;
-	return execfunc(this);
-}
-
-namespace _func727
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("HackingSystem::OnLoop", typeid(void (HackingSystem::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec4ce8????????80bbe4010000000f84????????80bbc0010000000f84????????8b8bac070000", argdata, 1, 5, &func);
-}
-
-void HackingSystem::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(HackingSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func727::func;
@@ -10118,17 +10118,31 @@ namespace _func728
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("HackingSystem::OnLoop", typeid(void (HackingSystem::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec4ce8????????80bbe4010000000f84????????80bbc0010000000f84????????8b8bac070000", argdata, 1, 5, &func);
+}
+
+void HackingSystem::OnLoop()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(HackingSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func728::func;
+	return execfunc(this);
+}
+
+namespace _func729
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("HackingSystem::SoundLoop", typeid(bool (HackingSystem::*)()), "80b9c00100000075??31c0c38d7426005589e55389cb83e4??e8????????83f8??74??", argdata, 1, 1, &func);
 }
 
 bool HackingSystem::SoundLoop()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(HackingSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func728::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func729::func;
 	return execfunc(this);
 }
 
-namespace _func729
+namespace _func730
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10138,11 +10152,11 @@ namespace _func729
 void InfoBox::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func729::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func730::func;
 	return execfunc(this);
 }
 
-namespace _func730
+namespace _func731
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10152,11 +10166,11 @@ namespace _func730
 void InfoBox::Clear()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func730::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func731::func;
 	return execfunc(this);
 }
 
-namespace _func731
+namespace _func732
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10166,11 +10180,11 @@ namespace _func731
 void InfoBox::SetDescription(Description *desc, int width, int height, InfoBox::ExpandDir dir)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, Description *desc_arg, int width_arg, int height_arg, InfoBox::ExpandDir dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func731::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func732::func;
 	return execfunc(this, desc, width, height, dir);
 }
 
-namespace _func732
+namespace _func733
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10180,11 +10194,11 @@ namespace _func732
 void InfoBox::SetText(const std::string &title, const std::string &text, int width, int height, InfoBox::ExpandDir dir)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const std::string &title_arg, const std::string &text_arg, int width_arg, int height_arg, InfoBox::ExpandDir dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func732::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func733::func;
 	return execfunc(this, title, text, width, height, dir);
 }
 
-namespace _func733
+namespace _func734
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10194,11 +10208,11 @@ namespace _func733
 void InfoBox::SetBlueprintWeapon(const WeaponBlueprint *bp, int status, bool hasWeaponSystem, int yShift)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const WeaponBlueprint *bp_arg, int status_arg, bool hasWeaponSystem_arg, int yShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func733::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func734::func;
 	return execfunc(this, bp, status, hasWeaponSystem, yShift);
 }
 
-namespace _func734
+namespace _func735
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10208,11 +10222,11 @@ namespace _func734
 void InfoBox::SetBlueprintDrone(const DroneBlueprint *bp, int status, bool hasDroneSystem, int yShift)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const DroneBlueprint *bp_arg, int status_arg, bool hasDroneSystem_arg, int yShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func734::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func735::func;
 	return execfunc(this, bp, status, hasDroneSystem, yShift);
 }
 
-namespace _func735
+namespace _func736
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10222,11 +10236,11 @@ namespace _func735
 void InfoBox::SetBlueprint(const ItemBlueprint *bp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const ItemBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func735::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func736::func;
 	return execfunc(this, bp);
 }
 
-namespace _func736
+namespace _func737
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -10236,11 +10250,11 @@ namespace _func736
 void InfoBox::SetBlueprintCrew(const CrewBlueprint *bp, int yShift, bool detailedCrew)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const CrewBlueprint *bp_arg, int yShift_arg, bool detailedCrew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func736::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func737::func;
 	return execfunc(this, bp, yShift, detailedCrew);
 }
 
-namespace _func737
+namespace _func738
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10250,11 +10264,11 @@ namespace _func737
 void InfoBox::SetBlueprintAugment(const AugmentBlueprint *bp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, const AugmentBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func737::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func738::func;
 	return execfunc(this, bp);
 }
 
-namespace _func738
+namespace _func739
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10264,11 +10278,11 @@ namespace _func738
 int InfoBox::CalcBoxHeight()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func738::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func739::func;
 	return execfunc(this);
 }
 
-namespace _func739
+namespace _func740
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10278,11 +10292,11 @@ namespace _func739
 bool InfoBox::IsEmpty()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func739::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func740::func;
 	return execfunc(this);
 }
 
-namespace _func740
+namespace _func741
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10292,11 +10306,11 @@ namespace _func740
 void InfoBox::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func740::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func741::func;
 	return execfunc(this);
 }
 
-namespace _func741
+namespace _func742
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10306,11 +10320,11 @@ namespace _func741
 void InfoBox::SetSystemId(int systemId, int maxPower, int currentLevel, int upgrade, int yShift, int forceSystemWidth)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, int systemId_arg, int maxPower_arg, int currentLevel_arg, int upgrade_arg, int yShift_arg, int forceSystemWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func741::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func742::func;
 	return execfunc(this, systemId, maxPower, currentLevel, upgrade, yShift, forceSystemWidth);
 }
 
-namespace _func742
+namespace _func743
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -10320,25 +10334,25 @@ namespace _func742
 void InfoBox::SetSystem(ShipSystem *system, int upgrade, int yShift, int forceSystemWidth)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InfoBox *this_arg, ShipSystem *system_arg, int upgrade_arg, int yShift_arg, int forceSystemWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func742::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func743::func;
 	return execfunc(this, system, upgrade, yShift, forceSystemWidth);
 }
 
 GL_Color *Global_InfoBox_detailsBarOn;
 
-namespace _var743
+namespace _var744
 {
     static VariableDefinition varObj("Global_InfoBox_detailsBarOn", "!83ec083bb514fdffffba(???????\?)b8(???????\?)", &Global_InfoBox_detailsBarOn);
 }
 
 GL_Color *Global_InfoBox_detailsBarOff;
 
-namespace _var744
+namespace _var745
 {
     static VariableDefinition varObj("Global_InfoBox_detailsBarOff", "", &Global_InfoBox_detailsBarOff);
 }
 
-namespace _func745
+namespace _func746
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10348,11 +10362,11 @@ namespace _func745
 void InputBox::TextEvent(CEvent::TextEvent event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InputBox *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func745::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func746::func;
 	return execfunc(this, event);
 }
 
-namespace _func746
+namespace _func747
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10362,11 +10376,11 @@ namespace _func746
 void InputBox::StartInput()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InputBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func746::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func747::func;
 	return execfunc(this);
 }
 
-namespace _func747
+namespace _func748
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10376,11 +10390,11 @@ namespace _func747
 void InputBox::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InputBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func747::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func748::func;
 	return execfunc(this);
 }
 
-namespace _func748
+namespace _func749
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10390,11 +10404,11 @@ namespace _func748
 void InputBox::TextInput(int ch)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(InputBox *this_arg, int ch_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func748::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func749::func;
 	return execfunc(this, ch);
 }
 
-namespace _func749
+namespace _func750
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10404,11 +10418,11 @@ namespace _func749
 Damage IonDrone::GetRoomDamage()
 {
 	typedef Damage __attribute__((thiscall)) (*custom_arg_funcptr_t)(IonDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func749::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func750::func;
 	return execfunc(this);
 }
 
-namespace _func750
+namespace _func751
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -10418,11 +10432,11 @@ namespace _func750
 void IonDrone::constructor(int iShipId, DroneBlueprint *blueprint)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(IonDrone *this_arg, int iShipId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func750::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func751::func;
 	return execfunc(this, iShipId, blueprint);
 }
 
-namespace _func751
+namespace _func752
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x1ff};
@@ -10432,11 +10446,11 @@ namespace _func751
 void IonDroneAnimation::constructor(int iShipId, Pointf position, bool enemy)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(IonDroneAnimation *this_arg, int iShipId_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func751::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func752::func;
 	return execfunc(this, iShipId, position, enemy);
 }
 
-namespace _func752
+namespace _func753
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10446,11 +10460,11 @@ namespace _func752
 void IonDroneAnimation::UpdateShooting()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(IonDroneAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func752::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func753::func;
 	return execfunc(this);
 }
 
-namespace _func753
+namespace _func754
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -10460,11 +10474,11 @@ namespace _func753
 void ItemStoreBox::constructor(ShipManager *ship, const std::string &resourceName)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ItemStoreBox *this_arg, ShipManager *ship_arg, const std::string &resourceName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func753::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func754::func;
 	return execfunc(this, ship, resourceName);
 }
 
-namespace _func754
+namespace _func755
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10474,18 +10488,18 @@ namespace _func754
 void LanguageChooser::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(LanguageChooser *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func754::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func755::func;
 	return execfunc(this);
 }
 
 std::vector<std::string> *Global_OptionsScreen_languageList;
 
-namespace _var755
+namespace _var756
 {
     static VariableDefinition varObj("Global_OptionsScreen_languageList", "!83ec1ca1(???????\?)c1e30301d8", &Global_OptionsScreen_languageList);
 }
 
-namespace _func756
+namespace _func757
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10495,11 +10509,11 @@ namespace _func756
 void LaserBlast::OnUpdate()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(LaserBlast *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func756::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func757::func;
 	return execfunc(this);
 }
 
-namespace _func757
+namespace _func758
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10509,25 +10523,25 @@ namespace _func757
 void LaserBlast::OnInit()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(LaserBlast *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func757::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func758::func;
 	return execfunc(this);
 }
 
 void **VTable_LaserBlast;
 
-namespace _var758
+namespace _var759
 {
     static VariableDefinition varObj("VTable_LaserBlast", "!660fefc989c3660fefd28b45b48b5598f30f2a4da4f30f2a55ac8b480489542410897c240c894da88b4d9c894c24148b4da8894c240889d90f28d9660f7ed0660f7e1c2489442404e8????????89f0ba????????83ec18f7ea660fefc089d9c703(???????\?)c74304(???????\?)c783a002000000000000c783a402000000000000", &VTable_LaserBlast);
 }
 
 void **VTable_Targetable_LaserBlast;
 
-namespace _var759
+namespace _var760
 {
     static VariableDefinition varObj("VTable_Targetable_LaserBlast", "", &VTable_Targetable_LaserBlast);
 }
 
-namespace _func760
+namespace _func761
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10537,11 +10551,11 @@ namespace _func760
 void LocationEvent::ClearEvent(bool force)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(LocationEvent *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func760::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func761::func;
 	return execfunc(this, force);
 }
 
-namespace _func761
+namespace _func762
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10551,11 +10565,11 @@ namespace _func761
 void LocationEvent::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(LocationEvent *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func761::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func762::func;
 	return execfunc(this);
 }
 
-namespace _func762
+namespace _func763
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10565,11 +10579,11 @@ namespace _func762
 void LockdownShard::Update()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(LockdownShard *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func762::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func763::func;
 	return execfunc(this);
 }
 
-namespace _func763
+namespace _func764
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10579,11 +10593,11 @@ namespace _func763
 void MainMenu::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func763::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func764::func;
 	return execfunc(this);
 }
 
-namespace _func764
+namespace _func765
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10593,11 +10607,11 @@ namespace _func764
 bool MainMenu::Open()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func764::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func765::func;
 	return execfunc(this);
 }
 
-namespace _func765
+namespace _func766
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10607,11 +10621,11 @@ namespace _func765
 void MainMenu::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func765::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func766::func;
 	return execfunc(this);
 }
 
-namespace _func766
+namespace _func767
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10621,11 +10635,11 @@ namespace _func766
 void MainMenu::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MainMenu *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func766::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func767::func;
 	return execfunc(this);
 }
 
-namespace _func767
+namespace _func768
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -10635,11 +10649,11 @@ namespace _func767
 void MainMenu::MouseClick(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MainMenu *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func767::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func768::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func768
+namespace _func769
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -10649,18 +10663,18 @@ namespace _func768
 void MainMenu::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MainMenu *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func768::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func769::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func769
+namespace _func770
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("MantisAnimation::__DO_NOT_HOOK", typeid(void (MantisAnimation::*)()), "5e5f5d8d67f85fc20400908d742600e8????????89c1e9????????8d7426000f1040080f114308eb??", argdata, 0, 4, &func);
 }
 
-namespace _func770
+namespace _func771
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10670,18 +10684,18 @@ namespace _func770
 std::string MantisAnimation::GetShootingSound()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func770::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func771::func;
 	return execfunc(this);
 }
 
-namespace _func771
+namespace _func772
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("MantisAnimation::__DO_NOT_HOOK2", typeid(void (MantisAnimation::*)()), "578d41088d7c240883e4f0ff77fc5589e5575389cb83ec108901", argdata, 0, 4, &func);
 }
 
-namespace _func772
+namespace _func773
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10691,11 +10705,11 @@ namespace _func772
 std::string MantisAnimation::GetDeathSound()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func772::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func773::func;
 	return execfunc(this);
 }
 
-namespace _func773
+namespace _func774
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10705,20 +10719,6 @@ namespace _func773
 bool MantisAnimation::FireShot()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(MantisAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func773::func;
-	return execfunc(this);
-}
-
-namespace _func774
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("MenuScreen::OnLanguageChange", typeid(void (MenuScreen::*)()), "578d7c240883e4f0ff77fc5589e557565389cb81ec????????8b511c89d085c0", argdata, 1, 5, &func);
-}
-
-void MenuScreen::OnLanguageChange()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func774::func;
 	return execfunc(this);
 }
@@ -10727,10 +10727,10 @@ namespace _func775
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("MenuScreen::constructor", typeid(void (MenuScreen::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb8db564ffffff81ec????????e8????????8d4b44c703????????c7432000000000c7432800000000c7432c00000000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("MenuScreen::OnLanguageChange", typeid(void (MenuScreen::*)()), "578d7c240883e4f0ff77fc5589e557565389cb81ec????????8b511c89d085c0", argdata, 1, 5, &func);
 }
 
-void MenuScreen::constructor()
+void MenuScreen::OnLanguageChange()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func775::func;
@@ -10741,10 +10741,10 @@ namespace _func776
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("MenuScreen::OnRender", typeid(void (MenuScreen::*)()), ".578d7c240883e4f0ff77fc5589e557565381ec????????80b9c0020000000f84????????", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("MenuScreen::constructor", typeid(void (MenuScreen::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb8db564ffffff81ec????????e8????????8d4b44c703????????c7432000000000c7432800000000c7432c00000000", argdata, 1, 5, &func);
 }
 
-void MenuScreen::OnRender()
+void MenuScreen::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func776::func;
@@ -10755,10 +10755,10 @@ namespace _func777
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("MenuScreen::Open", typeid(void (MenuScreen::*)()), ".578d7c240883e4f0ff77fc5589e557565389cf83c14c8d75d883ec5cc641b801", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("MenuScreen::OnRender", typeid(void (MenuScreen::*)()), ".578d7c240883e4f0ff77fc5589e557565381ec????????80b9c0020000000f84????????", argdata, 1, 5, &func);
 }
 
-void MenuScreen::Open()
+void MenuScreen::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func777::func;
@@ -10768,6 +10768,20 @@ void MenuScreen::Open()
 namespace _func778
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("MenuScreen::Open", typeid(void (MenuScreen::*)()), ".578d7c240883e4f0ff77fc5589e557565389cf83c14c8d75d883ec5cc641b801", argdata, 1, 5, &func);
+}
+
+void MenuScreen::Open()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MenuScreen *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func778::func;
+	return execfunc(this);
+}
+
+namespace _func779
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
 	static FunctionDefinition funcObj("MindBox::constructor", typeid(void (MindBox::*)(Point , MindSystem *)), "578d7c240883e4f0ff77fc5589e557565389cb81ec????????8b078b77088b5704c744240c000000008d7db4890424", argdata, 3, 5, &func);
 }
@@ -10775,11 +10789,11 @@ namespace _func778
 void MindBox::constructor(Point pos, MindSystem *sys)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MindBox *this_arg, Point pos_arg, MindSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func778::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func779::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func779
+namespace _func780
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10789,11 +10803,11 @@ namespace _func779
 void MindSystem::ReleaseCrew()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MindSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func779::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func780::func;
 	return execfunc(this);
 }
 
-namespace _func780
+namespace _func781
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10803,11 +10817,11 @@ namespace _func780
 void MindSystem::SetArmed(int armed)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MindSystem *this_arg, int armed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func780::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func781::func;
 	return execfunc(this, armed);
 }
 
-namespace _func781
+namespace _func782
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10817,11 +10831,11 @@ namespace _func781
 void MindSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MindSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func781::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func782::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func782
+namespace _func783
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10831,11 +10845,11 @@ namespace _func782
 void MindSystem::InitiateMindControl()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MindSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func782::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func783::func;
 	return execfunc(this);
 }
 
-namespace _func783
+namespace _func784
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10845,11 +10859,11 @@ namespace _func783
 void MindSystem::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MindSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func783::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func784::func;
 	return execfunc(this);
 }
 
-namespace _func784
+namespace _func785
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -10859,11 +10873,11 @@ namespace _func784
 void Missile::constructor(Pointf _position, int _ownerId, int _targetId, Pointf _target, float _heading)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Missile *this_arg, Pointf _position_arg, int _ownerId_arg, int _targetId_arg, Pointf _target_arg, float _heading_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func784::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func785::func;
 	return execfunc(this, _position, _ownerId, _targetId, _target, _heading);
 }
 
-namespace _func785
+namespace _func786
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -10871,20 +10885,6 @@ namespace _func785
 }
 
 void MouseControl::SetTooltip(const std::string &tooltip)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func785::func;
-	return execfunc(this, tooltip);
-}
-
-namespace _func786
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("MouseControl::SetTooltipTitle", typeid(void (MouseControl::*)(const std::string &)), "578d7c240883e4f0ff77fc5589e55783ec148b91300100008b0785d2751181c12c010000890424", argdata, 2, 5, &func);
-}
-
-void MouseControl::SetTooltipTitle(const std::string &tooltip)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltip_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func786::func;
@@ -10895,17 +10895,31 @@ namespace _func787
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("MouseControl::SetTooltipTitle", typeid(void (MouseControl::*)(const std::string &)), "578d7c240883e4f0ff77fc5589e55783ec148b91300100008b0785d2751181c12c010000890424", argdata, 2, 5, &func);
+}
+
+void MouseControl::SetTooltipTitle(const std::string &tooltip)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltip_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func787::func;
+	return execfunc(this, tooltip);
+}
+
+namespace _func788
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("MouseControl::MeasureTooltip", typeid(Point (MouseControl::*)(int )), "578d7c240883e4f0ff77fc5589e557565389cb8d4dd883ec4c8b37", argdata, 2, 9, &func);
 }
 
 Point MouseControl::MeasureTooltip(int unk)
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func787::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func788::func;
 	return execfunc(this, unk);
 }
 
-namespace _func788
+namespace _func789
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -10915,11 +10929,11 @@ namespace _func788
 void MouseControl::QueueStaticTooltip(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func788::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func789::func;
 	return execfunc(this, pos);
 }
 
-namespace _func789
+namespace _func790
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -10927,20 +10941,6 @@ namespace _func789
 }
 
 void MouseControl::OnLoop()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func789::func;
-	return execfunc(this);
-}
-
-namespace _func790
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("MouseControl::InstantTooltip", typeid(void (MouseControl::*)()), ".c6812801000001", argdata, 1, 5, &func);
-}
-
-void MouseControl::InstantTooltip()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func790::func;
@@ -10951,10 +10951,10 @@ namespace _func791
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("MouseControl::OnRender", typeid(void (MouseControl::*)()), "80b91d010000000f85????????578d7c240883e4f0ff77fc5589e557565389cf81ec????????0fb6411d8b592884c00f84????????", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("MouseControl::InstantTooltip", typeid(void (MouseControl::*)()), ".c6812801000001", argdata, 1, 5, &func);
 }
 
-void MouseControl::OnRender()
+void MouseControl::InstantTooltip()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func791::func;
@@ -10964,6 +10964,20 @@ void MouseControl::OnRender()
 namespace _func792
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("MouseControl::OnRender", typeid(void (MouseControl::*)()), "80b91d010000000f85????????578d7c240883e4f0ff77fc5589e557565389cf81ec????????0fb6411d8b592884c00f84????????", argdata, 1, 5, &func);
+}
+
+void MouseControl::OnRender()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func792::func;
+	return execfunc(this);
+}
+
+namespace _func793
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("MouseControl::SetDoor", typeid(void (MouseControl::*)(int )), "578d7c240883e4f0ff77fc5589e557565389ce83ec1c8b1f83fb0174??", argdata, 2, 5, &func);
 }
@@ -10971,11 +10985,11 @@ namespace _func792
 void MouseControl::SetDoor(int state)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, int state_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func792::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func793::func;
 	return execfunc(this, state);
 }
 
-namespace _func793
+namespace _func794
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -10985,11 +10999,11 @@ namespace _func793
 void MouseControl::SetValid(bool valid, bool newValid)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, bool valid_arg, bool newValid_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func793::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func794::func;
 	return execfunc(this, valid, newValid);
 }
 
-namespace _func794
+namespace _func795
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -10999,11 +11013,11 @@ namespace _func794
 void MouseControl::RenderTooltip(Point tooltipPoint, bool staticPos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, Point tooltipPoint_arg, bool staticPos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func794::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func795::func;
 	return execfunc(this, tooltipPoint, staticPos);
 }
 
-namespace _func795
+namespace _func796
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11013,11 +11027,11 @@ namespace _func795
 void MouseControl::ResetArmed()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func795::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func796::func;
 	return execfunc(this);
 }
 
-namespace _func796
+namespace _func797
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11027,11 +11041,11 @@ namespace _func796
 void MouseControl::Reset()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func796::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func797::func;
 	return execfunc(this);
 }
 
-namespace _func797
+namespace _func798
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11041,18 +11055,18 @@ namespace _func797
 void MouseControl::LoadTooltip(const std::string &tooltipName)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(MouseControl *this_arg, const std::string &tooltipName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func797::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func798::func;
 	return execfunc(this, tooltipName);
 }
 
 MouseControl *Global_MouseControl_Mouse;
 
-namespace _var798
+namespace _var799
 {
     static VariableDefinition varObj("Global_MouseControl_Mouse", "!e8????????e8????????b9(???????\?)", &Global_MouseControl_Mouse);
 }
 
-namespace _func799
+namespace _func800
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11062,11 +11076,11 @@ namespace _func799
 void OptionsScreen::OnInit()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OptionsScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func799::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func800::func;
 	return execfunc(this);
 }
 
-namespace _func800
+namespace _func801
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11076,11 +11090,11 @@ namespace _func800
 void OptionsScreen::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OptionsScreen *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func800::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func801::func;
 	return execfunc(this);
 }
 
-namespace _func801
+namespace _func802
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11090,18 +11104,18 @@ namespace _func801
 void OptionsScreen::Open(bool mainMenu)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OptionsScreen *this_arg, bool mainMenu_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func801::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func802::func;
 	return execfunc(this, mainMenu);
 }
 
 void **VTable_OuterHull;
 
-namespace _var802
+namespace _var803
 {
     static VariableDefinition varObj("VTable_OuterHull", "578d7c240883e4f0ff77fc5589f889e557565389cf8db7840000008d9f9c00000081ec4c0100008b00890424e8????????8d4f7c83ec04c707(???????\?)", &VTable_OuterHull);
 }
 
-namespace _func803
+namespace _func804
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11111,11 +11125,11 @@ namespace _func803
 void OuterHull::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OuterHull *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func803::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func804::func;
 	return execfunc(this);
 }
 
-namespace _func804
+namespace _func805
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -11125,11 +11139,11 @@ namespace _func804
 void OxygenSystem::UpdateBreach(int roomId, int count, bool silent)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, int count_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func804::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func805::func;
 	return execfunc(this, roomId, count, silent);
 }
 
-namespace _func805
+namespace _func806
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11139,11 +11153,11 @@ namespace _func805
 void OxygenSystem::UpdateAirlock(int roomId, int count)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, int count_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func805::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func806::func;
 	return execfunc(this, roomId, count);
 }
 
-namespace _func806
+namespace _func807
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11153,11 +11167,11 @@ namespace _func806
 void OxygenSystem::EmptyOxygen(int roomId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func806::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func807::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func807
+namespace _func808
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11167,11 +11181,11 @@ namespace _func807
 void OxygenSystem::ModifyRoomOxygen(int roomId, float value)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, float value_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func807::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func808::func;
 	return execfunc(this, roomId, value);
 }
 
-namespace _func808
+namespace _func809
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -11181,11 +11195,11 @@ namespace _func808
 void OxygenSystem::ComputeAirLoss(int roomId, float base_loss, bool silent)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int roomId_arg, float base_loss_arg, bool silent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func808::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func809::func;
 	return execfunc(this, roomId, base_loss, silent);
 }
 
-namespace _func809
+namespace _func810
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11195,11 +11209,11 @@ namespace _func809
 float OxygenSystem::GetRefillSpeed()
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func809::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func810::func;
 	return execfunc(this);
 }
 
-namespace _func810
+namespace _func811
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11209,11 +11223,11 @@ namespace _func810
 void OxygenSystem::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func810::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func811::func;
 	return execfunc(this);
 }
 
-namespace _func811
+namespace _func812
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -11223,11 +11237,11 @@ namespace _func811
 void OxygenSystem::constructor(int numRooms, int roomId, int shipId, int startingPower)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(OxygenSystem *this_arg, int numRooms_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func811::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func812::func;
 	return execfunc(this, numRooms, roomId, shipId, startingPower);
 }
 
-namespace _func812
+namespace _func813
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11237,11 +11251,11 @@ namespace _func812
 void PDSFire::CollisionCheck(Collideable *other)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(PDSFire *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func812::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func813::func;
 	return execfunc(this, other);
 }
 
-namespace _func813
+namespace _func814
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11251,11 +11265,11 @@ namespace _func813
 void PDSFire::OnUpdate()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(PDSFire *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func813::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func814::func;
 	return execfunc(this);
 }
 
-namespace _func814
+namespace _func815
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x2ff};
@@ -11265,11 +11279,11 @@ namespace _func814
 void PDSFire::constructor(Point pos, int destinationSpace, Pointf destination)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(PDSFire *this_arg, Point pos_arg, int destinationSpace_arg, Pointf destination_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func814::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func815::func;
 	return execfunc(this, pos, destinationSpace, destination);
 }
 
-namespace _func815
+namespace _func816
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -11279,11 +11293,11 @@ namespace _func815
 int Point::RelativeDistance(Point other)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Point *this_arg, Point other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func815::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func816::func;
 	return execfunc(this, other);
 }
 
-namespace _func816
+namespace _func817
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -11293,11 +11307,11 @@ namespace _func816
 int Point::Distance(Point other)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Point *this_arg, Point other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func816::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func817::func;
 	return execfunc(this, other);
 }
 
-namespace _func817
+namespace _func818
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11307,11 +11321,11 @@ namespace _func817
 void Pointf::constructor(float x, float y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Pointf *this_arg, float x_arg, float y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func817::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func818::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func818
+namespace _func819
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -11321,11 +11335,11 @@ namespace _func818
 float Pointf::RelativeDistance(Pointf other)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(Pointf *this_arg, Pointf other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func818::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func819::func;
 	return execfunc(this, other);
 }
 
-namespace _func819
+namespace _func820
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11335,11 +11349,11 @@ namespace _func819
 Pointf Pointf::Normalize()
 {
 	typedef Pointf __attribute__((thiscall)) (*custom_arg_funcptr_t)(Pointf *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func819::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func820::func;
 	return execfunc(this);
 }
 
-namespace _func820
+namespace _func821
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11349,11 +11363,11 @@ namespace _func820
 void PowerManager::SetHacked(bool val)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(PowerManager *this_arg, bool val_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func820::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func821::func;
 	return execfunc(this, val);
 }
 
-namespace _func821
+namespace _func822
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11363,11 +11377,11 @@ namespace _func821
 PowerManager *PowerManager::GetPowerManager(int iShipId)
 {
 	typedef PowerManager *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int iShipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func821::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func822::func;
 	return execfunc(iShipId);
 }
 
-namespace _func822
+namespace _func823
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -11377,11 +11391,11 @@ namespace _func822
 void PowerManager::RestartAll()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func822::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func823::func;
 	return execfunc();
 }
 
-namespace _func823
+namespace _func824
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11391,11 +11405,11 @@ namespace _func823
 void Projectile::CollisionCheck(Collideable *other)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Projectile *this_arg, Collideable *other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func823::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func824::func;
 	return execfunc(this, other);
 }
 
-namespace _func824
+namespace _func825
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff, 0x2ff};
@@ -11405,11 +11419,11 @@ namespace _func824
 void Projectile::constructor(Pointf position, int ownerId, int targetId, Pointf target)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Projectile *this_arg, Pointf position_arg, int ownerId_arg, int targetId_arg, Pointf target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func824::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func825::func;
 	return execfunc(this, position, ownerId, targetId, target);
 }
 
-namespace _func825
+namespace _func826
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11419,11 +11433,11 @@ namespace _func825
 void Projectile::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func825::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func826::func;
 	return execfunc(this);
 }
 
-namespace _func826
+namespace _func827
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11433,11 +11447,11 @@ namespace _func826
 void Projectile::Initialize(const WeaponBlueprint &bp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Projectile *this_arg, const WeaponBlueprint &bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func826::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func827::func;
 	return execfunc(this, bp);
 }
 
-namespace _func827
+namespace _func828
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11447,11 +11461,11 @@ namespace _func827
 bool Projectile::ValidTarget()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func827::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func828::func;
 	return execfunc(this);
 }
 
-namespace _func828
+namespace _func829
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11461,11 +11475,11 @@ namespace _func828
 int Projectile::ForceRenderLayer()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func828::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func829::func;
 	return execfunc(this);
 }
 
-namespace _func829
+namespace _func830
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11475,11 +11489,11 @@ namespace _func829
 void Projectile::OnUpdate()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Projectile *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func829::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func830::func;
 	return execfunc(this);
 }
 
-namespace _func830
+namespace _func831
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -11489,11 +11503,11 @@ namespace _func830
 CollisionResponse Projectile::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((thiscall)) (*custom_arg_funcptr_t)(Projectile *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func830::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func831::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func831
+namespace _func832
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11503,11 +11517,11 @@ namespace _func831
 Pointf Projectile::RandomSidePoint(int side)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int side_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func831::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func832::func;
 	return execfunc(side);
 }
 
-namespace _func832
+namespace _func833
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11517,11 +11531,11 @@ namespace _func832
 void ProjectileFactory::constructor(const WeaponBlueprint *bp, int shipId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, const WeaponBlueprint *bp_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func832::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func833::func;
 	return execfunc(this, bp, shipId);
 }
 
-namespace _func833
+namespace _func834
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11531,11 +11545,11 @@ namespace _func833
 void ProjectileFactory::SelectChargeGoal()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func833::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func834::func;
 	return execfunc(this);
 }
 
-namespace _func834
+namespace _func835
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11545,11 +11559,11 @@ namespace _func834
 bool ProjectileFactory::IsChargedGoal()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func834::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func835::func;
 	return execfunc(this);
 }
 
-namespace _func835
+namespace _func836
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11559,11 +11573,11 @@ namespace _func835
 void ProjectileFactory::SetHacked(int hacked)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, int hacked_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func835::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func836::func;
 	return execfunc(this, hacked);
 }
 
-namespace _func836
+namespace _func837
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11573,11 +11587,11 @@ namespace _func836
 void ProjectileFactory::SetCurrentShip(Targetable *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, Targetable *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func836::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func837::func;
 	return execfunc(this, ship);
 }
 
-namespace _func837
+namespace _func838
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11587,11 +11601,11 @@ namespace _func837
 void ProjectileFactory::SetCooldownModifier(float mod)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float mod_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func837::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func838::func;
 	return execfunc(this, mod);
 }
 
-namespace _func838
+namespace _func839
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11601,11 +11615,11 @@ namespace _func838
 void ProjectileFactory::ForceCoolup()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func838::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func839::func;
 	return execfunc(this);
 }
 
-namespace _func839
+namespace _func840
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11615,11 +11629,11 @@ namespace _func839
 void ProjectileFactory::RenderChargeBar(float unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func839::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func840::func;
 	return execfunc(this, unk);
 }
 
-namespace _func840
+namespace _func841
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -11629,11 +11643,11 @@ namespace _func840
 int ProjectileFactory::StringToWeapon(const std::string &str)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &str_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func840::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func841::func;
 	return execfunc(str);
 }
 
-namespace _func841
+namespace _func842
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11643,11 +11657,11 @@ namespace _func841
 bool ProjectileFactory::QueuedShots()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func841::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func842::func;
 	return execfunc(this);
 }
 
-namespace _func842
+namespace _func843
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11657,11 +11671,11 @@ namespace _func842
 void ProjectileFactory::LoadState(int fd)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func842::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func843::func;
 	return execfunc(this, fd);
 }
 
-namespace _func843
+namespace _func844
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11671,11 +11685,11 @@ namespace _func843
 void ProjectileFactory::Fire(std::vector<Pointf> &points, int target)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, std::vector<Pointf> &points_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func843::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func844::func;
 	return execfunc(this, points, target);
 }
 
-namespace _func844
+namespace _func845
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11683,20 +11697,6 @@ namespace _func844
 }
 
 bool ProjectileFactory::FireNextShot()
-{
-	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func844::func;
-	return execfunc(this);
-}
-
-namespace _func845
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ProjectileFactory::ReadyToFire", typeid(bool (ProjectileFactory::*)()), ".8b812c06000085c07e??0fb681f6000000", argdata, 1, 1, &func);
-}
-
-bool ProjectileFactory::ReadyToFire()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func845::func;
@@ -11707,17 +11707,31 @@ namespace _func846
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ProjectileFactory::ReadyToFire", typeid(bool (ProjectileFactory::*)()), ".8b812c06000085c07e??0fb681f6000000", argdata, 1, 1, &func);
+}
+
+bool ProjectileFactory::ReadyToFire()
+{
+	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func846::func;
+	return execfunc(this);
+}
+
+namespace _func847
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("ProjectileFactory::SpendMissiles", typeid(int (ProjectileFactory::*)()), "8b811406000085c00f8e????????578d7c240883e4f0ff77fc5589e55756538d7dd08d45cc8d75d889cb83ec3c89f9c745cc14000000c744240400000000", argdata, 1, 1, &func);
 }
 
 int ProjectileFactory::SpendMissiles()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func846::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func847::func;
 	return execfunc(this);
 }
 
-namespace _func847
+namespace _func848
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -11727,11 +11741,11 @@ namespace _func847
 void ProjectileFactory::OnRender(float alpha, bool forceVisual)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, float alpha_arg, bool forceVisual_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func847::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func848::func;
 	return execfunc(this, alpha, forceVisual);
 }
 
-namespace _func848
+namespace _func849
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11741,11 +11755,11 @@ namespace _func848
 int ProjectileFactory::NumTargetsRequired()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func848::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func849::func;
 	return execfunc(this);
 }
 
-namespace _func849
+namespace _func850
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11755,11 +11769,11 @@ namespace _func849
 void ProjectileFactory::Update()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func849::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func850::func;
 	return execfunc(this);
 }
 
-namespace _func850
+namespace _func851
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11769,20 +11783,6 @@ namespace _func850
 Projectile *ProjectileFactory::GetProjectile()
 {
 	typedef Projectile *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func850::func;
-	return execfunc(this);
-}
-
-namespace _func851
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ProjectileFactory::ClearAiming", typeid(void (ProjectileFactory::*)()), "8b91fc0000008b81000100005329d0c1f80385c07e2a8b591c83bbd8010000017e3e8b992c06000085db", argdata, 1, 5, &func);
-}
-
-void ProjectileFactory::ClearAiming()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func851::func;
 	return execfunc(this);
 }
@@ -11791,10 +11791,10 @@ namespace _func852
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ProjectileFactory::ClearProjectiles", typeid(void (ProjectileFactory::*)()), "8b8100060000898104060000c3", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ProjectileFactory::ClearAiming", typeid(void (ProjectileFactory::*)()), "8b91fc0000008b81000100005329d0c1f80385c07e2a8b591c83bbd8010000017e3e8b992c06000085db", argdata, 1, 5, &func);
 }
 
-void ProjectileFactory::ClearProjectiles()
+void ProjectileFactory::ClearAiming()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func852::func;
@@ -11805,10 +11805,10 @@ namespace _func853
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ProjectileFactory::destructor", typeid(void (ProjectileFactory::*)()), "5589e557565389cf83e4f083ec208b8100060000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ProjectileFactory::ClearProjectiles", typeid(void (ProjectileFactory::*)()), "8b8100060000898104060000c3", argdata, 1, 5, &func);
 }
 
-void ProjectileFactory::destructor()
+void ProjectileFactory::ClearProjectiles()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func853::func;
@@ -11818,6 +11818,20 @@ void ProjectileFactory::destructor()
 namespace _func854
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ProjectileFactory::destructor", typeid(void (ProjectileFactory::*)()), "5589e557565389cf83e4f083ec208b8100060000", argdata, 1, 5, &func);
+}
+
+void ProjectileFactory::destructor()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func854::func;
+	return execfunc(this);
+}
+
+namespace _func855
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("ProjectileFactory::LoadProjectile", typeid(Projectile *(*)(int )), "8d4c240483e4f0ff71fc5589e556535183ec6c8b19891c24", argdata, 1, 2, &func);
 }
@@ -11825,11 +11839,11 @@ namespace _func854
 Projectile *ProjectileFactory::LoadProjectile(int fd)
 {
 	typedef Projectile *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func854::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func855::func;
 	return execfunc(fd);
 }
 
-namespace _func855
+namespace _func856
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -11839,11 +11853,11 @@ namespace _func855
 void ProjectileFactory::SaveProjectile(Projectile *p, int fd)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Projectile *p_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func855::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func856::func;
 	return execfunc(p, fd);
 }
 
-namespace _func856
+namespace _func857
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11853,11 +11867,11 @@ namespace _func856
 void ProjectileFactory::SaveState(int fd)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func856::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func857::func;
 	return execfunc(this, fd);
 }
 
-namespace _func857
+namespace _func858
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11867,11 +11881,11 @@ namespace _func857
 void ProjectileFactory::SetAutoFire(bool autoFire)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ProjectileFactory *this_arg, bool autoFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func857::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func858::func;
 	return execfunc(this, autoFire);
 }
 
-namespace _func858
+namespace _func859
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11879,20 +11893,6 @@ namespace _func858
 }
 
 void ReactorButton::Accept()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func858::func;
-	return execfunc(this);
-}
-
-namespace _func859
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ReactorButton::OnClick", typeid(void (ReactorButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b4970e8????????03536c83fa180f8f????????807b40000f84????????", argdata, 1, 5, &func);
-}
-
-void ReactorButton::OnClick()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func859::func;
@@ -11903,10 +11903,10 @@ namespace _func860
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ReactorButton::OnRightClick", typeid(void (ReactorButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b496c85c97e??807b410075??", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ReactorButton::OnClick", typeid(void (ReactorButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b4970e8????????03536c83fa180f8f????????807b40000f84????????", argdata, 1, 5, &func);
 }
 
-void ReactorButton::OnRightClick()
+void ReactorButton::OnClick()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func860::func;
@@ -11917,24 +11917,38 @@ namespace _func861
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ReactorButton::OnRender", typeid(void (ReactorButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cf81ec????????898db4fbffffe8????????807f410074??807f40000f85????????", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ReactorButton::OnRightClick", typeid(void (ReactorButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b496c85c97e??807b410075??", argdata, 1, 5, &func);
 }
 
-void ReactorButton::OnRender()
+void ReactorButton::OnRightClick()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func861::func;
 	return execfunc(this);
 }
 
+namespace _func862
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ReactorButton::OnRender", typeid(void (ReactorButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cf81ec????????898db4fbffffe8????????807f410074??807f40000f85????????", argdata, 1, 5, &func);
+}
+
+void ReactorButton::OnRender()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ReactorButton *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func862::func;
+	return execfunc(this);
+}
+
 void **VTable_RepairAnimation;
 
-namespace _var862
+namespace _var863
 {
     static VariableDefinition varObj("VTable_RepairAnimation", "894424088d45ccc645da0089442404e8????????8b45cc83ec1439f874??890424e8????????8b4584c700(???????\?)c680ee09000001c7042438090000", &VTable_RepairAnimation);
 }
 
-namespace _func863
+namespace _func864
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -11944,11 +11958,11 @@ namespace _func863
 void RepairStoreBox::constructor(ShipManager *ship, bool repairAll, int price)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(RepairStoreBox *this_arg, ShipManager *ship_arg, bool repairAll_arg, int price_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func863::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func864::func;
 	return execfunc(this, ship, repairAll, price);
 }
 
-namespace _func864
+namespace _func865
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -11958,11 +11972,11 @@ namespace _func864
 void ResourceControl::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func864::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func865::func;
 	return execfunc(this);
 }
 
-namespace _func865
+namespace _func866
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -11972,11 +11986,11 @@ namespace _func865
 GL_Primitive *ResourceControl::CreateImagePrimitive(GL_Texture *tex, int unk1, int unk2, int unk3, GL_Color color, float alpha, bool mirror)
 {
 	typedef GL_Primitive *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg, int unk1_arg, int unk2_arg, int unk3_arg, GL_Color color_arg, float alpha_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func865::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func866::func;
 	return execfunc(this, tex, unk1, unk2, unk3, color, alpha, mirror);
 }
 
-namespace _func866
+namespace _func867
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -11986,11 +12000,11 @@ namespace _func866
 void ResourceControl::OnInit(int imageSwappingMode)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, int imageSwappingMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func866::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func867::func;
 	return execfunc(this, imageSwappingMode);
 }
 
-namespace _func867
+namespace _func868
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12000,11 +12014,11 @@ namespace _func867
 char *ResourceControl::LoadFile(const std::string &fileName)
 {
 	typedef char *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func867::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func868::func;
 	return execfunc(this, fileName);
 }
 
-namespace _func868
+namespace _func869
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -12014,11 +12028,11 @@ namespace _func868
 char *ResourceControl::LoadFromResourceFile(const std::string &fileName, std::size_t &fileSize, const std::string *unused_resourceFile)
 {
 	typedef char *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &fileName_arg, std::size_t &fileSize_arg, const std::string *unused_resourceFile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func868::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func869::func;
 	return execfunc(this, fileName, fileSize, unused_resourceFile);
 }
 
-namespace _func869
+namespace _func870
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12028,11 +12042,11 @@ namespace _func869
 GL_Texture *ResourceControl::GetImageId(const std::string &dir)
 {
 	typedef GL_Texture *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &dir_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func869::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func870::func;
 	return execfunc(this, dir);
 }
 
-namespace _func870
+namespace _func871
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -12042,11 +12056,11 @@ namespace _func870
 int ResourceControl::RenderImage(GL_Texture *tex, int x, int y, int rotation, GL_Color color, float opacity, bool mirror)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float opacity_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func870::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func871::func;
 	return execfunc(this, tex, x, y, rotation, color, opacity, mirror);
 }
 
-namespace _func871
+namespace _func872
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -12056,11 +12070,11 @@ namespace _func871
 int ResourceControl::RenderImageString(std::string &tex, int x, int y, int rotation, GL_Color color, float opacity, bool mirror)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, std::string &tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float opacity_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func871::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func872::func;
 	return execfunc(this, tex, x, y, rotation, color, opacity, mirror);
 }
 
-namespace _func872
+namespace _func873
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -12070,11 +12084,11 @@ namespace _func872
 GL_Primitive *ResourceControl::CreateImagePrimitiveString(const std::string &tex, int x, int y, int rotation, GL_Color color, float alpha, bool mirror)
 {
 	typedef GL_Primitive *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &tex_arg, int x_arg, int y_arg, int rotation_arg, GL_Color color_arg, float alpha_arg, bool mirror_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func872::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func873::func;
 	return execfunc(this, tex, x, y, rotation, color, alpha, mirror);
 }
 
-namespace _func873
+namespace _func874
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12084,11 +12098,11 @@ namespace _func873
 freetype::font_data &ResourceControl::GetFontData(int size, bool ignoreLanguage)
 {
 	typedef freetype::font_data &__attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, int size_arg, bool ignoreLanguage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func873::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func874::func;
 	return execfunc(this, size, ignoreLanguage);
 }
 
-namespace _func874
+namespace _func875
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12098,11 +12112,11 @@ namespace _func874
 ImageDesc ResourceControl::GetImageData(GL_Texture *tex)
 {
 	typedef ImageDesc __attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, GL_Texture *tex_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func874::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func875::func;
 	return execfunc(this, tex);
 }
 
-namespace _func875
+namespace _func876
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12112,11 +12126,11 @@ namespace _func875
 bool ResourceControl::PreloadResources(bool unk)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func875::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func876::func;
 	return execfunc(this, unk);
 }
 
-namespace _func876
+namespace _func877
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12126,11 +12140,11 @@ namespace _func876
 void ResourceControl::RenderLoadingBar(float initialProgress, float finalProgress)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, float initialProgress_arg, float finalProgress_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func876::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func877::func;
 	return execfunc(this, initialProgress, finalProgress);
 }
 
-namespace _func877
+namespace _func878
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12140,18 +12154,18 @@ namespace _func877
 bool ResourceControl::ImageExists(const std::string &name)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ResourceControl *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func877::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func878::func;
 	return execfunc(this, name);
 }
 
 ResourceControl *Global_ResourceControl_GlobalResources;
 
-namespace _var878
+namespace _var879
 {
     static VariableDefinition varObj("Global_ResourceControl_GlobalResources", "!8b45b8890424e8????????b9(???????\?)", &Global_ResourceControl_GlobalResources);
 }
 
-namespace _func879
+namespace _func880
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -12161,25 +12175,25 @@ namespace _func879
 void RockAnimation::constructor(const std::string &subRace, int iShipId, Pointf position, bool enemy)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(RockAnimation *this_arg, const std::string &subRace_arg, int iShipId_arg, Pointf position_arg, bool enemy_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func879::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func880::func;
 	return execfunc(this, subRace, iShipId, position, enemy);
-}
-
-namespace _func880
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK", typeid(void (RockAnimation::*)()), "5f5d8d67f85fc20400908d742600e8????????89c1e9????????8d7426000f1040080f114308", argdata, 0, 4, &func);
 }
 
 namespace _func881
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK2", typeid(void (RockAnimation::*)()), ".5f5d8d67f85fc20400908d742600e8????????89c1e9????????8d7426000f1040080f114308", argdata, 0, 4, &func);
+	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK", typeid(void (RockAnimation::*)()), "5f5d8d67f85fc20400908d742600e8????????89c1e9????????8d7426000f1040080f114308", argdata, 0, 4, &func);
 }
 
 namespace _func882
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK2", typeid(void (RockAnimation::*)()), ".5f5d8d67f85fc20400908d742600e8????????89c1e9????????8d7426000f1040080f114308", argdata, 0, 4, &func);
+}
+
+namespace _func883
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12189,25 +12203,25 @@ namespace _func882
 std::string RockAnimation::GetShootingSound()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(RockAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func882::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func883::func;
 	return execfunc(this);
-}
-
-namespace _func883
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK3", typeid(void (RockAnimation::*)()), "578d41088d7c240883e4f0ff77fc5589e5575389cb83ec108901", argdata, 0, 4, &func);
 }
 
 namespace _func884
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK4", typeid(void (RockAnimation::*)()), ".578d41088d7c240883e4f0ff77fc5589e5575389cb83ec108901", argdata, 0, 4, &func);
+	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK3", typeid(void (RockAnimation::*)()), "578d41088d7c240883e4f0ff77fc5589e5575389cb83ec108901", argdata, 0, 4, &func);
 }
 
 namespace _func885
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("RockAnimation::__DO_NOT_HOOK4", typeid(void (RockAnimation::*)()), ".578d41088d7c240883e4f0ff77fc5589e5575389cb83ec108901", argdata, 0, 4, &func);
+}
+
+namespace _func886
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12217,11 +12231,11 @@ namespace _func885
 std::string RockAnimation::GetDeathSound()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(RockAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func885::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func886::func;
 	return execfunc(this);
 }
 
-namespace _func886
+namespace _func887
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12231,11 +12245,11 @@ namespace _func886
 int Room::GetEmptySlots(bool intruder)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func886::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func887::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func887
+namespace _func888
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -12245,11 +12259,11 @@ namespace _func887
 void Room::constructor(int iShipId, int x, int y, int w, int h, int roomId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Room *this_arg, int iShipId_arg, int x_arg, int y_arg, int w_arg, int h_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func887::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func888::func;
 	return execfunc(this, iShipId, x, y, w, h, roomId);
 }
 
-namespace _func888
+namespace _func889
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12259,11 +12273,11 @@ namespace _func888
 void Room::OnRenderFloor(float alpha, bool experimental)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Room *this_arg, float alpha_arg, bool experimental_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func888::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func889::func;
 	return execfunc(this, alpha, experimental);
 }
 
-namespace _func889
+namespace _func890
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12273,18 +12287,18 @@ namespace _func889
 void Room::OnRenderWalls(float alpha)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Room *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func889::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func890::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func890
+namespace _func891
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("Room::__DO_NOT_HOOK", typeid(void (Room::*)()), "890424e8????????89742404893c2489c1c744240800000000e8????????89433883ec0c8d65f45b5e5f5d", argdata, 0, 4, &func);
 }
 
-namespace _func891
+namespace _func892
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12294,11 +12308,11 @@ namespace _func891
 void Room::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Room *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func891::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func892::func;
 	return execfunc(this);
 }
 
-namespace _func892
+namespace _func893
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12308,11 +12322,11 @@ namespace _func892
 int Room::GetEmptySlot(bool intruder)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func892::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func893::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func893
+namespace _func894
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12322,11 +12336,11 @@ namespace _func893
 bool Room::Full(bool intruder)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Room *this_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func893::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func894::func;
 	return execfunc(this, intruder);
 }
 
-namespace _func894
+namespace _func895
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12336,11 +12350,11 @@ namespace _func894
 void Room::FillSlot(int slot, bool intruder)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Room *this_arg, int slot_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func894::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func895::func;
 	return execfunc(this, slot, intruder);
 }
 
-namespace _func895
+namespace _func896
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12350,11 +12364,11 @@ namespace _func895
 bool ScoreKeeper::GetShipUnlocked(int shipId, int shipVariant)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int shipId_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func895::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func896::func;
 	return execfunc(this, shipId, shipVariant);
 }
 
-namespace _func896
+namespace _func897
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12364,11 +12378,11 @@ namespace _func896
 std::string ScoreKeeper::GetShipBlueprint(int index)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int index_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func896::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func897::func;
 	return execfunc(this, index);
 }
 
-namespace _func897
+namespace _func898
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12378,11 +12392,11 @@ namespace _func897
 void ScoreKeeper::OnInit()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func897::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func898::func;
 	return execfunc(this);
 }
 
-namespace _func898
+namespace _func899
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12392,11 +12406,11 @@ namespace _func898
 void ScoreKeeper::Save(bool newHighScore)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool newHighScore_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func898::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func899::func;
 	return execfunc(this, newHighScore);
 }
 
-namespace _func899
+namespace _func900
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12406,11 +12420,11 @@ namespace _func899
 void ScoreKeeper::OnRender(bool lastPlaythrough)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool lastPlaythrough_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func899::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func900::func;
 	return execfunc(this, lastPlaythrough);
 }
 
-namespace _func900
+namespace _func901
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -12420,11 +12434,11 @@ namespace _func900
 void ScoreKeeper::UnlockShip(int shipType, int shipVariant, bool save, bool hidePopup)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int shipType_arg, int shipVariant_arg, bool save_arg, bool hidePopup_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func900::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func901::func;
 	return execfunc(this, shipType, shipVariant, save, hidePopup);
 }
 
-namespace _func901
+namespace _func902
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12434,11 +12448,11 @@ namespace _func901
 void ScoreKeeper::SetVictory(bool victory)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool victory_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func901::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func902::func;
 	return execfunc(this, victory);
 }
 
-namespace _func902
+namespace _func903
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12448,11 +12462,11 @@ namespace _func902
 void ScoreKeeper::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func902::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func903::func;
 	return execfunc(this);
 }
 
-namespace _func903
+namespace _func904
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12462,11 +12476,11 @@ namespace _func903
 std::pair<int, int> ScoreKeeper::GetShipId(const std::string &blueprintName)
 {
 	typedef std::pair<int, int> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, const std::string &blueprintName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func903::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func904::func;
 	return execfunc(this, blueprintName);
 }
 
-namespace _func904
+namespace _func905
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12476,11 +12490,11 @@ namespace _func904
 void ScoreKeeper::LoadVersionFour(int file, int version)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int file_arg, int version_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func904::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func905::func;
 	return execfunc(this, file, version);
 }
 
-namespace _func905
+namespace _func906
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12490,11 +12504,11 @@ namespace _func905
 void ScoreKeeper::WipeProfile(bool permanent)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool permanent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func905::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func906::func;
 	return execfunc(this, permanent);
 }
 
-namespace _func906
+namespace _func907
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12504,11 +12518,11 @@ namespace _func906
 void ScoreKeeper::MouseClick(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func906::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func907::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func907
+namespace _func908
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12518,11 +12532,11 @@ namespace _func907
 void ScoreKeeper::SetupTopShip(int variant)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int variant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func907::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func908::func;
 	return execfunc(this, variant);
 }
 
-namespace _func908
+namespace _func909
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12532,11 +12546,11 @@ namespace _func908
 void ScoreKeeper::CheckTypes()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func908::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func909::func;
 	return execfunc(this);
 }
 
-namespace _func909
+namespace _func910
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12546,11 +12560,11 @@ namespace _func909
 void ScoreKeeper::AddTopScoreType(TopScore &topScore, int type)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, TopScore &topScore_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func909::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func910::func;
 	return execfunc(this, topScore, type);
 }
 
-namespace _func910
+namespace _func911
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12560,11 +12574,11 @@ namespace _func910
 int ScoreKeeper::AddTopScoreList(TopScore &score, std::vector<TopScore> &topScoreList)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, TopScore &score_arg, std::vector<TopScore> &topScoreList_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func910::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func911::func;
 	return execfunc(this, score, topScoreList);
 }
 
-namespace _func911
+namespace _func912
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x1ff};
@@ -12574,11 +12588,11 @@ namespace _func911
 void ScoreKeeper::RenderTopScores(const std::vector<TopScore> &topScoreList, Point position, int newHighScore)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, const std::vector<TopScore> &topScoreList_arg, Point position_arg, int newHighScore_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func911::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func912::func;
 	return execfunc(this, topScoreList, position, newHighScore);
 }
 
-namespace _func912
+namespace _func913
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12588,11 +12602,11 @@ namespace _func912
 void ScoreKeeper::CycleLeft()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func912::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func913::func;
 	return execfunc(this);
 }
 
-namespace _func913
+namespace _func914
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12602,11 +12616,11 @@ namespace _func913
 void ScoreKeeper::CycleRight()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func913::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func914::func;
 	return execfunc(this);
 }
 
-namespace _func914
+namespace _func915
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12616,11 +12630,11 @@ namespace _func914
 void ScoreKeeper::Open(bool fromGameOver)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, bool fromGameOver_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func914::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func915::func;
 	return execfunc(this, fromGameOver);
 }
 
-namespace _func915
+namespace _func916
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12630,11 +12644,11 @@ namespace _func915
 bool ScoreKeeper::KeyDown(SDLKey key)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func915::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func916::func;
 	return execfunc(this, key);
 }
 
-namespace _func916
+namespace _func917
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12644,11 +12658,11 @@ namespace _func916
 void ScoreKeeper::AddScrapCollected(int scrap)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int scrap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func916::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func917::func;
 	return execfunc(this, scrap);
 }
 
-namespace _func917
+namespace _func918
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12658,11 +12672,11 @@ namespace _func917
 void ScoreKeeper::SaveScores(int file, std::vector<TopScore> &topScores)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int file_arg, std::vector<TopScore> &topScores_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func917::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func918::func;
 	return execfunc(this, file, topScores);
 }
 
-namespace _func918
+namespace _func919
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12672,11 +12686,11 @@ namespace _func918
 void ScoreKeeper::SaveGame(int fd)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func918::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func919::func;
 	return execfunc(this, fd);
 }
 
-namespace _func919
+namespace _func920
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12686,11 +12700,11 @@ namespace _func919
 void ScoreKeeper::LoadGame(int fd)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func919::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func920::func;
 	return execfunc(this, fd);
 }
 
-namespace _func920
+namespace _func921
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12700,11 +12714,11 @@ namespace _func920
 void ScoreKeeper::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func920::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func921::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func921
+namespace _func922
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12714,18 +12728,18 @@ namespace _func921
 void ScoreKeeper::SetSector(int sector)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ScoreKeeper *this_arg, int sector_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func921::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func922::func;
 	return execfunc(this, sector);
 }
 
 ScoreKeeper *Global_ScoreKeeper_Keeper;
 
-namespace _var922
+namespace _var923
 {
     static VariableDefinition varObj("Global_ScoreKeeper_Keeper", "!8b430cb9(???????\?)c6804412000000c7042401000000", &Global_ScoreKeeper_Keeper);
 }
 
-namespace _func923
+namespace _func924
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -12735,11 +12749,11 @@ namespace _func923
 char Settings::GetCommandConsole()
 {
 	typedef char __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func923::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func924::func;
 	return execfunc();
 }
 
-namespace _func924
+namespace _func925
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -12749,11 +12763,11 @@ namespace _func924
 bool Settings::GetDlcEnabled()
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func924::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func925::func;
 	return execfunc();
 }
 
-namespace _func925
+namespace _func926
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12763,11 +12777,11 @@ namespace _func925
 std::string Settings::GetHotkeyName(const std::string &name)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func925::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func926::func;
 	return execfunc(name);
 }
 
-namespace _func926
+namespace _func927
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -12777,11 +12791,11 @@ namespace _func926
 SDLKey Settings::GetHotkey(const std::string &hotkeyName)
 {
 	typedef SDLKey __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &hotkeyName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func926::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func927::func;
 	return execfunc(hotkeyName);
 }
 
-namespace _func927
+namespace _func928
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -12791,11 +12805,11 @@ namespace _func927
 void Settings::SetHotkey(const std::string &hotkeyName, SDLKey key)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &hotkeyName_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func927::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func928::func;
 	return execfunc(hotkeyName, key);
 }
 
-namespace _func928
+namespace _func929
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -12803,20 +12817,6 @@ namespace _func928
 }
 
 void Settings::SaveSettings()
-{
-	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func928::func;
-	return execfunc();
-}
-
-namespace _func929
-{
-    static void *func = 0;
-	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("Settings::ResetHotkeys", typeid(void (*)()), ".8d4c240483e4f0ff71fc5589e557565351be????????83ec688b465c8b5e6039d88945a489c774??90", argdata, 0, 6, &func);
-}
-
-void Settings::ResetHotkeys()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func929::func;
@@ -12827,24 +12827,38 @@ namespace _func930
 {
     static void *func = 0;
 	static const short *argdata = NULL;
-	static FunctionDefinition funcObj("Settings::LoadSettings", typeid(void (*)()), ".8d4c240483e4f0ff71fc5589e5575653518d9d24ffffff81ec????????e8????????8d8d60ffffffe8????????a1????????c645d400", argdata, 0, 6, &func);
+	static FunctionDefinition funcObj("Settings::ResetHotkeys", typeid(void (*)()), ".8d4c240483e4f0ff71fc5589e557565351be????????83ec688b465c8b5e6039d88945a489c774??90", argdata, 0, 6, &func);
 }
 
-void Settings::LoadSettings()
+void Settings::ResetHotkeys()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func930::func;
 	return execfunc();
 }
 
+namespace _func931
+{
+    static void *func = 0;
+	static const short *argdata = NULL;
+	static FunctionDefinition funcObj("Settings::LoadSettings", typeid(void (*)()), ".8d4c240483e4f0ff71fc5589e5575653518d9d24ffffff81ec????????e8????????8d8d60ffffffe8????????a1????????c645d400", argdata, 0, 6, &func);
+}
+
+void Settings::LoadSettings()
+{
+	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func931::func;
+	return execfunc();
+}
+
 SettingValues *Global_Settings_Settings;
 
-namespace _var931
+namespace _var932
 {
     static VariableDefinition varObj("Global_Settings_Settings", "!5756535183ec588b01c745a8(???????\?)", &Global_Settings_Settings);
 }
 
-namespace _func932
+namespace _func933
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0xdff, 0x1ff};
@@ -12854,11 +12868,11 @@ namespace _func932
 CollisionResponse Shields::CollisionReal(float x, float y, Damage damage, bool force)
 {
 	typedef CollisionResponse __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg, float x_arg, float y_arg, Damage damage_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func932::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func933::func;
 	return execfunc(this, x, y, damage, force);
 }
 
-namespace _func933
+namespace _func934
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -12868,11 +12882,11 @@ namespace _func933
 void Shields::constructor(int roomId, int shipId, int startingPower, const std::string &shieldFile)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg, int roomId_arg, int shipId_arg, int startingPower_arg, const std::string &shieldFile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func933::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func934::func;
 	return execfunc(this, roomId, shipId, startingPower, shieldFile);
 }
 
-namespace _func934
+namespace _func935
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x4ff};
@@ -12882,11 +12896,11 @@ namespace _func934
 void Shields::SetBaseEllipse(Globals::Ellipse ellipse)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg, Globals::Ellipse ellipse_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func934::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func935::func;
 	return execfunc(this, ellipse);
 }
 
-namespace _func935
+namespace _func936
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -12896,11 +12910,11 @@ namespace _func935
 void Shields::SetHackingLevel(int hackingLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func935::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func936::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func936
+namespace _func937
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -12908,20 +12922,6 @@ namespace _func936
 }
 
 void Shields::InstantCharge()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func936::func;
-	return execfunc(this);
-}
-
-namespace _func937
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("Shields::Jump", typeid(void (Shields::*)()), "578d7c240883e4f0ff77fc5589e557565389cb8d7dd883ec3ce8????????f30f1015????????8b83040200000f28ca8d4b08f30f108314020000897dd0", argdata, 1, 5, &func);
-}
-
-void Shields::Jump()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func937::func;
@@ -12932,10 +12932,10 @@ namespace _func938
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("Shields::OnLoop", typeid(void (Shields::*)()), "578d7c240883e4f0ff77fc5589e557565389ce8d7dd083ec4ce8????????8d45d8893c24c745d8454e4552c745dc47595f53c745e04849454c8945d0", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("Shields::Jump", typeid(void (Shields::*)()), "578d7c240883e4f0ff77fc5589e557565389cb8d7dd883ec3ce8????????f30f1015????????8b83040200000f28ca8d4b08f30f108314020000897dd0", argdata, 1, 5, &func);
 }
 
-void Shields::OnLoop()
+void Shields::Jump()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func938::func;
@@ -12945,6 +12945,20 @@ void Shields::OnLoop()
 namespace _func939
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("Shields::OnLoop", typeid(void (Shields::*)()), "578d7c240883e4f0ff77fc5589e557565389ce8d7dd083ec4ce8????????8d45d8893c24c745d8454e4552c745dc47595f53c745e04849454c8945d0", argdata, 1, 5, &func);
+}
+
+void Shields::OnLoop()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func939::func;
+	return execfunc(this);
+}
+
+namespace _func940
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
 	static FunctionDefinition funcObj("Shields::AddSuperShield", typeid(void (Shields::*)(Point )), "57ba????????8d7c240883e4f0ff77fc5589e557565383ec1c8b81f40100008b378b7f0483c001", argdata, 2, 5, &func);
 }
@@ -12952,11 +12966,11 @@ namespace _func939
 void Shields::AddSuperShield(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func939::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func940::func;
 	return execfunc(this, pos);
 }
 
-namespace _func940
+namespace _func941
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -12966,11 +12980,11 @@ namespace _func940
 void Shields::RenderBase(float alpha, float superShieldOverwrite)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg, float alpha_arg, float superShieldOverwrite_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func940::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func941::func;
 	return execfunc(this, alpha, superShieldOverwrite);
 }
 
-namespace _func941
+namespace _func942
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0xdff};
@@ -12980,18 +12994,18 @@ namespace _func941
 CollisionResponse Shields::CollisionTest(float x, float y, Damage damage)
 {
 	typedef CollisionResponse __attribute__((thiscall)) (*custom_arg_funcptr_t)(Shields *this_arg, float x_arg, float y_arg, Damage damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func941::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func942::func;
 	return execfunc(this, x, y, damage);
 }
 
 GL_Color *Global_COLOR_GREEN;
 
-namespace _var942
+namespace _var943
 {
     static VariableDefinition varObj("Global_COLOR_GREEN", "!f30f1015(???????\?)f30f5ee6", &Global_COLOR_GREEN);
 }
 
-namespace _func943
+namespace _func944
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13001,11 +13015,11 @@ namespace _func943
 std::pair<int, int> Ship::ContainsHullBreach(int roomId)
 {
 	typedef std::pair<int, int> __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func943::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func944::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func944
+namespace _func945
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -13015,11 +13029,11 @@ namespace _func944
 int Ship::GetSelectedRoomId(int x, int y, bool unk)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int x_arg, int y_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func944::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func945::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func945
+namespace _func946
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff};
@@ -13029,11 +13043,11 @@ namespace _func945
 void Ship::LockdownRoom(int roomId, Pointf pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, Pointf pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func945::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func946::func;
 	return execfunc(this, roomId, pos);
 }
 
-namespace _func946
+namespace _func947
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13043,11 +13057,11 @@ namespace _func946
 bool Ship::RoomLocked(int roomId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func946::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func947::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func947
+namespace _func948
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13057,11 +13071,11 @@ namespace _func947
 bool Ship::DestroyedDone()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func947::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func948::func;
 	return execfunc(this);
 }
 
-namespace _func948
+namespace _func949
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13071,11 +13085,11 @@ namespace _func948
 bool Ship::FullRoom(int roomId, bool intruder)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func948::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func949::func;
 	return execfunc(this, roomId, intruder);
 }
 
-namespace _func949
+namespace _func950
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13085,11 +13099,11 @@ namespace _func949
 int Ship::EmptySlots(int roomId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func949::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func950::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func950
+namespace _func951
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13099,11 +13113,11 @@ namespace _func950
 int Ship::GetAvailableRoomSlot(int roomId, bool intruder)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func950::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func951::func;
 	return execfunc(this, roomId, intruder);
 }
 
-namespace _func951
+namespace _func952
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13113,11 +13127,11 @@ namespace _func951
 void Ship::OnRenderBreaches()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func951::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func952::func;
 	return execfunc(this);
 }
 
-namespace _func952
+namespace _func953
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13127,11 +13141,11 @@ namespace _func952
 void Ship::OnRenderWalls(bool forceView, bool doorControlMode)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, bool forceView_arg, bool doorControlMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func952::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func953::func;
 	return execfunc(this, forceView, doorControlMode);
 }
 
-namespace _func953
+namespace _func954
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13141,11 +13155,11 @@ namespace _func953
 void Ship::OnInit(ShipBlueprint &bp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, ShipBlueprint &bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func953::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func954::func;
 	return execfunc(this, bp);
 }
 
-namespace _func954
+namespace _func955
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13155,11 +13169,11 @@ namespace _func954
 void Ship::OnRenderSparks()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func954::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func955::func;
 	return execfunc(this);
 }
 
-namespace _func955
+namespace _func956
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13169,11 +13183,11 @@ namespace _func955
 void Ship::SetRoomBlackout(int roomId, bool blackout)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg, bool blackout_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func955::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func956::func;
 	return execfunc(this, roomId, blackout);
 }
 
-namespace _func956
+namespace _func957
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13181,20 +13195,6 @@ namespace _func956
 }
 
 void Ship::OnRenderBase(bool unk)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func956::func;
-	return execfunc(this, unk);
-}
-
-namespace _func957
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("Ship::OnRenderFloor", typeid(void (Ship::*)(bool )), "578d7c240883e4f0ff77fc5589f889e557565389cf83ec2c80b9b803000000", argdata, 2, 5, &func);
-}
-
-void Ship::OnRenderFloor(bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func957::func;
@@ -13205,17 +13205,31 @@ namespace _func958
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("Ship::OnRenderFloor", typeid(void (Ship::*)(bool )), "578d7c240883e4f0ff77fc5589f889e557565389cf83ec2c80b9b803000000", argdata, 2, 5, &func);
+}
+
+void Ship::OnRenderFloor(bool unk)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, bool unk_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func958::func;
+	return execfunc(this, unk);
+}
+
+namespace _func959
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("Ship::OnRenderJump", typeid(void (Ship::*)(float )), "578d7c240883e4f0ff77fc5589e557565389cb83ec5c8b4104f30f1027f30f1165d4890424", argdata, 2, 5, &func);
 }
 
 void Ship::OnRenderJump(float progress)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, float progress_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func958::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func959::func;
 	return execfunc(this, progress);
 }
 
-namespace _func959
+namespace _func960
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13225,11 +13239,11 @@ namespace _func959
 Point Ship::GetShipCorner()
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func959::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func960::func;
 	return execfunc(this);
 }
 
-namespace _func960
+namespace _func961
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13239,11 +13253,11 @@ namespace _func960
 Globals::Ellipse Ship::GetBaseEllipse()
 {
 	typedef Globals::Ellipse __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func960::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func961::func;
 	return execfunc(this);
 }
 
-namespace _func961
+namespace _func962
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13253,11 +13267,11 @@ namespace _func961
 void Ship::SetSelectedRoom(int roomId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func961::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func962::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func962
+namespace _func963
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13267,11 +13281,11 @@ namespace _func962
 void Ship::OnLoop(std::vector<float> &oxygenLevels)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, std::vector<float> &oxygenLevels_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func962::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func963::func;
 	return execfunc(this, oxygenLevels);
 }
 
-namespace _func963
+namespace _func964
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13281,11 +13295,11 @@ namespace _func963
 void Ship::BreachRandomHull(int roomId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func963::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func964::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func964
+namespace _func965
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13295,11 +13309,11 @@ namespace _func964
 bool Ship::BreachSpecificHull(int grid_x, int grid_y)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int grid_x_arg, int grid_y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func964::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func965::func;
 	return execfunc(this, grid_x, grid_y);
 }
 
-namespace _func965
+namespace _func966
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13309,11 +13323,11 @@ namespace _func965
 int Ship::GetAvailableRoom(int preferred, bool intruder)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, int preferred_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func965::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func966::func;
 	return execfunc(this, preferred, intruder);
 }
 
-namespace _func966
+namespace _func967
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13323,31 +13337,31 @@ namespace _func966
 std::vector<Repairable*> Ship::GetHullBreaches(bool onlyDamaged)
 {
 	typedef std::vector<Repairable*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(Ship *this_arg, bool onlyDamaged_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func966::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func967::func;
 	return execfunc(this, onlyDamaged);
-}
-
-namespace _noop967
-{
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_0", "!1ef7ffff(c6841d5afefeff01)");
 }
 
 namespace _noop968
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_1", "!89ca7d08(c6841d58fefeff01)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_0", "!1ef7ffff(c6841d5afefeff01)");
 }
 
 namespace _noop969
 {
-    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_2", "!89c87ddf(c6841d56fefeff01)");
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_1", "!89ca7d08(c6841d58fefeff01)");
 }
 
 namespace _noop970
 {
+    static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_2", "!89c87ddf(c6841d56fefeff01)");
+}
+
+namespace _noop971
+{
     static NoOpDefinition noOpObj("Global__NOP__Ship_OnInit_3", "!89c87d08(c6841d54fefeff01)");
 }
 
-namespace _func971
+namespace _func972
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13357,11 +13371,11 @@ namespace _func971
 void ShipAI::constructor(bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipAI *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func971::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func972::func;
 	return execfunc(this, unk);
 }
 
-namespace _func972
+namespace _func973
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13371,11 +13385,11 @@ namespace _func972
 void ShipAI::SetStalemate(bool stalemate)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipAI *this_arg, bool stalemate_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func972::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func973::func;
 	return execfunc(this, stalemate);
 }
 
-namespace _func973
+namespace _func974
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13385,11 +13399,11 @@ namespace _func973
 void ShipAI::OnLoop(bool hostile)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipAI *this_arg, bool hostile_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func973::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func974::func;
 	return execfunc(this, hostile);
 }
 
-namespace _func974
+namespace _func975
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13399,11 +13413,11 @@ namespace _func974
 std::pair<int, int> ShipAI::GetTeleportCommand()
 {
 	typedef std::pair<int, int> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipAI *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func974::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func975::func;
 	return execfunc(this);
 }
 
-namespace _func975
+namespace _func976
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13413,11 +13427,11 @@ namespace _func975
 void ShipBlueprint::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func975::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func976::func;
 	return execfunc(this);
 }
 
-namespace _func976
+namespace _func977
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13427,11 +13441,11 @@ namespace _func976
 void ShipBuilder::CheckTypes()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func976::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func977::func;
 	return execfunc(this);
 }
 
-namespace _func977
+namespace _func978
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13441,11 +13455,11 @@ namespace _func977
 void ShipBuilder::MouseClick(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func977::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func978::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func978
+namespace _func979
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13455,11 +13469,11 @@ namespace _func978
 void ShipBuilder::SwitchShip(int shipType, int shipVariant)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int shipType_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func978::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func979::func;
 	return execfunc(this, shipType, shipVariant);
 }
 
-namespace _func979
+namespace _func980
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13467,20 +13481,6 @@ namespace _func979
 }
 
 void ShipBuilder::CreateEquipmentBoxes()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func979::func;
-	return execfunc(this);
-}
-
-namespace _func980
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::CreateSystemBoxes", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec4c8bb9941000008b919010000089f829d0c1f802", argdata, 1, 5, &func);
-}
-
-void ShipBuilder::CreateSystemBoxes()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func980::func;
@@ -13491,10 +13491,10 @@ namespace _func981
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::SetupShipAchievements", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec5c8b816c1c0000c781781c0000ffffffff8981701c0000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CreateSystemBoxes", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec4c8bb9941000008b919010000089f829d0c1f802", argdata, 1, 5, &func);
 }
 
-void ShipBuilder::SetupShipAchievements()
+void ShipBuilder::CreateSystemBoxes()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func981::func;
@@ -13505,10 +13505,10 @@ namespace _func982
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::ClearShipAchievements", typeid(void (ShipBuilder::*)()), "8b816c1c0000c781781c0000ffffffff8981701c0000c390908db426000000005589e5575653", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipBuilder::SetupShipAchievements", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec5c8b816c1c0000c781781c0000ffffffff8981701c0000", argdata, 1, 5, &func);
 }
 
-void ShipBuilder::ClearShipAchievements()
+void ShipBuilder::SetupShipAchievements()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func982::func;
@@ -13518,6 +13518,20 @@ void ShipBuilder::ClearShipAchievements()
 namespace _func983
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ShipBuilder::ClearShipAchievements", typeid(void (ShipBuilder::*)()), "8b816c1c0000c781781c0000ffffffff8981701c0000c390908db426000000005589e5575653", argdata, 1, 5, &func);
+}
+
+void ShipBuilder::ClearShipAchievements()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func983::func;
+	return execfunc(this);
+}
+
+namespace _func984
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("ShipBuilder::SwapType", typeid(void (ShipBuilder::*)(int )), "578d7c240883e4f0ff77fc5589e557565389cb83ec1c8b098b3785c9", argdata, 2, 5, &func);
 }
@@ -13525,11 +13539,11 @@ namespace _func983
 void ShipBuilder::SwapType(int variant)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int variant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func983::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func984::func;
 	return execfunc(this, variant);
 }
 
-namespace _func984
+namespace _func985
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13537,20 +13551,6 @@ namespace _func984
 }
 
 void ShipBuilder::CycleShipNext()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func984::func;
-	return execfunc(this);
-}
-
-namespace _func985
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::CycleShipPrevious", typeid(void (ShipBuilder::*)()), ".578d7c240883e4f0ff77fc5589e557565389ce83ec2c8b0985c974??", argdata, 1, 5, &func);
-}
-
-void ShipBuilder::CycleShipPrevious()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func985::func;
@@ -13561,10 +13561,10 @@ namespace _func986
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::Open", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565381ec????????898d38fbffff", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CycleShipPrevious", typeid(void (ShipBuilder::*)()), ".578d7c240883e4f0ff77fc5589e557565389ce83ec2c8b0985c974??", argdata, 1, 5, &func);
 }
 
-void ShipBuilder::Open()
+void ShipBuilder::CycleShipPrevious()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func986::func;
@@ -13575,10 +13575,10 @@ namespace _func987
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::OnRender", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389cb81ec????????80b960120000000f85????????e8????????8b831c0f00008d7dd0", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipBuilder::Open", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565381ec????????898d38fbffff", argdata, 1, 5, &func);
 }
 
-void ShipBuilder::OnRender()
+void ShipBuilder::Open()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func987::func;
@@ -13589,10 +13589,10 @@ namespace _func988
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::OnLoop", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389cbb9????????81ec????????e8????????84c0", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipBuilder::OnRender", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389cb81ec????????80b960120000000f85????????e8????????8b831c0f00008d7dd0", argdata, 1, 5, &func);
 }
 
-void ShipBuilder::OnLoop()
+void ShipBuilder::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func988::func;
@@ -13603,10 +13603,10 @@ namespace _func989
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::constructor", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83c10c8d7dd08d75d883ec3cc741f800000000c741fc00000000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipBuilder::OnLoop", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389cbb9????????81ec????????e8????????84c0", argdata, 1, 5, &func);
 }
 
-void ShipBuilder::constructor()
+void ShipBuilder::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func989::func;
@@ -13616,6 +13616,20 @@ void ShipBuilder::constructor()
 namespace _func990
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ShipBuilder::constructor", typeid(void (ShipBuilder::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83c10c8d7dd08d75d883ec3cc741f800000000c741fc00000000", argdata, 1, 5, &func);
+}
+
+void ShipBuilder::constructor()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func990::func;
+	return execfunc(this);
+}
+
+namespace _func991
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipBuilder::MouseMove", typeid(void (ShipBuilder::*)(int , int )), "578d7c240883e4f0ff77fc5589f889e557565389cf81ec????????8b308b4004898570feffff8d81540f000089b574feffff", argdata, 3, 5, &func);
 }
@@ -13623,11 +13637,11 @@ namespace _func990
 void ShipBuilder::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func990::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func991::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func991
+namespace _func992
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13637,11 +13651,11 @@ namespace _func991
 void ShipBuilder::OnKeyDown(SDLKey key)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func991::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func992::func;
 	return execfunc(this, key);
 }
 
-namespace _func992
+namespace _func993
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13651,20 +13665,6 @@ namespace _func992
 ShipManager *ShipBuilder::GetShip()
 {
 	typedef ShipManager *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func992::func;
-	return execfunc(this);
-}
-
-namespace _func993
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::CycleTypeNext", typeid(void (ShipBuilder::*)()), "578d????0883e4f0ff????5589e557565389cf31f683ec1c8b81001c0000", argdata, 1, 5, &func);
-}
-
-void ShipBuilder::CycleTypeNext()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func993::func;
 	return execfunc(this);
 }
@@ -13673,10 +13673,10 @@ namespace _func994
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::CycleTypePrev", typeid(void (ShipBuilder::*)()), "578d????0883e4f0ff????5589e557565389cfbe02000000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CycleTypeNext", typeid(void (ShipBuilder::*)()), "578d????0883e4f0ff????5589e557565389cf31f683ec1c8b81001c0000", argdata, 1, 5, &func);
 }
 
-void ShipBuilder::CycleTypePrev()
+void ShipBuilder::CycleTypeNext()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func994::func;
@@ -13687,10 +13687,10 @@ namespace _func995
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipBuilder::Close", typeid(void (ShipBuilder::*)()), "5589e557565389cb83e4f083ec108bb94c0f0000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipBuilder::CycleTypePrev", typeid(void (ShipBuilder::*)()), "578d????0883e4f0ff????5589e557565389cfbe02000000", argdata, 1, 5, &func);
 }
 
-void ShipBuilder::Close()
+void ShipBuilder::CycleTypePrev()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func995::func;
@@ -13700,6 +13700,20 @@ void ShipBuilder::Close()
 namespace _func996
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ShipBuilder::Close", typeid(void (ShipBuilder::*)()), "5589e557565389cb83e4f083ec108bb94c0f0000", argdata, 1, 5, &func);
+}
+
+void ShipBuilder::Close()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipBuilder *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func996::func;
+	return execfunc(this);
+}
+
+namespace _func997
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipButton::constructor", typeid(void (ShipButton::*)(int , int )), "578d7c240883e4f0ff77fc5589e557565389ce81ec????????8b0789c389857cfdffff8b4704898580fdffffe8????????", argdata, 3, 5, &func);
 }
@@ -13707,11 +13721,11 @@ namespace _func996
 void ShipButton::constructor(int shipType, int shipVariant)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipButton *this_arg, int shipType_arg, int shipVariant_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func996::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func997::func;
 	return execfunc(this, shipType, shipVariant);
 }
 
-namespace _func997
+namespace _func998
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff};
@@ -13721,11 +13735,11 @@ namespace _func997
 void ShipButton::OnInit(const std::string &imgName, Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipButton *this_arg, const std::string &imgName_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func997::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func998::func;
 	return execfunc(this, imgName, pos);
 }
 
-namespace _func998
+namespace _func999
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13735,11 +13749,11 @@ namespace _func998
 void ShipButton::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipButton *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func998::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func999::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func999
+namespace _func1000
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -13749,11 +13763,11 @@ namespace _func999
 void ShipButton::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func999::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1000::func;
 	return execfunc(this);
 }
 
-namespace _func1000
+namespace _func1001
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13763,11 +13777,11 @@ namespace _func1000
 void ShipEvent::constructor(const ShipEvent &event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipEvent *this_arg, const ShipEvent &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1000::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1001::func;
 	return execfunc(this, event);
 }
 
-namespace _func1001
+namespace _func1002
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13777,11 +13791,11 @@ namespace _func1001
 ShipManager *ShipGenerator::CreateShip(const std::string &name, int sector, ShipEvent &event)
 {
 	typedef ShipManager *__attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &name_arg, int sector_arg, ShipEvent &event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1001::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1002::func;
 	return execfunc(name, sector, event);
 }
 
-namespace _func1002
+namespace _func1003
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13791,11 +13805,11 @@ namespace _func1002
 std::vector<int> ShipGenerator::GenerateSystemMaxes(const ShipBlueprint &ship, int level)
 {
 	typedef std::vector<int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(const ShipBlueprint &ship_arg, int level_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1002::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1003::func;
 	return execfunc(ship, level);
 }
 
-namespace _func1003
+namespace _func1004
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff};
@@ -13805,11 +13819,11 @@ namespace _func1003
 bool ShipGenerator::UpgradeSystem(ShipManager *ship, std::vector<int> &systemMaxes, unsigned int sysId)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, unsigned int sysId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1003::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1004::func;
 	return execfunc(ship, systemMaxes, sysId);
 }
 
-namespace _func1004
+namespace _func1005
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13819,20 +13833,6 @@ namespace _func1004
 std::vector<int> ShipGenerator::GetPossibleSystemUpgrades(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1004::func;
-	return execfunc(ship, systemMaxes, scrap, type);
-}
-
-namespace _func1005
-{
-    static void *func = 0;
-	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades0", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), "578d7c240883e4f0ff77fc5589e557565389ce83ec6c8945c0c70000000000c7400400000000c740080000000031c08955bcc745c8000000008db42600000000", argdata, 5, 2, &func);
-}
-
-std::vector<int> ShipGenerator::GetPossibleSystemUpgrades0(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
-{
-	typedef std::vector<int> __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1005::func;
 	return execfunc(ship, systemMaxes, scrap, type);
 }
@@ -13841,10 +13841,10 @@ namespace _func1006
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades1", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), "578d7c240883e4f0ff77fc5589e557565389ce83ec6c8945c0c70000000000c7400400000000c740080000000031c08955bcc745c800000000eb1c", argdata, 5, 2, &func);
+	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades0", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), "578d7c240883e4f0ff77fc5589e557565389ce83ec6c8945c0c70000000000c7400400000000c740080000000031c08955bcc745c8000000008db42600000000", argdata, 5, 2, &func);
 }
 
-std::vector<int> ShipGenerator::GetPossibleSystemUpgrades1(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
+std::vector<int> ShipGenerator::GetPossibleSystemUpgrades0(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1006::func;
@@ -13855,10 +13855,10 @@ namespace _func1007
 {
     static void *func = 0;
 	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades2", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), "578d7c240883e4f0ff77fc5589e557565389ce83ec6c8945c0c70000000000c7400400000000c740080000000031c08955bcc745c800000000eb1f", argdata, 5, 2, &func);
+	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades1", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), "578d7c240883e4f0ff77fc5589e557565389ce83ec6c8945c0c70000000000c7400400000000c740080000000031c08955bcc745c800000000eb1c", argdata, 5, 2, &func);
 }
 
-std::vector<int> ShipGenerator::GetPossibleSystemUpgrades2(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
+std::vector<int> ShipGenerator::GetPossibleSystemUpgrades1(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
 {
 	typedef std::vector<int> __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1007::func;
@@ -13868,6 +13868,20 @@ std::vector<int> ShipGenerator::GetPossibleSystemUpgrades2(ShipManager *ship, st
 namespace _func1008
 {
     static void *func = 0;
+	static short argdata[] = {0x100, 0x102, 0x101, 0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("ShipGenerator::GetPossibleSystemUpgrades2", typeid(std::vector<int> (*)(ShipManager *, std::vector<int> &, int , int )), "578d7c240883e4f0ff77fc5589e557565389ce83ec6c8945c0c70000000000c7400400000000c740080000000031c08955bcc745c800000000eb1f", argdata, 5, 2, &func);
+}
+
+std::vector<int> ShipGenerator::GetPossibleSystemUpgrades2(ShipManager *ship, std::vector<int> &systemMaxes, int scrap, int type)
+{
+	typedef std::vector<int> __attribute__((regparm(3))) (*custom_arg_funcptr_t)(ShipManager *ship_arg, std::vector<int> &systemMaxes_arg, int scrap_arg, int type_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1008::func;
+	return execfunc(ship, systemMaxes, scrap, type);
+}
+
+namespace _func1009
+{
+    static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipGenerator::GetPossibleWeaponList", typeid(std::vector<WeaponBlueprint*> (*)(ShipManager *, const std::string &, int , unsigned int )), "8d4c240483e4f0ff71fc5589c889e55756535181ec880000008b198b78088b49048b4010895da0897d9489459c", argdata, 5, 2, &func);
 }
@@ -13875,11 +13889,11 @@ namespace _func1008
 std::vector<WeaponBlueprint*> ShipGenerator::GetPossibleWeaponList(ShipManager *ship, const std::string &weaponList, int scrap, unsigned int flags)
 {
 	typedef std::vector<WeaponBlueprint*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &weaponList_arg, int scrap_arg, unsigned int flags_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1008::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1009::func;
 	return execfunc(ship, weaponList, scrap, flags);
 }
 
-namespace _func1009
+namespace _func1010
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13889,11 +13903,11 @@ namespace _func1009
 std::vector<DroneBlueprint*> ShipGenerator::GetPossibleDroneList(ShipManager *ship, const std::string &droneList, int scrap, unsigned int flags, bool repeat)
 {
 	typedef std::vector<DroneBlueprint*> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &droneList_arg, int scrap_arg, unsigned int flags_arg, bool repeat_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1009::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1010::func;
 	return execfunc(ship, droneList, scrap, flags, repeat);
 }
 
-namespace _func1010
+namespace _func1011
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -13903,11 +13917,11 @@ namespace _func1010
 std::vector<CrewBlueprint> ShipGenerator::GetPossibleCrewList(ShipManager *ship, const std::string &crewList, unsigned int flags)
 {
 	typedef std::vector<CrewBlueprint> __attribute__((cdecl)) (*custom_arg_funcptr_t)(ShipManager *ship_arg, const std::string &crewList_arg, unsigned int flags_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1010::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1011::func;
 	return execfunc(ship, crewList, flags);
 }
 
-namespace _func1011
+namespace _func1012
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -13917,11 +13931,11 @@ namespace _func1011
 ShipGraph *ShipGraph::GetShipInfo(int shipId)
 {
 	typedef ShipGraph *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1011::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1012::func;
 	return execfunc(shipId);
 }
 
-namespace _func1012
+namespace _func1013
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13931,11 +13945,11 @@ namespace _func1012
 std::vector<int> ShipGraph::ConnectivityDFS(int roomId)
 {
 	typedef std::vector<int> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1012::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1013::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1013
+namespace _func1014
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -13964,11 +13978,11 @@ FUNC_NAKED __int64 ShipGraph::GetSlotRenderPosition_DO_NOT_USE_DIRECTLY(int slot
 		"movl %%ebp, %%esp\n\t"
 		"popl %%ebp\n\t"
 		"ret $12\n\t"
-		 :: "m"(_func1013::func)
+		 :: "m"(_func1014::func)
 	);
 }
 
-namespace _func1014
+namespace _func1015
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -13978,11 +13992,11 @@ namespace _func1014
 int ShipGraph::DoorCount(int roomId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1014::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1015::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1015
+namespace _func1016
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -13992,11 +14006,11 @@ namespace _func1015
 std::vector<Door*> ShipGraph::GetDoors(int roomId)
 {
 	typedef std::vector<Door*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1015::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1016::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1016
+namespace _func1017
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14006,11 +14020,11 @@ namespace _func1016
 bool ShipGraph::IsRoomConnected(int room1, int room2)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room1_arg, int room2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1016::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1017::func;
 	return execfunc(this, room1, room2);
 }
 
-namespace _func1017
+namespace _func1018
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -14020,11 +14034,11 @@ namespace _func1017
 Door *ShipGraph::ConnectingDoor(int x1, int y1, int x2, int y2)
 {
 	typedef Door *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x1_arg, int y1_arg, int x2_arg, int y2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1017::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1018::func;
 	return execfunc(this, x1, y1, x2, y2);
 }
 
-namespace _func1018
+namespace _func1019
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -14034,11 +14048,11 @@ namespace _func1018
 int ShipGraph::ConnectedGridSquares(int x1, int y1, int x2, int y2)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x1_arg, int y1_arg, int x2_arg, int y2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1018::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1019::func;
 	return execfunc(this, x1, y1, x2, y2);
 }
 
-namespace _func1019
+namespace _func1020
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x2ff};
@@ -14048,11 +14062,11 @@ namespace _func1019
 int ShipGraph::ConnectedGridSquaresPoint(Point p1, Point p2)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1019::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1020::func;
 	return execfunc(this, p1, p2);
 }
 
-namespace _func1020
+namespace _func1021
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x2ff};
@@ -14062,11 +14076,11 @@ namespace _func1020
 Door *ShipGraph::ConnectingDoor(Point p1, Point p2)
 {
 	typedef Door *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1020::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1021::func;
 	return execfunc(this, p1, p2);
 }
 
-namespace _func1021
+namespace _func1022
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14076,11 +14090,11 @@ namespace _func1021
 int ShipGraph::GetNumSlots(int room)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1021::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1022::func;
 	return execfunc(this, room);
 }
 
-namespace _func1022
+namespace _func1023
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14090,11 +14104,11 @@ namespace _func1022
 int ShipGraph::PopClosestDoor(std::vector<int> &doors, std::vector<float> &distances)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, std::vector<int> &doors_arg, std::vector<float> &distances_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1022::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1023::func;
 	return execfunc(this, doors, distances);
 }
 
-namespace _func1023
+namespace _func1024
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x2ff, 0x1ff};
@@ -14104,11 +14118,11 @@ namespace _func1023
 Path ShipGraph::Dijkstra(Point start, Point goal, int shipId)
 {
 	typedef Path __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point start_arg, Point goal_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1023::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1024::func;
 	return execfunc(this, start, goal, shipId);
 }
 
-namespace _func1024
+namespace _func1025
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x2ff, 0x1ff};
@@ -14118,11 +14132,11 @@ namespace _func1024
 Path ShipGraph::FindPath(Point p1, Point p2, int shipId)
 {
 	typedef Path __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point p1_arg, Point p2_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1024::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1025::func;
 	return execfunc(this, p1, p2, shipId);
 }
 
-namespace _func1025
+namespace _func1026
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14132,11 +14146,11 @@ namespace _func1025
 float ShipGraph::ConvertToWorldAngle(float ang)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, float ang_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1025::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1026::func;
 	return execfunc(this, ang);
 }
 
-namespace _func1026
+namespace _func1027
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14146,11 +14160,11 @@ namespace _func1026
 float ShipGraph::ConvertToLocalAngle(float ang)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, float ang_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1026::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1027::func;
 	return execfunc(this, ang);
 }
 
-namespace _func1027
+namespace _func1028
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -14178,11 +14192,11 @@ FUNC_NAKED __int64 ShipGraph::ConvertToWorldPosition_DO_NOT_USE_DIRECTLY(Pointf 
 		"movl %%ebp, %%esp\n\t"
 		"popl %%ebp\n\t"
 		"ret $8\n\t"
-		 :: "m"(_func1027::func)
+		 :: "m"(_func1028::func)
 	);
 }
 
-namespace _func1028
+namespace _func1029
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -14211,11 +14225,11 @@ FUNC_NAKED __int64 ShipGraph::ConvertToLocalPosition_DO_NOT_USE_DIRECTLY(Pointf 
 		"movl %%ebp, %%esp\n\t"
 		"popl %%ebp\n\t"
 		"ret $12\n\t"
-		 :: "m"(_func1028::func)
+		 :: "m"(_func1029::func)
 	);
 }
 
-namespace _func1029
+namespace _func1030
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14225,11 +14239,11 @@ namespace _func1029
 void ShipGraph::ComputeCenter()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1029::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1030::func;
 	return execfunc(this);
 }
 
-namespace _func1030
+namespace _func1031
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14239,11 +14253,11 @@ namespace _func1030
 bool ShipGraph::ContainsPoint(int x, int y)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1030::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1031::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1031
+namespace _func1032
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -14253,11 +14267,11 @@ namespace _func1031
 int ShipGraph::GetSelectedRoom(int x, int y, bool unk)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int x_arg, int y_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1031::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1032::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func1032
+namespace _func1033
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14267,11 +14281,11 @@ namespace _func1032
 int ShipGraph::RoomCount()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1032::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1033::func;
 	return execfunc(this);
 }
 
-namespace _func1033
+namespace _func1034
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14281,11 +14295,11 @@ namespace _func1033
 Globals::Rect ShipGraph::GetRoomShape(int room)
 {
 	typedef Globals::Rect __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1033::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1034::func;
 	return execfunc(this, room);
 }
 
-namespace _func1034
+namespace _func1035
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14295,11 +14309,11 @@ namespace _func1034
 float ShipGraph::GetRoomOxygen(int room)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1034::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1035::func;
 	return execfunc(this, room);
 }
 
-namespace _func1035
+namespace _func1036
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14309,11 +14323,11 @@ namespace _func1035
 bool ShipGraph::GetRoomBlackedOut(int room)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int room_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1035::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1036::func;
 	return execfunc(this, room);
 }
 
-namespace _func1036
+namespace _func1037
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -14323,11 +14337,11 @@ namespace _func1036
 Slot ShipGraph::GetClosestSlot(Point pos, int shipId, bool intruder)
 {
 	typedef Slot __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, Point pos_arg, int shipId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1036::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1037::func;
 	return execfunc(this, pos, shipId, intruder);
 }
 
-namespace _func1037
+namespace _func1038
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14337,11 +14351,11 @@ namespace _func1037
 Point ShipGraph::GetSlotWorldPosition(int slotId, int roomId)
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipGraph *this_arg, int slotId_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1037::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1038::func;
 	return execfunc(this, slotId, roomId);
 }
 
-namespace _func1038
+namespace _func1039
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -14351,11 +14365,11 @@ namespace _func1038
 void ShipGraph::Restart()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1038::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1039::func;
 	return execfunc();
 }
 
-namespace _func1039
+namespace _func1040
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14365,11 +14379,11 @@ namespace _func1039
 char ShipInfo::AddAugmentation(const std::string &augment)
 {
 	typedef char __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1039::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1040::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1040
+namespace _func1041
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14379,11 +14393,11 @@ namespace _func1040
 bool ShipInfo::HasAugmentation(const std::string &augment)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1040::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1041::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1041
+namespace _func1042
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14393,11 +14407,11 @@ namespace _func1041
 float ShipInfo::GetAugmentationValue(const std::string &augment)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipInfo *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1041::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1042::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1042
+namespace _func1043
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14407,11 +14421,11 @@ namespace _func1042
 int ShipManager::constructor(int shipId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1042::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1043::func;
 	return execfunc(this, shipId);
 }
 
-namespace _func1043
+namespace _func1044
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14421,11 +14435,11 @@ namespace _func1043
 void ShipManager::AddInitialCrew(std::vector<CrewBlueprint> &blueprints)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, std::vector<CrewBlueprint> &blueprints_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1043::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1044::func;
 	return execfunc(this, blueprints);
 }
 
-namespace _func1044
+namespace _func1045
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14435,11 +14449,11 @@ namespace _func1044
 int ShipManager::GetDodgeFactor()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1044::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1045::func;
 	return execfunc(this);
 }
 
-namespace _func1045
+namespace _func1046
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14449,11 +14463,11 @@ namespace _func1045
 int ShipManager::GetNetDodgeFactor()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1045::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1046::func;
 	return execfunc(this);
 }
 
-namespace _func1046
+namespace _func1047
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14463,11 +14477,11 @@ namespace _func1046
 void ShipManager::OnRender(bool showInterior, bool doorControlMode)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool showInterior_arg, bool doorControlMode_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1046::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1047::func;
 	return execfunc(this, showInterior, doorControlMode);
 }
 
-namespace _func1047
+namespace _func1048
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14477,11 +14491,11 @@ namespace _func1047
 int ShipManager::CountCrew(bool boarders)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool boarders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1047::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1048::func;
 	return execfunc(this, boarders);
 }
 
-namespace _func1048
+namespace _func1049
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -14491,11 +14505,11 @@ namespace _func1048
 std::vector<CrewMember*> ShipManager::TeleportCrew(int roomId, bool intruders)
 {
 	typedef std::vector<CrewMember*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1048::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1049::func;
 	return execfunc(this, roomId, intruders);
 }
 
-namespace _func1049
+namespace _func1050
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14505,11 +14519,11 @@ namespace _func1049
 int ShipManager::OnInit(ShipBlueprint *bp, int shipLevel)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, ShipBlueprint *bp_arg, int shipLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1049::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1050::func;
 	return execfunc(this, bp, shipLevel);
 }
 
-namespace _func1050
+namespace _func1051
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14519,11 +14533,11 @@ namespace _func1050
 bool ShipManager::HasSystem(int systemId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1050::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1051::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1051
+namespace _func1052
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14533,11 +14547,11 @@ namespace _func1051
 ShipSystem *ShipManager::GetSystemInRoom(int roomId)
 {
 	typedef ShipSystem *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1051::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1052::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1052
+namespace _func1053
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14547,11 +14561,11 @@ namespace _func1052
 void ShipManager::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1052::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1053::func;
 	return execfunc(this);
 }
 
-namespace _func1053
+namespace _func1054
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14561,11 +14575,11 @@ namespace _func1053
 bool ShipManager::IncreaseSystemPower(int systemId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1053::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1054::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1054
+namespace _func1055
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14575,11 +14589,11 @@ namespace _func1054
 int ShipManager::CreateSystems()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1054::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1055::func;
 	return execfunc(this);
 }
 
-namespace _func1055
+namespace _func1056
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14589,11 +14603,11 @@ namespace _func1055
 int ShipManager::AddSystem(int systemId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1055::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1056::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1056
+namespace _func1057
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14603,11 +14617,11 @@ namespace _func1056
 void ShipManager::UpdateCrewMembers()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1056::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1057::func;
 	return execfunc(this);
 }
 
-namespace _func1057
+namespace _func1058
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14617,11 +14631,11 @@ namespace _func1057
 void ShipManager::KillEveryone(bool noClone)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool noClone_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1057::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1058::func;
 	return execfunc(this, noClone);
 }
 
-namespace _func1058
+namespace _func1059
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -14631,11 +14645,11 @@ namespace _func1058
 bool ShipManager::PowerDrone(Drone *drone, int roomId, bool userDriven, bool force)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Drone *drone_arg, int roomId_arg, bool userDriven_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1058::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1059::func;
 	return execfunc(this, drone, roomId, userDriven, force);
 }
 
-namespace _func1059
+namespace _func1060
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14645,11 +14659,11 @@ namespace _func1059
 void ShipManager::UpdateEnvironment()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1059::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1060::func;
 	return execfunc(this);
 }
 
-namespace _func1060
+namespace _func1061
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -14659,11 +14673,11 @@ namespace _func1060
 CrewMember *ShipManager::AddCrewMemberFromBlueprint(CrewBlueprint *bp, int slot, bool init, int roomId, bool intruder)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewBlueprint *bp_arg, int slot_arg, bool init_arg, int roomId_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1060::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1061::func;
 	return execfunc(this, bp, slot, init, roomId, intruder);
 }
 
-namespace _func1061
+namespace _func1062
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -14673,11 +14687,11 @@ namespace _func1061
 CrewMember *ShipManager::AddCrewMemberFromString(const std::string &name, const std::string &race, bool intruder, int roomId, bool init, bool male)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const std::string &name_arg, const std::string &race_arg, bool intruder_arg, int roomId_arg, bool init_arg, bool male_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1061::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1062::func;
 	return execfunc(this, name, race, intruder, roomId, init, male);
 }
 
-namespace _func1062
+namespace _func1063
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -14687,11 +14701,11 @@ namespace _func1062
 void ShipManager::AddCrewMember(CrewMember *crew, int roomId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1062::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1063::func;
 	return execfunc(this, crew, roomId);
 }
 
-namespace _func1063
+namespace _func1064
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14701,11 +14715,11 @@ namespace _func1063
 int ShipManager::GetOxygenPercentage()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1063::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1064::func;
 	return execfunc(this);
 }
 
-namespace _func1064
+namespace _func1065
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0xdff};
@@ -14715,11 +14729,11 @@ namespace _func1064
 bool ShipManager::DamageCrew(CrewMember *crew, Damage dmg)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, Damage dmg_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1064::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1065::func;
 	return execfunc(this, crew, dmg);
 }
 
-namespace _func1065
+namespace _func1066
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14729,11 +14743,11 @@ namespace _func1065
 void ShipManager::RemoveItem(const std::string &name)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1065::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1066::func;
 	return execfunc(this, name);
 }
 
-namespace _func1066
+namespace _func1067
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0xdff, 0x1ff};
@@ -14743,11 +14757,11 @@ namespace _func1066
 bool ShipManager::DamageArea(Pointf location, Damage dmg, bool forceHit)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf location_arg, Damage dmg_arg, bool forceHit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1066::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1067::func;
 	return execfunc(this, location, dmg, forceHit);
 }
 
-namespace _func1067
+namespace _func1068
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x2ff, 0xdff};
@@ -14757,11 +14771,11 @@ namespace _func1067
 bool ShipManager::DamageBeam(Pointf location1, Pointf location2, Damage dmg)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf location1_arg, Pointf location2_arg, Damage dmg_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1067::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1068::func;
 	return execfunc(this, location1, location2, dmg);
 }
 
-namespace _func1068
+namespace _func1069
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14771,11 +14785,11 @@ namespace _func1068
 void ShipManager::PulsarDamage()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1068::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1069::func;
 	return execfunc(this);
 }
 
-namespace _func1069
+namespace _func1070
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -14785,11 +14799,11 @@ namespace _func1069
 CrewBlueprint ShipManager::SelectRandomCrew(int seed, const std::string &racePref)
 {
 	typedef CrewBlueprint __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int seed_arg, const std::string &racePref_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1069::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1070::func;
 	return execfunc(this, seed, racePref);
 }
 
-namespace _func1070
+namespace _func1071
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14797,20 +14811,6 @@ namespace _func1070
 }
 
 void ShipManager::ClearStatusAll()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1070::func;
-	return execfunc(this);
-}
-
-namespace _func1071
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipManager::PrepareSuperDrones", typeid(void (ShipManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec7c8b816c0800003b81700800000f84????????8b0d????????ba????????83f90274??83f901", argdata, 1, 5, &func);
-}
-
-void ShipManager::PrepareSuperDrones()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1071::func;
@@ -14821,10 +14821,10 @@ namespace _func1072
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipManager::JumpLeave", typeid(void (ShipManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec3c83a994040000018b51188b8194040000c681d80400000185c0", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipManager::PrepareSuperDrones", typeid(void (ShipManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec7c8b816c0800003b81700800000f84????????8b0d????????ba????????83f90274??83f901", argdata, 1, 5, &func);
 }
 
-void ShipManager::JumpLeave()
+void ShipManager::PrepareSuperDrones()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1072::func;
@@ -14834,6 +14834,20 @@ void ShipManager::JumpLeave()
 namespace _func1073
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ShipManager::JumpLeave", typeid(void (ShipManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec3c83a994040000018b51188b8194040000c681d80400000185c0", argdata, 1, 5, &func);
+}
+
+void ShipManager::JumpLeave()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1073::func;
+	return execfunc(this);
+}
+
+namespace _func1074
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipManager::ModifyScrapCount", typeid(void (ShipManager::*)(int , bool )), "578d7c240883e4f0ff77fc5589e557565389cb83ec4c8b378b470485f6", argdata, 3, 5, &func);
 }
@@ -14841,11 +14855,11 @@ namespace _func1073
 void ShipManager::ModifyScrapCount(int scrap, bool income)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int scrap_arg, bool income_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1073::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1074::func;
 	return execfunc(this, scrap, income);
 }
 
-namespace _func1074
+namespace _func1075
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14855,11 +14869,11 @@ namespace _func1074
 void ShipManager::ModifyMissileCount(int missiles)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int missiles_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1074::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1075::func;
 	return execfunc(this, missiles);
 }
 
-namespace _func1075
+namespace _func1076
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14869,11 +14883,11 @@ namespace _func1075
 int ShipManager::GetMissileCount()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1075::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1076::func;
 	return execfunc(this);
 }
 
-namespace _func1076
+namespace _func1077
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14883,11 +14897,11 @@ namespace _func1076
 void ShipManager::ModifyDroneCount(int drones)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int drones_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1076::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1077::func;
 	return execfunc(this, drones);
 }
 
-namespace _func1077
+namespace _func1078
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14897,11 +14911,11 @@ namespace _func1077
 float ShipManager::GetOxygenLevel(int roomId)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1077::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1078::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1078
+namespace _func1079
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14911,11 +14925,11 @@ namespace _func1078
 std::vector<float> ShipManager::GetOxygenLevels()
 {
 	typedef std::vector<float> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1078::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1079::func;
 	return execfunc(this);
 }
 
-namespace _func1079
+namespace _func1080
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14925,11 +14939,11 @@ namespace _func1079
 bool ShipManager::DoSensorsProvide(int vision)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int vision_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1079::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1080::func;
 	return execfunc(this, vision);
 }
 
-namespace _func1080
+namespace _func1081
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14939,11 +14953,11 @@ namespace _func1080
 bool ShipManager::IsCrewFull()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1080::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1081::func;
 	return execfunc(this);
 }
 
-namespace _func1081
+namespace _func1082
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14953,11 +14967,11 @@ namespace _func1081
 bool ShipManager::ForceIncreaseSystemPower(int systemId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1081::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1082::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1082
+namespace _func1083
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -14967,11 +14981,11 @@ namespace _func1082
 bool ShipManager::IsCrewOverFull()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1082::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1083::func;
 	return execfunc(this);
 }
 
-namespace _func1083
+namespace _func1084
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14981,11 +14995,11 @@ namespace _func1083
 CrewDrone *ShipManager::CreateCrewDrone(const DroneBlueprint *bp)
 {
 	typedef CrewDrone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1083::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1084::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1084
+namespace _func1085
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -14995,11 +15009,11 @@ namespace _func1084
 SpaceDrone *ShipManager::CreateSpaceDrone(const DroneBlueprint *bp)
 {
 	typedef SpaceDrone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1084::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1085::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1085
+namespace _func1086
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15009,11 +15023,11 @@ namespace _func1085
 bool ShipManager::CommandCrewMoveRoom(CrewMember *crew, int roomId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1085::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1086::func;
 	return execfunc(this, crew, roomId);
 }
 
-namespace _func1086
+namespace _func1087
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15023,11 +15037,11 @@ namespace _func1086
 int ShipManager::GetSystemRoom(int sysId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int sysId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1086::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1087::func;
 	return execfunc(this, sysId);
 }
 
-namespace _func1087
+namespace _func1088
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15037,11 +15051,11 @@ namespace _func1087
 std::vector<ProjectileFactory*> ShipManager::GetWeaponList()
 {
 	typedef std::vector<ProjectileFactory*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1087::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1088::func;
 	return execfunc(this);
 }
 
-namespace _func1088
+namespace _func1089
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15051,11 +15065,11 @@ namespace _func1088
 Drone *ShipManager::AddDrone(const DroneBlueprint *bp, int slot)
 {
 	typedef Drone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const DroneBlueprint *bp_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1088::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1089::func;
 	return execfunc(this, bp, slot);
 }
 
-namespace _func1089
+namespace _func1090
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15065,11 +15079,11 @@ namespace _func1089
 void ShipManager::Restart()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1089::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1090::func;
 	return execfunc(this);
 }
 
-namespace _func1090
+namespace _func1091
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15079,11 +15093,11 @@ namespace _func1090
 int ShipManager::GetSystemPower(int systemId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1090::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1091::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1091
+namespace _func1092
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15093,11 +15107,11 @@ namespace _func1091
 bool ShipManager::SystemLocked(int systemId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1091::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1092::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1092
+namespace _func1093
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15107,11 +15121,11 @@ namespace _func1092
 int ShipManager::CountCrewShipId(int roomId, int shipId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg, int shipId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1092::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1093::func;
 	return execfunc(this, roomId, shipId);
 }
 
-namespace _func1093
+namespace _func1094
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15121,11 +15135,11 @@ namespace _func1093
 int ShipManager::GetSystemAvailablePower(int systemId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1093::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1094::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1094
+namespace _func1095
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15135,11 +15149,11 @@ namespace _func1094
 ShipSystem *ShipManager::GetSystem(int systemId)
 {
 	typedef ShipSystem *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1094::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1095::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1095
+namespace _func1096
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15149,11 +15163,11 @@ namespace _func1095
 void ShipManager::ExportShip(int file)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1095::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1096::func;
 	return execfunc(this, file);
 }
 
-namespace _func1096
+namespace _func1097
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15163,11 +15177,11 @@ namespace _func1096
 void ShipManager::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1096::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1097::func;
 	return execfunc(this);
 }
 
-namespace _func1097
+namespace _func1098
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15177,11 +15191,11 @@ namespace _func1097
 void ShipManager::destructor2()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1097::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1098::func;
 	return execfunc(this);
 }
 
-namespace _func1098
+namespace _func1099
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15191,11 +15205,11 @@ namespace _func1098
 void ShipManager::ImportShip(int file)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1098::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1099::func;
 	return execfunc(this, file);
 }
 
-namespace _func1099
+namespace _func1100
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15205,11 +15219,11 @@ namespace _func1099
 void ShipManager::CheckVision()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1099::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1100::func;
 	return execfunc(this);
 }
 
-namespace _func1100
+namespace _func1101
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15219,11 +15233,11 @@ namespace _func1100
 int ShipManager::IsSystemHacked(int systemId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1100::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1101::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1101
+namespace _func1102
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15233,11 +15247,11 @@ namespace _func1101
 int ShipManager::IsSystemHacked2(int systemId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1101::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1102::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1102
+namespace _func1103
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -15247,11 +15261,11 @@ namespace _func1102
 CrewMember *ShipManager::GetSelectedCrewPoint(int x, int y, bool intruder)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int x_arg, int y_arg, bool intruder_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1102::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1103::func;
 	return execfunc(this, x, y, intruder);
 }
 
-namespace _func1103
+namespace _func1104
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15261,11 +15275,11 @@ namespace _func1103
 void ShipManager::RenderWeapons()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1103::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1104::func;
 	return execfunc(this);
 }
 
-namespace _func1104
+namespace _func1105
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15275,11 +15289,11 @@ namespace _func1104
 void ShipManager::ClearStatusSystem(int system)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int system_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1104::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1105::func;
 	return execfunc(this, system);
 }
 
-namespace _func1105
+namespace _func1106
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15287,20 +15301,6 @@ namespace _func1105
 }
 
 void ShipManager::ResetScrapLevel()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1105::func;
-	return execfunc(this);
-}
-
-namespace _func1106
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipManager::JumpArrive", typeid(void (ShipManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce81c1????????83ec3c8b411cc741ec000000008941208b812cfcffff89810c040000c70424????????", argdata, 1, 5, &func);
-}
-
-void ShipManager::JumpArrive()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1106::func;
@@ -15311,10 +15311,10 @@ namespace _func1107
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("ShipManager::CheckSpreadDamage", typeid(void (ShipManager::*)()), "578d7c240883e4f0ff77fc5589e557565383ec4c8b51188b411cc745b80000000029d0c1f80285c00f84????????89cf", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("ShipManager::JumpArrive", typeid(void (ShipManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce81c1????????83ec3c8b411cc741ec000000008941208b812cfcffff89810c040000c70424????????", argdata, 1, 5, &func);
 }
 
-void ShipManager::CheckSpreadDamage()
+void ShipManager::JumpArrive()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1107::func;
@@ -15324,6 +15324,20 @@ void ShipManager::CheckSpreadDamage()
 namespace _func1108
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("ShipManager::CheckSpreadDamage", typeid(void (ShipManager::*)()), "578d7c240883e4f0ff77fc5589e557565383ec4c8b51188b411cc745b80000000029d0c1f80285c00f84????????89cf", argdata, 1, 5, &func);
+}
+
+void ShipManager::CheckSpreadDamage()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1108::func;
+	return execfunc(this);
+}
+
+namespace _func1109
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("ShipManager::SetSystemPowerLimit", typeid(void (ShipManager::*)(int , int )), ".578d????0883e4f0ff????55", argdata, 3, 5, &func);
 }
@@ -15331,11 +15345,11 @@ namespace _func1108
 void ShipManager::SetSystemPowerLimit(int systemId, int limit)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int limit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1108::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1109::func;
 	return execfunc(this, systemId, limit);
 }
 
-namespace _func1109
+namespace _func1110
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15345,11 +15359,11 @@ namespace _func1109
 void ShipManager::SetSystemPowerLoss(int systemId, int powerLoss)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int powerLoss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1109::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1110::func;
 	return execfunc(this, systemId, powerLoss);
 }
 
-namespace _func1110
+namespace _func1111
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15359,11 +15373,11 @@ namespace _func1110
 void ShipManager::SetSystemDividePower(int systemId, int amount)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1110::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1111::func;
 	return execfunc(this, systemId, amount);
 }
 
-namespace _func1111
+namespace _func1112
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15373,11 +15387,11 @@ namespace _func1111
 bool ShipManager::ForceDecreaseSystemPower(int sys)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1111::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1112::func;
 	return execfunc(this, sys);
 }
 
-namespace _func1112
+namespace _func1113
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15387,11 +15401,11 @@ namespace _func1112
 ShieldPower ShipManager::GetShieldPower()
 {
 	typedef ShieldPower __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1112::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1113::func;
 	return execfunc(this);
 }
 
-namespace _func1113
+namespace _func1114
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15401,11 +15415,11 @@ namespace _func1113
 int ShipManager::AddWeapon(const WeaponBlueprint *bp, int slot)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const WeaponBlueprint *bp_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1113::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1114::func;
 	return execfunc(this, bp, slot);
 }
 
-namespace _func1114
+namespace _func1115
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15415,11 +15429,11 @@ namespace _func1114
 void ShipManager::AddEquipmentFromList(std::vector<std::string> *equipmentList)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, std::vector<std::string> *equipmentList_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1114::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1115::func;
 	return execfunc(this, equipmentList);
 }
 
-namespace _func1115
+namespace _func1116
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15429,11 +15443,11 @@ namespace _func1115
 void ShipManager::RenderChargeBars()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1115::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1116::func;
 	return execfunc(this);
 }
 
-namespace _func1116
+namespace _func1117
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15441,20 +15455,6 @@ namespace _func1116
 }
 
 void ShipManager::ExportBattleState(int file)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1116::func;
-	return execfunc(this, file);
-}
-
-namespace _func1117
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("ShipManager::ImportBattleState", typeid(void (ShipManager::*)(int )), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b81c80400008b37837810ff0f84????????8b414c8d4ddc05????????", argdata, 2, 5, &func);
-}
-
-void ShipManager::ImportBattleState(int file)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1117::func;
@@ -15465,17 +15465,31 @@ namespace _func1118
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("ShipManager::ImportBattleState", typeid(void (ShipManager::*)(int )), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b81c80400008b37837810ff0f84????????8b414c8d4ddc05????????", argdata, 2, 5, &func);
+}
+
+void ShipManager::ImportBattleState(int file)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int file_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1118::func;
+	return execfunc(this, file);
+}
+
+namespace _func1119
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("ShipManager::SystemFunctions", typeid(bool (ShipManager::*)(int )), "558b81c804000089e583e4f08b55088b149031c083faff74??8b41188b0c908b01ff502c", argdata, 2, 1, &func);
 }
 
 bool ShipManager::SystemFunctions(int systemId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1118::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1119::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1119
+namespace _func1120
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15485,11 +15499,11 @@ namespace _func1119
 int ShipManager::SystemRoom(int systemId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1119::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1120::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1120
+namespace _func1121
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15499,11 +15513,11 @@ namespace _func1120
 bool ShipManager::CanFitSystem(int systemId)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1120::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1121::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1121
+namespace _func1122
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15533,11 +15547,11 @@ FUNC_NAKED bool ShipManager::CanFitSubsystem(int systemId)
 		"movl %%ebp, %%esp\n\t"
 		"popl %%ebp\n\t"
 		"ret $4\n\t"
-		 :: "m"(_func1121::func)
+		 :: "m"(_func1122::func)
 	);
 }
 
-namespace _func1122
+namespace _func1123
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15547,11 +15561,11 @@ namespace _func1122
 int ShipManager::DamageHull(int dmg, bool force)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int dmg_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1122::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1123::func;
 	return execfunc(this, dmg, force);
 }
 
-namespace _func1123
+namespace _func1124
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0xdff};
@@ -15561,11 +15575,11 @@ namespace _func1123
 void ShipManager::DamageSystem(int systemId, Damage damage)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, Damage damage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1123::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1124::func;
 	return execfunc(this, systemId, damage);
 }
 
-namespace _func1124
+namespace _func1125
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15575,11 +15589,11 @@ namespace _func1124
 void ShipManager::StartFire(int roomId)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1124::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1125::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1125
+namespace _func1126
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15589,11 +15603,11 @@ namespace _func1125
 CrewMember *ShipManager::FindCrew(const CrewBlueprint *bp)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, const CrewBlueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1125::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1126::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1126
+namespace _func1127
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15603,11 +15617,11 @@ namespace _func1126
 bool ShipManager::GetDodged()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1126::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1127::func;
 	return execfunc(this);
 }
 
-namespace _func1127
+namespace _func1128
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15617,11 +15631,11 @@ namespace _func1127
 void ShipManager::PrepareSuperBarrage()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1127::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1128::func;
 	return execfunc(this);
 }
 
-namespace _func1128
+namespace _func1129
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -15631,11 +15645,11 @@ namespace _func1128
 std::string ShipManager::GetTooltip(int x, int y)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1128::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1129::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1129
+namespace _func1130
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15645,11 +15659,11 @@ namespace _func1129
 bool ShipManager::RestoreCrewPositions()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1129::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1130::func;
 	return execfunc(this);
 }
 
-namespace _func1130
+namespace _func1131
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15659,11 +15673,11 @@ namespace _func1130
 CrewMember *ShipManager::GetCrewmember(int slot, bool present)
 {
 	typedef CrewMember *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int slot_arg, bool present_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1130::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1131::func;
 	return execfunc(this, slot, present);
 }
 
-namespace _func1131
+namespace _func1132
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15673,11 +15687,11 @@ namespace _func1131
 void ShipManager::RemoveCrewmember(CrewMember *crew)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, CrewMember *crew_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1131::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1132::func;
 	return execfunc(this, crew);
 }
 
-namespace _func1132
+namespace _func1133
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15687,11 +15701,11 @@ namespace _func1132
 int ShipManager::CanUpgrade(int systemId, int amount)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1132::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1133::func;
 	return execfunc(this, systemId, amount);
 }
 
-namespace _func1133
+namespace _func1134
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15701,11 +15715,11 @@ namespace _func1133
 ShipBlueprint ShipManager::SaveToBlueprint(bool overwrite)
 {
 	typedef ShipBlueprint __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool overwrite_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1133::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1134::func;
 	return execfunc(this, overwrite);
 }
 
-namespace _func1134
+namespace _func1135
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -15715,11 +15729,11 @@ namespace _func1134
 void ShipManager::CheckCrystalAugment(Pointf pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1134::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1135::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1135
+namespace _func1136
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -15729,11 +15743,11 @@ namespace _func1135
 CollisionResponse ShipManager::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1135::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1136::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func1136
+namespace _func1137
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15743,11 +15757,11 @@ namespace _func1136
 int ShipManager::GetSystemPowerMax(int systemId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1136::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1137::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1137
+namespace _func1138
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15757,11 +15771,11 @@ namespace _func1137
 std::vector<Drone*> ShipManager::GetDroneList()
 {
 	typedef std::vector<Drone*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1137::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1138::func;
 	return execfunc(this);
 }
 
-namespace _func1138
+namespace _func1139
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15771,11 +15785,11 @@ namespace _func1138
 int ShipManager::GetDroneCount()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1138::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1139::func;
 	return execfunc(this);
 }
 
-namespace _func1139
+namespace _func1140
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15785,11 +15799,11 @@ namespace _func1139
 void ShipManager::InstantPowerShields()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1139::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1140::func;
 	return execfunc(this);
 }
 
-namespace _func1140
+namespace _func1141
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15799,11 +15813,11 @@ namespace _func1140
 int ShipManager::GetSystemDamage(int systemId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1140::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1141::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1141
+namespace _func1142
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15813,11 +15827,11 @@ namespace _func1141
 int ShipManager::GetSystemHealth(int systemId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1141::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1142::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1142
+namespace _func1143
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15827,11 +15841,11 @@ namespace _func1142
 void ShipManager::SetDestroyed()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1142::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1143::func;
 	return execfunc(this);
 }
 
-namespace _func1143
+namespace _func1144
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15841,11 +15855,11 @@ namespace _func1143
 int ShipManager::GetFireCount(int roomId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1143::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1144::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1144
+namespace _func1145
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15855,11 +15869,11 @@ namespace _func1144
 bool ShipManager::DoorsFunction()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1144::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1145::func;
 	return execfunc(this);
 }
 
-namespace _func1145
+namespace _func1146
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15869,11 +15883,11 @@ namespace _func1145
 std::vector<CrewMember*> ShipManager::GetLeavingCrew(bool intruders)
 {
 	typedef std::vector<CrewMember*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, bool intruders_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1145::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1146::func;
 	return execfunc(this, intruders);
 }
 
-namespace _func1146
+namespace _func1147
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -15883,11 +15897,11 @@ namespace _func1146
 CollisionResponse ShipManager::CollisionShield(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1146::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1147::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func1147
+namespace _func1148
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15897,11 +15911,11 @@ namespace _func1147
 bool ShipManager::IsCloaked()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1147::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1148::func;
 	return execfunc(this);
 }
 
-namespace _func1148
+namespace _func1149
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -15911,11 +15925,11 @@ namespace _func1148
 void ShipManager::UpgradeSystem(int id, int amount)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, int id_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1148::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1149::func;
 	return execfunc(this, id, amount);
 }
 
-namespace _func1149
+namespace _func1150
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15925,11 +15939,11 @@ namespace _func1149
 int ShipManager::CountPlayerCrew()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1149::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1150::func;
 	return execfunc(this);
 }
 
-namespace _func1150
+namespace _func1151
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15939,11 +15953,11 @@ namespace _func1150
 void ShipManager::Wait()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1150::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1151::func;
 	return execfunc(this);
 }
 
-namespace _func1151
+namespace _func1152
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15953,11 +15967,11 @@ namespace _func1151
 void ShipManager::CreateArmory()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1151::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1152::func;
 	return execfunc(this);
 }
 
-namespace _func1152
+namespace _func1153
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -15967,11 +15981,11 @@ namespace _func1152
 Drone *ShipManager::CreateDrone(DroneBlueprint *drone)
 {
 	typedef Drone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg, DroneBlueprint *drone_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1152::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1153::func;
 	return execfunc(this, drone);
 }
 
-namespace _func1153
+namespace _func1154
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15981,11 +15995,11 @@ namespace _func1153
 void ShipManager::CloneHealing()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1153::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1154::func;
 	return execfunc(this);
 }
 
-namespace _func1154
+namespace _func1155
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -15995,11 +16009,11 @@ namespace _func1154
 void ShipManager::SaveCrewPositions()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1154::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1155::func;
 	return execfunc(this);
 }
 
-namespace _func1155
+namespace _func1156
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16009,11 +16023,11 @@ namespace _func1155
 int ShipObject::HasAugmentation(const std::string &augment)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1155::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1156::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1156
+namespace _func1157
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16023,11 +16037,11 @@ namespace _func1156
 float ShipObject::GetAugmentationValue(const std::string &augment)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1156::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1157::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1157
+namespace _func1158
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -16037,11 +16051,11 @@ namespace _func1157
 void ShipObject::RemoveEquipment(const std::string &blueName, bool completely)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &blueName_arg, bool completely_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1157::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1158::func;
 	return execfunc(this, blueName, completely);
 }
 
-namespace _func1158
+namespace _func1159
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16051,11 +16065,11 @@ namespace _func1158
 void ShipObject::RemoveAugmentation(const std::string &augment)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1158::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1159::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1159
+namespace _func1160
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16065,11 +16079,11 @@ namespace _func1159
 int ShipObject::HasEquipment(const std::string &equip)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1159::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1160::func;
 	return execfunc(this, equip);
 }
 
-namespace _func1160
+namespace _func1161
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16079,11 +16093,11 @@ namespace _func1160
 std::vector<std::string> ShipObject::GetAugmentationList()
 {
 	typedef std::vector<std::string> __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1160::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1161::func;
 	return execfunc(this);
 }
 
-namespace _func1161
+namespace _func1162
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16093,18 +16107,18 @@ namespace _func1161
 bool ShipObject::AddAugmentation(const std::string &augment)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg, const std::string &augment_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1161::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1162::func;
 	return execfunc(this, augment);
 }
 
-namespace _func1162
+namespace _func1163
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("ShipObject::__DO_NOT_HOOK", typeid(void (ShipObject::*)()), "89b5a4feffffe9????????c70424????????e8????????89c60fb68590feffff89f1894424088b8594feffff894424048b858cfeffff890424", argdata, 0, 4, &func);
 }
 
-namespace _func1163
+namespace _func1164
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16114,11 +16128,11 @@ namespace _func1163
 int ShipObject::GetAugmentationCount()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1163::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1164::func;
 	return execfunc(this);
 }
 
-namespace _func1164
+namespace _func1165
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16128,18 +16142,18 @@ namespace _func1164
 void ShipObject::ClearShipInfo()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipObject *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1164::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1165::func;
 	return execfunc(this);
 }
 
 ShipInfo **Global_ShipObject_ShipInfoList;
 
-namespace _var1165
+namespace _var1166
 {
     static VariableDefinition varObj("Global_ShipObject_ShipInfoList", "!6bc0340305(???????\?)8b4030c3", &Global_ShipObject_ShipInfoList);
 }
 
-namespace _func1166
+namespace _func1167
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16149,11 +16163,11 @@ namespace _func1166
 void ShipSelect::SelectShip(int shipType)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, int shipType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1166::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1167::func;
 	return execfunc(this, shipType);
 }
 
-namespace _func1167
+namespace _func1168
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16163,11 +16177,11 @@ namespace _func1167
 void ShipSelect::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1167::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1168::func;
 	return execfunc(this);
 }
 
-namespace _func1168
+namespace _func1169
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16177,11 +16191,11 @@ namespace _func1168
 void ShipSelect::ClearShipButtons()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1168::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1169::func;
 	return execfunc(this);
 }
 
-namespace _func1169
+namespace _func1170
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -16191,11 +16205,11 @@ namespace _func1169
 void ShipSelect::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1169::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1170::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1170
+namespace _func1171
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16205,11 +16219,11 @@ namespace _func1170
 void ShipSelect::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1170::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1171::func;
 	return execfunc(this);
 }
 
-namespace _func1171
+namespace _func1172
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16219,11 +16233,11 @@ namespace _func1171
 int ShipSelect::KeyDown(SDLKey key)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1171::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1172::func;
 	return execfunc(this, key);
 }
 
-namespace _func1172
+namespace _func1173
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16233,11 +16247,11 @@ namespace _func1172
 void ShipSelect::MouseClick()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1172::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1173::func;
 	return execfunc(this);
 }
 
-namespace _func1173
+namespace _func1174
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16247,11 +16261,11 @@ namespace _func1173
 void ShipSelect::PreSelectShip(int shipType)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, int shipType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1173::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1174::func;
 	return execfunc(this, shipType);
 }
 
-namespace _func1174
+namespace _func1175
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16261,11 +16275,11 @@ namespace _func1174
 void ShipSelect::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1174::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1175::func;
 	return execfunc(this);
 }
 
-namespace _func1175
+namespace _func1176
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16275,11 +16289,11 @@ namespace _func1175
 int ShipSelect::GetSelectedShip()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1175::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1176::func;
 	return execfunc(this);
 }
 
-namespace _func1176
+namespace _func1177
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -16289,11 +16303,11 @@ namespace _func1176
 void ShipSelect::Open(int currentId, int currentType)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg, int currentId_arg, int currentType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1176::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1177::func;
 	return execfunc(this, currentId, currentType);
 }
 
-namespace _func1177
+namespace _func1178
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16303,11 +16317,11 @@ namespace _func1177
 void ShipSelect::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSelect *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1177::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1178::func;
 	return execfunc(this);
 }
 
-namespace _func1178
+namespace _func1179
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16317,11 +16331,11 @@ namespace _func1178
 void ShipStatus::RenderHealth(bool renderText)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool renderText_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1178::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1179::func;
 	return execfunc(this, renderText);
 }
 
-namespace _func1179
+namespace _func1180
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -16331,11 +16345,11 @@ namespace _func1179
 void ShipStatus::OnInit(Point location, float size)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipStatus *this_arg, Point location_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1179::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1180::func;
 	return execfunc(this, location, size);
 }
 
-namespace _func1180
+namespace _func1181
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16345,11 +16359,11 @@ namespace _func1180
 void ShipStatus::RenderResources(bool renderText)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool renderText_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1180::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1181::func;
 	return execfunc(this, renderText);
 }
 
-namespace _func1181
+namespace _func1182
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16359,11 +16373,11 @@ namespace _func1181
 void ShipStatus::RenderEvadeOxygen(bool renderText)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipStatus *this_arg, bool renderText_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1181::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1182::func;
 	return execfunc(this, renderText);
 }
 
-namespace _func1182
+namespace _func1183
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16373,11 +16387,11 @@ namespace _func1182
 void ShipStatus::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1182::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1183::func;
 	return execfunc(this);
 }
 
-namespace _func1183
+namespace _func1184
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16409,11 +16423,11 @@ FUNC_NAKED void ShipStatus::RenderShields(bool renderText)
 		"movl %%ebp, %%esp\n\t"
 		"popl %%ebp\n\t"
 		"ret $4\n\t"
-		 :: "m"(_func1183::func)
+		 :: "m"(_func1184::func)
 	);
 }
 
-namespace _func1184
+namespace _func1185
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16423,11 +16437,11 @@ namespace _func1184
 void ShipStatus::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1184::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1185::func;
 	return execfunc(this);
 }
 
-namespace _func1185
+namespace _func1186
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16437,11 +16451,11 @@ namespace _func1185
 bool ShipSystem::DamageOverTime(float unk)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, float unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1185::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1186::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1186
+namespace _func1187
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16451,11 +16465,11 @@ namespace _func1186
 void ShipSystem::CheckForRepower()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1186::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1187::func;
 	return execfunc(this);
 }
 
-namespace _func1187
+namespace _func1188
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16465,11 +16479,11 @@ namespace _func1187
 int ShipSystem::NameToSystemId(const std::string &name)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1187::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1188::func;
 	return execfunc(name);
 }
 
-namespace _func1188
+namespace _func1189
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16479,11 +16493,11 @@ namespace _func1188
 int ShipSystem::IsMannedBoost()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1188::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1189::func;
 	return execfunc(this);
 }
 
-namespace _func1189
+namespace _func1190
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -16493,11 +16507,11 @@ namespace _func1189
 std::string ShipSystem::SystemIdToName(int systemId)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1189::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1190::func;
 	return execfunc(systemId);
 }
 
-namespace _func1190
+namespace _func1191
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16507,11 +16521,11 @@ namespace _func1190
 void ShipSystem::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1190::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1191::func;
 	return execfunc(this);
 }
 
-namespace _func1191
+namespace _func1192
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16521,11 +16535,11 @@ namespace _func1191
 bool ShipSystem::Ioned(int num)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int num_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1191::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1192::func;
 	return execfunc(this, num);
 }
 
-namespace _func1192
+namespace _func1193
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16535,11 +16549,11 @@ namespace _func1192
 int ShipSystem::SetPowerLoss(int power)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int power_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1192::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1193::func;
 	return execfunc(this, power);
 }
 
-namespace _func1193
+namespace _func1194
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16549,11 +16563,11 @@ namespace _func1193
 void ShipSystem::SetDividePower(int val)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int val_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1193::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1194::func;
 	return execfunc(this, val);
 }
 
-namespace _func1194
+namespace _func1195
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16563,11 +16577,11 @@ namespace _func1194
 bool ShipSystem::RawDecreasePower()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1194::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1195::func;
 	return execfunc(this);
 }
 
-namespace _func1195
+namespace _func1196
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -16577,11 +16591,11 @@ namespace _func1195
 void ShipSystem::constructor(int systemId, int roomId, int shipId, int startingPower)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int systemId_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1195::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1196::func;
 	return execfunc(this, systemId, roomId, shipId, startingPower);
 }
 
-namespace _func1196
+namespace _func1197
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16591,11 +16605,11 @@ namespace _func1196
 int ShipSystem::GetPowerCap()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1196::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1197::func;
 	return execfunc(this);
 }
 
-namespace _func1197
+namespace _func1198
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16605,11 +16619,11 @@ namespace _func1197
 void ShipSystem::SetPowerCap(int cap)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int cap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1197::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1198::func;
 	return execfunc(this, cap);
 }
 
-namespace _func1198
+namespace _func1199
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16619,11 +16633,11 @@ namespace _func1198
 void ShipSystem::LockSystem(int lock)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1198::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1199::func;
 	return execfunc(this, lock);
 }
 
-namespace _func1199
+namespace _func1200
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16633,11 +16647,11 @@ namespace _func1199
 bool ShipSystem::ForceDecreasePower(int powerLoss)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int powerLoss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1199::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1200::func;
 	return execfunc(this, powerLoss);
 }
 
-namespace _func1200
+namespace _func1201
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16647,11 +16661,11 @@ namespace _func1200
 int ShipSystem::GetEffectivePower()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1200::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1201::func;
 	return execfunc(this);
 }
 
-namespace _func1201
+namespace _func1202
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16661,11 +16675,11 @@ namespace _func1201
 int ShipSystem::GetMaxPower()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1201::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1202::func;
 	return execfunc(this);
 }
 
-namespace _func1202
+namespace _func1203
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -16675,11 +16689,11 @@ namespace _func1202
 void ShipSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1202::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1203::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func1203
+namespace _func1204
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16689,18 +16703,18 @@ namespace _func1203
 void ShipSystem::CheckMaxPower()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1203::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1204::func;
 	return execfunc(this);
 }
 
-namespace _func1204
+namespace _func1205
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
 	static FunctionDefinition funcObj("ShipSystem::__DO_NOT_HOOK", typeid(void (ShipSystem::*)()), "55c701????????89e583e4f0e8????????c9c390909090909090909090909090b8????????", argdata, 1, 5, &func);
 }
 
-namespace _func1205
+namespace _func1206
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16710,11 +16724,11 @@ namespace _func1205
 bool ShipSystem::PartialDamage(float amount)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, float amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1205::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1206::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1206
+namespace _func1207
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16724,11 +16738,11 @@ namespace _func1206
 void ShipSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1206::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1207::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func1207
+namespace _func1208
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -16738,11 +16752,11 @@ namespace _func1207
 bool ShipSystem::IsSubsystem(int systemType)
 {
 	typedef bool __attribute__((cdecl)) (*custom_arg_funcptr_t)(int systemType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1207::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1208::func;
 	return execfunc(systemType);
 }
 
-namespace _func1208
+namespace _func1209
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16752,11 +16766,11 @@ namespace _func1208
 void ShipSystem::ClearStatus()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1208::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1209::func;
 	return execfunc(this);
 }
 
-namespace _func1209
+namespace _func1210
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -16766,11 +16780,11 @@ namespace _func1209
 std::string ShipSystem::GetLevelDescription(int systemId, int level, bool tooltip)
 {
 	typedef std::string __attribute__((cdecl)) (*custom_arg_funcptr_t)(int systemId_arg, int level_arg, bool tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1209::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1210::func;
 	return execfunc(systemId, level, tooltip);
 }
 
-namespace _func1210
+namespace _func1211
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16780,11 +16794,11 @@ namespace _func1210
 bool ShipSystem::GetLocked()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1210::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1211::func;
 	return execfunc(this);
 }
 
-namespace _func1211
+namespace _func1212
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16794,11 +16808,11 @@ namespace _func1211
 void ShipSystem::AddLock(int lock)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int lock_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1211::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1212::func;
 	return execfunc(this, lock);
 }
 
-namespace _func1212
+namespace _func1213
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16808,11 +16822,11 @@ namespace _func1212
 void ShipSystem::StopHacking()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1212::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1213::func;
 	return execfunc(this);
 }
 
-namespace _func1213
+namespace _func1214
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16820,20 +16834,6 @@ namespace _func1213
 }
 
 void ShipSystem::SaveState(int file)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1213::func;
-	return execfunc(this, file);
-}
-
-namespace _func1214
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("ShipSystem::LoadState", typeid(void (ShipSystem::*)(int )), "5589e5565389cb83e4f083ec108b7508893424e8????????89342489831c010000e8????????893424898320010000e8????????8983240100008d65f85b", argdata, 2, 5, &func);
-}
-
-void ShipSystem::LoadState(int file)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1214::func;
@@ -16844,17 +16844,31 @@ namespace _func1215
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("ShipSystem::LoadState", typeid(void (ShipSystem::*)(int )), "5589e5565389cb83e4f083ec108b7508893424e8????????89342489831c010000e8????????893424898320010000e8????????8983240100008d65f85b", argdata, 2, 5, &func);
+}
+
+void ShipSystem::LoadState(int file)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int file_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1215::func;
+	return execfunc(this, file);
+}
+
+namespace _func1216
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("ShipSystem::UpgradeSystem", typeid(bool (ShipSystem::*)(int )), "8b015589e556538b401089cb8b750883e4f03d????????75??8b810001000085c00f94c001735401b304010000", argdata, 2, 1, &func);
 }
 
 bool ShipSystem::UpgradeSystem(int amount)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1215::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1216::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1216
+namespace _func1217
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -16864,11 +16878,11 @@ namespace _func1216
 bool ShipSystem::IncreasePower(int amount, bool force)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1216::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1217::func;
 	return execfunc(this, amount, force);
 }
 
-namespace _func1217
+namespace _func1218
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16878,11 +16892,11 @@ namespace _func1217
 bool ShipSystem::DecreasePower(bool force)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1217::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1218::func;
 	return execfunc(this, force);
 }
 
-namespace _func1218
+namespace _func1219
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -16892,11 +16906,11 @@ namespace _func1218
 bool ShipSystem::PartialRepair(float speed, bool autoRepair)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, float speed_arg, bool autoRepair_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1218::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1219::func;
 	return execfunc(this, speed, autoRepair);
 }
 
-namespace _func1219
+namespace _func1220
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -16906,11 +16920,11 @@ namespace _func1219
 int ShipSystem::RenderPowerBoxes(int x, int y, int width, int height, int gap, int heightMod, bool flash)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int x_arg, int y_arg, int width_arg, int height_arg, int gap_arg, int heightMod_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1219::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1220::func;
 	return execfunc(this, x, y, width, height, gap, heightMod, flash);
 }
 
-namespace _func1220
+namespace _func1221
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16920,11 +16934,11 @@ namespace _func1220
 void ShipSystem::AddDamage(int amount)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1220::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1221::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1221
+namespace _func1222
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -16934,11 +16948,11 @@ namespace _func1221
 void ShipSystem::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1221::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1222::func;
 	return execfunc(this);
 }
 
-namespace _func1222
+namespace _func1223
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16948,11 +16962,11 @@ namespace _func1222
 bool ShipSystem::BlockedBoosted(bool countLimit)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool countLimit_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1222::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1223::func;
 	return execfunc(this, countLimit);
 }
 
-namespace _func1223
+namespace _func1224
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -16962,11 +16976,11 @@ namespace _func1223
 int ShipSystem::RenderPowerBoxesPlain(int x, int y, int width, int height, int gap, int current, int temp, int max)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int x_arg, int y_arg, int width_arg, int height_arg, int gap_arg, int current_arg, int temp_arg, int max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1223::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1224::func;
 	return execfunc(x, y, width, height, gap, current, temp, max);
 }
 
-namespace _func1224
+namespace _func1225
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -16976,11 +16990,11 @@ namespace _func1224
 void ShipSystem::RenderSystemSymbol(bool forPowerUI, int forceColor)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, bool forPowerUI_arg, int forceColor_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1224::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1225::func;
 	return execfunc(this, forPowerUI, forceColor);
 }
 
-namespace _func1225
+namespace _func1226
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -16990,11 +17004,11 @@ namespace _func1225
 TimerHelper ShipSystem::GetLockTimer()
 {
 	typedef TimerHelper __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1225::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1226::func;
 	return execfunc(this);
 }
 
-namespace _func1226
+namespace _func1227
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17004,116 +17018,116 @@ namespace _func1226
 void ShipSystem::IonDamage(int amount)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(ShipSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1226::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1227::func;
 	return execfunc(this, amount);
 }
 
 GL_Primitive **ShipSystem__glowBlue;
 
-namespace _var1227
+namespace _var1228
 {
     static VariableDefinition varObj("ShipSystem__glowBlue", "f30f11542404c7042400000000e8????????a1(???????\?)890424e8????????e8????????", &ShipSystem__glowBlue);
 }
 
 GL_Primitive **ShipSystem__glowWhite;
 
-namespace _var1228
+namespace _var1229
 {
     static VariableDefinition varObj("ShipSystem__glowWhite", "c7042400000000f30f11442404e8????????a1(???????\?)890424", &ShipSystem__glowWhite);
 }
 
 GL_Primitive **ShipSystem__glowRed;
 
-namespace _var1229
+namespace _var1230
 {
     static VariableDefinition varObj("ShipSystem__glowRed", "f30f11742404c7042400000000e8????????a1(???????\?)890424", &ShipSystem__glowRed);
 }
 
 GL_Primitive **ShipSystem__manningOutline;
 
-namespace _var1230
+namespace _var1231
 {
     static VariableDefinition varObj("ShipSystem__manningOutline", "a1(???????\?)bef0ffffffbb10000000890424e8????????", &ShipSystem__manningOutline);
 }
 
 GL_Primitive **ShipSystem__manningWhite;
 
-namespace _var1231
+namespace _var1232
 {
     static VariableDefinition varObj("ShipSystem__manningWhite", "a1(???????\?)bef0ffffffbb10000000e9????????a1(???????\?)bee8ffffffbb18000000e9????????a1(???????\?)bee8ffffffbb18000000e9????????", &ShipSystem__manningWhite);
 }
 
 GL_Primitive **ShipSystem__manningGreen;
 
-namespace _var1232
+namespace _var1233
 {
     static VariableDefinition varObj("ShipSystem__manningGreen", "", &ShipSystem__manningGreen);
 }
 
 GL_Primitive **ShipSystem__manningYellow;
 
-namespace _var1233
+namespace _var1234
 {
     static VariableDefinition varObj("ShipSystem__manningYellow", "", &ShipSystem__manningYellow);
 }
 
 GL_Primitive **ShipSystem__manningBarOn;
 
-namespace _var1234
+namespace _var1235
 {
     static VariableDefinition varObj("ShipSystem__manningBarOn", "a1(???????\?)74??c704240100000089f9f30f114dcce8????????83ec0484c0a1(???????\?)0f4505(???????\?)f30f104dcc", &ShipSystem__manningBarOn);
 }
 
 GL_Primitive **ShipSystem__manningBarOff;
 
-namespace _var1235
+namespace _var1236
 {
     static VariableDefinition varObj("ShipSystem__manningBarOff", "", &ShipSystem__manningBarOff);
 }
 
 GL_Primitive **ShipSystem__manningBarIon;
 
-namespace _var1236
+namespace _var1237
 {
     static VariableDefinition varObj("ShipSystem__manningBarIon", "", &ShipSystem__manningBarIon);
 }
 
 GL_Primitive **ShipSystem__lockBlue;
 
-namespace _var1237
+namespace _var1238
 {
     static VariableDefinition varObj("ShipSystem__lockBlue", "8b1d(???????\?)83faff895dbc0f85????????8b1d(???????\?)c745c8ff000000baff000000c745ccff000000895dbce9????????a1(???????\?)", &ShipSystem__lockBlue);
 }
 
 GL_Primitive **ShipSystem__lockWhite;
 
-namespace _var1238
+namespace _var1239
 {
     static VariableDefinition varObj("ShipSystem__lockWhite", "", &ShipSystem__lockWhite);
 }
 
 GL_Primitive **ShipSystem__lockHack;
 
-namespace _var1239
+namespace _var1240
 {
     static VariableDefinition varObj("ShipSystem__lockHack", "", &ShipSystem__lockHack);
 }
 
 GL_Primitive **ShipSystem__sabotageImage;
 
-namespace _var1240
+namespace _var1241
 {
     static VariableDefinition varObj("ShipSystem__sabotageImage", "a1(???????\?)890424e8????????c744240800000000c74424040000c0c1c7042400000000", &ShipSystem__sabotageImage);
 }
 
 GL_Primitive **ShipSystem__fireImage;
 
-namespace _var1241
+namespace _var1242
 {
     static VariableDefinition varObj("ShipSystem__fireImage", "a1(???????\?)890424e8????????c744240800000000c74424040000b0c1c7042400000000e8????????f30f105dd4", &ShipSystem__fireImage);
 }
 
-namespace _func1242
+namespace _func1243
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -17123,11 +17137,11 @@ namespace _func1242
 int SoundControl::PlaySoundMix(const std::string &soundName, float volume, bool loop)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(SoundControl *this_arg, const std::string &soundName_arg, float volume_arg, bool loop_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1242::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1243::func;
 	return execfunc(this, soundName, volume, loop);
 }
 
-namespace _func1243
+namespace _func1244
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17137,11 +17151,11 @@ namespace _func1243
 void SoundControl::StopPlaylist(int fadeOut)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SoundControl *this_arg, int fadeOut_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1243::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1244::func;
 	return execfunc(this, fadeOut);
 }
 
-namespace _func1244
+namespace _func1245
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17151,11 +17165,11 @@ namespace _func1244
 void SoundControl::StartPlaylist(std::vector<std::string> &playlist)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SoundControl *this_arg, std::vector<std::string> &playlist_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1244::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1245::func;
 	return execfunc(this, playlist);
 }
 
-namespace _func1245
+namespace _func1246
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17165,11 +17179,11 @@ namespace _func1245
 void SoundControl::UpdateSoundLoop(const std::string &loopId, float count)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SoundControl *this_arg, const std::string &loopId_arg, float count_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1245::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1246::func;
 	return execfunc(this, loopId, count);
 }
 
-namespace _func1246
+namespace _func1247
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17179,18 +17193,18 @@ namespace _func1246
 void SoundControl::StopChannel(int channel, float fade)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SoundControl *this_arg, int channel_arg, float fade_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1246::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1247::func;
 	return execfunc(this, channel, fade);
 }
 
 SoundControl *Global_SoundControl_Sounds;
 
-namespace _var1247
+namespace _var1248
 {
     static VariableDefinition varObj("Global_SoundControl_Sounds", "!8b4b08e8????????0fb6c0b9(???????\?)890424e8????????b9", &Global_SoundControl_Sounds);
 }
 
-namespace _func1248
+namespace _func1249
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -17200,11 +17214,11 @@ namespace _func1248
 float SpaceDrone::UpdateAimingAngle(Pointf location, float percentage, float forceDesired)
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Pointf location_arg, float percentage_arg, float forceDesired_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1248::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1249::func;
 	return execfunc(this, location, percentage, forceDesired);
 }
 
-namespace _func1249
+namespace _func1250
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17214,11 +17228,11 @@ namespace _func1249
 void SpaceDrone::SetDeployed(bool deployed)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, bool deployed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1249::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1250::func;
 	return execfunc(this, deployed);
 }
 
-namespace _func1250
+namespace _func1251
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17228,11 +17242,11 @@ namespace _func1250
 void SpaceDrone::SetMovementTarget(Targetable *target)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Targetable *target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1250::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1251::func;
 	return execfunc(this, target);
 }
 
-namespace _func1251
+namespace _func1252
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x2ff, 0xdff, 0x1ff};
@@ -17242,11 +17256,11 @@ namespace _func1251
 CollisionResponse SpaceDrone::CollisionMoving(Pointf start, Pointf finish, Damage damage, bool raytrace)
 {
 	typedef CollisionResponse __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, Pointf start_arg, Pointf finish_arg, Damage damage_arg, bool raytrace_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1251::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1252::func;
 	return execfunc(this, start, finish, damage, raytrace);
 }
 
-namespace _func1252
+namespace _func1253
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17256,11 +17270,11 @@ namespace _func1252
 Projectile *SpaceDrone::GetNextProjectile()
 {
 	typedef Projectile *__attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1252::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1253::func;
 	return execfunc(this);
 }
 
-namespace _func1253
+namespace _func1254
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -17270,11 +17284,11 @@ namespace _func1253
 void SpaceDrone::constructor(int iShipId, int selfId, DroneBlueprint *blueprint)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg, int iShipId_arg, int selfId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1253::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1254::func;
 	return execfunc(this, iShipId, selfId, blueprint);
 }
 
-namespace _func1254
+namespace _func1255
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17284,11 +17298,11 @@ namespace _func1254
 void SpaceDrone::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1254::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1255::func;
 	return execfunc(this);
 }
 
-namespace _func1255
+namespace _func1256
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17298,11 +17312,11 @@ namespace _func1255
 void SpaceManager::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1255::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1256::func;
 	return execfunc(this);
 }
 
-namespace _func1256
+namespace _func1257
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17312,11 +17326,11 @@ namespace _func1256
 int SpaceManager::GetScreenShake()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1256::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1257::func;
 	return execfunc(this);
 }
 
-namespace _func1257
+namespace _func1258
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17326,11 +17340,11 @@ namespace _func1257
 void SpaceManager::SaveSpace(int fileHelper)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1257::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1258::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1258
+namespace _func1259
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17340,11 +17354,11 @@ namespace _func1258
 ImageDesc SpaceManager::SwitchBeacon()
 {
 	typedef ImageDesc __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1258::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1259::func;
 	return execfunc(this);
 }
 
-namespace _func1259
+namespace _func1260
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17354,11 +17368,11 @@ namespace _func1259
 ImageDesc SpaceManager::SwitchPlanet(const std::string &name)
 {
 	typedef ImageDesc __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1259::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1260::func;
 	return execfunc(this, name);
 }
 
-namespace _func1260
+namespace _func1261
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17368,11 +17382,11 @@ namespace _func1260
 void SpaceManager::UpdatePlanetImage()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1260::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1261::func;
 	return execfunc(this);
 }
 
-namespace _func1261
+namespace _func1262
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x701, 0x701, 0x701};
@@ -17382,11 +17396,11 @@ namespace _func1261
 void SpaceManager::SwitchImages(ImageDesc planet, ImageDesc unk1, ImageDesc unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, ImageDesc planet_arg, ImageDesc unk1_arg, ImageDesc unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1261::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1262::func;
 	return execfunc(this, planet, unk1, unk2);
 }
 
-namespace _func1262
+namespace _func1263
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17396,11 +17410,11 @@ namespace _func1262
 ImageDesc SpaceManager::SwitchBackground(const std::string &name)
 {
 	typedef ImageDesc __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, const std::string &name_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1262::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1263::func;
 	return execfunc(this, name);
 }
 
-namespace _func1263
+namespace _func1264
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17410,11 +17424,11 @@ namespace _func1263
 void SpaceManager::StartAsteroids(int shieldCount, bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int shieldCount_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1263::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1264::func;
 	return execfunc(this, shieldCount, unk);
 }
 
-namespace _func1264
+namespace _func1265
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17424,11 +17438,11 @@ namespace _func1264
 void SpaceManager::SetPlanetaryDefense(char state, int target)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, char state_arg, int target_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1264::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1265::func;
 	return execfunc(this, state, target);
 }
 
-namespace _func1265
+namespace _func1266
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17438,11 +17452,11 @@ namespace _func1265
 void SpaceManager::SetPulsarLevel(bool pulsarLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool pulsarLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1265::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1266::func;
 	return execfunc(this, pulsarLevel);
 }
 
-namespace _func1266
+namespace _func1267
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17452,11 +17466,11 @@ namespace _func1266
 bool SpaceManager::DangerousEnvironment()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1266::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1267::func;
 	return execfunc(this);
 }
 
-namespace _func1267
+namespace _func1268
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -17466,11 +17480,11 @@ namespace _func1267
 void SpaceManager::MouseMove(int x, int y, int unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int x_arg, int y_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1267::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1268::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func1268
+namespace _func1269
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -17480,11 +17494,11 @@ namespace _func1268
 SpaceDrone *SpaceManager::GetSelectedDrone(int x, int y, int unk)
 {
 	typedef SpaceDrone *__attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int x_arg, int y_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1268::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1269::func;
 	return execfunc(this, x, y, unk);
 }
 
-namespace _func1269
+namespace _func1270
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17494,11 +17508,11 @@ namespace _func1269
 float SpaceManager::GetFlashOpacity()
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1269::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1270::func;
 	return execfunc(this);
 }
 
-namespace _func1270
+namespace _func1271
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17508,20 +17522,6 @@ namespace _func1270
 GL_Color SpaceManager::GetColorTint()
 {
 	typedef GL_Color __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1270::func;
-	return execfunc(this);
-}
-
-namespace _func1271
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::OnRenderBackground", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e55756", argdata, 1, 5, &func);
-}
-
-void SpaceManager::OnRenderBackground()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1271::func;
 	return execfunc(this);
 }
@@ -17530,10 +17530,10 @@ namespace _func1272
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::OnRenderFleet", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e557", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnRenderBackground", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e55756", argdata, 1, 5, &func);
 }
 
-void SpaceManager::OnRenderFleet()
+void SpaceManager::OnRenderBackground()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1272::func;
@@ -17544,10 +17544,10 @@ namespace _func1273
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::OnRenderForeground", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e557", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnRenderFleet", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e557", argdata, 1, 5, &func);
 }
 
-void SpaceManager::OnRenderForeground()
+void SpaceManager::OnRenderFleet()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1273::func;
@@ -17557,6 +17557,20 @@ void SpaceManager::OnRenderForeground()
 namespace _func1274
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("SpaceManager::OnRenderForeground", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e557", argdata, 1, 5, &func);
+}
+
+void SpaceManager::OnRenderForeground()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1274::func;
+	return execfunc(this);
+}
+
+namespace _func1275
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("SpaceManager::SetDangerZone", typeid(void (SpaceManager::*)(int )), ".578d7c240883e4f0ff77fc5589e557", argdata, 2, 5, &func);
 }
@@ -17564,11 +17578,11 @@ namespace _func1274
 void SpaceManager::SetDangerZone(int fleetType)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fleetType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1274::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1275::func;
 	return execfunc(this, fleetType);
 }
 
-namespace _func1275
+namespace _func1276
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17578,11 +17592,11 @@ namespace _func1275
 void SpaceManager::OnRenderAsteroids(int fieldLayers, float unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fieldLayers_arg, float unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1275::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1276::func;
 	return execfunc(this, fieldLayers, unk2);
 }
 
-namespace _func1276
+namespace _func1277
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17592,11 +17606,11 @@ namespace _func1276
 void SpaceManager::OnRenderProjectiles(int iShipId, int layerCommand)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int iShipId_arg, int layerCommand_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1276::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1277::func;
 	return execfunc(this, iShipId, layerCommand);
 }
 
-namespace _func1277
+namespace _func1278
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17604,20 +17618,6 @@ namespace _func1277
 }
 
 void SpaceManager::OnInit()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1277::func;
-	return execfunc(this);
-}
-
-namespace _func1278
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::Restart", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e55756", argdata, 1, 5, &func);
-}
-
-void SpaceManager::Restart()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1278::func;
@@ -17628,10 +17628,10 @@ namespace _func1279
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::ClearEnvironment", typeid(void (SpaceManager::*)()), ".c6818802000000c6818902000000c6819802000000c7819c02000002000000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::Restart", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e55756", argdata, 1, 5, &func);
 }
 
-void SpaceManager::ClearEnvironment()
+void SpaceManager::Restart()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1279::func;
@@ -17642,10 +17642,10 @@ namespace _func1280
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::Clear", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e5575653", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::ClearEnvironment", typeid(void (SpaceManager::*)()), ".c6818802000000c6818902000000c6819802000000c7819c02000002000000", argdata, 1, 5, &func);
 }
 
-void SpaceManager::Clear()
+void SpaceManager::ClearEnvironment()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1280::func;
@@ -17656,10 +17656,10 @@ namespace _func1281
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::ClearProjectiles", typeid(void (SpaceManager::*)()), ".5589e55756538b1189ce", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::Clear", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e5575653", argdata, 1, 5, &func);
 }
 
-void SpaceManager::ClearProjectiles()
+void SpaceManager::Clear()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1281::func;
@@ -17669,25 +17669,25 @@ void SpaceManager::ClearProjectiles()
 namespace _func1282
 {
     static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::UpdateProjectile", typeid(void (SpaceManager::*)(Projectile *)), ".578d7c240883e4f0ff77fc5589e557", argdata, 2, 5, &func);
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("SpaceManager::ClearProjectiles", typeid(void (SpaceManager::*)()), ".5589e55756538b1189ce", argdata, 1, 5, &func);
 }
 
-void SpaceManager::UpdateProjectile(Projectile *proj)
+void SpaceManager::ClearProjectiles()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1282::func;
-	return execfunc(this, proj);
+	return execfunc(this);
 }
 
 namespace _func1283
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::TransferProjectile", typeid(void (SpaceManager::*)(Projectile *)), ".5589e556538b5d0883e4f0", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::UpdateProjectile", typeid(void (SpaceManager::*)(Projectile *)), ".578d7c240883e4f0ff77fc5589e557", argdata, 2, 5, &func);
 }
 
-void SpaceManager::TransferProjectile(Projectile *proj)
+void SpaceManager::UpdateProjectile(Projectile *proj)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1283::func;
@@ -17698,17 +17698,31 @@ namespace _func1284
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("SpaceManager::TransferProjectile", typeid(void (SpaceManager::*)(Projectile *)), ".5589e556538b5d0883e4f0", argdata, 2, 5, &func);
+}
+
+void SpaceManager::TransferProjectile(Projectile *proj)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1284::func;
+	return execfunc(this, proj);
+}
+
+namespace _func1285
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("SpaceManager::AddShip", typeid(void (SpaceManager::*)(ShipManager *)), ".578d7c240883e4f0ff77fc5589f8", argdata, 2, 5, &func);
 }
 
 void SpaceManager::AddShip(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1284::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1285::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1285
+namespace _func1286
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17718,11 +17732,11 @@ namespace _func1285
 void SpaceManager::AddProjectile(Projectile *proj)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, Projectile *proj_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1285::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1286::func;
 	return execfunc(this, proj);
 }
 
-namespace _func1286
+namespace _func1287
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17732,11 +17746,11 @@ namespace _func1286
 void SpaceManager::LoadSpace(int fileHelper)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1286::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1287::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1287
+namespace _func1288
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17744,20 +17758,6 @@ namespace _func1287
 }
 
 void SpaceManager::UpdatePDS()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1287::func;
-	return execfunc(this);
-}
-
-namespace _func1288
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::OnLoopNebulas", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e5", argdata, 1, 5, &func);
-}
-
-void SpaceManager::OnLoopNebulas()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1288::func;
@@ -17768,10 +17768,10 @@ namespace _func1289
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("SpaceManager::OnLoop", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e557", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::OnLoopNebulas", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e5", argdata, 1, 5, &func);
 }
 
-void SpaceManager::OnLoop()
+void SpaceManager::OnLoopNebulas()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1289::func;
@@ -17781,25 +17781,25 @@ void SpaceManager::OnLoop()
 namespace _func1290
 {
     static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::SetNebula", typeid(void (SpaceManager::*)(bool )), ".578d7c240883e4f0ff77fc5589e55756", argdata, 2, 5, &func);
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("SpaceManager::OnLoop", typeid(void (SpaceManager::*)()), ".578d7c240883e4f0ff77fc5589e557", argdata, 1, 5, &func);
 }
 
-void SpaceManager::SetNebula(bool state)
+void SpaceManager::OnLoop()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1290::func;
-	return execfunc(this, state);
+	return execfunc(this);
 }
 
 namespace _func1291
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::SetStorm", typeid(void (SpaceManager::*)(bool )), ".578d7c240883e4f0ff77fc5589e5", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::SetNebula", typeid(void (SpaceManager::*)(bool )), ".578d7c240883e4f0ff77fc5589e55756", argdata, 2, 5, &func);
 }
 
-void SpaceManager::SetStorm(bool state)
+void SpaceManager::SetNebula(bool state)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1291::func;
@@ -17810,10 +17810,10 @@ namespace _func1292
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("SpaceManager::SetFireLevel", typeid(void (SpaceManager::*)(bool )), "578d7c240883e4f0ff77fc5589f889e55756538d99b802000089cf8d75d083ec3c8b0088818802000089d9", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("SpaceManager::SetStorm", typeid(void (SpaceManager::*)(bool )), ".578d7c240883e4f0ff77fc5589e5", argdata, 2, 5, &func);
 }
 
-void SpaceManager::SetFireLevel(bool state)
+void SpaceManager::SetStorm(bool state)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1292::func;
@@ -17823,6 +17823,20 @@ void SpaceManager::SetFireLevel(bool state)
 namespace _func1293
 {
     static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("SpaceManager::SetFireLevel", typeid(void (SpaceManager::*)(bool )), "578d7c240883e4f0ff77fc5589f889e55756538d99b802000089cf8d75d083ec3c8b0088818802000089d9", argdata, 2, 5, &func);
+}
+
+void SpaceManager::SetFireLevel(bool state)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceManager *this_arg, bool state_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1293::func;
+	return execfunc(this, state);
+}
+
+namespace _func1294
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff};
 	static FunctionDefinition funcObj("SpaceStatus::OnInit", typeid(void (SpaceStatus::*)(SpaceManager *, Point )), "578d????0883e4??ff????5589e557565389cb89de81ec????????", argdata, 3, 5, &func);
 }
@@ -17830,11 +17844,11 @@ namespace _func1293
 void SpaceStatus::OnInit(SpaceManager *space, Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg, SpaceManager *space_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1293::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1294::func;
 	return execfunc(this, space, pos);
 }
 
-namespace _func1294
+namespace _func1295
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17844,11 +17858,11 @@ namespace _func1294
 void SpaceStatus::RenderWarningText(int effect, int textOffset)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg, int effect_arg, int textOffset_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1294::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1295::func;
 	return execfunc(this, effect, textOffset);
 }
 
-namespace _func1295
+namespace _func1296
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17858,11 +17872,11 @@ namespace _func1295
 void SpaceStatus::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1295::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1296::func;
 	return execfunc(this);
 }
 
-namespace _func1296
+namespace _func1297
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -17872,11 +17886,11 @@ namespace _func1296
 void SpaceStatus::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1296::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1297::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1297
+namespace _func1298
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17886,11 +17900,11 @@ namespace _func1297
 void SpaceStatus::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SpaceStatus *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1297::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1298::func;
 	return execfunc(this);
 }
 
-namespace _func1298
+namespace _func1299
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17900,11 +17914,11 @@ namespace _func1298
 int Spreader_Fire::CounterRoom(int roomId)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(Spreader_Fire *this_arg, int roomId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1298::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1299::func;
 	return execfunc(this, roomId);
 }
 
-namespace _func1299
+namespace _func1300
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17914,11 +17928,11 @@ namespace _func1299
 void Spreader_Fire::UpdateSpread()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Spreader_Fire *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1299::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1300::func;
 	return execfunc(this);
 }
 
-namespace _func1300
+namespace _func1301
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -17928,11 +17942,11 @@ namespace _func1300
 void StarMap::SetPosition(Point unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1300::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1301::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1301
+namespace _func1302
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17942,11 +17956,11 @@ namespace _func1301
 void StarMap::KeyDown(int unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1301::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1302::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1302
+namespace _func1303
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17956,11 +17970,11 @@ namespace _func1302
 int StarMap::GetNextDangerMove()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1302::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1303::func;
 	return execfunc(this);
 }
 
-namespace _func1303
+namespace _func1304
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17970,11 +17984,11 @@ namespace _func1303
 void StarMap::Open()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1303::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1304::func;
 	return execfunc(this);
 }
 
-namespace _func1304
+namespace _func1305
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -17984,11 +17998,11 @@ namespace _func1304
 void StarMap::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1304::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1305::func;
 	return execfunc(this);
 }
 
-namespace _func1305
+namespace _func1306
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -17998,11 +18012,11 @@ namespace _func1305
 void StarMap::SetOpen(bool unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, bool unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1305::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1306::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1306
+namespace _func1307
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18010,20 +18024,6 @@ namespace _func1306
 }
 
 void StarMap::InitMapTitle()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1306::func;
-	return execfunc(this);
-}
-
-namespace _func1307
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::InitNoFuelText", typeid(void (StarMap::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb8d", argdata, 1, 5, &func);
-}
-
-void StarMap::InitNoFuelText()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1307::func;
@@ -18034,10 +18034,10 @@ namespace _func1308
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::InitBossMessageBox", typeid(void (StarMap::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb83", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("StarMap::InitNoFuelText", typeid(void (StarMap::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb8d", argdata, 1, 5, &func);
 }
 
-void StarMap::InitBossMessageBox()
+void StarMap::InitNoFuelText()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1308::func;
@@ -18048,10 +18048,10 @@ namespace _func1309
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::OnLanguageChange", typeid(void (StarMap::*)()), ".5589e55389cb83e4f0e812f7ffff89d9e8ebfaff", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("StarMap::InitBossMessageBox", typeid(void (StarMap::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb83", argdata, 1, 5, &func);
 }
 
-void StarMap::OnLanguageChange()
+void StarMap::InitBossMessageBox()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1309::func;
@@ -18062,17 +18062,31 @@ namespace _func1310
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("StarMap::OnLanguageChange", typeid(void (StarMap::*)()), ".5589e55389cb83e4f0e812f7ffff89d9e8ebfaff", argdata, 1, 5, &func);
+}
+
+void StarMap::OnLanguageChange()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1310::func;
+	return execfunc(this);
+}
+
+namespace _func1311
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("StarMap::GetRandomSectorChoice", typeid(int (StarMap::*)()), ".5589e583e4f0803d????????007435e8a46e1500", argdata, 1, 1, &func);
 }
 
 int StarMap::GetRandomSectorChoice()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1310::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1311::func;
 	return execfunc(this);
 }
 
-namespace _func1311
+namespace _func1312
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18082,11 +18096,11 @@ namespace _func1311
 bool StarMap::NeighboringSector(int potentialSector)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int potentialSector_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1311::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1312::func;
 	return execfunc(this, potentialSector);
 }
 
-namespace _func1312
+namespace _func1313
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -18096,11 +18110,11 @@ namespace _func1312
 void StarMap::GetSelectedSector(int unk0, int unk1, int unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg, int unk1_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1312::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1313::func;
 	return execfunc(this, unk0, unk1, unk2);
 }
 
-namespace _func1313
+namespace _func1314
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18110,11 +18124,11 @@ namespace _func1313
 void StarMap::StartSecretSector()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1313::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1314::func;
 	return execfunc(this);
 }
 
-namespace _func1314
+namespace _func1315
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18122,20 +18136,6 @@ namespace _func1314
 }
 
 void StarMap::ReachSector(Sector *unk0)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1314::func;
-	return execfunc(this, unk0);
-}
-
-namespace _func1315
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("StarMap::UpdateSectorMap", typeid(void (StarMap::*)(Sector *)), ".578d7c240883e4f0ff77fc5589f889e557565389", argdata, 2, 5, &func);
-}
-
-void StarMap::UpdateSectorMap(Sector *unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1315::func;
@@ -18146,17 +18146,31 @@ namespace _func1316
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("StarMap::UpdateSectorMap", typeid(void (StarMap::*)(Sector *)), ".578d7c240883e4f0ff77fc5589f889e557565389", argdata, 2, 5, &func);
+}
+
+void StarMap::UpdateSectorMap(Sector *unk0)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1316::func;
+	return execfunc(this, unk0);
+}
+
+namespace _func1317
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::SaveGame", typeid(void (StarMap::*)(int )), ".578d7c240883e4f0ff77fc5589f889e557565389", argdata, 2, 5, &func);
 }
 
 void StarMap::SaveGame(int file)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1316::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1317::func;
 	return execfunc(this, file);
 }
 
-namespace _func1317
+namespace _func1318
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18164,20 +18178,6 @@ namespace _func1317
 }
 
 void StarMap::InitStatistics()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1317::func;
-	return execfunc(this);
-}
-
-namespace _func1318
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::PrintStatistics", typeid(void (StarMap::*)()), ".f3c38db426000000008dbc2700000000f3c38db4", argdata, 1, 5, &func);
-}
-
-void StarMap::PrintStatistics()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1318::func;
@@ -18188,10 +18188,10 @@ namespace _func1319
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::AnalyzeMap", typeid(void (StarMap::*)()), ".f3c38db426000000008dbc27000000008b442404", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("StarMap::PrintStatistics", typeid(void (StarMap::*)()), ".f3c38db426000000008dbc2700000000f3c38db4", argdata, 1, 5, &func);
 }
 
-void StarMap::AnalyzeMap()
+void StarMap::PrintStatistics()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1319::func;
@@ -18201,6 +18201,20 @@ void StarMap::AnalyzeMap()
 namespace _func1320
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("StarMap::AnalyzeMap", typeid(void (StarMap::*)()), ".f3c38db426000000008dbc27000000008b442404", argdata, 1, 5, &func);
+}
+
+void StarMap::AnalyzeMap()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1320::func;
+	return execfunc(this);
+}
+
+namespace _func1321
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::ModifyPursuit", typeid(void (StarMap::*)(int )), ".8b442404018198040000c2040090669031c083b9", argdata, 2, 5, &func);
 }
@@ -18208,11 +18222,11 @@ namespace _func1320
 void StarMap::ModifyPursuit(int unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1320::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1321::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1321
+namespace _func1322
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18220,20 +18234,6 @@ namespace _func1321
 }
 
 void StarMap::AtBeacon()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1321::func;
-	return execfunc(this);
-}
-
-namespace _func1322
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::GetWaitLocation", typeid(void (StarMap::*)()), ".80797c00741a80b9ac060000007411c6417c00c6", argdata, 1, 5, &func);
-}
-
-void StarMap::GetWaitLocation()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1322::func;
@@ -18244,10 +18244,10 @@ namespace _func1323
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::StartBeacon", typeid(void (StarMap::*)()), ".8b919004000031c085d27e04c38d760056538b71", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("StarMap::GetWaitLocation", typeid(void (StarMap::*)()), ".80797c00741a80b9ac060000007411c6417c00c6", argdata, 1, 5, &func);
 }
 
-void StarMap::StartBeacon()
+void StarMap::GetWaitLocation()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1323::func;
@@ -18257,6 +18257,20 @@ void StarMap::StartBeacon()
 namespace _func1324
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("StarMap::StartBeacon", typeid(void (StarMap::*)()), ".8b919004000031c085d27e04c38d760056538b71", argdata, 1, 5, &func);
+}
+
+void StarMap::StartBeacon()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1324::func;
+	return execfunc(this);
+}
+
+namespace _func1325
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::LocationsConnected", typeid(void (StarMap::*)(Location *, Location *)), ".538b4424088b5c240c8b48088b500c29cac1fa02", argdata, 3, 5, &func);
 }
@@ -18264,11 +18278,11 @@ namespace _func1324
 void StarMap::LocationsConnected(Location *unk0, Location *unk1)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg, Location *unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1324::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1325::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1325
+namespace _func1326
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -18278,11 +18292,11 @@ namespace _func1325
 Point StarMap::PointToGrid(float x, float y)
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, float x_arg, float y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1325::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1326::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1326
+namespace _func1327
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18292,11 +18306,11 @@ namespace _func1326
 void StarMap::TravelToLocation(Location *unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1326::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1327::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1327
+namespace _func1328
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18306,11 +18320,11 @@ namespace _func1327
 void StarMap::ForceExitBeacon()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1327::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1328::func;
 	return execfunc(this);
 }
 
-namespace _func1328
+namespace _func1329
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18320,11 +18334,11 @@ namespace _func1328
 void StarMap::OnRenderFogEffect()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1328::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1329::func;
 	return execfunc(this);
 }
 
-namespace _func1329
+namespace _func1330
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18332,20 +18346,6 @@ namespace _func1329
 }
 
 void StarMap::LocationHasBoss(Location *unk0)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1329::func;
-	return execfunc(this, unk0);
-}
-
-namespace _func1330
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("StarMap::LocationHasStore", typeid(void (StarMap::*)(Location *)), ".56538b54240c8b422085c074258b801c06000085", argdata, 2, 5, &func);
-}
-
-void StarMap::LocationHasStore(Location *unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1330::func;
@@ -18356,10 +18356,10 @@ namespace _func1331
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("StarMap::LocationHasShip", typeid(void (StarMap::*)(Location *)), ".8b4424048b402085c074070fb6401cc2040031c0", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("StarMap::LocationHasStore", typeid(void (StarMap::*)(Location *)), ".56538b54240c8b422085c074258b801c06000085", argdata, 2, 5, &func);
 }
 
-void StarMap::LocationHasShip(Location *unk0)
+void StarMap::LocationHasStore(Location *unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1331::func;
@@ -18369,25 +18369,25 @@ void StarMap::LocationHasShip(Location *unk0)
 namespace _func1332
 {
     static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::AdvanceWorldLevel", typeid(void (StarMap::*)()), ".8b819004000083c00183f8038981900400007f01", argdata, 1, 5, &func);
+	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("StarMap::LocationHasShip", typeid(void (StarMap::*)(Location *)), ".8b4424048b402085c074070fb6401cc2040031c0", argdata, 2, 5, &func);
 }
 
-void StarMap::AdvanceWorldLevel()
+void StarMap::LocationHasShip(Location *unk0)
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1332::func;
-	return execfunc(this);
+	return execfunc(this, unk0);
 }
 
 namespace _func1333
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::ReverseBossPath", typeid(void (StarMap::*)()), ".568b8174080000538b997808000080b170080000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("StarMap::AdvanceWorldLevel", typeid(void (StarMap::*)()), ".8b819004000083c00183f8038981900400007f01", argdata, 1, 5, &func);
 }
 
-void StarMap::ReverseBossPath()
+void StarMap::AdvanceWorldLevel()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1333::func;
@@ -18398,10 +18398,10 @@ namespace _func1334
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::ForceBossJump", typeid(void (StarMap::*)()), ".80b97008000000c6817108000001751a8b817808", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("StarMap::ReverseBossPath", typeid(void (StarMap::*)()), ".568b8174080000538b997808000080b170080000", argdata, 1, 5, &func);
 }
 
-void StarMap::ForceBossJump()
+void StarMap::ReverseBossPath()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1334::func;
@@ -18412,10 +18412,10 @@ namespace _func1335
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StarMap::ClearBoss", typeid(void (StarMap::*)()), ".578d7c240883e4f0ff77fc5589e557565331db89", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("StarMap::ForceBossJump", typeid(void (StarMap::*)()), ".80b97008000000c6817108000001751a8b817808", argdata, 1, 5, &func);
 }
 
-void StarMap::ClearBoss()
+void StarMap::ForceBossJump()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1335::func;
@@ -18425,6 +18425,20 @@ void StarMap::ClearBoss()
 namespace _func1336
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("StarMap::ClearBoss", typeid(void (StarMap::*)()), ".578d7c240883e4f0ff77fc5589e557565331db89", argdata, 1, 5, &func);
+}
+
+void StarMap::ClearBoss()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1336::func;
+	return execfunc(this);
+}
+
+namespace _func1337
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("StarMap::SetBossStage", typeid(void (StarMap::*)(int )), ".8b4424048981e4090000c2040090669031c083b9", argdata, 2, 5, &func);
 }
@@ -18432,11 +18446,11 @@ namespace _func1336
 void StarMap::SetBossStage(int stage)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int stage_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1336::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1337::func;
 	return execfunc(this, stage);
 }
 
-namespace _func1337
+namespace _func1338
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18446,11 +18460,11 @@ namespace _func1337
 void StarMap::CheckGameOver()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1337::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1338::func;
 	return execfunc(this);
 }
 
-namespace _func1338
+namespace _func1339
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18460,11 +18474,11 @@ namespace _func1338
 std::string StarMap::GetPotentialSectorChoiceName()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1338::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1339::func;
 	return execfunc(this);
 }
 
-namespace _func1339
+namespace _func1340
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18474,11 +18488,11 @@ namespace _func1339
 void StarMap::RenderLabels()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1339::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1340::func;
 	return execfunc(this);
 }
 
-namespace _func1340
+namespace _func1341
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18488,11 +18502,11 @@ namespace _func1340
 void StarMap::DeleteMap()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1340::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1341::func;
 	return execfunc(this);
 }
 
-namespace _func1341
+namespace _func1342
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -18502,11 +18516,11 @@ namespace _func1341
 void StarMap::MouseClick(int unk0, int unk1)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg, int unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1341::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1342::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1342
+namespace _func1343
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18516,11 +18530,11 @@ namespace _func1342
 void StarMap::AddSectorColumn()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1342::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1343::func;
 	return execfunc(this);
 }
 
-namespace _func1343
+namespace _func1344
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18530,11 +18544,11 @@ namespace _func1343
 void StarMap::PushSectorColumn()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1343::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1344::func;
 	return execfunc(this);
 }
 
-namespace _func1344
+namespace _func1345
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18544,11 +18558,11 @@ namespace _func1344
 void StarMap::SelectNewSector(int unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1344::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1345::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1345
+namespace _func1346
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18558,11 +18572,11 @@ namespace _func1345
 void StarMap::GenerateSectorMap()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1345::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1346::func;
 	return execfunc(this);
 }
 
-namespace _func1346
+namespace _func1347
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18572,11 +18586,11 @@ namespace _func1346
 void StarMap::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1346::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1347::func;
 	return execfunc(this);
 }
 
-namespace _func1347
+namespace _func1348
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x4ff};
@@ -18586,11 +18600,11 @@ namespace _func1347
 void StarMap::RenderSectorName(Sector *unk0, GL_Color unk1)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Sector *unk0_arg, GL_Color unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1347::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1348::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1348
+namespace _func1349
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18600,11 +18614,11 @@ namespace _func1348
 void StarMap::UpdateDangerZone()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1348::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1349::func;
 	return execfunc(this);
 }
 
-namespace _func1349
+namespace _func1350
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18614,11 +18628,11 @@ namespace _func1349
 Location *StarMap::GetNewLocation()
 {
 	typedef Location *__attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1349::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1350::func;
 	return execfunc(this);
 }
 
-namespace _func1350
+namespace _func1351
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18628,11 +18642,11 @@ namespace _func1350
 void StarMap::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1350::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1351::func;
 	return execfunc(this);
 }
 
-namespace _func1351
+namespace _func1352
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18642,11 +18656,11 @@ namespace _func1351
 void StarMap::GenerateEvents(bool tutorial)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, bool tutorial_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1351::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1352::func;
 	return execfunc(this, tutorial);
 }
 
-namespace _func1352
+namespace _func1353
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18656,11 +18670,11 @@ namespace _func1352
 void StarMap::AddConnections(Location *unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1352::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1353::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1353
+namespace _func1354
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18670,11 +18684,11 @@ namespace _func1353
 bool StarMap::MapConnected()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1353::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1354::func;
 	return execfunc(this);
 }
 
-namespace _func1354
+namespace _func1355
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x2ff};
@@ -18684,11 +18698,11 @@ namespace _func1354
 void StarMap::ConnectLocations(Point unk0, Point unk1)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg, Point unk1_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1354::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1355::func;
 	return execfunc(this, unk0, unk1);
 }
 
-namespace _func1355
+namespace _func1356
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -18698,11 +18712,11 @@ namespace _func1355
 void StarMap::PopulateGrid(Point unk0)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Point unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1355::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1356::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1356
+namespace _func1357
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -18712,11 +18726,11 @@ namespace _func1356
 Location *StarMap::PopClosestLoc(std::vector<Location*> &vec, std::map<Location*, int> &map)
 {
 	typedef Location *__attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, std::vector<Location*> &vec_arg, std::map<Location*, int> &map_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1356::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1357::func;
 	return execfunc(this, vec, map);
 }
 
-namespace _func1357
+namespace _func1358
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -18726,11 +18740,11 @@ namespace _func1357
 bool StarMap::AddQuest(const std::string &questEvent, bool force)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, const std::string &questEvent_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1357::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1358::func;
 	return execfunc(this, questEvent, force);
 }
 
-namespace _func1358
+namespace _func1359
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -18740,11 +18754,11 @@ namespace _func1358
 Location *StarMap::GenerateMap(bool tutorial, bool seed)
 {
 	typedef Location *__attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, bool tutorial_arg, bool seed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1358::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1359::func;
 	return execfunc(this, tutorial, seed);
 }
 
-namespace _func1359
+namespace _func1360
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18754,11 +18768,11 @@ namespace _func1359
 Location *StarMap::NewGame(bool unk0)
 {
 	typedef Location *__attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, bool unk0_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1359::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1360::func;
 	return execfunc(this, unk0);
 }
 
-namespace _func1360
+namespace _func1361
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18768,11 +18782,11 @@ namespace _func1360
 std::vector<Location*> StarMap::Dijkstra(Location *start, Location *finish, bool include_unknown)
 {
 	typedef std::vector<Location*> __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *start_arg, Location *finish_arg, bool include_unknown_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1360::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1361::func;
 	return execfunc(this, start, finish, include_unknown);
 }
 
-namespace _func1361
+namespace _func1362
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -18782,11 +18796,11 @@ namespace _func1361
 void StarMap::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1361::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1362::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1362
+namespace _func1363
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -18796,11 +18810,11 @@ namespace _func1362
 void StarMap::OnTouch(TouchAction unk0, int unk1, int unk2, int unk3, int unk4, int unk5)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, TouchAction unk0_arg, int unk1_arg, int unk2_arg, int unk3_arg, int unk4_arg, int unk5_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1362::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1363::func;
 	return execfunc(this, unk0, unk1, unk2, unk3, unk4, unk5);
 }
 
-namespace _func1363
+namespace _func1364
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18810,11 +18824,11 @@ namespace _func1363
 Location *StarMap::LoadGame(int fileHelper)
 {
 	typedef Location *__attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int fileHelper_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1363::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1364::func;
 	return execfunc(this, fileHelper);
 }
 
-namespace _func1364
+namespace _func1365
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -18824,11 +18838,11 @@ namespace _func1364
 void StarMap::RenderLeftInsetButton(float unk0, float unk1, bool unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, float unk0_arg, float unk1_arg, bool unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1364::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1365::func;
 	return execfunc(this, unk0, unk1, unk2);
 }
 
-namespace _func1365
+namespace _func1366
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18838,11 +18852,11 @@ namespace _func1365
 void StarMap::RenderDistressButtons()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1365::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1366::func;
 	return execfunc(this);
 }
 
-namespace _func1366
+namespace _func1367
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18852,11 +18866,11 @@ namespace _func1366
 void StarMap::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1366::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1367::func;
 	return execfunc(this);
 }
 
-namespace _func1367
+namespace _func1368
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -18866,11 +18880,11 @@ namespace _func1367
 void StarMap::DrawConnection(const Pointf &pos1, const Pointf &pos2, const GL_Color *color)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, const Pointf &pos1_arg, const Pointf &pos2_arg, const GL_Color *color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1367::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1368::func;
 	return execfunc(this, pos1, pos2, color);
 }
 
-namespace _func1368
+namespace _func1369
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18880,11 +18894,11 @@ namespace _func1368
 void StarMap::TurnIntoFleetLocation(Location *loc)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1368::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1369::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1369
+namespace _func1370
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -18894,11 +18908,11 @@ namespace _func1369
 std::string StarMap::GetLocationText(const Location *loc)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, const Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1369::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1370::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1370
+namespace _func1371
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -18908,11 +18922,11 @@ namespace _func1370
 void StarMap::SetupNoFuel(int seed, const std::string &forceEscape)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, int seed_arg, const std::string &forceEscape_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1370::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1371::func;
 	return execfunc(this, seed, forceEscape);
 }
 
-namespace _func1371
+namespace _func1372
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18922,11 +18936,11 @@ namespace _func1371
 void StarMap::GenerateNebulas(const std::vector<std::string> &names)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg, const std::vector<std::string> &names_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1371::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1372::func;
 	return execfunc(this, names);
 }
 
-namespace _func1372
+namespace _func1373
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -18936,11 +18950,11 @@ namespace _func1372
 void StarMap::UpdateBoss()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StarMap *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1372::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1373::func;
 	return execfunc(this);
 }
 
-namespace _func1373
+namespace _func1374
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
@@ -18950,11 +18964,11 @@ namespace _func1373
 StatusEffect StatusEffect::GetNebulaEffect()
 {
 	typedef StatusEffect __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1373::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1374::func;
 	return execfunc();
 }
 
-namespace _func1374
+namespace _func1375
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -18964,11 +18978,11 @@ namespace _func1374
 void Store::OnInit(ShipManager *shopper, Equipment *equip, int worldLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, ShipManager *shopper_arg, Equipment *equip_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1374::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1375::func;
 	return execfunc(this, shopper, equip, worldLevel);
 }
 
-namespace _func1375
+namespace _func1376
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -18978,11 +18992,11 @@ namespace _func1375
 void Store::CreateStoreBoxes(int type, Equipment *equip)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, int type_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1375::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1376::func;
 	return execfunc(this, type, equip);
 }
 
-namespace _func1376
+namespace _func1377
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -18992,11 +19006,11 @@ namespace _func1376
 bool Store::KeyDown(SDLKey key)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1376::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1377::func;
 	return execfunc(this, key);
 }
 
-namespace _func1377
+namespace _func1378
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19006,11 +19020,11 @@ namespace _func1377
 void Store::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1377::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1378::func;
 	return execfunc(this);
 }
 
-namespace _func1378
+namespace _func1379
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19020,11 +19034,11 @@ namespace _func1378
 void Store::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1378::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1379::func;
 	return execfunc(this);
 }
 
-namespace _func1379
+namespace _func1380
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19034,11 +19048,11 @@ namespace _func1379
 void Store::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1379::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1380::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1380
+namespace _func1381
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19048,11 +19062,11 @@ namespace _func1380
 void Store::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1380::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1381::func;
 	return execfunc(this);
 }
 
-namespace _func1381
+namespace _func1382
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19062,11 +19076,11 @@ namespace _func1381
 void Store::SaveStore(int file)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, int file_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1381::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1382::func;
 	return execfunc(this, file);
 }
 
-namespace _func1382
+namespace _func1383
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19076,11 +19090,11 @@ namespace _func1382
 void Store::RelinkShip(ShipManager *ship, Equipment *equip)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, ShipManager *ship_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1382::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1383::func;
 	return execfunc(this, ship, equip);
 }
 
-namespace _func1383
+namespace _func1384
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19090,11 +19104,11 @@ namespace _func1383
 bool Store::HasType(int type)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, int type_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1383::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1384::func;
 	return execfunc(this, type);
 }
 
-namespace _func1384
+namespace _func1385
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19104,11 +19118,11 @@ namespace _func1384
 void Store::Clear()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1384::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1385::func;
 	return execfunc(this);
 }
 
-namespace _func1385
+namespace _func1386
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff};
@@ -19118,11 +19132,11 @@ namespace _func1385
 void Store::InitHeading(int index, Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, int index_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1385::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1386::func;
 	return execfunc(this, index, pos);
 }
 
-namespace _func1386
+namespace _func1387
 {
     static void *func = 0;
 	static const short *argdata = NULL;
@@ -19132,11 +19146,11 @@ namespace _func1386
 void Store::DrawBuySellTabText()
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)();
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1386::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1387::func;
 	return execfunc();
 }
 
-namespace _func1387
+namespace _func1388
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19146,11 +19160,11 @@ namespace _func1387
 void Store::MouseClick(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1387::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1388::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1388
+namespace _func1389
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19160,11 +19174,11 @@ namespace _func1388
 void Store::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1388::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1389::func;
 	return execfunc(this);
 }
 
-namespace _func1389
+namespace _func1390
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19174,11 +19188,11 @@ namespace _func1389
 void Store::SetPositions()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1389::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1390::func;
 	return execfunc(this);
 }
 
-namespace _func1390
+namespace _func1391
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19188,11 +19202,11 @@ namespace _func1390
 void Store::LoadStore(int file, int worldLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, int file_arg, int worldLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1390::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1391::func;
 	return execfunc(this, file, worldLevel);
 }
 
-namespace _func1391
+namespace _func1392
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -19202,11 +19216,11 @@ namespace _func1391
 void Store::SetPosition(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1391::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1392::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1392
+namespace _func1393
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19216,11 +19230,11 @@ namespace _func1392
 void Store::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Store *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1392::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1393::func;
 	return execfunc(this);
 }
 
-namespace _func1393
+namespace _func1394
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19230,11 +19244,11 @@ namespace _func1393
 void StoreBox::MouseClick(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1393::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1394::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1394
+namespace _func1395
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19244,11 +19258,11 @@ namespace _func1394
 void StoreBox::Activate()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1394::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1395::func;
 	return execfunc(this);
 }
 
-namespace _func1395
+namespace _func1396
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19258,11 +19272,11 @@ namespace _func1395
 void StoreBox::InitBlueprint(Blueprint *bp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg, Blueprint *bp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1395::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1396::func;
 	return execfunc(this, bp);
 }
 
-namespace _func1396
+namespace _func1397
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -19272,11 +19286,11 @@ namespace _func1396
 void StoreBox::constructor(const std::string &buttonImage, ShipManager *shopper, Equipment *equip)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg, const std::string &buttonImage_arg, ShipManager *shopper_arg, Equipment *equip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1396::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1397::func;
 	return execfunc(this, buttonImage, shopper, equip);
 }
 
-namespace _func1397
+namespace _func1398
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19286,11 +19300,11 @@ namespace _func1397
 void StoreBox::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1397::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1398::func;
 	return execfunc(this);
 }
 
-namespace _func1398
+namespace _func1399
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -19300,11 +19314,11 @@ namespace _func1398
 void StoreBox::SetPosition(Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1398::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1399::func;
 	return execfunc(this, pos);
 }
 
-namespace _func1399
+namespace _func1400
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19312,20 +19326,6 @@ namespace _func1399
 }
 
 void StoreBox::OnRender()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1399::func;
-	return execfunc(this);
-}
-
-namespace _func1400
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("StoreBox::Purchase", typeid(void (StoreBox::*)()), "57ba????????8d7c240883e4f0ff77fc5589e55756538d7dd08d75d889cbb9????????83ec3c8975d0", argdata, 1, 5, &func);
-}
-
-void StoreBox::Purchase()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1400::func;
@@ -19336,17 +19336,31 @@ namespace _func1401
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("StoreBox::Purchase", typeid(void (StoreBox::*)()), "57ba????????8d7c240883e4f0ff77fc5589e55756538d7dd08d75d889cbb9????????83ec3c8975d0", argdata, 1, 5, &func);
+}
+
+void StoreBox::Purchase()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(StoreBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1401::func;
+	return execfunc(this);
+}
+
+namespace _func1402
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("SuperShieldDrone::GetWeaponCooldown", typeid(float (SuperShieldDrone::*)()), "578d????0883e4f0ff????5589e55783ec348b8150010000", argdata, 1, 1, &func);
 }
 
 float SuperShieldDrone::GetWeaponCooldown()
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(SuperShieldDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1401::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1402::func;
 	return execfunc(this);
 }
 
-namespace _func1402
+namespace _func1403
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19356,11 +19370,11 @@ namespace _func1402
 void SuperShieldDrone::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SuperShieldDrone *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1402::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1403::func;
 	return execfunc(this);
 }
 
-namespace _func1403
+namespace _func1404
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -19370,11 +19384,11 @@ namespace _func1403
 void SuperShieldDrone::constructor(int iShipId, int selfId, DroneBlueprint *blueprint)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SuperShieldDrone *this_arg, int iShipId_arg, int selfId_arg, DroneBlueprint *blueprint_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1403::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1404::func;
 	return execfunc(this, iShipId, selfId, blueprint);
 }
 
-namespace _func1404
+namespace _func1405
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19384,11 +19398,11 @@ namespace _func1404
 void SystemBox::OnRender(bool ignoreStatus)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemBox *this_arg, bool ignoreStatus_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1404::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1405::func;
 	return execfunc(this, ignoreStatus);
 }
 
-namespace _func1405
+namespace _func1406
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19398,11 +19412,11 @@ namespace _func1405
 void SystemBox::MouseRightClick(bool force)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemBox *this_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1405::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1406::func;
 	return execfunc(this, force);
 }
 
-namespace _func1406
+namespace _func1407
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -19412,11 +19426,11 @@ namespace _func1406
 void SystemBox::constructor(Point pos, ShipSystem *sys, bool playerUI)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, bool playerUI_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1406::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1407::func;
 	return execfunc(this, pos, sys, playerUI);
 }
 
-namespace _func1407
+namespace _func1408
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19426,11 +19440,11 @@ namespace _func1407
 void SystemBox::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemBox *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1407::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1408::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1408
+namespace _func1409
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19440,11 +19454,11 @@ namespace _func1408
 bool SystemBox::MouseClick(bool shift)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemBox *this_arg, bool shift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1408::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1409::func;
 	return execfunc(this, shift);
 }
 
-namespace _func1409
+namespace _func1410
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19454,11 +19468,11 @@ namespace _func1409
 void SystemBox::KeyDown(SDLKey key, bool shift)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemBox *this_arg, SDLKey key_arg, bool shift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1409::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1410::func;
 	return execfunc(this, key, shift);
 }
 
-namespace _func1410
+namespace _func1411
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19468,11 +19482,11 @@ namespace _func1410
 void SystemBox::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1410::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1411::func;
 	return execfunc(this);
 }
 
-namespace _func1411
+namespace _func1412
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19482,11 +19496,11 @@ namespace _func1411
 void SystemControl::CreateSystemBoxes()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1411::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1412::func;
 	return execfunc(this);
 }
 
-namespace _func1412
+namespace _func1413
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19496,11 +19510,11 @@ namespace _func1412
 SystemBox *SystemControl::GetSystemBox(int systemId)
 {
 	typedef SystemBox *__attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemControl *this_arg, int systemId_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1412::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1413::func;
 	return execfunc(this, systemId);
 }
 
-namespace _func1413
+namespace _func1414
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19510,11 +19524,11 @@ namespace _func1413
 void SystemControl::RenderPowerBar()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1413::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1414::func;
 	return execfunc(this);
 }
 
-namespace _func1414
+namespace _func1415
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19524,11 +19538,11 @@ namespace _func1414
 void SystemControl::OnRender(bool front)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemControl *this_arg, bool front_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1414::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1415::func;
 	return execfunc(this, front);
 }
 
-namespace _func1415
+namespace _func1416
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -19538,11 +19552,11 @@ namespace _func1415
 SystemControl::PowerBars *SystemControl::GetPowerBars(int width, int height, int gap, bool useShieldGap)
 {
 	typedef SystemControl::PowerBars *__attribute__((cdecl)) (*custom_arg_funcptr_t)(int width_arg, int height_arg, int gap_arg, bool useShieldGap_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1415::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1416::func;
 	return execfunc(width, height, gap, useShieldGap);
 }
 
-namespace _func1416
+namespace _func1417
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19552,25 +19566,25 @@ namespace _func1416
 void SystemControl::UpdateSubSystemBox()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1416::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1417::func;
 	return execfunc(this);
 }
 
 Point *Global_SystemControl_weapon_position;
 
-namespace _var1417
+namespace _var1418
 {
     static VariableDefinition varObj("Global_SystemControl_weapon_position", "!a3(???????\?)8915????????e8????????8b55e08b45dc83ec088b7b0c8915????????8b5308a3(???????\?)", &Global_SystemControl_weapon_position);
 }
 
 Point *Global_SystemControl_drone_position;
 
-namespace _var1418
+namespace _var1419
 {
     static VariableDefinition varObj("Global_SystemControl_drone_position", "", &Global_SystemControl_drone_position);
 }
 
-namespace _func1419
+namespace _func1420
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -19580,11 +19594,11 @@ namespace _func1419
 void SystemCustomBox::constructor(Point pos, ShipSystem *sys, ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemCustomBox *this_arg, Point pos_arg, ShipSystem *sys_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1419::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1420::func;
 	return execfunc(this, pos, sys, ship);
 }
 
-namespace _func1420
+namespace _func1421
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19594,11 +19608,11 @@ namespace _func1420
 void SystemStoreBox::SetExtraData(int droneChoice)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, int droneChoice_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1420::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1421::func;
 	return execfunc(this, droneChoice);
 }
 
-namespace _func1421
+namespace _func1422
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -19608,11 +19622,11 @@ namespace _func1421
 void SystemStoreBox::constructor(ShipManager *shopper, Equipment *equip, int sys)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, ShipManager *shopper_arg, Equipment *equip_arg, int sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1421::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1422::func;
 	return execfunc(this, shopper, equip, sys);
 }
 
-namespace _func1422
+namespace _func1423
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19622,11 +19636,11 @@ namespace _func1422
 bool SystemStoreBox::CanHold()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1422::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1423::func;
 	return execfunc(this);
 }
 
-namespace _func1423
+namespace _func1424
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19636,11 +19650,11 @@ namespace _func1423
 void SystemStoreBox::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1423::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1424::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1424
+namespace _func1425
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19650,11 +19664,11 @@ namespace _func1424
 void SystemStoreBox::Activate()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1424::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1425::func;
 	return execfunc(this);
 }
 
-namespace _func1425
+namespace _func1426
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19664,11 +19678,11 @@ namespace _func1425
 void SystemStoreBox::Purchase()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1425::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1426::func;
 	return execfunc(this);
 }
 
-namespace _func1426
+namespace _func1427
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19678,11 +19692,11 @@ namespace _func1426
 TextString SystemStoreBox::GetConfirmText()
 {
 	typedef TextString __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1426::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1427::func;
 	return execfunc(this);
 }
 
-namespace _func1427
+namespace _func1428
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19692,11 +19706,11 @@ namespace _func1427
 int SystemStoreBox::SetInfoBox(InfoBox *box, int forceSystemInfoWidth)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(SystemStoreBox *this_arg, InfoBox *box_arg, int forceSystemInfoWidth_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1427::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1428::func;
 	return execfunc(this, box, forceSystemInfoWidth);
 }
 
-namespace _func1428
+namespace _func1429
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19706,11 +19720,11 @@ namespace _func1428
 void TabbedWindow::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TabbedWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1428::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1429::func;
 	return execfunc(this);
 }
 
-namespace _func1429
+namespace _func1430
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -19720,11 +19734,11 @@ namespace _func1429
 void TabbedWindow::AddWindow(const std::string &name, Button *button, FocusWindow *window)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TabbedWindow *this_arg, const std::string &name_arg, Button *button_arg, FocusWindow *window_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1429::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1430::func;
 	return execfunc(this, name, button, window);
 }
 
-namespace _func1430
+namespace _func1431
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19734,11 +19748,11 @@ namespace _func1430
 void TabbedWindow::SetTab(unsigned int tab)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TabbedWindow *this_arg, unsigned int tab_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1430::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1431::func;
 	return execfunc(this, tab);
 }
 
-namespace _func1431
+namespace _func1432
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19748,11 +19762,11 @@ namespace _func1431
 void TabbedWindow::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TabbedWindow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1431::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1432::func;
 	return execfunc(this);
 }
 
-namespace _func1432
+namespace _func1433
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -19762,11 +19776,11 @@ namespace _func1432
 void TabbedWindow::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TabbedWindow *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1432::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1433::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1433
+namespace _func1434
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -19776,18 +19790,18 @@ namespace _func1433
 void TeleportBox::constructor(Point pos, TeleportSystem *sys)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportBox *this_arg, Point pos_arg, TeleportSystem *sys_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1433::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1434::func;
 	return execfunc(this, pos, sys);
 }
 
-namespace _func1434
+namespace _func1435
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("TeleportSystem::__DO_NOT_HOOK", typeid(void (TeleportSystem::*)()), "8d????0483e4f0ff????5589e5535183ec408b15????????a1????????", argdata, 0, 4, &func);
 }
 
-namespace _func1435
+namespace _func1436
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19797,11 +19811,11 @@ namespace _func1435
 void TeleportSystem::SetHackingLevel(int hackingLevel)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int hackingLevel_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1435::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1436::func;
 	return execfunc(this, hackingLevel);
 }
 
-namespace _func1436
+namespace _func1437
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19811,11 +19825,11 @@ namespace _func1436
 void TeleportSystem::OnRenderFloor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1436::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1437::func;
 	return execfunc(this);
 }
 
-namespace _func1437
+namespace _func1438
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -19825,11 +19839,11 @@ namespace _func1437
 void TeleportSystem::constructor(int systemId, int roomId, int shipId, int startingPower)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int systemId_arg, int roomId_arg, int shipId_arg, int startingPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1437::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1438::func;
 	return execfunc(this, systemId, roomId, shipId, startingPower);
 }
 
-namespace _func1438
+namespace _func1439
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19839,11 +19853,11 @@ namespace _func1438
 float TeleportSystem::GetChargedPercent()
 {
 	typedef float __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1438::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1439::func;
 	return execfunc(this);
 }
 
-namespace _func1439
+namespace _func1440
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19853,11 +19867,11 @@ namespace _func1439
 bool TeleportSystem::Charged()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1439::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1440::func;
 	return execfunc(this);
 }
 
-namespace _func1440
+namespace _func1441
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19867,11 +19881,11 @@ namespace _func1440
 void TeleportSystem::ClearCrewLocations()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1440::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1441::func;
 	return execfunc(this);
 }
 
-namespace _func1441
+namespace _func1442
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19881,11 +19895,11 @@ namespace _func1441
 void TeleportSystem::UpdateCrewLocation(int unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1441::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1442::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1442
+namespace _func1443
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -19895,11 +19909,11 @@ namespace _func1442
 void TeleportSystem::SetArmed(int armed)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg, int armed_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1442::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1443::func;
 	return execfunc(this, armed);
 }
 
-namespace _func1443
+namespace _func1444
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -19909,20 +19923,6 @@ namespace _func1443
 void TeleportSystem::ForceReady()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1443::func;
-	return execfunc(this);
-}
-
-namespace _func1444
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("TeleportSystem::CanSend", typeid(bool (TeleportSystem::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b490c85c975??80bbc401000000", argdata, 1, 1, &func);
-}
-
-bool TeleportSystem::CanSend()
-{
-	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1444::func;
 	return execfunc(this);
 }
@@ -19931,10 +19931,10 @@ namespace _func1445
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("TeleportSystem::CanReceive", typeid(bool (TeleportSystem::*)()), ".5589e556538b750883e4f080b9c50100000075??8b410c85c074??8b0189cbff502c84c0", argdata, 1, 1, &func);
+	static FunctionDefinition funcObj("TeleportSystem::CanSend", typeid(bool (TeleportSystem::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b490c85c975??80bbc401000000", argdata, 1, 1, &func);
 }
 
-bool TeleportSystem::CanReceive()
+bool TeleportSystem::CanSend()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1445::func;
@@ -19945,12 +19945,12 @@ namespace _func1446
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("TeleportSystem::InitiateTeleport", typeid(void (TeleportSystem::*)()), ".578d7c240883e4f0ff77fc5589e5575389cb83ec30e8????????83e80131d283f80277??", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("TeleportSystem::CanReceive", typeid(bool (TeleportSystem::*)()), ".5589e556538b750883e4f080b9c50100000075??8b410c85c074??8b0189cbff502c84c0", argdata, 1, 1, &func);
 }
 
-void TeleportSystem::InitiateTeleport()
+bool TeleportSystem::CanReceive()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
+	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1446::func;
 	return execfunc(this);
 }
@@ -19959,10 +19959,10 @@ namespace _func1447
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("TeleportSystem::OnLoop", typeid(void (TeleportSystem::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb83ec4ce8????????8b0389d9", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("TeleportSystem::InitiateTeleport", typeid(void (TeleportSystem::*)()), ".578d7c240883e4f0ff77fc5589e5575389cb83ec30e8????????83e80131d283f80277??", argdata, 1, 5, &func);
 }
 
-void TeleportSystem::OnLoop()
+void TeleportSystem::InitiateTeleport()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1447::func;
@@ -19973,10 +19973,10 @@ namespace _func1448
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("TeleportSystem::Jump", typeid(void (TeleportSystem::*)()), ".5589e55389cb83e4f0e8????????c783c0010000000000008b5dfc", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("TeleportSystem::OnLoop", typeid(void (TeleportSystem::*)()), ".578d7c240883e4f0ff77fc5589e557565389cb83ec4ce8????????8b0389d9", argdata, 1, 5, &func);
 }
 
-void TeleportSystem::Jump()
+void TeleportSystem::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1448::func;
@@ -19987,17 +19987,31 @@ namespace _func1449
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("TeleportSystem::Jump", typeid(void (TeleportSystem::*)()), ".5589e55389cb83e4f0e8????????c783c0010000000000008b5dfc", argdata, 1, 5, &func);
+}
+
+void TeleportSystem::Jump()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TeleportSystem *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1449::func;
+	return execfunc(this);
+}
+
+namespace _func1450
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("TextButton::ResetPrimitives", typeid(void (TextButton::*)()), "5589e55756538d79548d594889ce83e4f083ec108b0383c304890424e8????????c743fc0000000039fb75??", argdata, 1, 5, &func);
 }
 
 void TextButton::ResetPrimitives()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1449::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1450::func;
 	return execfunc(this);
 }
 
-namespace _func1450
+namespace _func1451
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20007,18 +20021,18 @@ namespace _func1450
 int TextButton::GetIdealButtonWidth()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1450::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1451::func;
 	return execfunc(this);
 }
 
-namespace _func1451
+namespace _func1452
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("TextButton::__DO_NOT_HOOK", typeid(void (TextButton::*)()), ".83c30439f375??8d65f85b5e5dc204008d742600ffd08d65f85b", argdata, 0, 4, &func);
 }
 
-namespace _func1452
+namespace _func1453
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20028,11 +20042,11 @@ namespace _func1452
 void TextButton::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1452::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1453::func;
 	return execfunc(this);
 }
 
-namespace _func1453
+namespace _func1454
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x2ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20042,11 +20056,11 @@ namespace _func1453
 void TextButton::OnInit(Point pos, Point size, int cornerInset, TextString *buttonLabel, int font)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, Point pos_arg, Point size_arg, int cornerInset_arg, TextString *buttonLabel_arg, int font_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1453::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1454::func;
 	return execfunc(this, pos, size, cornerInset, buttonLabel, font);
 }
 
-namespace _func1454
+namespace _func1455
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20056,11 +20070,11 @@ namespace _func1454
 void TextButton::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1454::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1455::func;
 	return execfunc(this);
 }
 
-namespace _func1455
+namespace _func1456
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20070,11 +20084,11 @@ namespace _func1455
 void TextButton::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1455::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1456::func;
 	return execfunc(this);
 }
 
-namespace _func1456
+namespace _func1457
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20100,11 +20114,11 @@ FUNC_NAKED __int64 TextButton::GetSize_DO_NOT_USE_DIRECTLY()
 		"movl %%ebp, %%esp\n\t"
 		"popl %%ebp\n\t"
 		"ret\n\t"
-		 :: "m"(_func1456::func)
+		 :: "m"(_func1457::func)
 	);
 }
 
-namespace _func1457
+namespace _func1458
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20114,11 +20128,11 @@ namespace _func1457
 void TextButton::OnInitRect(Globals::Rect &rect, int cornerInset, TextString &buttonLabel, int font)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, Globals::Rect &rect_arg, int cornerInset_arg, TextString &buttonLabel_arg, int font_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1457::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1458::func;
 	return execfunc(this, rect, cornerInset, buttonLabel, font);
 }
 
-namespace _func1458
+namespace _func1459
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x1ff};
@@ -20128,11 +20142,11 @@ namespace _func1458
 void TextButton::SetBaseImage(const std::string &name, Point pos, int autoWidthMin)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, const std::string &name_arg, Point pos_arg, int autoWidthMin_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1458::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1459::func;
 	return execfunc(this, name, pos, autoWidthMin);
 }
 
-namespace _func1459
+namespace _func1460
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20142,11 +20156,11 @@ namespace _func1459
 void TextButton::SetAutoWidth(bool autoWidth, bool autoRightAlign, int margin, int min)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, bool autoWidth_arg, bool autoRightAlign_arg, int margin_arg, int min_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1459::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1460::func;
 	return execfunc(this, autoWidth, autoRightAlign, margin, min);
 }
 
-namespace _func1460
+namespace _func1461
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20156,11 +20170,11 @@ namespace _func1460
 void TextButton::UpdateAutoWidth()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1460::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1461::func;
 	return execfunc(this);
 }
 
-namespace _func1461
+namespace _func1462
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x4ff};
@@ -20168,20 +20182,6 @@ namespace _func1461
 }
 
 void TextButton::SetInactiveColor(GL_Color color)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1461::func;
-	return execfunc(this, color);
-}
-
-namespace _func1462
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x4ff};
-	static FunctionDefinition funcObj("TextButton::SetActiveColor", typeid(void (TextButton::*)(GL_Color )), ".5589e557565389cb83e4f083ec10807964000f85????????f30f1005????????c6416401f30f100d????????c741740000803ff30f1015????????", argdata, 2, 5, &func);
-}
-
-void TextButton::SetActiveColor(GL_Color color)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1462::func;
@@ -20192,10 +20192,10 @@ namespace _func1463
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x4ff};
-	static FunctionDefinition funcObj("TextButton::SetSelectedColor", typeid(void (TextButton::*)(GL_Color )), ".5589e557565389cb83e4f083ec10807964000f85????????f30f1005????????c6416401f30f100d????????c741740000803ff30f1015????????f30f5ec8c781840000000000803f", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("TextButton::SetActiveColor", typeid(void (TextButton::*)(GL_Color )), ".5589e557565389cb83e4f083ec10807964000f85????????f30f1005????????c6416401f30f100d????????c741740000803ff30f1015????????", argdata, 2, 5, &func);
 }
 
-void TextButton::SetSelectedColor(GL_Color color)
+void TextButton::SetActiveColor(GL_Color color)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1463::func;
@@ -20206,10 +20206,10 @@ namespace _func1464
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x4ff};
-	static FunctionDefinition funcObj("TextButton::SetTextColor", typeid(void (TextButton::*)(GL_Color )), ".807964000f85????????f30f1005????????c6416401f30f100d????????c741740000803ff30f1015????????f30f5ec8c781840000000000803ff30f101d????????c781940000000000803ff30f5ed0f30f114970f30f100d????????", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("TextButton::SetSelectedColor", typeid(void (TextButton::*)(GL_Color )), ".5589e557565389cb83e4f083ec10807964000f85????????f30f1005????????c6416401f30f100d????????c741740000803ff30f1015????????f30f5ec8c781840000000000803f", argdata, 2, 5, &func);
 }
 
-void TextButton::SetTextColor(GL_Color color)
+void TextButton::SetSelectedColor(GL_Color color)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1464::func;
@@ -20219,6 +20219,20 @@ void TextButton::SetTextColor(GL_Color color)
 namespace _func1465
 {
     static void *func = 0;
+	static short argdata[] = {0x101, 0x4ff};
+	static FunctionDefinition funcObj("TextButton::SetTextColor", typeid(void (TextButton::*)(GL_Color )), ".807964000f85????????f30f1005????????c6416401f30f100d????????c741740000803ff30f1015????????f30f5ec8c781840000000000803ff30f101d????????c781940000000000803ff30f5ed0f30f114970f30f100d????????", argdata, 2, 5, &func);
+}
+
+void TextButton::SetTextColor(GL_Color color)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg, GL_Color color_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1465::func;
+	return execfunc(this, color);
+}
+
+namespace _func1466
+{
+    static void *func = 0;
 	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("TextButton::InitPrimitives", typeid(void (TextButton::*)()), "578d7c240883e4f0ff77fc5589e557565389cf81ec????????807964000f84????????8b4704c745c000000000c745c400000000c745c8000000008945b08b4708", argdata, 1, 5, &func);
 }
@@ -20226,11 +20240,11 @@ namespace _func1465
 void TextButton::InitPrimitives()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextButton *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1465::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1466::func;
 	return execfunc(this);
 }
 
-namespace _func1466
+namespace _func1467
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -20240,11 +20254,11 @@ namespace _func1466
 void TextInput::constructor(int maxChars, TextInput::AllowedCharType allowedCharType, const std::string &prompt)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg, int maxChars_arg, TextInput::AllowedCharType allowedCharType_arg, const std::string &prompt_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1466::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1467::func;
 	return execfunc(this, maxChars, allowedCharType, prompt);
 }
 
-namespace _func1467
+namespace _func1468
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff};
@@ -20254,11 +20268,11 @@ namespace _func1467
 void TextInput::OnRender(int font, Point pos)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg, int font_arg, Point pos_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1467::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1468::func;
 	return execfunc(this, font, pos);
 }
 
-namespace _func1468
+namespace _func1469
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20268,11 +20282,11 @@ namespace _func1468
 void TextInput::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1468::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1469::func;
 	return execfunc(this);
 }
 
-namespace _func1469
+namespace _func1470
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -20282,11 +20296,11 @@ namespace _func1469
 void TextInput::OnTextEvent(CEvent::TextEvent event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg, CEvent::TextEvent event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1469::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1470::func;
 	return execfunc(this, event);
 }
 
-namespace _func1470
+namespace _func1471
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20296,11 +20310,11 @@ namespace _func1470
 bool TextInput::GetActive()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1470::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1471::func;
 	return execfunc(this);
 }
 
-namespace _func1471
+namespace _func1472
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -20310,11 +20324,11 @@ namespace _func1471
 std::string TextInput::GetText()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1471::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1472::func;
 	return execfunc(this);
 }
 
-namespace _func1472
+namespace _func1473
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20324,11 +20338,11 @@ namespace _func1472
 void TextInput::Start()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1472::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1473::func;
 	return execfunc(this);
 }
 
-namespace _func1473
+namespace _func1474
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20338,11 +20352,11 @@ namespace _func1473
 void TextInput::Stop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1473::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1474::func;
 	return execfunc(this);
 }
 
-namespace _func1474
+namespace _func1475
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -20352,11 +20366,11 @@ namespace _func1474
 int TextInput::SetText(const std::string &text)
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1474::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1475::func;
 	return execfunc(this, text);
 }
 
-namespace _func1475
+namespace _func1476
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -20366,11 +20380,11 @@ namespace _func1475
 void TextInput::OnTextInput(int asciiChar)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextInput *this_arg, int asciiChar_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1475::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1476::func;
 	return execfunc(this, asciiChar);
 }
 
-namespace _func1476
+namespace _func1477
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -20380,11 +20394,11 @@ namespace _func1476
 std::string TextLibrary::GetText(const std::string &name, const std::string &lang)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextLibrary *this_arg, const std::string &name_arg, const std::string &lang_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1476::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1477::func;
 	return execfunc(this, name, lang);
 }
 
-namespace _func1477
+namespace _func1478
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -20394,11 +20408,11 @@ namespace _func1477
 std::string TextString::GetText()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(TextString *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1477::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1478::func;
 	return execfunc(this);
 }
 
-namespace _func1478
+namespace _func1479
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -20408,11 +20422,11 @@ namespace _func1478
 void TimerHelper::Start(int goal)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TimerHelper *this_arg, int goal_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1478::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1479::func;
 	return execfunc(this, goal);
 }
 
-namespace _func1479
+namespace _func1480
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20422,11 +20436,11 @@ namespace _func1479
 bool TimerHelper::Running()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1479::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1480::func;
 	return execfunc(this);
 }
 
-namespace _func1480
+namespace _func1481
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -20436,11 +20450,11 @@ namespace _func1480
 void TimerHelper::ResetMinMax(int min, int max)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TimerHelper *this_arg, int min_arg, int max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1480::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1481::func;
 	return execfunc(this, min, max);
 }
 
-namespace _func1481
+namespace _func1482
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -20450,11 +20464,11 @@ namespace _func1481
 void TimerHelper::SetMaxTime(float max)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TimerHelper *this_arg, float max_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1481::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1482::func;
 	return execfunc(this, max);
 }
 
-namespace _func1482
+namespace _func1483
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20462,20 +20476,6 @@ namespace _func1482
 }
 
 void TimerHelper::Stop()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1482::func;
-	return execfunc(this);
-}
-
-namespace _func1483
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("TimerHelper::Update", typeid(void (TimerHelper::*)()), ".8079110075??c389f68dbc27000000005589e55389cbb9????????83e4f0", argdata, 1, 5, &func);
-}
-
-void TimerHelper::Update()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1483::func;
@@ -20486,17 +20486,31 @@ namespace _func1484
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("TimerHelper::Update", typeid(void (TimerHelper::*)()), ".8079110075??c389f68dbc27000000005589e55389cbb9????????83e4f0", argdata, 1, 5, &func);
+}
+
+void TimerHelper::Update()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1484::func;
+	return execfunc(this);
+}
+
+namespace _func1485
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("TimerHelper::Done", typeid(bool (TimerHelper::*)()), ".0fb6411184c074??f30f1041080f2e410c76??5589e55756530fb6711083e4f0", argdata, 1, 1, &func);
 }
 
 bool TimerHelper::Done()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TimerHelper *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1484::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1485::func;
 	return execfunc(this);
 }
 
-namespace _func1485
+namespace _func1486
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -20506,11 +20520,11 @@ namespace _func1485
 void TopScore::copy_constructor(const TopScore &other)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TopScore *this_arg, const TopScore &other_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1485::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1486::func;
 	return execfunc(this, other);
 }
 
-namespace _func1486
+namespace _func1487
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20520,11 +20534,11 @@ namespace _func1486
 void TutorialManager::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1486::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1487::func;
 	return execfunc(this);
 }
 
-namespace _func1487
+namespace _func1488
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20534,11 +20548,11 @@ namespace _func1487
 bool TutorialManager::Running()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1487::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1488::func;
 	return execfunc(this);
 }
 
-namespace _func1488
+namespace _func1489
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -20548,11 +20562,11 @@ namespace _func1488
 void TutorialManager::OnInit(ShipManager *ship, CommandGui *gui, CrewControl *crewControl, Upgrades *upgradesScreen, CombatControl *combatControl, SystemControl *sysControl, TabbedWindow *unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TutorialManager *this_arg, ShipManager *ship_arg, CommandGui *gui_arg, CrewControl *crewControl_arg, Upgrades *upgradesScreen_arg, CombatControl *combatControl_arg, SystemControl *sysControl_arg, TabbedWindow *unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1488::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1489::func;
 	return execfunc(this, ship, gui, crewControl, upgradesScreen, combatControl, sysControl, unk);
 }
 
-namespace _func1489
+namespace _func1490
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20562,11 +20576,11 @@ namespace _func1489
 void TutorialManager::LoadTutorial()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1489::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1490::func;
 	return execfunc(this);
 }
 
-namespace _func1490
+namespace _func1491
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20576,11 +20590,11 @@ namespace _func1490
 bool TutorialManager::MouseClick()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1490::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1491::func;
 	return execfunc(this);
 }
 
-namespace _func1491
+namespace _func1492
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -20590,11 +20604,11 @@ namespace _func1491
 void TutorialManager::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TutorialManager *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1491::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1492::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1492
+namespace _func1493
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20602,20 +20616,6 @@ namespace _func1492
 }
 
 void TutorialManager::OnLoop()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1492::func;
-	return execfunc(this);
-}
-
-namespace _func1493
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("TutorialManager::OnRender", typeid(void (TutorialManager::*)()), "80390075??f3c3", argdata, 1, 5, &func);
-}
-
-void TutorialManager::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1493::func;
@@ -20626,17 +20626,31 @@ namespace _func1494
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("TutorialManager::OnRender", typeid(void (TutorialManager::*)()), "80390075??f3c3", argdata, 1, 5, &func);
+}
+
+void TutorialManager::OnRender()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1494::func;
+	return execfunc(this);
+}
+
+namespace _func1495
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("TutorialManager::AllowJumping", typeid(bool (TutorialManager::*)()), "57ba4d5f0000", argdata, 1, 1, &func);
 }
 
 bool TutorialManager::AllowJumping()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1494::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1495::func;
 	return execfunc(this);
 }
 
-namespace _func1495
+namespace _func1496
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20646,18 +20660,18 @@ namespace _func1495
 bool TutorialManager::AllowUpgrades()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(TutorialManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1495::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1496::func;
 	return execfunc(this);
 }
 
 TutorialManager *Global_TutorialManager_Tutorial;
 
-namespace _var1496
+namespace _var1497
 {
     static VariableDefinition varObj("Global_TutorialManager_Tutorial", "!b9(???????\?)e8????????84c075??8b4b08", &Global_TutorialManager_Tutorial);
 }
 
-namespace _func1497
+namespace _func1498
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -20667,11 +20681,11 @@ namespace _func1497
 void UnlockArrow::constructor(Point pos, int unk1, int unk2)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UnlockArrow *this_arg, Point pos_arg, int unk1_arg, int unk2_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1497::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1498::func;
 	return execfunc(this, pos, unk1, unk2);
 }
 
-namespace _func1498
+namespace _func1499
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -20681,11 +20695,11 @@ namespace _func1498
 bool UnlockArrow::MouseMove(int x, int y)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(UnlockArrow *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1498::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1499::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1499
+namespace _func1500
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20695,11 +20709,11 @@ namespace _func1499
 void UnlockArrow::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UnlockArrow *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1499::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1500::func;
 	return execfunc(this);
 }
 
-namespace _func1500
+namespace _func1501
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff};
@@ -20709,11 +20723,11 @@ namespace _func1500
 void UpgradeBox::constructorEmpty(Point pos, bool subsystem)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, Point pos_arg, bool subsystem_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1500::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1501::func;
 	return execfunc(this, pos, subsystem);
 }
 
-namespace _func1501
+namespace _func1502
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x2ff, 0x1ff};
@@ -20723,11 +20737,11 @@ namespace _func1501
 void UpgradeBox::constructorSystem(ShipManager *ship, ShipSystem *sys, Point pos, bool subsystem)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, ShipManager *ship_arg, ShipSystem *sys_arg, Point pos_arg, bool subsystem_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1501::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1502::func;
 	return execfunc(this, ship, sys, pos, subsystem);
 }
 
-namespace _func1502
+namespace _func1503
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20737,11 +20751,11 @@ namespace _func1502
 void UpgradeBox::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1502::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1503::func;
 	return execfunc(this);
 }
 
-namespace _func1503
+namespace _func1504
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20751,11 +20765,11 @@ namespace _func1503
 void UpgradeBox::OnRender()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1503::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1504::func;
 	return execfunc(this);
 }
 
-namespace _func1504
+namespace _func1505
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -20763,20 +20777,6 @@ namespace _func1504
 }
 
 void UpgradeBox::MouseMove(int mX, int mY)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1504::func;
-	return execfunc(this, mX, mY);
-}
-
-namespace _func1505
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("UpgradeBox::MouseClick", typeid(void (UpgradeBox::*)(int , int )), "8b1185d20f84????????8b4118807840000f84????????807841000f84????????8b42540341143b82a00100000f8d????????5783e8018d7c240883e4f0ff77fc5589e557", argdata, 3, 5, &func);
-}
-
-void UpgradeBox::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1505::func;
@@ -20787,10 +20787,10 @@ namespace _func1506
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
-	static FunctionDefinition funcObj("UpgradeBox::MouseRightClick", typeid(void (UpgradeBox::*)(int , int )), "8b1185d20f84????????8b4118807840000f84????????807841000f84????????8b411485c00f8e????????578d7c240883e4f0ff77fc5589e557", argdata, 3, 5, &func);
+	static FunctionDefinition funcObj("UpgradeBox::MouseClick", typeid(void (UpgradeBox::*)(int , int )), "8b1185d20f84????????8b4118807840000f84????????807841000f84????????8b42540341143b82a00100000f8d????????5783e8018d7c240883e4f0ff77fc5589e557", argdata, 3, 5, &func);
 }
 
-void UpgradeBox::MouseRightClick(int mX, int mY)
+void UpgradeBox::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1506::func;
@@ -20800,25 +20800,25 @@ void UpgradeBox::MouseRightClick(int mX, int mY)
 namespace _func1507
 {
     static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("UpgradeBox::Undo", typeid(void (UpgradeBox::*)()), "8b411485c07e??578d7c240883e4f0ff77fc5589e557565389cb83ec1c8d76008b1331f60342548b53088b8ac4000000", argdata, 1, 5, &func);
+	static short argdata[] = {0x101, 0x1ff, 0x1ff};
+	static FunctionDefinition funcObj("UpgradeBox::MouseRightClick", typeid(void (UpgradeBox::*)(int , int )), "8b1185d20f84????????8b4118807840000f84????????807841000f84????????8b411485c00f8e????????578d7c240883e4f0ff77fc5589e557", argdata, 3, 5, &func);
 }
 
-void UpgradeBox::Undo()
+void UpgradeBox::MouseRightClick(int mX, int mY)
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg, int mX_arg, int mY_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1507::func;
-	return execfunc(this);
+	return execfunc(this, mX, mY);
 }
 
 namespace _func1508
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("UpgradeBox::Accept", typeid(void (UpgradeBox::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b0985c90f84????????8b4314890424e8????????8b0b83ec04", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("UpgradeBox::Undo", typeid(void (UpgradeBox::*)()), "8b411485c07e??578d7c240883e4f0ff77fc5589e557565389cb83ec1c8d76008b1331f60342548b53088b8ac4000000", argdata, 1, 5, &func);
 }
 
-void UpgradeBox::Accept()
+void UpgradeBox::Undo()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1508::func;
@@ -20828,6 +20828,20 @@ void UpgradeBox::Accept()
 namespace _func1509
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("UpgradeBox::Accept", typeid(void (UpgradeBox::*)()), "578d7c240883e4f0ff77fc5589e557565389cb83ec3c8b0985c90f84????????8b4314890424e8????????8b0b83ec04", argdata, 1, 5, &func);
+}
+
+void UpgradeBox::Accept()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(UpgradeBox *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1509::func;
+	return execfunc(this);
+}
+
+namespace _func1510
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("Upgrades::OnInit", typeid(void (Upgrades::*)(ShipManager *)), "578d7c240883e4f0ff77fc5589e557565389cb8d75bc81ec????????8b07c64105018d7dd489412c8945888b4118894424048b41148d4dcc", argdata, 2, 5, &func);
 }
@@ -20835,11 +20849,11 @@ namespace _func1509
 void Upgrades::OnInit(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1509::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1510::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1510
+namespace _func1511
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20849,11 +20863,11 @@ namespace _func1510
 void Upgrades::ClearUpgradeBoxes()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1510::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1511::func;
 	return execfunc(this);
 }
 
-namespace _func1511
+namespace _func1512
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -20863,11 +20877,11 @@ namespace _func1511
 void Upgrades::MouseMove(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1511::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1512::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1512
+namespace _func1513
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20877,11 +20891,11 @@ namespace _func1512
 void Upgrades::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1512::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1513::func;
 	return execfunc(this);
 }
 
-namespace _func1513
+namespace _func1514
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -20891,11 +20905,11 @@ namespace _func1513
 void Upgrades::MouseClick(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1513::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1514::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1514
+namespace _func1515
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -20905,11 +20919,11 @@ namespace _func1514
 void Upgrades::MouseRightClick(int mX, int mY)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg, int mX_arg, int mY_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1514::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1515::func;
 	return execfunc(this, mX, mY);
 }
 
-namespace _func1515
+namespace _func1516
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -20917,20 +20931,6 @@ namespace _func1515
 }
 
 void Upgrades::OnRender()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1515::func;
-	return execfunc(this);
-}
-
-namespace _func1516
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("Upgrades::Close", typeid(void (Upgrades::*)()), "8079040075??c389f68dbc2700000000578d7c240883e4f0ff77fc5589e557565389cf31db8d75d883ec4c", argdata, 1, 5, &func);
-}
-
-void Upgrades::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1516::func;
@@ -20941,10 +20941,10 @@ namespace _func1517
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("Upgrades::ConfirmUpgrades", typeid(void (Upgrades::*)()), "578d7c240883e4f0ff77fc5589e557565331f68d7dd883ec4c8b51248b4120894dc489d129c1c1f902", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("Upgrades::Close", typeid(void (Upgrades::*)()), "8079040075??c389f68dbc2700000000578d7c240883e4f0ff77fc5589e557565389cf31db8d75d883ec4c", argdata, 1, 5, &func);
 }
 
-void Upgrades::ConfirmUpgrades()
+void Upgrades::Close()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1517::func;
@@ -20955,10 +20955,10 @@ namespace _func1518
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("Upgrades::Open", typeid(void (Upgrades::*)()), "578d????0883e4f0ff????5589e5575389cb83ec10e8????????8b432c89d9", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("Upgrades::ConfirmUpgrades", typeid(void (Upgrades::*)()), "578d7c240883e4f0ff77fc5589e557565331f68d7dd883ec4c8b51248b4120894dc489d129c1c1f902", argdata, 1, 5, &func);
 }
 
-void Upgrades::Open()
+void Upgrades::ConfirmUpgrades()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1518::func;
@@ -20969,12 +20969,12 @@ namespace _func1519
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("WarningMessage::Start", typeid(void (WarningMessage::*)()), "8079140075??578d7c240883e4f0ff77fc5589e5575389cb", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("Upgrades::Open", typeid(void (Upgrades::*)()), "578d????0883e4f0ff????5589e5575389cb83ec10e8????????8b432c89d9", argdata, 1, 5, &func);
 }
 
-void WarningMessage::Start()
+void Upgrades::Open()
 {
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(Upgrades *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1519::func;
 	return execfunc(this);
 }
@@ -20983,10 +20983,10 @@ namespace _func1520
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("WarningMessage::OnRender", typeid(void (WarningMessage::*)()), "807916000f85????????807914000f84????????578d7c240883e4f0ff77fc5589e55753", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("WarningMessage::Start", typeid(void (WarningMessage::*)()), "8079140075??578d7c240883e4f0ff77fc5589e5575389cb", argdata, 1, 5, &func);
 }
 
-void WarningMessage::OnRender()
+void WarningMessage::Start()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1520::func;
@@ -20996,6 +20996,20 @@ void WarningMessage::OnRender()
 namespace _func1521
 {
     static void *func = 0;
+	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("WarningMessage::OnRender", typeid(void (WarningMessage::*)()), "807916000f85????????807914000f84????????578d7c240883e4f0ff77fc5589e55753", argdata, 1, 5, &func);
+}
+
+void WarningMessage::OnRender()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1521::func;
+	return execfunc(this);
+}
+
+namespace _func1522
+{
+    static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("WarningMessage::RenderWithAlpha", typeid(void (WarningMessage::*)(float )), "578d7c240883e4f0ff77fc5589e557565389cb81ec8c00000080792800f30f100f744d", argdata, 2, 5, &func);
 }
@@ -21003,11 +21017,11 @@ namespace _func1521
 void WarningMessage::RenderWithAlpha(float alpha)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1521::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1522::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func1522
+namespace _func1523
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21017,11 +21031,11 @@ namespace _func1522
 void WarningMessage::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1522::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1523::func;
 	return execfunc(this);
 }
 
-namespace _func1523
+namespace _func1524
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x1ff, 0x1ff};
@@ -21031,11 +21045,11 @@ namespace _func1523
 void WarningMessage::InitImage(const std::string &imageName, Point position, float time, bool flash)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &imageName_arg, Point position_arg, float time_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1523::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1524::func;
 	return execfunc(this, imageName, position, time, flash);
 }
 
-namespace _func1524
+namespace _func1525
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x2ff, 0x1ff, 0x4ff, 0x1ff, 0x1ff};
@@ -21045,11 +21059,11 @@ namespace _func1524
 void WarningMessage::InitText(const TextString &text, Point position, float time, GL_Color textColor, bool centerText, bool flash)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg, Point position_arg, float time_arg, GL_Color textColor_arg, bool centerText_arg, bool flash_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1524::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1525::func;
 	return execfunc(this, text, position, time, textColor, centerText, flash);
 }
 
-namespace _func1525
+namespace _func1526
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21059,11 +21073,11 @@ namespace _func1525
 void WarningMessage::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1525::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1526::func;
 	return execfunc(this);
 }
 
-namespace _func1526
+namespace _func1527
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21073,11 +21087,11 @@ namespace _func1526
 void WarningMessage::SetImage(const std::string &imageName)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &imageName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1526::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1527::func;
 	return execfunc(this, imageName);
 }
 
-namespace _func1527
+namespace _func1528
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21087,11 +21101,11 @@ namespace _func1527
 void WarningMessage::SetText(const TextString &text)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1527::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1528::func;
 	return execfunc(this, text);
 }
 
-namespace _func1528
+namespace _func1529
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x4ff};
@@ -21101,11 +21115,11 @@ namespace _func1528
 void WarningMessage::SetText(const TextString &text, GL_Color textColor)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const TextString &text_arg, GL_Color textColor_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1528::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1529::func;
 	return execfunc(this, text, textColor);
 }
 
-namespace _func1529
+namespace _func1530
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff};
@@ -21115,11 +21129,11 @@ namespace _func1529
 void WarningMessage::SetPosition(Point position)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, Point position_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1529::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1530::func;
 	return execfunc(this, position);
 }
 
-namespace _func1530
+namespace _func1531
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21129,11 +21143,11 @@ namespace _func1530
 void WarningMessage::SetLoop(bool loop)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, bool loop_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1530::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1531::func;
 	return execfunc(this, loop);
 }
 
-namespace _func1531
+namespace _func1532
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21143,11 +21157,11 @@ namespace _func1531
 void WarningMessage::SetSound(const std::string &sound)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WarningMessage *this_arg, const std::string &sound_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1531::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1532::func;
 	return execfunc(this, sound);
 }
 
-namespace _func1532
+namespace _func1533
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21157,11 +21171,11 @@ namespace _func1532
 void WeaponAnimation::SaveState(int fd)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, int fd_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1532::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1533::func;
 	return execfunc(this, fd);
 }
 
-namespace _func1533
+namespace _func1534
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21171,11 +21185,11 @@ namespace _func1533
 void WeaponAnimation::SetBoostLevel(int value)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, int value_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1533::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1534::func;
 	return execfunc(this, value);
 }
 
-namespace _func1534
+namespace _func1535
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21185,11 +21199,11 @@ namespace _func1534
 bool WeaponAnimation::StartFire()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1534::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1535::func;
 	return execfunc(this);
 }
 
-namespace _func1535
+namespace _func1536
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21199,11 +21213,11 @@ namespace _func1535
 void WeaponAnimation::SetFireTime(float time)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float time_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1535::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1536::func;
 	return execfunc(this, time);
 }
 
-namespace _func1536
+namespace _func1537
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21213,11 +21227,11 @@ namespace _func1536
 Pointf WeaponAnimation::GetSlide()
 {
 	typedef Pointf __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1536::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1537::func;
 	return execfunc(this);
 }
 
-namespace _func1537
+namespace _func1538
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21227,11 +21241,11 @@ namespace _func1537
 void WeaponAnimation::SetPowered(bool powered)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, bool powered_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1537::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1538::func;
 	return execfunc(this, powered);
 }
 
-namespace _func1538
+namespace _func1539
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21241,11 +21255,11 @@ namespace _func1538
 void WeaponAnimation::SetChargedLevel(float charged)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float charged_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1538::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1539::func;
 	return execfunc(this, charged);
 }
 
-namespace _func1539
+namespace _func1540
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21255,11 +21269,11 @@ namespace _func1539
 void WeaponAnimation::Update()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1539::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1540::func;
 	return execfunc(this);
 }
 
-namespace _func1540
+namespace _func1541
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21269,11 +21283,11 @@ namespace _func1540
 Point WeaponAnimation::GetFireLocation()
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1540::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1541::func;
 	return execfunc(this);
 }
 
-namespace _func1541
+namespace _func1542
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21283,11 +21297,11 @@ namespace _func1541
 void WeaponAnimation::OnRender(float alpha)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1541::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1542::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func1542
+namespace _func1543
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21297,18 +21311,18 @@ namespace _func1542
 void WeaponAnimation::RenderChargeBar(float alpha)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponAnimation *this_arg, float alpha_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1542::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1543::func;
 	return execfunc(this, alpha);
 }
 
-namespace _func1543
+namespace _func1544
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("WeaponBlueprint::__DO_NOT_HOOK", typeid(void (WeaponBlueprint::*)()), "5589e55389cb83e4f083ec108b81c4000000c701????????85c074??890424e8????????8b83a00000008d93a8000000c703????????39d0", argdata, 0, 4, &func);
 }
 
-namespace _func1544
+namespace _func1545
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21318,11 +21332,11 @@ namespace _func1544
 void WeaponBlueprint::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1544::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1545::func;
 	return execfunc(this);
 }
 
-namespace _func1545
+namespace _func1546
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21332,11 +21346,11 @@ namespace _func1545
 void WeaponBlueprint::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1545::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1546::func;
 	return execfunc(this);
 }
 
-namespace _func1546
+namespace _func1547
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -21346,11 +21360,11 @@ namespace _func1546
 std::string WeaponBlueprint::GetDescription(bool tooltip)
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg, bool tooltip_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1546::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1547::func;
 	return execfunc(this, tooltip);
 }
 
-namespace _func1547
+namespace _func1548
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21360,11 +21374,11 @@ namespace _func1547
 void WeaponBlueprint::RenderIcon(float scale)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg, float scale_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1547::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1548::func;
 	return execfunc(this, scale);
 }
 
-namespace _func1548
+namespace _func1549
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21374,11 +21388,11 @@ namespace _func1548
 Point WeaponBlueprint::GetDimensions()
 {
 	typedef Point __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponBlueprint *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1548::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1549::func;
 	return execfunc(this);
 }
 
-namespace _func1549
+namespace _func1550
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -21388,11 +21402,11 @@ namespace _func1549
 void WeaponBox::RenderBox(bool dragging, bool flashPowerBox)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponBox *this_arg, bool dragging_arg, bool flashPowerBox_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1549::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1550::func;
 	return execfunc(this, dragging, flashPowerBox);
 }
 
-namespace _func1550
+namespace _func1551
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21402,11 +21416,11 @@ namespace _func1550
 std::string WeaponBox::GenerateTooltip()
 {
 	typedef std::string __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponBox *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1550::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1551::func;
 	return execfunc(this);
 }
 
-namespace _func1551
+namespace _func1552
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -21416,11 +21430,11 @@ namespace _func1551
 void WeaponControl::Fire(std::vector<Pointf> &points, int target, bool autoFire)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, std::vector<Pointf> &points_arg, int target_arg, bool autoFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1551::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1552::func;
 	return execfunc(this, points, target, autoFire);
 }
 
-namespace _func1552
+namespace _func1553
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21430,11 +21444,11 @@ namespace _func1552
 void WeaponControl::OnRender(bool unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, bool unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1552::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1553::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1553
+namespace _func1554
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -21444,11 +21458,11 @@ namespace _func1553
 bool WeaponControl::LButton(int x, int y, bool holdingShift)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, int x_arg, int y_arg, bool holdingShift_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1553::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1554::func;
 	return execfunc(this, x, y, holdingShift);
 }
 
-namespace _func1554
+namespace _func1555
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -21458,11 +21472,11 @@ namespace _func1554
 void WeaponControl::MouseMove(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1554::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1555::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1555
+namespace _func1556
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21472,11 +21486,11 @@ namespace _func1555
 void WeaponControl::LinkShip(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1555::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1556::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1556
+namespace _func1557
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21486,11 +21500,11 @@ namespace _func1556
 void WeaponControl::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1556::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1557::func;
 	return execfunc(this);
 }
 
-namespace _func1557
+namespace _func1558
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -21500,11 +21514,11 @@ namespace _func1557
 void WeaponControl::SetAutofiring(bool on, bool simple)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, bool on_arg, bool simple_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1557::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1558::func;
 	return execfunc(this, on, simple);
 }
 
-namespace _func1558
+namespace _func1559
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21514,11 +21528,11 @@ namespace _func1558
 bool WeaponControl::KeyDown(SDLKey key)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, SDLKey key_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1558::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1559::func;
 	return execfunc(this, key);
 }
 
-namespace _func1559
+namespace _func1560
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21528,11 +21542,11 @@ namespace _func1559
 void WeaponControl::RenderAiming()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1559::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1560::func;
 	return execfunc(this);
 }
 
-namespace _func1560
+namespace _func1561
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21542,11 +21556,11 @@ namespace _func1560
 void WeaponControl::RenderSelfAiming()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1560::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1561::func;
 	return execfunc(this);
 }
 
-namespace _func1561
+namespace _func1562
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21556,11 +21570,11 @@ namespace _func1561
 void WeaponControl::SelectArmament(unsigned int armamentSlot)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, unsigned int armamentSlot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1561::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1562::func;
 	return execfunc(this, armamentSlot);
 }
 
-namespace _func1562
+namespace _func1563
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21570,11 +21584,11 @@ namespace _func1562
 void WeaponControl::OnLanguageChange()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1562::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1563::func;
 	return execfunc(this);
 }
 
-namespace _func1563
+namespace _func1564
 {
     static void *func = 0;
 	static short argdata[] = {0x2ff, 0x2ff, 0x1ff};
@@ -21584,11 +21598,11 @@ namespace _func1563
 void WeaponControl::RenderBeamAiming(Pointf one, Pointf two, bool bAutoFire)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(Pointf one_arg, Pointf two_arg, bool bAutoFire_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1563::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1564::func;
 	return execfunc(one, two, bAutoFire);
 }
 
-namespace _func1564
+namespace _func1565
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21598,11 +21612,11 @@ namespace _func1564
 void WeaponControl::RenderWarnings()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1564::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1565::func;
 	return execfunc(this);
 }
 
-namespace _func1565
+namespace _func1566
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21612,11 +21626,11 @@ namespace _func1565
 TextString WeaponControl::HolderLabel()
 {
 	typedef TextString __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1565::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1566::func;
 	return execfunc(this);
 }
 
-namespace _func1566
+namespace _func1567
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21626,11 +21640,11 @@ namespace _func1566
 SDLKey WeaponControl::ArmamentHotkey(unsigned int i)
 {
 	typedef SDLKey __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg, unsigned int i_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1566::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1567::func;
 	return execfunc(this, i);
 }
 
-namespace _func1567
+namespace _func1568
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21640,11 +21654,11 @@ namespace _func1567
 void WeaponControl::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponControl *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1567::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1568::func;
 	return execfunc(this);
 }
 
-namespace _func1568
+namespace _func1569
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -21654,11 +21668,11 @@ namespace _func1568
 void WeaponEquipBox::constructor(Point location, WeaponSystem *sys, int slot)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponEquipBox *this_arg, Point location_arg, WeaponSystem *sys_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1568::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1569::func;
 	return execfunc(this, location, sys, slot);
 }
 
-namespace _func1569
+namespace _func1570
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -21668,18 +21682,18 @@ namespace _func1569
 void DroneEquipBox::constructor(Point location, DroneSystem *sys, int slot)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(DroneEquipBox *this_arg, Point location_arg, DroneSystem *sys_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1569::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1570::func;
 	return execfunc(this, location, sys, slot);
 }
 
-namespace _func1570
+namespace _func1571
 {
     static void *func = 0;
 	static const short *argdata = NULL;
 	static FunctionDefinition funcObj("WeaponStoreBox::__DO_NOT_HOOK", typeid(void (WeaponStoreBox::*)()), "c7442404000000008904248975d0e8????????8b55ccc7400c655f627583ec08c74010795f7765c7401461706f6e89d9c64018738945d08955d8c700????????c740046555492fc7400873746f72", argdata, 0, 4, &func);
 }
 
-namespace _func1571
+namespace _func1572
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -21689,11 +21703,11 @@ namespace _func1571
 void WeaponStoreBox::constructor(ShipManager *ship, Equipment *equip, const WeaponBlueprint *weaponBp)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponStoreBox *this_arg, ShipManager *ship_arg, Equipment *equip_arg, const WeaponBlueprint *weaponBp_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1571::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1572::func;
 	return execfunc(this, ship, equip, weaponBp);
 }
 
-namespace _func1572
+namespace _func1573
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21703,11 +21717,11 @@ namespace _func1572
 bool WeaponSystem::ForceIncreasePower(int amount)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg, int amount_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1572::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1573::func;
 	return execfunc(this, amount);
 }
 
-namespace _func1573
+namespace _func1574
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21717,11 +21731,11 @@ namespace _func1573
 ProjectileFactory *WeaponSystem::RemoveWeapon(int slot)
 {
 	typedef ProjectileFactory *__attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg, int slot_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1573::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1574::func;
 	return execfunc(this, slot);
 }
 
-namespace _func1574
+namespace _func1575
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff};
@@ -21731,11 +21745,11 @@ namespace _func1574
 bool WeaponSystem::PowerWeapon(ProjectileFactory *weapon, bool userDriven, bool force)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg, ProjectileFactory *weapon_arg, bool userDriven_arg, bool force_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1574::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1575::func;
 	return execfunc(this, weapon, userDriven, force);
 }
 
-namespace _func1575
+namespace _func1576
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -21745,11 +21759,11 @@ namespace _func1575
 void WeaponSystem::SetBonusPower(int amount, int permanentPower)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg, int amount_arg, int permanentPower_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1575::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1576::func;
 	return execfunc(this, amount, permanentPower);
 }
 
-namespace _func1576
+namespace _func1577
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -21759,11 +21773,11 @@ namespace _func1576
 bool WeaponSystem::DePowerWeapon(ProjectileFactory *weapon, bool userDriven)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg, ProjectileFactory *weapon_arg, bool userDriven_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1576::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1577::func;
 	return execfunc(this, weapon, userDriven);
 }
 
-namespace _func1577
+namespace _func1578
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21773,11 +21787,11 @@ namespace _func1577
 void WeaponSystem::OnLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponSystem *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1577::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1578::func;
 	return execfunc(this);
 }
 
-namespace _func1578
+namespace _func1579
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x2ff, 0x1ff, 0x1ff};
@@ -21787,11 +21801,11 @@ namespace _func1578
 void WeaponSystemBox::constructor(Point pos, ShipSystem *sys, WeaponControl *weapCtrl)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WeaponSystemBox *this_arg, Point pos_arg, ShipSystem *sys_arg, WeaponControl *weapCtrl_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1578::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1579::func;
 	return execfunc(this, pos, sys, weapCtrl);
 }
 
-namespace _func1579
+namespace _func1580
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -21801,11 +21815,11 @@ namespace _func1579
 void WindowFrame::Draw(int x, int y)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WindowFrame *this_arg, int x_arg, int y_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1579::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1580::func;
 	return execfunc(this, x, y);
 }
 
-namespace _func1580
+namespace _func1581
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21815,11 +21829,11 @@ namespace _func1580
 void WindowFrame::DrawMask(int unk)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WindowFrame *this_arg, int unk_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1580::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1581::func;
 	return execfunc(this, unk);
 }
 
-namespace _func1581
+namespace _func1582
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -21829,11 +21843,11 @@ namespace _func1581
 void WindowFrame::constructor(int x, int y, int w, int h)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WindowFrame *this_arg, int x_arg, int y_arg, int w_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1581::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1582::func;
 	return execfunc(this, x, y, w, h);
 }
 
-namespace _func1582
+namespace _func1583
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21843,11 +21857,11 @@ namespace _func1582
 void WindowFrame::destructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WindowFrame *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1582::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1583::func;
 	return execfunc(this);
 }
 
-namespace _func1583
+namespace _func1584
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21857,11 +21871,11 @@ namespace _func1583
 void WorldManager::constructor()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1583::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1584::func;
 	return execfunc(this);
 }
 
-namespace _func1584
+namespace _func1585
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21871,11 +21885,11 @@ namespace _func1584
 int WorldManager::OnInit()
 {
 	typedef int __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1584::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1585::func;
 	return execfunc(this);
 }
 
-namespace _func1585
+namespace _func1586
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -21885,11 +21899,11 @@ namespace _func1585
 CompleteShip *WorldManager::CreateShip(ShipEvent *shipEvent, bool boss)
 {
 	typedef CompleteShip *__attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, ShipEvent *shipEvent_arg, bool boss_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1585::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1586::func;
 	return execfunc(this, shipEvent, boss);
 }
 
-namespace _func1586
+namespace _func1587
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21899,11 +21913,11 @@ namespace _func1586
 void WorldManager::CreateLocation(Location *loc)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, Location *loc_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1586::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1587::func;
 	return execfunc(this, loc);
 }
 
-namespace _func1587
+namespace _func1588
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21913,11 +21927,11 @@ namespace _func1587
 void WorldManager::ClearLocation()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1587::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1588::func;
 	return execfunc(this);
 }
 
-namespace _func1588
+namespace _func1589
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -21927,11 +21941,11 @@ namespace _func1588
 void WorldManager::SaveGame()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1588::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1589::func;
 	return execfunc(this);
 }
 
-namespace _func1589
+namespace _func1590
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -21939,20 +21953,6 @@ namespace _func1589
 }
 
 void WorldManager::CreateChoiceBox(LocationEvent *event)
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1589::func;
-	return execfunc(this, event);
-}
-
-namespace _func1590
-{
-    static void *func = 0;
-	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("WorldManager::CreateChoiceBox0", typeid(void (WorldManager::*)(LocationEvent *)), "578d7c240883e4f0ff77fc5589e557565389cb83ec1c8b018b378b48088b018b40443d????????752a0fb6819904000084c0751185f6742889342489d9e8????????83ec04", argdata, 2, 5, &func);
-}
-
-void WorldManager::CreateChoiceBox0(LocationEvent *event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1590::func;
@@ -21963,10 +21963,10 @@ namespace _func1591
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("WorldManager::UpdateLocation", typeid(void (WorldManager::*)(LocationEvent *)), "578d7c240883e4f0ff77fc5589e557565381ec????????8b3f898d70fbffff807f1c000f85????????8d85bcfbffff89ce898568fbffff8d85c4fbffff898564fbffff8d874406000089f1890424", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("WorldManager::CreateChoiceBox0", typeid(void (WorldManager::*)(LocationEvent *)), "578d7c240883e4f0ff77fc5589e557565389cb83ec1c8b018b378b48088b018b40443d????????752a0fb6819904000084c0751185f6742889342489d9e8????????83ec04", argdata, 2, 5, &func);
 }
 
-void WorldManager::UpdateLocation(LocationEvent *event)
+void WorldManager::CreateChoiceBox0(LocationEvent *event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1591::func;
@@ -21977,10 +21977,10 @@ namespace _func1592
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
-	static FunctionDefinition funcObj("WorldManager::UpdateLocation0", typeid(void (WorldManager::*)(LocationEvent *)), "578d7c240883e4f0ff77fc5589e557565389cb83ec1c8b018b378b48088b018b40443d????????75270fb6819904000084c0750d89342489d9e8????????83ec04", argdata, 2, 5, &func);
+	static FunctionDefinition funcObj("WorldManager::UpdateLocation", typeid(void (WorldManager::*)(LocationEvent *)), "578d7c240883e4f0ff77fc5589e557565381ec????????8b3f898d70fbffff807f1c000f85????????8d85bcfbffff89ce898568fbffff8d85c4fbffff898564fbffff8d874406000089f1890424", argdata, 2, 5, &func);
 }
 
-void WorldManager::UpdateLocation0(LocationEvent *event)
+void WorldManager::UpdateLocation(LocationEvent *event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1592::func;
@@ -21991,17 +21991,31 @@ namespace _func1593
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
+	static FunctionDefinition funcObj("WorldManager::UpdateLocation0", typeid(void (WorldManager::*)(LocationEvent *)), "578d7c240883e4f0ff77fc5589e557565389cb83ec1c8b018b378b48088b018b40443d????????75270fb6819904000084c0750d89342489d9e8????????83ec04", argdata, 2, 5, &func);
+}
+
+void WorldManager::UpdateLocation0(LocationEvent *event)
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1593::func;
+	return execfunc(this, event);
+}
+
+namespace _func1594
+{
+    static void *func = 0;
+	static short argdata[] = {0x101, 0x1ff};
 	static FunctionDefinition funcObj("WorldManager::ModifyResources", typeid(LocationEvent *(WorldManager::*)(LocationEvent *)), "578d7c240883e4f0ff77fc5589e557565389ce8d8d2cfeffff81ec????????8b078985d8fcffff", argdata, 2, 1, &func);
 }
 
 LocationEvent *WorldManager::ModifyResources(LocationEvent *event)
 {
 	typedef LocationEvent *__attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1593::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1594::func;
 	return execfunc(this, event);
 }
 
-namespace _func1594
+namespace _func1595
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -22011,11 +22025,11 @@ namespace _func1594
 void WorldManager::ModifyEnvironment(int envFlag, int envTarget)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, int envFlag_arg, int envTarget_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1594::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1595::func;
 	return execfunc(this, envFlag, envTarget);
 }
 
-namespace _func1595
+namespace _func1596
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -22025,11 +22039,11 @@ namespace _func1595
 void WorldManager::CheckStatusEffects(std::vector<StatusEffect> &vec)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, std::vector<StatusEffect> &vec_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1595::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1596::func;
 	return execfunc(this, vec);
 }
 
-namespace _func1596
+namespace _func1597
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x4ff, 0x1ff, 0x1ff};
@@ -22039,11 +22053,11 @@ namespace _func1596
 void WorldManager::ModifyStatusEffect(StatusEffect effect, ShipManager *target, int targetType)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, StatusEffect effect_arg, ShipManager *target_arg, int targetType_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1596::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1597::func;
 	return execfunc(this, effect, target, targetType);
 }
 
-namespace _func1597
+namespace _func1598
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -22053,11 +22067,11 @@ namespace _func1597
 void WorldManager::StartGame(ShipManager *ship)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, ShipManager *ship_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1597::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1598::func;
 	return execfunc(this, ship);
 }
 
-namespace _func1598
+namespace _func1599
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -22067,11 +22081,11 @@ namespace _func1598
 void WorldManager::Restart()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1598::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1599::func;
 	return execfunc(this);
 }
 
-namespace _func1599
+namespace _func1600
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -22081,11 +22095,11 @@ namespace _func1599
 void WorldManager::LoadGame(const std::string &fileName)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1599::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1600::func;
 	return execfunc(this, fileName);
 }
 
-namespace _func1600
+namespace _func1601
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -22093,20 +22107,6 @@ namespace _func1600
 }
 
 void WorldManager::OnLoop()
-{
-	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1600::func;
-	return execfunc(this);
-}
-
-namespace _func1601
-{
-    static void *func = 0;
-	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("WorldManager::PauseLoop", typeid(void (WorldManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec5c8b098b01ff500c83be3408000001", argdata, 1, 5, &func);
-}
-
-void WorldManager::PauseLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1601::func;
@@ -22117,10 +22117,10 @@ namespace _func1602
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
-	static FunctionDefinition funcObj("WorldManager::CreateNewGame", typeid(void (WorldManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce8d5dd88d7dd083ec3c8b018b480881c1????????e8????????8b068b5008895dd08b8aa4060000", argdata, 1, 5, &func);
+	static FunctionDefinition funcObj("WorldManager::PauseLoop", typeid(void (WorldManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce83ec5c8b098b01ff500c83be3408000001", argdata, 1, 5, &func);
 }
 
-void WorldManager::CreateNewGame()
+void WorldManager::PauseLoop()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1602::func;
@@ -22131,17 +22131,31 @@ namespace _func1603
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
+	static FunctionDefinition funcObj("WorldManager::CreateNewGame", typeid(void (WorldManager::*)()), "578d7c240883e4f0ff77fc5589e557565389ce8d5dd88d7dd083ec3c8b018b480881c1????????e8????????8b068b5008895dd08b8aa4060000", argdata, 1, 5, &func);
+}
+
+void WorldManager::CreateNewGame()
+{
+	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1603::func;
+	return execfunc(this);
+}
+
+namespace _func1604
+{
+    static void *func = 0;
+	static short argdata[] = {0x101};
 	static FunctionDefinition funcObj("WorldManager::HostileEnvironment", typeid(bool (WorldManager::*)()), "5589e55389cb83c10883e4f0e8????????84c075??8b038b4808b8????????8b91f007000085d274??", argdata, 1, 1, &func);
 }
 
 bool WorldManager::HostileEnvironment()
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1603::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1604::func;
 	return execfunc(this);
 }
 
-namespace _func1604
+namespace _func1605
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -22151,11 +22165,11 @@ namespace _func1604
 bool WorldManager::AddBoarders(BoardingEvent &boardingEvent)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, BoardingEvent &boardingEvent_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1604::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1605::func;
 	return execfunc(this, boardingEvent);
 }
 
-namespace _func1605
+namespace _func1606
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff};
@@ -22165,11 +22179,11 @@ namespace _func1605
 void WorldManager::CreateStore(LocationEvent *event)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1605::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1606::func;
 	return execfunc(this, event);
 }
 
-namespace _func1606
+namespace _func1607
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff};
@@ -22179,11 +22193,11 @@ namespace _func1606
 bool WorldManager::CheckRequirements(LocationEvent *event, bool hidden)
 {
 	typedef bool __attribute__((thiscall)) (*custom_arg_funcptr_t)(WorldManager *this_arg, LocationEvent *event_arg, bool hidden_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1606::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1607::func;
 	return execfunc(this, event, hidden);
 }
 
-namespace _func1607
+namespace _func1608
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22193,11 +22207,11 @@ namespace _func1607
 Pointf freetype::easy_measurePrintLines(int fontSize, float x, float y, int line_length, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1607::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1608::func;
 	return execfunc(fontSize, x, y, line_length, text);
 }
 
-namespace _func1608
+namespace _func1609
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -22207,11 +22221,11 @@ namespace _func1608
 int freetype::easy_measureWidth(int fontSize, const std::string &text)
 {
 	typedef int __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1608::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1609::func;
 	return execfunc(fontSize, text);
 }
 
-namespace _func1609
+namespace _func1610
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22221,11 +22235,11 @@ namespace _func1609
 Pointf freetype::easy_print(int fontSize, float x, float y, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1609::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1610::func;
 	return execfunc(fontSize, x, y, text);
 }
 
-namespace _func1610
+namespace _func1611
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22235,11 +22249,11 @@ namespace _func1610
 Pointf freetype::easy_printRightAlign(int fontSize, float x, float y, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1610::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1611::func;
 	return execfunc(fontSize, x, y, text);
 }
 
-namespace _func1611
+namespace _func1612
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22249,11 +22263,11 @@ namespace _func1611
 Pointf freetype::easy_printNewlinesCentered(int fontSize, float x, float y, int line_length, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1611::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1612::func;
 	return execfunc(fontSize, x, y, line_length, text);
 }
 
-namespace _func1612
+namespace _func1613
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22263,11 +22277,11 @@ namespace _func1612
 Pointf freetype::easy_printAutoNewlines(int fontSize, float x, float y, int line_length, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, int line_length_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1612::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1613::func;
 	return execfunc(fontSize, x, y, line_length, text);
 }
 
-namespace _func1613
+namespace _func1614
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22277,11 +22291,11 @@ namespace _func1613
 Pointf freetype::easy_printCenter(int fontSize, float x, float y, const std::string &text)
 {
 	typedef Pointf __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontSize_arg, float x_arg, float y_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1613::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1614::func;
 	return execfunc(fontSize, x, y, text);
 }
 
-namespace _func1614
+namespace _func1615
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22291,11 +22305,11 @@ namespace _func1614
 void freetype::easy_printAutoShrink(int fontId, float x, float y, int maxWidth, bool centered, const std::string &text)
 {
 	typedef void __attribute__((cdecl)) (*custom_arg_funcptr_t)(int fontId_arg, float x_arg, float y_arg, int maxWidth_arg, bool centered_arg, const std::string &text_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1614::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1615::func;
 	return execfunc(fontId, x, y, maxWidth, centered, text);
 }
 
-namespace _func1615
+namespace _func1616
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22305,11 +22319,11 @@ namespace _func1615
 void freetype::font_data::init(const void *buffer, int bufferSize, unsigned int h, bool glow)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(freetype::font_data *this_arg, const void *buffer_arg, int bufferSize_arg, unsigned int h_arg, bool glow_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1615::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1616::func;
 	return execfunc(this, buffer, bufferSize, h, glow);
 }
 
-namespace _func1616
+namespace _func1617
 {
     static void *func = 0;
 	static short argdata[] = {0x101, 0x1ff, 0x1ff, 0x1ff, 0x1ff};
@@ -22319,11 +22333,11 @@ namespace _func1616
 void freetype::font_data::init_bitmap(const void *buffer, int bufferSize, int size, int h)
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(freetype::font_data *this_arg, const void *buffer_arg, int bufferSize_arg, int size_arg, int h_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1616::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1617::func;
 	return execfunc(this, buffer, bufferSize, size, h);
 }
 
-namespace _func1617
+namespace _func1618
 {
     static void *func = 0;
 	static short argdata[] = {0x101};
@@ -22333,11 +22347,11 @@ namespace _func1617
 void freetype::font_data::clean()
 {
 	typedef void __attribute__((thiscall)) (*custom_arg_funcptr_t)(freetype::font_data *this_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1617::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1618::func;
 	return execfunc(this);
 }
 
-namespace _func1618
+namespace _func1619
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -22347,11 +22361,11 @@ namespace _func1618
 float __stdcall font_baseline(int font_id, float size)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(int font_id_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1618::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1619::func;
 	return execfunc(font_id, size);
 }
 
-namespace _func1619
+namespace _func1620
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff, 0x1ff};
@@ -22361,13 +22375,13 @@ namespace _func1619
 float __stdcall font_height(int font_id, float size)
 {
 	typedef float __attribute__((cdecl)) (*custom_arg_funcptr_t)(int font_id_arg, float size_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1619::func;
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func1620::func;
 	return execfunc(font_id, size);
 }
 
 float *Global_freetype_sil_freetype_outline;
 
-namespace _var1620
+namespace _var1621
 {
     static VariableDefinition varObj("Global_freetype_sil_freetype_outline", "!89108b559cc705(???????\?)000000408950048b55a0", &Global_freetype_sil_freetype_outline);
 }

--- a/FTLGameWin32.h
+++ b/FTLGameWin32.h
@@ -4705,6 +4705,7 @@ struct CommandGui
 {
 	LIBZHL_API void AddEnemyShip(CompleteShip *ship);
 	LIBZHL_API void CheckGameover();
+	LIBZHL_API void ClearLocation();
 	LIBZHL_API Store *CreateNewStore(int sectorNumber);
 	LIBZHL_API Point GetWorldCoordinates(Point point, bool fromTarget);
 	LIBZHL_API bool IsGameOver();

--- a/libzhlgen/test/functions/ELF_amd64/1.6.13/CommandGui.zhl
+++ b/libzhlgen/test/functions/ELF_amd64/1.6.13/CommandGui.zhl
@@ -8,6 +8,8 @@ cleanup __amd64 bool CommandGui::IsGameOver(CommandGui *this);
 cleanup __amd64 void CommandGui::OnInit(CommandGui *this);
 ".4154554889f5534889fb488dbf880500004883ec30":
 cleanup __amd64 void CommandGui::AddEnemyShip(CommandGui *this, CompleteShip *ship);
+".53??8b8770190000??89fb??8dbf88050000??8b40108bb08c020000":
+cleanup __amd64 void CommandGui::ClearLocation(CommandGui *this);
 ".415731d2415641554154554889":
 cleanup __amd64 void CommandGui::LinkShip(CommandGui *this, CompleteShip *ship);
 ".41544189d4554889fd534889f34883ec204889e7":

--- a/libzhlgen/test/functions/ELF_x86/1.6.13/CommandGui.zhl
+++ b/libzhlgen/test/functions/ELF_x86/1.6.13/CommandGui.zhl
@@ -36,3 +36,5 @@ cleanup __cdecl void CommandGui::NewLocation(CommandGui *this, const std::string
 cleanup __cdecl void CommandGui::RenderPlayerShip(CommandGui *this, Point &shipCenter, float jumpScale);
 ".5557565383ec2c8b7424408b44244c8b7c24448b6c2448":
 cleanup __cdecl void CommandGui::LButtonUp(CommandGui *this, int mX, int mY, bool shiftHeld);
+"5383ec188b5c????8b83b41200008b40088b887c010000":
+cleanup __cdecl void CommandGui::ClearLocation(CommandGui *this);

--- a/libzhlgen/test/functions/win32/1.6.9/CommandGui.zhl
+++ b/libzhlgen/test/functions/win32/1.6.9/CommandGui.zhl
@@ -36,3 +36,5 @@ __thiscall void CommandGui::LButtonUp(CommandGui *this, int mX, int mY, bool shi
 __thiscall void CommandGui::LinkShip(CommandGui *this,CompleteShip *ship);
 "578d7c240883e4f0ff77fc5589e557568d??????????5389cb8dbbc8030000":
 __thiscall void CommandGui::Restart(CommandGui *this);
+"5589e5538b8108170000c781541700005e01000089cb8d89c803000083e4f0":
+__thiscall void CommandGui::ClearLocation(CommandGui *this);


### PR DESCRIPTION
### Bugfix
The `instantEscape` tag previously did not remove the ship box and UI from the right side of the screen when called with a neutral ship. Resolves issue #629.
### ZHL Changes
New signatures on all platforms for `CommandGui::ClearLocation`.