### PR TITLE
Add the X11 dev packages SDL3 needs

### DIFF
--- a/.devcontainer/Dockerfile-actual
+++ b/.devcontainer/Dockerfile-actual
@@ -73,7 +73,9 @@ RUN echo deb http://dk.archive.ubuntu.com/ubuntu/ xenial main >> /etc/apt/source
     && apt update
 
 # SDL3 dependencies for linux (Required to build from vcpkg).
-RUN apt install -y --no-install-recommends libx11-dev libxext-dev libxtst-dev \
+RUN apt install -y --no-install-recommends \
+        libx11-dev libxext-dev libxcursor-dev libxi-dev libxfixes-dev libxrandr-dev \
+        libxrender-dev libxss-dev libxtst-dev \
         libwayland-dev wayland-protocols libxkbcommon-dev libegl1-mesa-dev
 
 # Install common build tools

--- a/.devcontainer/devcontainer-fixes.sh
+++ b/.devcontainer/devcontainer-fixes.sh
@@ -8,8 +8,9 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 MINGW_HEADERS_VERSION=8.0.0
 
 # Keep in sync with the SDL3 dependencies in Dockerfile-actual.
-SDL3_LINUX_PACKAGES="libx11-dev libxext-dev libxtst-dev libwayland-dev wayland-protocols \
-libxkbcommon-dev libegl1-mesa-dev"
+SDL3_LINUX_PACKAGES="libx11-dev libxext-dev libxcursor-dev libxi-dev libxfixes-dev libxrandr-dev \
+libxrender-dev libxss-dev libxtst-dev libwayland-dev wayland-protocols libxkbcommon-dev \
+libegl1-mesa-dev"
 
 # Update toolchains
 sync_toolchains() {


### PR DESCRIPTION
This pull request updates the SDL3 Linux dependencies in the development container setup to ensure all required libraries are installed for building SDL3 from source. 

Dependency updates for SDL3:

- Added `libxcursor-dev`, `libxi-dev`, `libxfixes-dev`, `libxrandr-dev`, `libxrender-dev`, and `libxss-dev` to the list of installed packages in `.devcontainer/Dockerfile-actual` to cover all required X11 dependencies for SDL3.
- Synchronized the `SDL3_LINUX_PACKAGES` variable in `.devcontainer/devcontainer-fixes.sh` to include the same additional libraries, ensuring consistency between the Dockerfile and the script.