### PR TITLE
Linux silent crash on 1.22.1

### DIFF
--- a/FTLGameELF32.cpp
+++ b/FTLGameELF32.cpp
@@ -9512,7 +9512,7 @@ namespace _func685
 {
     static void *func = 0;
 	static short argdata[] = {0x1ff};
-	static FunctionDefinition funcObj("FileHelper::fileLength_OnlyForHooking", typeid(int (*)(int )), ".b8", argdata, 1, 2, &func);
+	static FunctionDefinition funcObj("FileHelper::fileLength_OnlyForHooking", typeid(int (*)(int )), ".b801", argdata, 1, 2, &func);
 }
 
 int FileHelper::fileLength_OnlyForHooking(int fd)

--- a/FTLGameELF64.cpp
+++ b/FTLGameELF64.cpp
@@ -8765,27 +8765,27 @@ void FileHelper::initFileHelper()
 namespace _func677
 {
     static void *func = 0;
+	static FunctionDefinition funcObj("FileHelper::fileLength_OnlyForHooking", typeid(int (*)(int )), ".b801", nullptr, 0, 0, &func);
+}
+
+int FileHelper::fileLength_OnlyForHooking(int fd)
+{
+	typedef int (*custom_arg_funcptr_t)(int fd_arg);
+	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func677::func;
+	return execfunc(fd);
+}
+
+namespace _func678
+{
+    static void *func = 0;
 	static FunctionDefinition funcObj("FileHelper::fileExists", typeid(bool (*)(const std::string &)), ".4883ec08488b3f31f6", nullptr, 0, 0, &func);
 }
 
 bool FileHelper::fileExists(const std::string &fileName)
 {
 	typedef bool (*custom_arg_funcptr_t)(const std::string &fileName_arg);
-	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func677::func;
-	return execfunc(fileName);
-}
-
-namespace _func678
-{
-    static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::fileLength_OnlyForHooking", typeid(int (*)(int )), ".b8", nullptr, 0, 0, &func);
-}
-
-int FileHelper::fileLength_OnlyForHooking(int fd)
-{
-	typedef int (*custom_arg_funcptr_t)(int fd_arg);
 	custom_arg_funcptr_t execfunc = (custom_arg_funcptr_t) _func678::func;
-	return execfunc(fd);
+	return execfunc(fileName);
 }
 
 namespace _func679

--- a/FTLGameMacOSAMD64.cpp
+++ b/FTLGameMacOSAMD64.cpp
@@ -8963,7 +8963,7 @@ void FileHelper::initFileHelper()
 namespace _func710
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("FileHelper::fileLength_OnlyForHooking", typeid(int (*)(int )), "5548", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("FileHelper::fileLength_OnlyForHooking", typeid(int (*)(int )), ".5548", nullptr, 0, 0, &func);
 }
 
 int FileHelper::fileLength_OnlyForHooking(int fd)

--- a/libzhlgen/test/functions/ELF_amd64/1.6.13/FileHelper.zhl
+++ b/libzhlgen/test/functions/ELF_amd64/1.6.13/FileHelper.zhl
@@ -8,10 +8,10 @@ static cleanup __amd64 std::string FileHelper::getUserFolder();
 static cleanup __amd64 std::string FileHelper::getSaveFile();
 ".4883ec28c605????????01":
 static cleanup __amd64 void FileHelper::initFileHelper();
+".b801":
+static cleanup __amd64 int FileHelper::fileLength_OnlyForHooking(int fd);
 ".4883ec08488b3f31f6":
 static cleanup __amd64 bool FileHelper::fileExists(const std::string& fileName);
-".b8":
-static cleanup __amd64 int FileHelper::fileLength_OnlyForHooking(int fd);
 "!.488b36488b3f":
 static cleanup __amd64 void FileHelper::renameFile(const std::string& fileName, const std::string& newName);
 ".534889fb488b3f31f6":

--- a/libzhlgen/test/functions/ELF_x86/1.6.13/FileHelper.zhl
+++ b/libzhlgen/test/functions/ELF_x86/1.6.13/FileHelper.zhl
@@ -8,7 +8,7 @@ static cleanup __cdecl std::string FileHelper::getUserFolder();
 static cleanup __cdecl std::string FileHelper::getSaveFile();
 "565383ec34c605????????018d5c241f":
 static cleanup __cdecl void FileHelper::initFileHelper();
-".b8":
+".b801":
 static cleanup __cdecl int FileHelper::fileLength_OnlyForHooking(int fd);
 "83ec1c8b442420c7442404000000008b00":
 static cleanup __cdecl bool FileHelper::fileExists(const std::string& fileName);

--- a/libzhlgen/test/functions/mac/1.6.13/FileHelper.zhl
+++ b/libzhlgen/test/functions/mac/1.6.13/FileHelper.zhl
@@ -9,7 +9,7 @@ static cleanup __amd64 std::string FileHelper::getUserFolder();
 static cleanup __amd64 std::string FileHelper::getSaveFile();
 ".554889e54157415641554154534883ec18e8":
 static cleanup __amd64 void FileHelper::initFileHelper();
-"5548":
+".5548":
 static cleanup __amd64 int FileHelper::fileLength_OnlyForHooking(int fd);
 ".554889e5????????????01480f45471031f64889":
 static cleanup __amd64 bool FileHelper::fileExists(const std::string& fileName);


### PR DESCRIPTION
Fixed linux crashing related to [issue 748](https://github.com/FTL-Hyperspace/FTL-Hyperspace/issues/748) and also the SHIP ALL fix being non functional for MacOS