### PR TITLE
fix #732

### DIFF
--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -115,8 +115,8 @@ void ShipManager_Extend::Initialize(bool restarting)
 
 HOOK_METHOD_PRIORITY(ShipManager, ResetScrapLevel, 9999, () -> void)
 {
-    // In super() on amd64, it fails to read Global::difficulty due to detour.h not relocating the relative address correctly
-    // This is a workaround to fix that issue, but it may be better to fix the detour.h code instead?
+    // On x86_64, super() can read the wrong difficulty because detours.h does not relocate RIP-relative DISP32 addresses correctly
+    // Workaround: re-implement the vanilla scrap initialization here (it would be preferable to fix detours.h instead)
     LOG_HOOK("HOOK_METHOD_PRIORITY -> ShipManager::ResetScrapLevel -> Begin (CustomShips.cpp)\n")
     currentScrap = 30;
     if (*Global::difficulty == 1)

--- a/CustomShips.cpp
+++ b/CustomShips.cpp
@@ -113,6 +113,22 @@ void ShipManager_Extend::Initialize(bool restarting)
     }
 }
 
+HOOK_METHOD_PRIORITY(ShipManager, ResetScrapLevel, 9999, () -> void)
+{
+    // In super() on amd64, it fails to read Global::difficulty due to detour.h not relocating the relative address correctly
+    // This is a workaround to fix that issue, but it may be better to fix the detour.h code instead?
+    LOG_HOOK("HOOK_METHOD_PRIORITY -> ShipManager::ResetScrapLevel -> Begin (CustomShips.cpp)\n")
+    currentScrap = 30;
+    if (*Global::difficulty == 1)
+    {
+        currentScrap = 10;
+    }
+    else if (*Global::difficulty == 2)
+    {
+        currentScrap = 0;
+    }
+}
+
 HOOK_METHOD(ShipManager, ResetScrapLevel, () -> void)
 {
     LOG_HOOK("HOOK_METHOD -> ShipManager::ResetScrapLevel -> Begin (CustomShips.cpp)\n")
@@ -164,7 +180,7 @@ HOOK_METHOD_PRIORITY(ShipManager, ImportShip, -1000, (int fileHelper) -> void)
 HOOK_METHOD(ShipManager, AddSystem, (int systemId) -> int)
 {
     LOG_HOOK("HOOK_METHOD -> ShipManager::AddSystem -> Begin (CustomShips.cpp)\n")
-    
+
     //Set the image defined in systemInfo to the proper value when adding artillery systems
     auto shipDef = CustomShipSelect::GetInstance()->GetDefinition(myBlueprint.blueprintName);
     if (shipDef.artilleryRoomImages.size() > 1 && systemId == SYS_ARTILLERY)
@@ -1168,7 +1184,7 @@ HOOK_METHOD(ShipManager, DamageArea, (Pointf location, Damage dmg, bool forceHit
         msg->color.a = 1.f;
         damMessages.push_back(msg);
     }
-    
+
     return ret;
 }
 
@@ -1186,14 +1202,14 @@ HOOK_METHOD(ShipManager, DamageBeam, (Pointf location1, Pointf location2, Damage
             dmg.iSystemDamage += dmg.iDamage;
             dmg.iPersDamage += dmg.iDamage;
             dmg.iDamage = 0;
-            
+
             if (room1 > -1)
             {
                 auto msg1 = new DamageMessage(1.f, ship.GetRoomCenter(room1), DamageMessage::MessageType::RESIST);
                 msg1->color.a = 1.f;
                 damMessages.push_back(msg1);
             }
-            
+
         }
     }
 
@@ -1474,7 +1490,7 @@ void Ship::RenderEngineAnimation(bool showEngines, float alpha)
     SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pShip, 0);
     lua_pushnumber(context->GetLua(), showEngines);
     lua_pushnumber(context->GetLua(), alpha);
-    
+
     int idx = context->getLibScript()->call_on_render_event_pre_callbacks(RenderEvents::SHIP_ENGINES, 3);
     if (showEngines && idx >= 0)
     {
@@ -1534,13 +1550,13 @@ HOOK_METHOD_PRIORITY(Ship, OnRenderBase, 9999, (bool engines) -> void)
         alphaOther = 0.5f;
         alphaHull = 0.375f;
     }
-    
+
     // Lua callback init
     auto context = Global::GetInstance()->getLuaContext();
-    
+
     SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pShip, 0);
     lua_pushnumber(context->GetLua(), alphaCloak);
-    
+
     int idx = context->getLibScript()->call_on_render_event_pre_callbacks(RenderEvents::SHIP_HULL, 2);
 
     if (idx >= 0)
@@ -1605,7 +1621,7 @@ HOOK_METHOD_PRIORITY(Ship, OnRenderJump, 9999, (float progress) -> void)
     LOG_HOOK("HOOK_METHOD_PRIORITY -> Ship::OnRenderJump -> Begin (CustomShips.cpp)\n")
 
     ShipGraph *shipGraph = ShipGraph::GetShipInfo(iShipId);
-    float sparkProgress = progress/0.75; 
+    float sparkProgress = progress/0.75;
     float sparkScale = 0.0;
     float sparkX = 0.0;
     float sparkY = 0.0;
@@ -1898,7 +1914,7 @@ bool WorldManager::SwitchShip(std::string shipName)
 HOOK_METHOD(ShipManager, SaveToBlueprint, (bool overwrite) -> ShipBlueprint)
 {
     LOG_HOOK("HOOK_METHOD -> ShipManager::SaveToBlueprint -> Begin (CustomShips.cpp)\n")
-    
+
     if (overrideTransfer) overwrite = false;
 
     return super(overwrite);
@@ -1975,7 +1991,7 @@ bool WorldManager::SwitchShipTransfer(std::string shipName, int overrideSystem)
                 if (bp->systemInfo[playerShipManager->vSystemList[i]->GetId()].location.size() > 0 && (playerShipManager->vSystemList[i]->GetId() != SYS_ARTILLERY || !addedArtillery))
                 {
                     newSystems.push_back(playerShipManager->vSystemList[i]->GetId());
-                    if (playerShipManager->vSystemList[i]->GetId() == SYS_ARTILLERY) 
+                    if (playerShipManager->vSystemList[i]->GetId() == SYS_ARTILLERY)
                     {
                         for (int i=0; i<bp->systemInfo[SYS_ARTILLERY].location.size() - 1; ++i)
                         {
@@ -1997,7 +2013,7 @@ bool WorldManager::SwitchShipTransfer(std::string shipName, int overrideSystem)
             }
             bp->systems = newSystems;
         }
-        
+
         playerShipManager->myBlueprint = *bp;
         int save_max_health = bp->health;
 
@@ -2023,7 +2039,7 @@ bool WorldManager::SwitchShipTransfer(std::string shipName, int overrideSystem)
             for (auto system : save_systems)
             {
                 if (playerShipManager->HasSystem(system.first))
-                {   
+                {
                     ShipSystem* sys = playerShipManager->GetSystem(system.first);
                     if (sys) sys->powerState.second = system.second;
                 }


### PR DESCRIPTION
Fix #732 

Now the game starts with the correct number of scraps for each difficulty on linux. GPT found the issue was lied on detour.h failed to detect RIP relative address thus calling super() would take difficulty from a wrong address.

The solution GPT gave me didnt work, so I simply put rewrite code and dont let game run the original code.

Thank @CanadaHonk for providing the rewrite of ShipManager::ResetScrapLevel


<details>
<summary>FYI GPT's answer</summary>
<pre>
<code>
I identified the cause with fairly high confidence. The issue is not inlining itself, but a missing RIP-relative address relocation in the Linux AMD64 detour trampoline.

The execution paths differ as follows:

- Starting from the hangar:
  `WorldManager::StartGame` → `ShipManager::ResetScrapLevel`
- Restarting from the menu:
  `ResetScrapLevel` is inlined directly into `ShipManager::Restart`

In Ghidra, the Linux AMD64 version of `ResetScrapLevel` begins with:

```asm
004b80e0  8B 05 EE B3 58 00    MOV EAX,[RIP+0x58b3ee] ; Settings::difficulty
004b80e6  C7 87 ... 1E ...     MOV [RDI+0x670],30
004b80f0  83 F8 01             CMP EAX,1
```

Hyperspace hooks this function in CustomShips.cpp:116 and calls `super()`.

However, the RIP-relative instruction check in detours.h:592 uses this condition:

```cpp
hs.modrm == 0x0d
```

The actual ModRM byte of the initial `8B 05` instruction is `0x05`. As a result, its RIP-relative displacement is not adjusted when the instruction is copied into the trampoline.

When `super()` executes the relocated instruction, it reads from the wrong address instead of the real `Settings::difficulty`. The resulting value is apparently treated as zero, so the function always follows the Easy-difficulty path and assigns 30 scrap.

The restart path does not call the hooked function. It executes an inlined copy that reads the real difficulty value directly, so it correctly assigns 30, 10, or 0 scrap.

The Windows and Linux x86 versions use an absolute address instruction instead of RIP-relative addressing:

```text
Windows:   A1 ???????? ...
Linux x86: A1 ???????? ...
Linux x64: 8B 05 ???????? ...  ← RIP-relative
```

The corresponding signatures can be seen in FTLGameELF64.cpp:13793 and FTLGameWin32.cpp:15709.

The check should be changed to something like:

```cpp
if ((hs.flags & F_MODRM) &&
    hs.modrm_mod == 0 &&
    hs.modrm_rm == 5 &&
    (hs.flags & F_DISP32))
```

Therefore, this is not specific to `ResetScrapLevel`. It is a general Linux AMD64 detour bug that may affect any hooked function whose overwritten instructions contain RIP-relative memory access. Fixing the relocation check should address the root cause of this issue.
</code>
</pre>
</details>