### PR TITLE
Fix the SDL3 build on Windows, Linux and macOS

### DIFF
--- a/.devcontainer/Dockerfile-actual
+++ b/.devcontainer/Dockerfile-actual
@@ -72,8 +72,9 @@ RUN echo deb http://dk.archive.ubuntu.com/ubuntu/ xenial main >> /etc/apt/source
     && dpkg --add-architecture i386 \
     && apt update
 
-# SDL3 dependencies for linux (Required to build from vcpkg)
-RUN apt install -y libx11-dev libxft-dev libxext-dev libwayland-dev libxkbcommon-dev libegl1-mesa-dev libibus-1.0-dev
+# SDL3 dependencies for linux (Required to build from vcpkg).
+RUN apt install -y --no-install-recommends libx11-dev libxext-dev libxtst-dev \
+        libwayland-dev wayland-protocols libxkbcommon-dev libegl1-mesa-dev
 
 # Install common build tools
 # TODO: Use latest ninja instead of one from system packages (vcpkg requires it)
@@ -108,6 +109,17 @@ RUN (curl -sL \
     > /tmp/pwsh.deb \
     && apt install -y --no-install-recommends /mingw-build/mingw-dwarf2-build/*.deb /tmp/pwsh.deb \
     && pwsh -Command "Write-Output 'Powershell installed successfully.'"
+
+# Focal has the mingw-w64 7.0.0 headers, which are too old for SDL3: the Direct3D renderers need
+# dxgidebug.h and the WASAPI backend needs the stream options from a newer audioclient.h. Jammy has
+# 8.0.0 with both, and they are architecture independent so the compiler above stays untouched.
+# Keep in sync with upgrade_mingw_headers() in devcontainer-fixes.sh.
+RUN cd /tmp \
+    && echo "deb http://archive.ubuntu.com/ubuntu jammy universe" > /etc/apt/sources.list.d/jammy.list \
+    && apt update \
+    && apt-get download mingw-w64-common/jammy mingw-w64-i686-dev/jammy \
+    && dpkg -i --force-overwrite mingw-w64-common_*.deb mingw-w64-i686-dev_*.deb \
+    && rm -f mingw-w64-*.deb /etc/apt/sources.list.d/jammy.list
 
 
 # Setup vcpkg

--- a/.devcontainer/Dockerfile-actual
+++ b/.devcontainer/Dockerfile-actual
@@ -109,13 +109,6 @@ RUN (curl -sL \
     && apt install -y --no-install-recommends /mingw-build/mingw-dwarf2-build/*.deb /tmp/pwsh.deb \
     && pwsh -Command "Write-Output 'Powershell installed successfully.'"
 
-# Setup SDL
-# Note: We're using the system-provided SDL because vcpkg-built SDL is very sensitive to the optional dependencies.
-#       For some of them it's a mess to correctly install both amd64 and i386 version at the same time.
-#       The most immediate symptom if the SDL is built without optional deps is that you don't see any of the error
-#       message boxes.
-# RUN apt install -y --no-install-recommends libsdl2-dev:amd64 libsdl2-dev:i386
-
 
 # Setup vcpkg
 RUN cd / \

--- a/.devcontainer/deps_prefetch_project/vcpkg.json
+++ b/.devcontainer/deps_prefetch_project/vcpkg.json
@@ -2,20 +2,27 @@
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
     "name": "hyperspace",
     "version": "0.1.0",
-    "description": "Hyperspace mod required libs. !!!Do not add boost-filesystem until boost-atomic 'lib -> a' naming/linking issue is fixed in vcpkg.!!!",
     "dependencies": [
         "boost-atomic",
+        "boost-filesystem",
         "boost-conversion",
         "boost-algorithm",
-        "boost-math",
+        "boost-lexical-cast",
         "boost-format",
         "boost-crc",
         "discord-rpc",
         "opengl",
         "lua",
-        "sdl3",
+        {
+            "name": "sdl3",
+            "default-features": false,
+            "features": [
+                { "name": "x11", "platform": "linux" },
+                { "name": "wayland", "platform": "linux" }
+            ]
+        },
         "minizip"
-    ],   
+    ],
     "builtin-baseline": "4ff4b6bb22fad8afcc0e88ca6970c423bf3f7bfd",
     "overrides": [
         {

--- a/.devcontainer/devcontainer-fixes.sh
+++ b/.devcontainer/devcontainer-fixes.sh
@@ -1,36 +1,75 @@
 #!/bin/bash
 set -e
 
-# This script applies fixes to a bug caused by a x86-windows-ftl.cmake triplet or/and toolchain.
-# For some reason only boost_atomic library is being built with .lib naming instead of .a like all other boost libs.
-# This causes linking errors when boost-filesystem (which depends on boost-atomic) is used in a MinGW build.
-# As a workaround, we manually copy boost_atomic.lib to libboost
+# Applies fixes that an older devcontainer image is missing. Usage: devcontainer-fixes.sh <platform>...
 
-if [ "$#" -eq 0 ]; then
-    BUILD_DIRS=(build-windows-debug build-windows-release)
-else
-    BUILD_DIRS=("$@")
-fi
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-copy_boost_atomic_alias() {
-    local build_dir="$1"
-    local config_dir="$2"
-    local src="$build_dir/vcpkg_installed/x86-windows-ftl/${config_dir}lib/boost_atomic.lib"
-    local dst="$build_dir/vcpkg_installed/x86-windows-ftl/${config_dir}lib/libboost_atomic.a"
+MINGW_HEADERS_VERSION=8.0.0
 
-    if [ -f "$src" ] && ! cmp -s "$src" "$dst"; then
-        cp "$src" "$dst"
-    fi
+# Keep in sync with the SDL3 dependencies in Dockerfile-actual.
+SDL3_LINUX_PACKAGES="libx11-dev libxext-dev libxtst-dev libwayland-dev wayland-protocols \
+libxkbcommon-dev libegl1-mesa-dev"
+
+# Update toolchains
+sync_toolchains() {
+    cp "$SCRIPT_DIR"/toolchains/* /vcpkg/scripts/toolchains/
 }
 
-for build_dir in "${BUILD_DIRS[@]}"; do
-    /vcpkg/vcpkg install \
-        --triplet=x86-windows-ftl \
-        --host-triplet=x86-windows-ftl \
-        --x-install-root="$build_dir/vcpkg_installed" || true
+# Focal ships the mingw-w64 7.0.0 headers, which are too old for SDL3: the Direct3D renderers need
+# dxgidebug.h and the WASAPI backend needs the stream options from a newer audioclient.h. Jammy has
+# 8.0.0 with both, and they are architecture independent so the compiler itself stays untouched.
+upgrade_mingw_headers() {
+    local installed
+    installed=$(dpkg-query -W -f='${Version}' mingw-w64-i686-dev 2>/dev/null || true)
 
-    copy_boost_atomic_alias "$build_dir" ""
-    copy_boost_atomic_alias "$build_dir" "debug/"
+    if [ -n "$installed" ] && dpkg --compare-versions "$installed" ge "$MINGW_HEADERS_VERSION"; then
+        echo "mingw-w64 headers are $installed, nothing to fix"
+        return
+    fi
+
+    echo "mingw-w64 headers are ${installed:-missing}, taking $MINGW_HEADERS_VERSION from jammy"
+
+    cd /tmp
+    echo "deb http://archive.ubuntu.com/ubuntu jammy universe" > /etc/apt/sources.list.d/jammy.list
+    apt update
+    apt-get download mingw-w64-common/jammy mingw-w64-i686-dev/jammy
+    dpkg -i --force-overwrite mingw-w64-common_*.deb mingw-w64-i686-dev_*.deb
+    rm -f mingw-w64-*.deb /etc/apt/sources.list.d/jammy.list
+}
+
+# vcpkg builds sdl3 from source on linux and needs the headers of the features it enables. Images
+# built before SDL3 was added do not carry them.
+install_sdl3_linux_deps() {
+    local missing=""
+    for package in $SDL3_LINUX_PACKAGES; do
+        # The trailing newline matters, multi-arch packages report one status line per architecture
+        dpkg-query -W -f='${Status}\n' "$package" 2>/dev/null | grep -q "^install ok installed$" \
+            || missing="$missing $package"
+    done
+
+    if [ -z "$missing" ]; then
+        echo "SDL3 linux dependencies are installed, nothing to fix"
+        return
+    fi
+
+    echo "Installing missing SDL3 linux dependencies:$missing"
+    apt update
+    apt install -y --no-install-recommends $missing
+}
+
+for platform in "$@"; do
+    case "$platform" in
+        windows)
+            sync_toolchains
+            upgrade_mingw_headers
+            ;;
+        linux)
+            install_sdl3_linux_deps
+            ;;
+        *)
+            echo "Unknown platform: $platform" >&2
+            exit 1
+            ;;
+    esac
 done
-
-echo "Devcontainer fixes applied successfully"

--- a/.devcontainer/toolchains/x86-windows-ftl.cmake
+++ b/.devcontainer/toolchains/x86-windows-ftl.cmake
@@ -26,6 +26,9 @@ string(CONCAT _compiler_flags
     # Disable multiple definition of std::type_info::operator==
     " -D__GXX_TYPEINFO_EQUALITY_INLINE=0"
 
+    # Target Windows 8, mingw-w64 defaults to XP which is too old for Boost.WinAPI
+    " -D_WIN32_WINNT=0x0602 -DWINVER=0x0602"
+
     # Use DWARF exceptions
     " -fdwarf-exceptions"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,11 +54,7 @@ swig_add_library(
     SOURCES ${swigfiles}
 )
 
-if(APPLE)
-    target_compile_features(Hyperspace PRIVATE cxx_std_14)
-else()
-    target_compile_features(Hyperspace PRIVATE cxx_std_11)
-endif()
+target_compile_features(Hyperspace PRIVATE cxx_std_14)
 
 target_include_directories(
     Hyperspace PRIVATE
@@ -84,6 +80,7 @@ target_link_libraries(
     ZLIB::ZLIB
     Boost::filesystem
     Threads::Threads
+    SDL3::SDL3
 )
 
 # Automatically include all source files from root directory
@@ -190,33 +187,16 @@ target_compile_options(
     # -Wall
 )
 
+target_compile_options(Hyperspace PRIVATE -std=c++14)
 if(APPLE)
-    target_compile_options(Hyperspace PRIVATE -std=c++14 -Wno-deprecated-declarations)
-else()
-    target_compile_options(Hyperspace PRIVATE -std=c++11)
+    target_compile_options(Hyperspace PRIVATE -Wno-deprecated-declarations)
 endif()
 
 target_compile_definitions(Hyperspace PRIVATE _REENTRANT)
 if(UNIX)
-    # SDL3
-    target_link_libraries(Hyperspace PRIVATE SDL3::SDL3)
-
     if (APPLE)
-        target_link_libraries(Hyperspace PRIVATE
-            "-framework Cocoa"
-            "-framework IOKit"
-            "-framework CoreFoundation"
-            "-framework CoreVideo"
-            "-framework CoreAudio"
-            "-framework OpenGL"
-            "-framework AudioToolbox"
-            "-framework ForceFeedback"
-            "-framework Carbon"
-            "-framework Metal"
-            "-framework QuartzCore"
-            "-framework GameController"
-            "-framework CoreHaptics"
-        )
+        # SDL3 loads OpenGL dynamically on macOS. 
+        target_link_libraries(Hyperspace PRIVATE "-framework OpenGL")
     endif()
 
     # Disable Discord integration by default

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ swig_add_library(
     SOURCES ${swigfiles}
 )
 
-target_compile_features(Hyperspace PRIVATE cxx_std_14)
+target_compile_features(Hyperspace PRIVATE cxx_std_11)
 
 target_include_directories(
     Hyperspace PRIVATE
@@ -187,7 +187,7 @@ target_compile_options(
     # -Wall
 )
 
-target_compile_options(Hyperspace PRIVATE -std=c++14)
+target_compile_options(Hyperspace PRIVATE -std=c++11)
 if(APPLE)
     target_compile_options(Hyperspace PRIVATE -Wno-deprecated-declarations)
 endif()

--- a/CustomShipGenerator.cpp
+++ b/CustomShipGenerator.cpp
@@ -1,8 +1,8 @@
 #include "CustomShipGenerator.h"
 #include "CustomShipSelect.h"
-#include <boost/math/special_functions/fpclassify.hpp>
-
 #include <boost/lexical_cast.hpp>
+
+#include <cmath>
 
 bool CustomShipGenerator::enabled = false;
 std::unordered_map<std::string,CustomShipGenerator> CustomShipGenerator::customShipGenerators = std::unordered_map<std::string,CustomShipGenerator>();
@@ -170,7 +170,7 @@ void CustomShipGenerator::SectorScaling::Parse(rapidxml::xml_node<char> *node)
         }
     }
 
-    if (boost::math::isnan(maxSector))
+    if (std::isnan(maxSector))
     {
         maxSector = minSector + 8.f;
     }

--- a/Global.cpp
+++ b/Global.cpp
@@ -2,9 +2,7 @@
 #include "Resources.h"
 #include <chrono>
 
-#if defined(__linux__) || defined (__APPLE__)
 #include <SDL3/SDL_messagebox.h>
-#endif // defined
 
 Global *Global::instance = new Global();
 
@@ -69,37 +67,10 @@ void ErrorMessage(const std::string &msg)
     ErrorMessage(msg.c_str());
 }
 
-#ifdef _WIN32
-std::wstring ConvertToUtf16(const char *str, UINT codepage)
-{
-    std::wstring utf16String;
-    bool success = ([&]() {
-        int size = MultiByteToWideChar(codepage, 0, str, -1, NULL, 0);
-        if (size == 0) {
-            return false;
-        }
-
-        utf16String.resize(size);
-        return MultiByteToWideChar(codepage, 0, str, -1, &utf16String[0], size) != 0;
-    })();
-
-    if (!success) {
-        printf("ErrorMessage(): Unable to convert '%s' to UTF-16.", str);
-        return L"Hyperspace Error: MultiByteToWideChar() failed in ConvertToUtf16().";
-    }
-    return utf16String;
-}
-#endif
-
 void ErrorMessage(const char *msg)
 {
-    #ifdef _WIN32
-        std::wstring utf16String = ConvertToUtf16(msg, CP_UTF8);
-        MessageBoxW(NULL, utf16String.c_str(), L"Error", MB_ICONERROR | MB_SETFOREGROUND);
-    #elif defined(__linux__) || defined (__APPLE__)
-        SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Error", msg, NULL);
-        fprintf(stderr, "%s", msg);
-    #endif
+    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Error", msg, NULL);
+    fprintf(stderr, "%s", msg);
 }
 
 

--- a/buildscripts/ci/setup-macos.sh
+++ b/buildscripts/ci/setup-macos.sh
@@ -6,10 +6,20 @@ REPO_ROOT=$(cd $SCRIPT_DIR/../.. && pwd)
 
 echo "=== Setting up macOS build environment ==="
 
+# Force --yes on Homebrew commands to avoid interactive prompts.
+export NONINTERACTIVE=1
+export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_INSTALL_CLEANUP=1
+
 # Check if Homebrew is installed
 if ! command -v brew &> /dev/null; then
     echo "Installing Homebrew (arm64)..."
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+    # On Apple Silicon brew lands in /opt/homebrew, which is not on the default PATH
+    BREW_PREFIX=$([ -x /opt/homebrew/bin/brew ] && echo /opt/homebrew || echo /usr/local)
+    echo "eval \"\$($BREW_PREFIX/bin/brew shellenv)\"" >> "$HOME/.zprofile"
+    eval "$("$BREW_PREFIX/bin/brew" shellenv)"
 else
     echo "Homebrew (arm64) already installed"
 fi

--- a/buildscripts/ci/setup-macos.sh
+++ b/buildscripts/ci/setup-macos.sh
@@ -18,17 +18,6 @@ fi
 echo "Installing arm64 build dependencies..."
 brew install cmake git ninja lld swig
 
-# Install x86 Homebrew if not present
-if [ ! -f "/usr/local/bin/brew" ]; then
-    echo "Installing x86 Homebrew (Rosetta)..."
-    arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-else
-    echo "x86 Homebrew already installed"
-fi
-
-# Install SDL2 via x86 Homebrew
-# echo "Installing x86 dependencies..."
-# arch -x86_64 /usr/local/bin/brew install sdl2
 
 # Clone and bootstrap vcpkg
 if [ ! -d "$REPO_ROOT/vcpkg" ]; then

--- a/buildscripts/docker-run-in-devcontainer.sh
+++ b/buildscripts/docker-run-in-devcontainer.sh
@@ -10,20 +10,23 @@ source "$SCRIPT_DIR/../.devcontainer/devcontainer.sh"
 
 COMMAND="${1:?Error: Command argument is required}"
 PRE_COMMAND=""
+PLATFORMS=""
+DOCKER_ENV=""
 
-case "$COMMAND" in
-    buildscripts/windows/build-debugonly.sh)
-        PRE_COMMAND="bash .devcontainer/devcontainer-fixes.sh build-windows-debug && "
-        ;;
-    buildscripts/windows/build-releaseonly.sh)
-        PRE_COMMAND="bash .devcontainer/devcontainer-fixes.sh build-windows-release && "
-        ;;
-    buildscripts/buildall.sh)
-        PRE_COMMAND="bash .devcontainer/devcontainer-fixes.sh build-windows-debug build-windows-release && "
-        ;;
-    buildscripts/buildall-release-only.sh)
-        PRE_COMMAND="bash .devcontainer/devcontainer-fixes.sh build-windows-release && "
-        ;;
+# Emulating the amd64 image on an arm host makes vcpkg's own cmake hang waiting on children that
+# already exited.
+case "$(uname -m)" in
+    arm64 | aarch64) DOCKER_ENV="-e VCPKG_FORCE_SYSTEM_BINARIES=1" ;;
 esac
 
-docker run --rm -v "$SCRIPT_DIR/..:/workspaces/FTL-Hyperspace" "$DEVCONTAINER_FULL" bash -c "cd /workspaces/FTL-Hyperspace && ${PRE_COMMAND}$COMMAND"
+case "$COMMAND" in
+    buildscripts/windows/*) PLATFORMS="windows" ;;
+    buildscripts/linux-*/*) PLATFORMS="linux" ;;
+    buildscripts/buildall*.sh) PLATFORMS="windows linux" ;;
+esac
+
+if [ -n "$PLATFORMS" ]; then
+    PRE_COMMAND="bash .devcontainer/devcontainer-fixes.sh $PLATFORMS && "
+fi
+
+docker run --rm $DOCKER_ENV -v "$SCRIPT_DIR/..:/workspaces/FTL-Hyperspace" "$DEVCONTAINER_FULL" bash -c "cd /workspaces/FTL-Hyperspace && ${PRE_COMMAND}$COMMAND"

--- a/src/features/sdl-test/SdlTest.cpp
+++ b/src/features/sdl-test/SdlTest.cpp
@@ -1,0 +1,102 @@
+#include "SdlTest.h"
+
+#ifdef HS_TEST_SDL
+/**
+ * Reports which SDL3 subsystems come up inside the Hyperspace binary, drawn over the game.
+ *
+ */
+
+#include "Global.h"
+
+#include <SDL3/SDL.h>
+
+#include <string>
+#include <vector>
+
+static std::string g_report;
+static SDL_Gamepad *g_pad = nullptr;
+static SDL_AudioStream *g_beep = nullptr;
+
+static bool InitSubsystem(const char *name, SDL_InitFlags flag)
+{
+    bool ok = SDL_InitSubSystem(flag);
+    g_report += std::string(name) + (ok ? ": ok" : std::string(": FAILED - ") + SDL_GetError()) + "\n";
+    return ok;
+}
+
+static void PlayBeep()
+{
+    std::vector<float> tone(4800);
+    for (size_t i = 0; i < tone.size(); ++i)
+        tone[i] = 0.2f * SDL_sinf(2.0f * SDL_PI_F * 440.0f * i / 48000.0f);
+
+    SDL_PutAudioStreamData(g_beep, tone.data(), (int)(tone.size() * sizeof(float)));
+}
+
+void SdlTest::Init()
+{
+    if (InitSubsystem("Audio", SDL_INIT_AUDIO))
+    {
+        g_report += std::string("Audio driver: ") + SDL_GetCurrentAudioDriver() + "\n";
+
+        int deviceCount = 0;
+        SDL_AudioDeviceID *devices = SDL_GetAudioPlaybackDevices(&deviceCount);
+        g_report += "Audio devices: " + std::to_string(deviceCount) + "\n";
+        SDL_free(devices);
+
+        SDL_AudioSpec spec = { SDL_AUDIO_F32, 1, 48000 };
+        g_beep = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, nullptr, nullptr);
+        if (g_beep) SDL_ResumeAudioStreamDevice(g_beep);
+    }
+
+    if (InitSubsystem("Gamepad", SDL_INIT_GAMEPAD))
+    {
+        int padCount = 0;
+        SDL_JoystickID *padIds = SDL_GetGamepads(&padCount);
+        if (padCount > 0) g_pad = SDL_OpenGamepad(padIds[0]);
+        SDL_free(padIds);
+
+        g_report += std::string("Gamepad: ") + (g_pad ? SDL_GetGamepadName(g_pad) : "none connected") + "\n";
+    }
+
+    g_report += "Press the X (A) button on the gamepad to hear a beep\n";
+}
+
+void SdlTest::Render()
+{
+    // FTL owns the event loop, so nothing refreshes gamepad state for us
+    SDL_UpdateGamepads();
+
+    std::string live = "Gamepad state: ";
+    if (g_pad)
+    {
+        live += "LX " + std::to_string(SDL_GetGamepadAxis(g_pad, SDL_GAMEPAD_AXIS_LEFTX))
+              + "  LY " + std::to_string(SDL_GetGamepadAxis(g_pad, SDL_GAMEPAD_AXIS_LEFTY));
+
+        static bool wasDown = false;
+        bool isDown = SDL_GetGamepadButton(g_pad, SDL_GAMEPAD_BUTTON_SOUTH);
+        if (isDown && !wasDown && g_beep) PlayBeep();
+        wasDown = isDown;
+    }
+    else
+    {
+        live += "no gamepad";
+    }
+
+    CSurface::GL_SetColor(GL_Color(0.4f, 1.0f, 0.6f, 1.0f));
+
+    float y = 40.0f;
+    size_t start = 0;
+    while (start < g_report.size())
+    {
+        size_t end = g_report.find('\n', start);
+        freetype::easy_print(10, 40.0f, y, g_report.substr(start, end - start));
+        y += 18.0f;
+        start = end + 1;
+    }
+    freetype::easy_print(10, 40.0f, y + 18.0f, live);
+
+    CSurface::GL_SetColor(GL_Color(1.0f, 1.0f, 1.0f, 1.0f));
+}
+
+#endif // HS_TEST_SDL

--- a/src/features/sdl-test/SdlTest.h
+++ b/src/features/sdl-test/SdlTest.h
@@ -1,0 +1,17 @@
+#pragma once
+
+// Manual check that SDL3 works from inside Hyperspace. Draws what it finds over the game and beeps
+// when a gamepad button is pressed. Uncomment the define to build it in.
+//#define HS_TEST_SDL
+
+#ifdef HS_TEST_SDL
+
+namespace SdlTest {
+    // Bring up the SDL subsystems that do not need the macOS main thread. Called from CApp::OnInit.
+    void Init();
+
+    // Draw the findings and poll the gamepad. Called from a hook that runs every frame.
+    void Render();
+}
+
+#endif // HS_TEST_SDL

--- a/src/features/sdl-test/SdlTestHooks.cpp
+++ b/src/features/sdl-test/SdlTestHooks.cpp
@@ -1,0 +1,22 @@
+#include "SdlTest.h"
+
+#ifdef HS_TEST_SDL
+
+#include "Global.h"
+
+HOOK_METHOD(CApp, OnInit, () -> bool)
+{
+    LOG_HOOK("HOOK_METHOD -> CApp::OnInit -> Begin (SdlTestHooks.cpp)\n")
+    SdlTest::Init();
+    return super();
+}
+
+// The cursor is drawn last, so rendering before it puts the report on top of everything
+HOOK_METHOD(MouseControl, OnRender, () -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> MouseControl::OnRender -> Begin (SdlTestHooks.cpp)\n")
+    SdlTest::Render();
+    super();
+}
+
+#endif // HS_TEST_SDL

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,15 +7,22 @@
         "boost-filesystem",
         "boost-conversion",
         "boost-algorithm",
-        "boost-math",
+        "boost-lexical-cast",
         "boost-format",
         "boost-crc",
         "discord-rpc",
         "opengl",
         "lua",
+        {
+            "name": "sdl3",
+            "default-features": false,
+            "features": [
+                { "name": "x11", "platform": "linux" },
+                { "name": "wayland", "platform": "linux" }
+            ]
+        },
         "minizip"
     ],
-
     "builtin-baseline": "4ff4b6bb22fad8afcc0e88ca6970c423bf3f7bfd",
     "overrides": [
         {

--- a/zhl.cpp
+++ b/zhl.cpp
@@ -10,14 +10,15 @@
 #include "PALMemoryProtection.h"
 #include <inttypes.h>
 
+#include <SDL3/SDL_messagebox.h>
+#include <cstdlib>
+
 #ifdef _WIN32
     #define OUR_OWN_FUNCTIONS_CALLEE_DOES_CLEANUP 1
 #elif defined(__linux__) || defined(__APPLE__)
     #define OUR_OWN_FUNCTIONS_CALLEE_DOES_CLEANUP 0
     #define USE_STACK_ALIGNMENT
     #define STACK_ALIGNMENT_SIZE 0x10
-	#include <SDL3/SDL_messagebox.h>
-	#include <cstdlib>
 #else
     #define "Unknown OS"
 #endif
@@ -44,28 +45,16 @@ void ZHL::Init()
 
 	if(!Definition::Init())
 	{
-        // TODO: Maybe change this over to SDL_ShowSimpleMessageBox for all systems; however, we'll have to add libsdl to the build & maybe the sdl.dll runtime DLL on Windows
-        // SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Error", FunctionDefinition::GetLastError(), NULL);
-#ifdef _WIN32
-		MessageBox(0, FunctionDefinition::GetLastError(), "Error", MB_ICONERROR);
-		ExitProcess(1);
-#elif defined(__linux__) || defined(__APPLE__)
 		SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Fatal Error", FunctionDefinition::GetLastError(), NULL);
         fprintf(stderr, "Fatal Error %s:", FunctionDefinition::GetLastError());
         exit(1);
-#endif
 	}
 
 	if(!FunctionHook_private::Init())
 	{
-#ifdef _WIN32
-		MessageBox(0, FunctionHook_private::GetLastError(), "Error", MB_ICONERROR);
-		ExitProcess(1);
-#elif defined(__linux__) || defined(__APPLE__)
 		SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Fatal Error", FunctionHook_private::GetLastError(), NULL);
         fprintf(stderr, "Fatal Error %s:", FunctionHook_private::GetLastError());
         exit(1);
-#endif
 	}
 
 	initialized = true;


### PR DESCRIPTION
This pull request fixes the `SDL3` branch building on all three platforms. It adapts the repository to SDL3, fixes the devcontainer so the Windows and Linux builds work, and repairs the macOS build, which had broken when Homebrew removed x86 native `sdl2` formula. It also raises the minimum Windows version that current Boost releases require, drops a Boost-math dependency the Linux toolchain cannot satisfy, and routes error dialogs through SDL3 on every platform.

**What SDL3 features are currently supported:**

| Subsystem | Windows | Linux | macOS |
| --- | --- | --- | --- |
| Message boxes | yes | yes | yes |
| Gamepads | yes | yes | yes |
| Audio | yes | yes | yes |
| Windows and rendering | no | no | no |
| Keyboard and mouse | no | no | no |
| Text input | no | no | no |

FTL owns the window and the event loop, so we get keyboard, mouse and rendering from FTL's own hooks instead. Gamepads are polled from the OS directly, which is why they work, and they are the one thing FTL does not already provide.

Windows and rendering could be added later. `SDL_CreateWindowWithProperties` can in theory wrap FTL's existing window, so SDL3 would not need one of its own. It needs more work: OpenGL state has to be kept out of FTL's way.

**Dependencies and Build Configuration**

- Declared `sdl3` in both vcpkg manifests and linked `SDL3::SDL3` on every platform rather than Unix only.
- Turned off the sdl3 port's default features and requested only `x11` and `wayland` on Linux. The defaults include `ibus` for Chinese and Japanese text input, which we do not use and which the port ships broken, stopping the mod from loading on Linux.
- Dropped `boost-math`. It served one `isnan` call, and its 1.90 release needs a C++14 standard library that the Linux toolchain cannot provide (libstdc++ 4.8). Replaced with `std::isnan`.
- Declared `boost-lexical-cast` explicitly. Before the change it was resolved transitively through `boost-math`.
- Put every platform on C++11. macOS was the only one on C++14 because of old SDL2 dependency and nothing in the codebase needs it.
- Reduced the macOS framework list to `OpenGL` alone.

**Devcontainer and Toolchain**

- Set `_WIN32_WINNT`/`WINVER` to `0x0602`. `boost-atomic` needs SRW locks and `boost-filesystem` needs `WaitOnAddress`, neither of which Boost.WinAPI declares at mingw-w64's default XP-era level.
- Take the mingw-w64 headers from jammy (8.0.0). Focal ships 7.0.0, predating `dxgidebug.h` and the WASAPI stream options SDL3's Direct3D renderers and audio backend need.
- Corrected the Linux SDL3 package list: dropped `libxft-dev`, added `libxtst-dev` and `wayland-protocols`.
- Reworked `devcontainer-fixes.sh` to take a platform rather than build directories, and removed the obsolete `boost-atomic` naming workaround.
- Restored boost-filesystem to the prefetch manifest. The boost-atomic naming workaround it was held back for no longer applies.
- Force system cmake when the amd64 container runs emulated on an arm host; vcpkg's own cmake deadlocks on already-exited children.
- Made `setup-macos.sh` run unattended.
- Removed Homebrew x86 setup from `setup-macos.sh` that was used only for SDL2 compiling. (Makes Mac build faster by ~ 5 min)

**Error Dialogs and Diagnostics**

- `ErrorMessage` and both `ZHL::Init` failure paths now use `SDL_ShowSimpleMessageBox` everywhere, replacing the Win32 `MessageBoxW` branch and its UTF-16 conversion. Resolves the standing TODO in `zhl.cpp`.
- Added `src/features/sdl-test/`. Disabled by default, can be enabled with `HS_TEST_SDL` definition. Reporting which SDL3 subsystems initialise inside Hyperspace.

**Notes**

- Minimum Windows is now 8. The previous XP era floor was an unset default, not a decision.
- The two fatal paths in `zhl.cpp` are now the same on every platform. Windows used `ExitProcess(1)`, the others used `exit(1)`, and both now use `exit(1)`. 
- SDL3 video and rendering are unavailable in-process on macOS: `Cocoa_CreateDevice()` returns NULL off the main thread and FTL calls hooks from a worker thread. Message boxes, audio, and gamepads work.
- The devcontainer image must be rebuilt before these changes take effect. `devcontainer-fixes.sh` patches a stale container in the meantime and self-disables once the image carries the newer headers. 
- Afterwards `sync_toolchains`, `upgrade_mingw_headers` and `install_sdl3_linux_deps` functions can be manually removed
