### PR TITLE
GitHub app workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+      - question
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bugfixes
+      labels:
+        - hs bug
+        - vanilla bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Translations
+      labels:
+        - translation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,19 @@ jobs:
     needs: check-hooks
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.INSTALLER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.INSTALLER_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: master
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Bump version
         run: |
@@ -36,7 +43,7 @@ jobs:
 
       - name: Push changes and create tag
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git push origin master:master
           git tag v${{ inputs.version }} master
@@ -45,6 +52,7 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
+          token: ${{ steps.app-token.outputs.token }}
           tag_name: v${{ inputs.version }}
           name: ${{ inputs.version }}
           generate_release_notes: true


### PR DESCRIPTION
This pull request updates the release workflow to use a GitHub App token for authentication instead of the default `GITHUB_TOKEN`, and introduces a new changelog configuration to categorize release notes. The main changes improve security, automation, and release note organization.

**Release workflow improvements:**

* Updated the release workflow (`.github/workflows/release.yml`) to generate and use a GitHub App token for all steps that interact with the repository, enhancing security and permissions management.

**Changelog configuration:**

* Added a new `.github/release.yml` file to define changelog categories and exclude certain labels, improving the organization and clarity of release notes.