### PR TITLE
Fix: Initialize `StatBoost::crewSource` to prevent crash on save load

### DIFF
--- a/StatBoost.h
+++ b/StatBoost.h
@@ -227,7 +227,7 @@ struct StatBoost
 
     int iStacks = 1;
 
-    CrewMember* crewSource;
+    CrewMember* crewSource = nullptr;
     int crewSourceId;
     TimerHelper timerHelper;
 


### PR DESCRIPTION
**Problem:** The game crashes when reloading a save if a crew member has a power effect that has multiple statBoosts with SELF crewTarget.

![JThopTR4UJx4qcxO](https://github.com/user-attachments/assets/937d37a0-55e8-45a7-8926-237387bcceab)

**Cause:** The crash is caused by the `StatBoost::crewSource` pointer being uninitialized.
- In the `StatBoost` constructor, `crewSource` was not explicitly initialized. While debug builds often initialize pointers to `nullptr`, release builds do not, leaving the pointer with a garbage value.
- The `StatBoost::LoadStatBoost` function, which is responsible for loading stat boosts from a save, also did not initialize this pointer.
- When a save was loaded, functions such as `CrewMember_Extend::BoostCheck` would then attempt to dereference this invalid `crewSource` pointer, resulting in a crash.

**Solution:** This PR resolves the issue by ensuring `StatBoost::crewSource` is always initialized to a safe value.
- `StatBoost::crewSource` in `StatBoost.h` have been updated to explicitly initialize `crewSource` to `nullptr`.