### PR TITLE
ShipManager::JumpArrive Fix

### DIFF
--- a/CustomSystems.cpp
+++ b/CustomSystems.cpp
@@ -1894,7 +1894,7 @@ HOOK_METHOD_PRIORITY(ShipManager, JumpArrive, 9999, () -> void)
         }
         if (this->systemKey[SYS_ENGINES] != -1)
         {
-            this->vSystemList[SYS_ENGINES]->LockSystem(0);
+            this->vSystemList[this->systemKey[SYS_ENGINES]]->LockSystem(0);
         }
         if (this->systemKey[SYS_WEAPONS] != -1)
         {
@@ -1902,7 +1902,7 @@ HOOK_METHOD_PRIORITY(ShipManager, JumpArrive, 9999, () -> void)
         }
         if (this->systemKey[SYS_PILOT] != -1)
         {
-            this->vSystemList[SYS_PILOT]->LockSystem(0);
+            this->vSystemList[this->systemKey[SYS_PILOT]]->LockSystem(0);
         }
     }
     // Set current beacon as unsafe by default


### PR DESCRIPTION
Fixed vector iteration in ShipManager::JumpArrive rewrite. I previously iterated with a set number instead of the returned value from a vector storing they correct keys for that.

Reported by Swagdude7 https://discord.com/channels/604415384979898464/1488647863587180705