### PR TITLE
Fix crew dismissal for multiple pages

### DIFF
--- a/CustomCrewManifest.cpp
+++ b/CustomCrewManifest.cpp
@@ -775,12 +775,14 @@ HOOK_METHOD(CrewManifest, Close, () -> void)
 HOOK_METHOD(CrewManifest, MouseClick, (int mX, int mY) -> void)
 {
     LOG_HOOK("HOOK_METHOD -> CrewManifest::MouseClick -> Begin (CustomCrewManifest.cpp)\n")
+    if (this->deleteDialog.bOpen) return super(mX, mY);
     CustomCrewManifest::GetInstance()->MouseClick(mX, mY);
 }
 
 HOOK_METHOD(CrewManifest, MouseMove, (int mX, int mY) -> void)
 {
     LOG_HOOK("HOOK_METHOD -> CrewManifest::MouseMove -> Begin (CustomCrewManifest.cpp)\n")
+    if (this->deleteDialog.bOpen) return super(mX, mY);
     CustomCrewManifest::GetInstance()->MouseMove(mX, mY);
 }
 

--- a/CustomCrewManifest.cpp
+++ b/CustomCrewManifest.cpp
@@ -775,7 +775,6 @@ HOOK_METHOD(CrewManifest, Close, () -> void)
 HOOK_METHOD(CrewManifest, MouseClick, (int mX, int mY) -> void)
 {
     LOG_HOOK("HOOK_METHOD -> CrewManifest::MouseClick -> Begin (CustomCrewManifest.cpp)\n")
-    if (this->deleteDialog.bOpen) return super(mX, mY);
     CustomCrewManifest::GetInstance()->MouseClick(mX, mY);
 }
 


### PR DESCRIPTION
Reported by @qaser7 in https://github.com/FTL-Hyperspace/FTL-Hyperspace/issues/766
- Prevent crew pages from being changed when dismiss window is open
