### PR TITLE
Made ScoreKeeper::AddExploredLocations linux signature GOG compatible

### DIFF
--- a/FTLGameELF64.cpp
+++ b/FTLGameELF64.cpp
@@ -11828,7 +11828,7 @@ void ScoreKeeper::SetVictory(bool victory)
 namespace _func924
 {
     static void *func = 0;
-	static FunctionDefinition funcObj("ScoreKeeper::AddExploredLocations", typeid(void (ScoreKeeper::*)()), ".534889fbbf60a6a300e8", nullptr, 0, 0, &func);
+	static FunctionDefinition funcObj("ScoreKeeper::AddExploredLocations", typeid(void (ScoreKeeper::*)()), ".534889fbbf????a300e8", nullptr, 0, 0, &func);
 }
 
 void ScoreKeeper::AddExploredLocations()

--- a/libzhlgen/test/functions/ELF_amd64/1.6.13/ScoreKeeper.zhl
+++ b/libzhlgen/test/functions/ELF_amd64/1.6.13/ScoreKeeper.zhl
@@ -14,7 +14,7 @@ forceDetour cleanup __amd64 bool ScoreKeeper::GetShipUnlocked(ScoreKeeper *this,
 cleanup __amd64 void ScoreKeeper::SetSector(ScoreKeeper *this, int sector);
 ".4084f64088b798010000":
 cleanup __amd64 void ScoreKeeper::SetVictory(ScoreKeeper *this, bool victory);
-".534889fbbf60a6a300e8":
+".534889fbbf????a300e8":
 cleanup __amd64 void ScoreKeeper::AddExploredLocations(ScoreKeeper *this);
 ".5589f5534889fb":
 cleanup __amd64 void ScoreKeeper::AddScrapCollected(ScoreKeeper *this, int scrap);


### PR DESCRIPTION
Signature only worked for Steam because I forgot to wildcard two bytes