### PR TITLE
Remove file paths from crash detection logs

### DIFF
--- a/src/features/crash-detection/core/CrashDetector.cpp
+++ b/src/features/crash-detection/core/CrashDetector.cpp
@@ -60,7 +60,7 @@ void CrashDetector::WriteCrashFlag()
     std::string crashFlagPath = GetCrashFlagPath();
     int file = FileHelper::createBinaryFile(crashFlagPath);
     FileHelper::closeBinaryFile(file);
-    hs_log_file("Crash detection flag written to: %s\n", crashFlagPath.c_str());
+    hs_log_file("Crash detection flag written\n");
 }
 
 void CrashDetector::ClearCrashFlag()
@@ -70,7 +70,7 @@ void CrashDetector::ClearCrashFlag()
     if (FileHelper::fileExists(crashFlagPath))
     {
         FileHelper::deleteFile(crashFlagPath);
-        hs_log_file("Crash flag cleared - game exited normally (was: %s)\n", crashFlagPath.c_str());
+        hs_log_file("Crash flag cleared - game exited normally\n");
     }
 }
 

--- a/src/features/crash-detection/core/CrashReporter.cpp
+++ b/src/features/crash-detection/core/CrashReporter.cpp
@@ -57,14 +57,14 @@ std::string CrashReporter::CreateBugReportZip()
     fs::path userFolder(FileHelper::getUserFolder());
     std::string zipPath = GenerateBugReportPath();
 
-    hs_log_file("Creating bug report zip: %s\n", zipPath.c_str());
+    hs_log_file("Creating bug report zip\n");
 
     int err = 0;
     zipFile zf = zipOpen(zipPath.c_str(), APPEND_STATUS_CREATE);
 
     if (zf == nullptr)
     {
-        hs_log_file("Failed to create zip file: %s\n", zipPath.c_str());
+        hs_log_file("Failed to create zip file\n");
         return "";
     }
 
@@ -129,7 +129,7 @@ std::string CrashReporter::CreateBugReportZip()
         err = zipClose(zf, nullptr);
         if (err == ZIP_OK)
         {
-            hs_log_file("Bug report zip created successfully: %s\n", zipPath.c_str());
+            hs_log_file("Bug report zip created successfully\n");
             return zipPath;
         }
         else
@@ -152,7 +152,7 @@ void CrashReporter::OpenBugReport(const std::string& bugReportZipPath)
     size_t lastSlash = bugReportZipPath.find_last_of("\\/");
     if (lastSlash == std::string::npos)
     {
-        hs_log_file("Invalid bug report path: %s\n", bugReportZipPath.c_str());
+        hs_log_file("Invalid bug report path\n");
         return;
     }
 


### PR DESCRIPTION
Strip absolute paths from `hs_log_file` calls in `CrashDetector` and `CrashReporter` to stop leaking usernames in shared bug reports