### PR TITLE
Fix game crash caused by AddSystem when the removed system has more power than new system's max power

### DIFF
--- a/CustomSystems.cpp
+++ b/CustomSystems.cpp
@@ -1034,10 +1034,10 @@ inline int getTrueSystemMaxPower(int systemId, int maxPower) {
         return maxPower;
     }
     auto* sysBp = G_->GetBlueprints()->GetSystemBlueprint(ShipSystem::SystemIdToName(systemId));
-    if (sysBp == nullptr) {
-        return maxPower;
+    if (sysBp)  {
+        maxPower = sysBp->maxPower;
     }
-    return sysBp->maxPower;
+    return maxPower > 0 ? maxPower : 1; // Return at least 1 as a safe default
 }
 
 inline int getTrueSystemStartPower(int systemId, int startPower) {
@@ -1045,10 +1045,10 @@ inline int getTrueSystemStartPower(int systemId, int startPower) {
         return startPower;
     }
     auto* sysBp = G_->GetBlueprints()->GetSystemBlueprint(ShipSystem::SystemIdToName(systemId));
-    if (sysBp == nullptr) {
-        return startPower;
+    if (sysBp)  {
+        startPower = sysBp->startPower;
     }
-    return sysBp->startPower;
+    return startPower > 0 ? startPower : 1; // Return at least 1 as a safe default
 }
 
 HOOK_METHOD(ShipManager, AddSystem, (int systemId) -> int)


### PR DESCRIPTION
According to Lily (@IonShieldQuad) :
> if 2 system are mutually exclusive, and they have different max levels, trying to swap from the system that has more levels than the other one allows causes the game to crash

This PR fixes this bug by downgrading the removed system to new system's max power level before removing it.