### PR TITLE
Prevent the player from selecting beacons on the map whilst waiting

### DIFF
--- a/StarMap.cpp
+++ b/StarMap.cpp
@@ -491,7 +491,7 @@ bool StarMap::WillBeOvertaken(Location *loc)
 
 HOOK_METHOD_PRIORITY(StarMap, MouseMove, -9999, (int mX, int mY) -> void)
 {
-    LOG_HOOK("HOOK_METHOD -> StarMap::MouseMove -> Begin (Misc.cpp)\n")
+    LOG_HOOK("HOOK_METHOD -> StarMap::MouseMove -> Begin (StarMap.cpp)\n")
 
     // Prevents the player from jumping when waiting (Lead to a softlock)
     if (this->waiting.running) return;

--- a/StarMap.cpp
+++ b/StarMap.cpp
@@ -488,3 +488,12 @@ bool StarMap::WillBeOvertaken(Location *loc)
     Pointf nextDangerZone = Pointf(dangerZone.x + dangerMove, dangerZone.y);
     return loc->loc.RelativeDistance(nextDangerZone) < (dangerZoneRadius * dangerZoneRadius);
 }
+
+HOOK_METHOD_PRIORITY(StarMap, MouseMove, -9999, (int mX, int mY) -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> StarMap::MouseMove -> Begin (Misc.cpp)\n")
+
+    // Prevents the player from jumping when waiting (Lead to a softlock)
+    if (this->waiting.running) return;
+    super(mX, mY);
+}


### PR DESCRIPTION
- Prevents the player from running into a soft-lock

Reported by @Aleev141 in: https://github.com/FTL-Hyperspace/FTL-Hyperspace/issues/730