### PR TITLE
Fix double-delete introduced by RemoveChoice

### DIFF
--- a/FTLGameELF32.h
+++ b/FTLGameELF32.h
@@ -5752,16 +5752,15 @@ struct LocationEvent
             newChoice.text.isLiteral = true;
             newChoice.requirement = requirement;
             newChoice.hiddenReward = hiddenReward;
- 
+
             this->choices.push_back(newChoice);
         }
     }
- 
+
     bool RemoveChoice(int index)
     {
         if (index >= 0 && index < this->choices.size())
         {
-            delete this->choices[index].event;
             this->choices.erase(this->choices.begin() + index);
             return true;
         }

--- a/FTLGameELF64.h
+++ b/FTLGameELF64.h
@@ -5774,16 +5774,15 @@ struct LocationEvent
             newChoice.text.isLiteral = true;
             newChoice.requirement = requirement;
             newChoice.hiddenReward = hiddenReward;
- 
+
             this->choices.push_back(newChoice);
         }
     }
- 
+
     bool RemoveChoice(int index)
     {
         if (index >= 0 && index < this->choices.size())
         {
-            delete this->choices[index].event;
             this->choices.erase(this->choices.begin() + index);
             return true;
         }

--- a/FTLGameWin32.h
+++ b/FTLGameWin32.h
@@ -5772,16 +5772,15 @@ struct LocationEvent
             newChoice.text.isLiteral = true;
             newChoice.requirement = requirement;
             newChoice.hiddenReward = hiddenReward;
- 
+
             this->choices.push_back(newChoice);
         }
     }
- 
+
     bool RemoveChoice(int index)
     {
         if (index >= 0 && index < this->choices.size())
         {
-            delete this->choices[index].event;
             this->choices.erase(this->choices.begin() + index);
             return true;
         }

--- a/libzhlgen/test/functions/ELF_amd64/1.6.13/LocationEvent.zhl
+++ b/libzhlgen/test/functions/ELF_amd64/1.6.13/LocationEvent.zhl
@@ -38,16 +38,15 @@ struct LocationEvent depends (LocationEvent::Choice)
             newChoice.text.isLiteral = true;
             newChoice.requirement = requirement;
             newChoice.hiddenReward = hiddenReward;
- 
+
             this->choices.push_back(newChoice);
         }
     }
- 
+
     bool RemoveChoice(int index)
     {
         if (index >= 0 && index < this->choices.size())
         {
-            delete this->choices[index].event;
             this->choices.erase(this->choices.begin() + index);
             return true;
         }

--- a/libzhlgen/test/functions/ELF_x86/1.6.13/LocationEvent.zhl
+++ b/libzhlgen/test/functions/ELF_x86/1.6.13/LocationEvent.zhl
@@ -38,16 +38,15 @@ struct LocationEvent depends (LocationEvent::Choice)
             newChoice.text.isLiteral = true;
             newChoice.requirement = requirement;
             newChoice.hiddenReward = hiddenReward;
- 
+
             this->choices.push_back(newChoice);
         }
     }
- 
+
     bool RemoveChoice(int index)
     {
         if (index >= 0 && index < this->choices.size())
         {
-            delete this->choices[index].event;
             this->choices.erase(this->choices.begin() + index);
             return true;
         }

--- a/libzhlgen/test/functions/win32/1.6.9/LocationEvent.zhl
+++ b/libzhlgen/test/functions/win32/1.6.9/LocationEvent.zhl
@@ -38,16 +38,15 @@ struct LocationEvent depends (LocationEvent::Choice)
             newChoice.text.isLiteral = true;
             newChoice.requirement = requirement;
             newChoice.hiddenReward = hiddenReward;
- 
+
             this->choices.push_back(newChoice);
         }
     }
- 
+
     bool RemoveChoice(int index)
     {
         if (index >= 0 && index < this->choices.size())
         {
-            delete this->choices[index].event;
             this->choices.erase(this->choices.begin() + index);
             return true;
         }


### PR DESCRIPTION
Whenever a `LocationEvent` is created via `EventGenerator::CreateEvent` (The usual way of creating LocationEvents) it is added to the `EventGenerator`'s `trashList` for cleanup when appropriate. The HS `LocationEvent::RemoveChoice` method introduces a premature delete leading to a crash on proper cleanup.