### PR TITLE
Expose some missing lua types and correct some function argument types

### DIFF
--- a/CustomCrew.h
+++ b/CustomCrew.h
@@ -311,13 +311,13 @@ struct ActivatedPowerDefinition
         powerDefs.push_back(this);
     }
 
-    void AssignName(std::string &_name)
+    void AssignName(const std::string &_name)
     {
         name = _name;
         nameDefList[name] = this;
     }
 
-    static ActivatedPowerDefinition* GetPowerByName(std::string &_name)
+    static ActivatedPowerDefinition* GetPowerByName(const std::string &_name)
     {
         auto it = nameDefList.find(_name);
         if (it == nameDefList.end()) // unused name
@@ -330,7 +330,7 @@ struct ActivatedPowerDefinition
         }
     }
 
-    static ActivatedPowerDefinition* AddUndefinedPower(std::string &_name)
+    static ActivatedPowerDefinition* AddUndefinedPower(const std::string &_name)
     {
         auto it = undefinedNameDefList.find(_name);
         if (it == undefinedNameDefList.end()) // unused name
@@ -346,7 +346,7 @@ struct ActivatedPowerDefinition
         }
     }
 
-    static ActivatedPowerDefinition* AddNamedDefinition(std::string &_name, ActivatedPowerDefinition* copyDef)
+    static ActivatedPowerDefinition* AddNamedDefinition(const std::string &_name, ActivatedPowerDefinition* copyDef)
     {
         ActivatedPowerDefinition *def;
 
@@ -377,7 +377,7 @@ struct ActivatedPowerDefinition
         return def;
     }
 
-    void AssignActivateGroup(std::string &_name)
+    void AssignActivateGroup(const std::string &_name)
     {
         auto it = activateGroupNameIndexList.find(_name);
         if (it == activateGroupNameIndexList.end()) // if name is unused assign the next unused index
@@ -391,7 +391,7 @@ struct ActivatedPowerDefinition
         }
     }
 
-    static unsigned int GetReplaceGroup(std::string &_name)
+    static unsigned int GetReplaceGroup(const std::string &_name)
     {
         auto it = replaceGroupNameIndexList.find(_name);
         if (it == replaceGroupNameIndexList.end()) // if name is unused assign the next unused index
@@ -406,12 +406,12 @@ struct ActivatedPowerDefinition
         }
     }
 
-    void AssignReplaceGroup(std::string &_name)
+    void AssignReplaceGroup(const std::string &_name)
     {
         replaceGroupIndex = GetReplaceGroup(_name);
     }
 
-    void AssignGroup(std::string &_name)
+    void AssignGroup(const std::string &_name)
     {
         AssignActivateGroup(_name);
         AssignReplaceGroup(_name);
@@ -527,13 +527,13 @@ struct PowerResourceDefinition
         powerDefs.push_back(this);
     }
 
-    void AssignName(std::string &_name)
+    void AssignName(const std::string &_name)
     {
         name = _name;
         nameDefList[name] = this;
     }
 
-    static PowerResourceDefinition* GetByName(std::string &_name)
+    static PowerResourceDefinition* GetByName(const std::string &_name)
     {
         auto it = nameDefList.find(_name);
         if (it == nameDefList.end()) // unused name
@@ -546,7 +546,7 @@ struct PowerResourceDefinition
         }
     }
 
-    static PowerResourceDefinition* AddUndefined(std::string &_name)
+    static PowerResourceDefinition* AddUndefined(const std::string &_name)
     {
         auto it = undefinedNameDefList.find(_name);
         if (it == undefinedNameDefList.end()) // unused name
@@ -562,7 +562,7 @@ struct PowerResourceDefinition
         }
     }
 
-    static PowerResourceDefinition* AddNamedDefinition(std::string &_name, PowerResourceDefinition* copyDef)
+    static PowerResourceDefinition* AddNamedDefinition(const std::string &_name, PowerResourceDefinition* copyDef)
     {
         PowerResourceDefinition *def;
 
@@ -593,7 +593,7 @@ struct PowerResourceDefinition
         return def;
     }
 
-    void AssignGroup(std::string &_name)
+    void AssignGroup(const std::string &_name)
     {
         auto it = ActivatedPowerDefinition::replaceGroupNameIndexList.find(_name);
         if (it == ActivatedPowerDefinition::replaceGroupNameIndexList.end()) // if name is unused assign the next unused index

--- a/CustomEvents.cpp
+++ b/CustomEvents.cpp
@@ -4583,7 +4583,7 @@ void CustomEventsParser::QueueEvent(EventQueueEvent &event)
     eventQueue.push_back(event);
 }
 
-void CustomEventsParser::QueueEvent(std::string &event, int seed)
+void CustomEventsParser::QueueEvent(const std::string &event, int seed)
 {
     EventQueueEvent queueEvent;
 

--- a/CustomEvents.h
+++ b/CustomEvents.h
@@ -971,7 +971,7 @@ public:
     void LoadEvent(WorldManager *world, EventLoadList *eventList, int seed, CustomEvent *parentEvent = nullptr);
     void LoadEvent(WorldManager *world, std::string eventName, bool ignoreUnique, int seed, CustomEvent *parentEvent = nullptr);
     static void QueueEvent(EventQueueEvent &event);
-    static void QueueEvent(std::string &event, int seed);
+    static void QueueEvent(const std::string &event, int seed);
 
     static bool LocationRemoveNebula(Location *loc);
 

--- a/ShipUnlocks.cpp
+++ b/ShipUnlocks.cpp
@@ -675,7 +675,7 @@ void CustomShipUnlocks::CheckMultiVictoryUnlocks()
 }
 
 // this overload checks a specific victory on its own to see if it suffices to unlock something (for when achievements are locked)
-void CustomShipUnlocks::CheckMultiVictoryUnlocks(std::string &victoryShip, std::string &victoryType)
+void CustomShipUnlocks::CheckMultiVictoryUnlocks(const std::string &victoryShip, std::string &victoryType)
 {
     for (auto i : customShipUnlocks)
     {

--- a/ShipUnlocks.h
+++ b/ShipUnlocks.h
@@ -66,7 +66,7 @@ public:
     void CheckSectorUnlocks(const std::string& currentShip, int sector);
     void CheckMultiUnlocks();
     void CheckMultiVictoryUnlocks();
-    void CheckMultiVictoryUnlocks(std::string &victoryShip, std::string &victoryType);
+    void CheckMultiVictoryUnlocks(const std::string &victoryShip, std::string &victoryType);
     void CheckBasicUnlock(const std::string& currentShip, ShipUnlock::UnlockType type);
     bool CheckVanillaUnlocks(const ShipUnlock& unlock, const std::string& currentShip);
     void UnlockAllShips();

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -290,6 +290,7 @@ namespace std {
 	%template(vector_DamageMessage) vector<DamageMessage*>;
 	%template(vector_Projectile) vector<Projectile*>;
     %template(vector_Animation) vector<Animation>;
+    %template(vector_vector_Animation) vector<vector<Animation>>;
 	%template(vector_MiniProjectile) vector<WeaponBlueprint::MiniProjectile>;
 //	%template(vector_ShieldAnimation) vector<ShieldAnimation>;
     %template(pair_int_int) pair<int, int>;
@@ -333,6 +334,11 @@ namespace std {
     %template(vector_AugmentCrystalShard) vector<AugmentCrystalShard>;
     %template(vector_p_ShipButtonList) vector<ShipButtonList*>;
     %template(vector_p_GL_Texture) vector<GL_Texture*>;
+    %template(vector_p_ActivatedPowerDefinition) vector<ActivatedPowerDefinition*>;
+    %template(vector_AnimationTracker) vector<AnimationTracker>;
+    %template(vector_vector_AnimationTracker) vector<vector<AnimationTracker>>;
+    %template(vector_bool) vector<bool>;
+    %template(vector_vector_bool) vector<vector<bool>>;
 }
 /*
 OBSOLETE METHOD FOR DOWNCASTING:
@@ -3420,6 +3426,12 @@ We can expose them once the root cause is identified and the crash is fixed.
 %rename("%s") CrewMember::movementTarget;
 %rename("%s") CrewMember::bCloned;
 
+%rename("%s") BoardingGoal;
+%rename("%s") BoardingGoal::fHealthLimit;
+%rename("%s") BoardingGoal::causedDamage;
+%rename("%s") BoardingGoal::targetsDestroyed;
+%rename("%s") BoardingGoal::target;
+%rename("%s") BoardingGoal::damageType;
 
 %nodefaultctor CrewAnimation;
 %nodefaultdtor CrewAnimation;


### PR DESCRIPTION
This pull request addresses two issues that were causing problems with lua scripting:
- Several C++ functions that accept string arguments were using `std::string&` instead of `const std::string&`. This prevented them from being called from lua with string literals. These function signatures need to be corrected.
- Some class members were exposed to Lua, but their associated types were not, leading to errors when trying to access them. The necessary type definitions have now been exposed to Lua.

The following functions have been updated to use `const std::string&`:
- `ActivatedPowerDefinition::GetPowerByName`
- `ActivatedPowerDefinition::AddNamedDefinition`
- `ActivatedPowerDefinition::AssignName`
- `ActivatedPowerDefinition::AssignGroup`
- `ActivatedPowerDefinition::AssignActivateGroup`
- `ActivatedPowerDefinition::AssignReplaceGroup`
- `PowerResourceDefinition::AssignName`
- `PowerResourceDefinition::AssignGroup`
- `PowerResourceDefinition::GetByName`
- `PowerResourceDefinition::AddNamedDefinition`
- `CustomEventsParser::QueueEvent`
- `CustomShipUnlocks::CheckMultiVictoryUnlocks`

The following types have been exposed to support existing class members:
- `BoardingGoal` for `Hyperspace.CrewMember.boardingGoal`
- `vector<vector<Animation>>` for `Hyperspace.CrewMember.crewAnim.anims`
- `vector<ActivatedPowerDefinition*>` for `Hyperspace.CrewMember.extend.powerChange`
- `vector<bool>` and `vector<vector<bool>>` for `Hyperspace.CrewMember.skillsEarned`
- `vector<vector<AnimationTracker>>` for `Hyperspace.CrewMember.skillUp`