### PR TITLE
Expose Blueprint Vectors, Constructors, and add helper functions to make modifcation of blueprints and weapons easier.

### DIFF
--- a/CooldownNumbers.cpp
+++ b/CooldownNumbers.cpp
@@ -65,7 +65,7 @@ HOOK_METHOD(WeaponBox, RenderBox, (bool dragging, bool flashPowerBox) -> void)
         }
         std::string shotLimitString;
         auto weaponDef = CustomWeaponManager::instance->GetWeaponDefinition(pWeapon->blueprint->name);
-        if (weaponDef->shotLimit >= 0)
+        if (weaponDef && weaponDef->shotLimit >= 0)
         {
             int numShotsRemaining = weaponDef->shotLimit - pWeapon->shotsFiredAtTarget;
             shotLimitString = G_->GetTextLibrary()->GetText("shots_remaining");

--- a/CustomWeapons.cpp
+++ b/CustomWeapons.cpp
@@ -714,7 +714,7 @@ HOOK_METHOD(WeaponAnimation, StartFire, () -> bool)
     return ret;
 }
 
-HOOK_METHOD(ProjectileFactory, constructor, (const WeaponBlueprint* bp, int shipId) -> void)
+HOOK_METHOD_PRIORITY(ProjectileFactory, constructor, 999, (const WeaponBlueprint* bp, int shipId) -> void)
 {
     LOG_HOOK("HOOK_METHOD -> ProjectileFactory::constructor -> Begin (CustomWeapons.cpp)\n")
     if (bp->type == -1) // If the blueprint doesn't exist, revert to the default laser
@@ -723,7 +723,7 @@ HOOK_METHOD(ProjectileFactory, constructor, (const WeaponBlueprint* bp, int ship
     }
 
     super(bp, shipId);
-    HS_MAKE_TABLE(this)
+
     if (bp->type != 2)
     {
         auto def = CustomWeaponManager::instance->GetWeaponDefinition(blueprint->name);
@@ -732,18 +732,6 @@ HOOK_METHOD(ProjectileFactory, constructor, (const WeaponBlueprint* bp, int ship
             weaponVisual.SetFireTime(def->fireTime);
         }
     }
-
-    auto context = G_->getLuaContext();
-    SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pProjectileFactory, 0);
-    context->getLibScript()->call_on_internal_event_callbacks(InternalEvents::CONSTRUCT_PROJECTILE_FACTORY, 1);
-    lua_pop(context->GetLua(), 1);
-}
-
-HOOK_METHOD(ProjectileFactory, destructor, () -> void)
-{
-    LOG_HOOK("HOOK_METHOD -> ProjectileFactory::destructor -> Begin (CustomWeapons.cpp)\n")
-    HS_BREAK_TABLE(this)
-    super();
 }
 
 // Fix for weapon animations with many frames.

--- a/CustomWeapons.cpp
+++ b/CustomWeapons.cpp
@@ -897,7 +897,7 @@ void CustomWeaponManager::ProcessMiniProjectile(Projectile *proj, const WeaponBl
 bool ProjectileFactory::HitShotLimit()
 {
     auto def = CustomWeaponManager::instance->GetWeaponDefinition(blueprint->name);
-    return def->shotLimit >=0 && def->shotLimit <= shotsFiredAtTarget;
+    return def && def->shotLimit >=0 && def->shotLimit <= shotsFiredAtTarget;
 }
 //Shot limit is implemented in the same context as checks on WeaponBlueprint::missiles as a way of implementing a requirement on weapon usage
 //TODO: Possibly add callback for arbitrary requirements on weapon usage

--- a/FTLGameELF32.h
+++ b/FTLGameELF32.h
@@ -6782,6 +6782,7 @@ struct ProjectileFactory : ShipObject
 	std::vector<Projectile*> queuedProjectiles;
 	int iBonusPower;
 	bool bFiredOnce;
+	uint8_t gap_ex_1[2];
 	int iSpendMissile;
 	float cooldownModifier;
 	int shotsFiredAtTarget;
@@ -6792,6 +6793,7 @@ struct ProjectileFactory : ShipObject
 	int iHackLevel;
 	int goalChargeLevel;
 	bool isArtillery;
+	uint8_t gap_ex_2[2];
 };
 
 struct RepairAnimation : CrewAnimation

--- a/FTLGameELF64.h
+++ b/FTLGameELF64.h
@@ -6810,10 +6810,12 @@ struct ProjectileFactory : ShipObject
 	int numShots;
 	float currentFiringAngle;
 	float currentEntryAngle;
+	uint8_t gap_ex_1[4];
 	Targetable *currentShipTarget;
 	CloakingSystem *cloakingSystem;
 	WeaponAnimation weaponVisual;
 	WeaponMount mount;
+	uint8_t gap_ex_2[4];
 	std::vector<Projectile*> queuedProjectiles;
 	int iBonusPower;
 	bool bFiredOnce;

--- a/FTLGameMacOSAMD64.h
+++ b/FTLGameMacOSAMD64.h
@@ -7235,10 +7235,12 @@ struct ProjectileFactory : ShipObject
 	int numShots;
 	float currentFiringAngle;
 	float currentEntryAngle;
+	uint8_t gap_ex_1[4];
 	Targetable *currentShipTarget;
 	CloakingSystem *cloakingSystem;
 	WeaponAnimation weaponVisual;
 	WeaponMount mount;
+	uint8_t gap_ex_2[4];
 	std::vector<Projectile*> queuedProjectiles;
 	int iBonusPower;
 	bool bFiredOnce;

--- a/FTLGameWin32.h
+++ b/FTLGameWin32.h
@@ -6810,6 +6810,7 @@ struct ProjectileFactory : ShipObject
 	std::vector<Projectile*> queuedProjectiles;
 	int iBonusPower;
 	bool bFiredOnce;
+	uint8_t gap_ex_1[2];
 	int iSpendMissile;
 	float cooldownModifier;
 	int shotsFiredAtTarget;
@@ -6820,6 +6821,7 @@ struct ProjectileFactory : ShipObject
 	int iHackLevel;
 	int goalChargeLevel;
 	bool isArtillery;
+	uint8_t gap_ex_2[2];
 };
 
 struct RepairAnimation : CrewAnimation

--- a/FTL_HyperspaceGCC.cbp
+++ b/FTL_HyperspaceGCC.cbp
@@ -1227,6 +1227,12 @@
 		<Unit filename="Projectile_Extend.h">
 			<Option virtualFolder="Core/Weapons/" />
 		</Unit>
+		<Unit filename="ProjectileFactory_Extend.cpp">
+			<Option virtualFolder="Core/Weapons/" />
+		</Unit>
+		<Unit filename="ProjectileFactory_Extend.h">
+			<Option virtualFolder="Core/Weapons/" />
+		</Unit>
 		<Unit filename="RedesignedTooltips.cpp">
 			<Option virtualFolder="Core/Equipment/" />
 		</Unit>

--- a/ProjectileFactory_Extend.cpp
+++ b/ProjectileFactory_Extend.cpp
@@ -1,0 +1,70 @@
+#include "ProjectileFactory_Extend.h"
+
+
+HOOK_METHOD_PRIORITY(ProjectileFactory, constructor, 900, (int iShipId) -> void)
+{
+    LOG_HOOK("HOOK_METHOD_PRIORITY -> ProjectileFactory::constructor -> Begin (ProjectileFactory_Extend.cpp)\n")
+
+
+	super(iShipId);
+
+	auto ex = new ProjectileFactory_Extend();
+
+    uintptr_t dEx = (uintptr_t)ex;
+
+#ifdef __amd64__
+    this->gap_ex_1[2] = (dEx >> 56) & 0xFF;
+    this->gap_ex_1[3] = (dEx >> 48) & 0xFF;
+    this->gap_ex_2[2] = (dEx >> 40) & 0xFF;
+    this->gap_ex_2[3] = (dEx >> 32) & 0xFF;
+#endif // __amd64__
+	this->gap_ex_1[0] = (dEx >> 24) & 0xFF;
+	this->gap_ex_1[1] = (dEx >> 16) & 0xFF;
+	this->gap_ex_2[0] = (dEx >> 8) & 0xFF;
+	this->gap_ex_2[1] = dEx & 0xFF;
+	ex->orig = this;
+
+    HS_MAKE_TABLE(this)
+
+    auto context = G_->getLuaContext();
+    SWIG_NewPointerObj(context->GetLua(), this, context->getLibScript()->types.pProjectileFactory, 0);
+    context->getLibScript()->call_on_internal_event_callbacks(InternalEvents::CONSTRUCT_PROJECTILE_FACTORY, 1);
+    lua_pop(context->GetLua(), 1);
+}
+
+HOOK_METHOD(ProjectileFactory, destructor, () -> void)
+{
+    LOG_HOOK("HOOK_METHOD -> ProjectileFactory::destructor -> Begin (ProjectileFactory_Extend.cpp)\n")
+    HS_BREAK_TABLE(this)
+    delete PF_EX(this);
+
+    return super();
+}
+
+ProjectileFactory_Extend* Get_ProjectileFactory_Extend(ProjectileFactory* c)
+{
+    if (!c) return nullptr;
+
+    uintptr_t dEx = 0;
+
+#ifdef __amd64__
+    dEx <<= 8;
+    dEx |= c->gap_ex_1[2];
+    dEx <<= 8;
+    dEx |= c->gap_ex_1[3];
+    dEx <<= 8;
+    dEx |= c->gap_ex_2[2];
+    dEx <<= 8;
+    dEx |= c->gap_ex_2[3];
+#endif // __amd64__
+    dEx <<= 8;
+    dEx |= c->gap_ex_1[0];
+    dEx <<= 8;
+    dEx |= c->gap_ex_1[1];
+    dEx <<= 8;
+    dEx |= c->gap_ex_2[0];
+    dEx <<= 8;
+    dEx |= c->gap_ex_2[1];
+
+    return (ProjectileFactory_Extend*)dEx;
+}

--- a/ProjectileFactory_Extend.cpp
+++ b/ProjectileFactory_Extend.cpp
@@ -1,5 +1,6 @@
 #include "ProjectileFactory_Extend.h"
-
+#include "luaInclude.h"
+#include "Global.h"
 
 HOOK_METHOD_PRIORITY(ProjectileFactory, constructor, 900, (const WeaponBlueprint *bp, int shipId) -> void)
 {

--- a/ProjectileFactory_Extend.cpp
+++ b/ProjectileFactory_Extend.cpp
@@ -1,12 +1,12 @@
 #include "ProjectileFactory_Extend.h"
 
 
-HOOK_METHOD_PRIORITY(ProjectileFactory, constructor, 900, (int iShipId) -> void)
+HOOK_METHOD_PRIORITY(ProjectileFactory, constructor, 900, (const WeaponBlueprint *bp, int shipId) -> void)
 {
     LOG_HOOK("HOOK_METHOD_PRIORITY -> ProjectileFactory::constructor -> Begin (ProjectileFactory_Extend.cpp)\n")
 
 
-	super(iShipId);
+	super(bp, shipId);
 
 	auto ex = new ProjectileFactory_Extend();
 

--- a/ProjectileFactory_Extend.h
+++ b/ProjectileFactory_Extend.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "FTLGame.h"
+
+struct ProjectileFactory_Extend
+{
+    ProjectileFactory *orig;
+    bool cleanUpBlueprint = false;
+
+    ~ProjectileFactory_Extend()
+    {
+        if (this->cleanUpBlueprint && this->orig) {
+            delete this->orig->blueprint;
+            this->orig->blueprint = nullptr;
+        }
+    }
+};
+
+ProjectileFactory_Extend* Get_ProjectileFactory_Extend(ProjectileFactory* c);
+
+#define PF_EX Get_ProjectileFactory_Extend

--- a/ProjectileFactory_Extend.h
+++ b/ProjectileFactory_Extend.h
@@ -4,13 +4,15 @@
 struct ProjectileFactory_Extend
 {
     ProjectileFactory *orig;
-    bool cleanUpBlueprint = false;
+    const WeaponBlueprint *detachedBlueprint = nullptr;
 
     ~ProjectileFactory_Extend()
     {
-        if (this->cleanUpBlueprint && this->orig) {
-            delete this->orig->blueprint;
-            this->orig->blueprint = nullptr;
+        if (this->detachedBlueprint) {
+            if (this->orig && this->orig->blueprint == this->detachedBlueprint) {
+                this->orig->blueprint = nullptr;
+            }
+            delete this->detachedBlueprint;
         }
     }
 };

--- a/libzhlgen/test/functions/ELF_amd64/FTLGameStripped.h
+++ b/libzhlgen/test/functions/ELF_amd64/FTLGameStripped.h
@@ -3633,10 +3633,12 @@ struct ProjectileFactory
   int numShots;
   float currentFiringAngle;
   float currentEntryAngle;
+  uint8_t gap_ex_1[4];
   Targetable *currentShipTarget;
   CloakingSystem *cloakingSystem;
   WeaponAnimation weaponVisual;
   WeaponMount mount;
+  uint8_t gap_ex_2[4];
   std__vector_12ProjectileZ1 queuedProjectiles;
   int iBonusPower;
   bool bFiredOnce;

--- a/libzhlgen/test/functions/ELF_x86/FTLGameStripped.ELF32.h
+++ b/libzhlgen/test/functions/ELF_x86/FTLGameStripped.ELF32.h
@@ -3637,6 +3637,7 @@ struct ProjectileFactory
   std__vector_12ProjectileZ1 queuedProjectiles;
   int iBonusPower;
   bool bFiredOnce;
+  uint8_t gap_ex_1[2]
   int iSpendMissile;
   float cooldownModifier;
   int shotsFiredAtTarget;
@@ -3647,6 +3648,7 @@ struct ProjectileFactory
   int iHackLevel;
   int goalChargeLevel;
   bool isArtillery;
+  uint8_t gap_ex_2[2]
 };
 
 /* 554 */

--- a/libzhlgen/test/functions/ELF_x86/FTLGameStripped.ELF32.h
+++ b/libzhlgen/test/functions/ELF_x86/FTLGameStripped.ELF32.h
@@ -3637,7 +3637,7 @@ struct ProjectileFactory
   std__vector_12ProjectileZ1 queuedProjectiles;
   int iBonusPower;
   bool bFiredOnce;
-  uint8_t gap_ex_1[2]
+  uint8_t gap_ex_1[2];
   int iSpendMissile;
   float cooldownModifier;
   int shotsFiredAtTarget;
@@ -3648,7 +3648,7 @@ struct ProjectileFactory
   int iHackLevel;
   int goalChargeLevel;
   bool isArtillery;
-  uint8_t gap_ex_2[2]
+  uint8_t gap_ex_2[2];
 };
 
 /* 554 */

--- a/libzhlgen/test/functions/mac/FTLGameStripped.h
+++ b/libzhlgen/test/functions/mac/FTLGameStripped.h
@@ -3645,10 +3645,12 @@ struct ProjectileFactory
   int numShots;
   float currentFiringAngle;
   float currentEntryAngle;
+  uint8_t gap_ex_1[4];
   Targetable *currentShipTarget;
   CloakingSystem *cloakingSystem;
   WeaponAnimation weaponVisual;
   WeaponMount mount;
+  uint8_t gap_ex_2[4];
   std__vector_12ProjectileZ1 queuedProjectiles;
   int iBonusPower;
   bool bFiredOnce;

--- a/libzhlgen/test/functions/win32/FTLGameStripped.h
+++ b/libzhlgen/test/functions/win32/FTLGameStripped.h
@@ -3642,6 +3642,7 @@ struct ProjectileFactory
   std__vector_12ProjectileZ1 queuedProjectiles;
   int iBonusPower;
   bool bFiredOnce;
+  uint8_t gap_ex_1[2];
   int iSpendMissile;
   float cooldownModifier;
   int shotsFiredAtTarget;
@@ -3652,6 +3653,7 @@ struct ProjectileFactory
   int iHackLevel;
   int goalChargeLevel;
   bool isArtillery;
+  uint8_t gap_ex_2[2];
 };
 
 /* 554 */

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -2838,12 +2838,14 @@ We can expose them once the root cause is identified and the crash is fixed.
 
 //%nodefaultctor AugmentBlueprint;
 %nodefaultdtor AugmentBlueprint;
+%copyctor AugmentBlueprint;
 %rename("%s") AugmentBlueprint;
 %rename("%s") AugmentBlueprint::value;
 %rename("%s") AugmentBlueprint::stacking;
 
 //%nodefaultctor WeaponBlueprint;
 %nodefaultdtor WeaponBlueprint;
+%copyctor WeaponBlueprint;
 %rename("%s") WeaponBlueprint;
 %rename("%s") WeaponBlueprint::BoostPower;
 %rename("%s") WeaponBlueprint::BoostPower::type;
@@ -3960,6 +3962,7 @@ We can expose them once the root cause is identified and the crash is fixed.
 %rename("%s") DroneBlueprint;
 //%nodefaultctor DroneBlueprint;
 %nodefaultdtor DroneBlueprint;
+%copyctor DroneBlueprint;
 
 //%immutable DroneBlueprint::typeName;
 %rename("%s") DroneBlueprint::typeName;

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -2463,13 +2463,14 @@ We can expose them once the root cause is identified and the crash is fixed.
 
 %rename("%s") ProjectileFactory::DetachFromGlobalBlueprint;
 %extend ProjectileFactory {
-    ShipManager_Extend* extend;
+    ProjectileFactory_Extend* extend;
     void DetachFromGlobalBlueprint() 
     {
-        if ($self->extend && !$self->extend->cleanupBlueprint && $self->blueprint) {
+        ProjectileFactory_Extend* ex = Get_ProjectileFactory_Extend($self);
+        if (ex && !ex->cleanUpBlueprint && $self->blueprint) {
             $self->blueprint = new WeaponBlueprint(*$self->blueprint);
-            $self->extend->cleanUpBlueprint = true;
-        } 
+            ex->cleanUpBlueprint = true;
+        }
     };
 }
 %wrapper %{

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -16,6 +16,7 @@
 #include "CustomShipSelect.h"
 #include "CrewMember_Extend.h"
 #include "Projectile_Extend.h"
+#include "ProjectileFactory_Extend.h"
 #include "ShipManager_Extend.h"
 #include "System_Extend.h"
 #include "SystemBox_Extend.h"
@@ -2457,6 +2458,31 @@ We can expose them once the root cause is identified and the crash is fixed.
 %rename("%s") ProjectileFactory::goalChargeLevel;
 %rename("%s") ProjectileFactory::isArtillery;
 
+%immutable ProjectileFactory::extend;
+%rename("%s") ProjectileFactory::extend;
+
+%extend ProjectileFactory {
+    ShipManager_Extend* extend;
+    void DetachFromGlobalBlueprint() 
+    {
+        if (this->extend && !this->extend->cleanupBlueprint && this->blueprint) {
+            this->blueprint = new WeaponBlueprint(*this->blueprint);
+            this->extend->cleanUpBlueprint = true;
+        } 
+    };
+}
+%wrapper %{
+    static ProjectileFactory_Extend *ProjectileFactory_extend_get(ProjectileFactory* ProjectileFactory)
+    {
+        return Get_ProjectileFactory_Extend(ProjectileFactory);
+    };
+%}
+
+%nodefaultctor ProjectileFactory_Extend;
+%rename("%s") ProjectileFactory_Extend;
+%rename("%s") ProjectileFactory_Extend::cleanUpBlueprint;
+%immutable ProjectileFactory_Extend::cleanUpBlueprint;
+
 %nodefaultctor WeaponMount;
 %nodefaultdtor WeaponMount;
 %rename("%s") WeaponMount;
@@ -4731,6 +4757,7 @@ We can expose them once the root cause is identified and the crash is fixed.
 %include "CustomShips.h"
 %include "CrewMember_Extend.h"
 %include "Projectile_Extend.h"
+%include "ProjectileFactory_Extend.h"
 %include "ShipManager_Extend.h"
 %include "System_Extend.h"
 %include "SystemBox_Extend.h"

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -2796,26 +2796,47 @@ We can expose them once the root cause is identified and the crash is fixed.
 //%rename("%s") BlueprintManager::GetSystemBlueprint;
 %rename("%s") BlueprintManager::GetWeaponBlueprint;
 %rename("%s") BlueprintManager::GetBlueprintList;
-
 %rename("%s") BlueprintManager::GetRandomAugment;
 %rename("%s") BlueprintManager::GetRandomDrone;
 %rename("%s") BlueprintManager::GetRandomWeapon;
+%extend BlueprintManager {
+    void RegisterAugmentBlueprint(const AugmentBlueprint& bp)
+    {
+        $self->augmentBlueprints.emplace(bp.name, bp)
+    }
+    void RegisterDroneBlueprint(const DroneBlueprint& bp)
+    {
+        $self->droneBlueprints.emplace(bp.name, bp)
+    }
+    void RegisterWeaponBlueprint(const WeaponBlueprint& bp)
+    {
+        $self->weaponBlueprints.emplace(bp.name, bp)
+    }
+}
 
 %rename("%s") BlueprintManager::shipBlueprints;
+%immutable BlueprintManager::shipBlueprints;
 %rename("%s") BlueprintManager::weaponBlueprints;
+%immutable BlueprintManager::weaponBlueprints;
 %rename("%s") BlueprintManager::droneBlueprints;
+%immutable BlueprintManager::droneBlueprints;
 %rename("%s") BlueprintManager::augmentBlueprints;
+%immutable BlueprintManager::augmentBlueprints;
 %rename("%s") BlueprintManager::crewBlueprints;
+%immutable BlueprintManager::crewBlueprints;
 //%rename("%s") BlueprintManager::systemBlueprints;
+//%immutable BlueprintManager::systemBlueprints;
 %rename("%s") BlueprintManager::blueprintLists;
+%immutable BlueprintManager::blueprintLists;
 
-%nodefaultctor AugmentBlueprint;
+
+//%nodefaultctor AugmentBlueprint;
 %nodefaultdtor AugmentBlueprint;
 %rename("%s") AugmentBlueprint;
 %rename("%s") AugmentBlueprint::value;
 %rename("%s") AugmentBlueprint::stacking;
 
-%nodefaultctor WeaponBlueprint;
+//%nodefaultctor WeaponBlueprint;
 %nodefaultdtor WeaponBlueprint;
 %rename("%s") WeaponBlueprint;
 %rename("%s") WeaponBlueprint::BoostPower;
@@ -3931,28 +3952,28 @@ We can expose them once the root cause is identified and the crash is fixed.
 
 
 %rename("%s") DroneBlueprint;
-%nodefaultctor DroneBlueprint;
+//%nodefaultctor DroneBlueprint;
 %nodefaultdtor DroneBlueprint;
 
-%immutable DroneBlueprint::typeName;
+//%immutable DroneBlueprint::typeName;
 %rename("%s") DroneBlueprint::typeName;
-%immutable DroneBlueprint::level;
+//%immutable DroneBlueprint::level;
 %rename("%s") DroneBlueprint::level;
-%immutable DroneBlueprint::targetType;
+//%immutable DroneBlueprint::targetType;
 %rename("%s") DroneBlueprint::targetType;
-%immutable DroneBlueprint::power;
+//%immutable DroneBlueprint::power;
 %rename("%s") DroneBlueprint::power;
-%immutable DroneBlueprint::cooldown;
+//%immutable DroneBlueprint::cooldown;
 %rename("%s") DroneBlueprint::cooldown;
-%immutable DroneBlueprint::speed;
+//%immutable DroneBlueprint::speed;
 %rename("%s") DroneBlueprint::speed;
-%immutable DroneBlueprint::dodge;
+//%immutable DroneBlueprint::dodge;
 %rename("%s") DroneBlueprint::dodge;
-%immutable DroneBlueprint::weaponBlueprint;
+//%immutable DroneBlueprint::weaponBlueprint;
 %rename("%s") DroneBlueprint::weaponBlueprint;
-%immutable DroneBlueprint::droneImage;
+//%immutable DroneBlueprint::droneImage;
 %rename("%s") DroneBlueprint::droneImage;
-%immutable DroneBlueprint::combatIcon;
+//%immutable DroneBlueprint::combatIcon;
 %rename("%s") DroneBlueprint::combatIcon;
 
 %luacode {

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -2481,6 +2481,7 @@ We can expose them once the root cause is identified and the crash is fixed.
 %}
 
 %nodefaultctor ProjectileFactory_Extend;
+%nodefaultdtor ProjectileFactory_Extend;
 %rename("%s") ProjectileFactory_Extend;
 %immutable ProjectileFactory_Extend::isBlueprintDetached;
 %rename("%s") ProjectileFactory_Extend::isBlueprintDetached;

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -2461,6 +2461,7 @@ We can expose them once the root cause is identified and the crash is fixed.
 %immutable ProjectileFactory::extend;
 %rename("%s") ProjectileFactory::extend;
 
+%rename("%s") ProjectileFactory::DetachFromGlobalBlueprint;
 %extend ProjectileFactory {
     ShipManager_Extend* extend;
     void DetachFromGlobalBlueprint() 
@@ -2831,6 +2832,9 @@ We can expose them once the root cause is identified and the crash is fixed.
 %rename("%s") BlueprintManager::GetRandomAugment;
 %rename("%s") BlueprintManager::GetRandomDrone;
 %rename("%s") BlueprintManager::GetRandomWeapon;
+%rename("%s") BlueprintManager::RegisterAugmentBlueprint;
+%rename("%s") BlueprintManager::RegisterDroneBlueprint;
+%rename("%s") BlueprintManager::RegisterWeaponBlueprint;
 %extend BlueprintManager {
     void RegisterAugmentBlueprint(const AugmentBlueprint& bp)
     {

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -370,6 +370,12 @@ namespace std {
     %template(vector_vector_AnimationTracker) vector<vector<AnimationTracker>>;
     %template(vector_bool) vector<bool>;
     %template(vector_vector_bool) vector<vector<bool>>;
+    %template(map_string_ShipBlueprint) map<string, ShipBlueprint>;
+    %template(map_string_WeaponBlueprint) map<string, WeaponBlueprint>;
+    %template(map_string_DroneBlueprint) map<string, DroneBlueprint>;
+    %template(map_string_AugmentBlueprint) map<string, AugmentBlueprint>;
+    %template(map_string_CrewBlueprint) map<string, CrewBlueprint>;
+    %template(map_string_vector_string) map<string, vector<string>>;
 }
 /*
 OBSOLETE METHOD FOR DOWNCASTING:

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -2466,9 +2466,9 @@ We can expose them once the root cause is identified and the crash is fixed.
     ShipManager_Extend* extend;
     void DetachFromGlobalBlueprint() 
     {
-        if (this->extend && !this->extend->cleanupBlueprint && this->blueprint) {
-            this->blueprint = new WeaponBlueprint(*this->blueprint);
-            this->extend->cleanUpBlueprint = true;
+        if ($self->extend && !$self->extend->cleanupBlueprint && $self->blueprint) {
+            $self->blueprint = new WeaponBlueprint(*$self->blueprint);
+            $self->extend->cleanUpBlueprint = true;
         } 
     };
 }
@@ -2838,15 +2838,15 @@ We can expose them once the root cause is identified and the crash is fixed.
 %extend BlueprintManager {
     void RegisterAugmentBlueprint(const AugmentBlueprint& bp)
     {
-        $self->augmentBlueprints.emplace(bp.name, bp)
+        $self->augmentBlueprints.emplace(bp.name, bp);
     }
     void RegisterDroneBlueprint(const DroneBlueprint& bp)
     {
-        $self->droneBlueprints.emplace(bp.name, bp)
+        $self->droneBlueprints.emplace(bp.name, bp);
     }
     void RegisterWeaponBlueprint(const WeaponBlueprint& bp)
     {
-        $self->weaponBlueprints.emplace(bp.name, bp)
+        $self->weaponBlueprints.emplace(bp.name, bp);
     }
 }
 

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -2464,12 +2464,12 @@ We can expose them once the root cause is identified and the crash is fixed.
 %rename("%s") ProjectileFactory::DetachFromGlobalBlueprint;
 %extend ProjectileFactory {
     ProjectileFactory_Extend* extend;
-    void DetachFromGlobalBlueprint() 
+    void DetachFromGlobalBlueprint()
     {
         ProjectileFactory_Extend* ex = Get_ProjectileFactory_Extend($self);
-        if (ex && !ex->cleanUpBlueprint && $self->blueprint) {
+        if (ex && !ex->detachedBlueprint && $self->blueprint) {
             $self->blueprint = new WeaponBlueprint(*$self->blueprint);
-            ex->cleanUpBlueprint = true;
+            ex->detachedBlueprint = $self->blueprint;
         }
     };
 }
@@ -2482,8 +2482,18 @@ We can expose them once the root cause is identified and the crash is fixed.
 
 %nodefaultctor ProjectileFactory_Extend;
 %rename("%s") ProjectileFactory_Extend;
-%rename("%s") ProjectileFactory_Extend::cleanUpBlueprint;
-%immutable ProjectileFactory_Extend::cleanUpBlueprint;
+%immutable ProjectileFactory_Extend::isBlueprintDetached;
+%rename("%s") ProjectileFactory_Extend::isBlueprintDetached;
+%extend ProjectileFactory_Extend {
+    bool isBlueprintDetached;
+}
+%wrapper %{
+    static bool ProjectileFactory_Extend_isBlueprintDetached_get(ProjectileFactory_Extend* ex)
+    {
+        return ex->detachedBlueprint && ex->orig
+                && ex->detachedBlueprint == ex->orig->blueprint;
+    };
+%}
 
 %nodefaultctor WeaponMount;
 %nodefaultdtor WeaponMount;
@@ -2875,7 +2885,7 @@ We can expose them once the root cause is identified and the crash is fixed.
 %rename("%s") AugmentBlueprint::stacking;
 
 //%nodefaultctor WeaponBlueprint;
-%nodefaultdtor WeaponBlueprint;
+//%nodefaultdtor WeaponBlueprint;
 %copyctor WeaponBlueprint;
 %rename("%s") WeaponBlueprint;
 %rename("%s") WeaponBlueprint::BoostPower;

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -2793,8 +2793,21 @@ We can expose them once the root cause is identified and the crash is fixed.
 %rename("%s") BlueprintManager::GetCrewBlueprint;
 %rename("%s") BlueprintManager::GetDroneBlueprint;
 %rename("%s") BlueprintManager::GetShipBlueprint;
+//%rename("%s") BlueprintManager::GetSystemBlueprint;
 %rename("%s") BlueprintManager::GetWeaponBlueprint;
 %rename("%s") BlueprintManager::GetBlueprintList;
+
+%rename("%s") BlueprintManager::GetRandomAugment;
+%rename("%s") BlueprintManager::GetRandomDrone;
+%rename("%s") BlueprintManager::GetRandomWeapon;
+
+%rename("%s") BlueprintManager::shipBlueprints;
+%rename("%s") BlueprintManager::weaponBlueprints;
+%rename("%s") BlueprintManager::droneBlueprints;
+%rename("%s") BlueprintManager::augmentBlueprints;
+%rename("%s") BlueprintManager::crewBlueprints;
+//%rename("%s") BlueprintManager::systemBlueprints;
+%rename("%s") BlueprintManager::blueprintLists;
 
 %nodefaultctor AugmentBlueprint;
 %nodefaultdtor AugmentBlueprint;

--- a/wiki/Lua-Hyperspace-Module.md
+++ b/wiki/Lua-Hyperspace-Module.md
@@ -2999,6 +2999,8 @@ Accessed via `Hyperspace.CustomAugmentManager.GetInstance()`
 - `void :SetCooldownModifier(float mod)`
 - `void :SetCurrentShip(Targetable *ship)`
 - `void :SetHacked(int hacked)`
+- `void :DetachFromGlobalBlueprint()`
+   - Detaches this weapon's blueprint from the global blueprint used by all weapons of this type, this lets you modify this weapon's blueprint without affecting all other weapons of this type.
 
 ### Fields
 - `std::pair<float, float>` `.cooldown`
@@ -3036,6 +3038,17 @@ Accessed via `Hyperspace.CustomAugmentManager.GetInstance()`
 - `int` `.iHackLevel`
 - `int` `.goalChargeLevel`
 - `bool` `.isArtillery`
+- [`ProjectileFactory_Extend`](#ProjectileFactory_Extend) `.extend`
+   - **read-only**
+
+## ProjectileFactory_Extend
+
+Accessed via `ProjectileFactory`'s `.extend` field
+
+### Fields
+- `bool` `.cleanUpBlueprint`
+   - **read-only**
+   - Indicates whether the blueprint of this weapon has been detached from the global blueprint for this weapon type. If true the blueprint for this weapon will be destroyed with the weapon.
 
 ## WeaponMount
 

--- a/wiki/Lua-Hyperspace-Module.md
+++ b/wiki/Lua-Hyperspace-Module.md
@@ -3046,7 +3046,7 @@ Accessed via `Hyperspace.CustomAugmentManager.GetInstance()`
 Accessed via `ProjectileFactory`'s `.extend` field
 
 ### Fields
-- `bool` `.cleanUpBlueprint`
+- `bool` `.isBlueprintDetached`
    - **read-only**
    - Indicates whether the blueprint of this weapon has been detached from the global blueprint for this weapon type. If true the blueprint for this weapon will be destroyed with the weapon.
 

--- a/wiki/Lua-Hyperspace-Module.md
+++ b/wiki/Lua-Hyperspace-Module.md
@@ -3187,7 +3187,18 @@ Accessed via `Hyperspace.CustomAugmentManager.GetInstance()`
 - [`DroneBlueprint`](#DroneBlueprint) `:*GetDroneBlueprint(std::string name)`
 - [`ShipBlueprint`](#ShipBlueprint) `:*GetShipBlueprint(std::string name, int sector)`
 - [`WeaponBlueprint`](#WeaponBlueprint) `:*GetWeaponBlueprint(std::string name)`
-- `std::vector<std::string> :GetBlueprintList(std::string name)`
+- `std::vector<std::string>` `:GetBlueprintList(std::string name)`
+- [`std::vector<AugmentBlueprint*>`](#AugmentBlueprint) `:GetRandomAugment(int count, bool demo_lock);`
+- [`std::vector<DroneBlueprint*>`](#DroneBlueprint) `:GetRandomDrone(int count, bool demo_lock)`
+- [`std::vector<WeaponBlueprint*>`](#WeaponBlueprint) `:GetRandomWeapon(int count, bool demo_lock)`
+
+### Fields
+- [`std::map<std::string, ShipBlueprint>`](#ShipBlueprint) `.shipBlueprints;`
+- [`std::map<std::string, WeaponBlueprint>`](#WeaponBlueprint) `.weaponBlueprints;`
+- [`std::map<std::string, DroneBlueprint>`](#DroneBlueprint) `.droneBlueprints;`
+- [`std::map<std::string, AugmentBlueprint>`](#AugmentBlueprint) `.augmentBlueprints;`
+- [`std::map<std::string, CrewBlueprint>`](#CrewBlueprint) `.crewBlueprints;`
+- `std::map<std::string, std::vector<std::string>>` `.blueprintLists;`
 
 ## AugmentBlueprint
 

--- a/wiki/Lua-Hyperspace-Module.md
+++ b/wiki/Lua-Hyperspace-Module.md
@@ -1327,7 +1327,6 @@ No methods are exposed currently.
 **Extends [`Blueprint`](#blueprint)**
 
 ### Fields
-**All fields are read-only**
 - `std::string` `.typeName`
 - `int` `.level`
 - `int` `.targetType`
@@ -3191,14 +3190,26 @@ Accessed via `Hyperspace.CustomAugmentManager.GetInstance()`
 - [`std::vector<AugmentBlueprint*>`](#AugmentBlueprint) `:GetRandomAugment(int count, bool demo_lock);`
 - [`std::vector<DroneBlueprint*>`](#DroneBlueprint) `:GetRandomDrone(int count, bool demo_lock)`
 - [`std::vector<WeaponBlueprint*>`](#WeaponBlueprint) `:GetRandomWeapon(int count, bool demo_lock)`
+- `void` `:RegisterAugmentBlueprint(AugmentBlueprint bp)`
+   - Registers a lua created augment blueprint to the relevant blueprint list
+- `void` `:RegisterDroneBlueprint(DroneBlueprint bp)`
+   - Registers a lua created drone blueprint to the relevant blueprint list
+- `void` `:RegisterWeaponBlueprint(WeaponBlueprint bp)`
+   - Registers a lua created weapon blueprint to the relevant blueprint list
 
 ### Fields
 - [`std::map<std::string, ShipBlueprint>`](#ShipBlueprint) `.shipBlueprints;`
+   - **read-only**
 - [`std::map<std::string, WeaponBlueprint>`](#WeaponBlueprint) `.weaponBlueprints;`
+   - **read-only**
 - [`std::map<std::string, DroneBlueprint>`](#DroneBlueprint) `.droneBlueprints;`
+   - **read-only**
 - [`std::map<std::string, AugmentBlueprint>`](#AugmentBlueprint) `.augmentBlueprints;`
+   - **read-only**
 - [`std::map<std::string, CrewBlueprint>`](#CrewBlueprint) `.crewBlueprints;`
+   - **read-only**
 - `std::map<std::string, std::vector<std::string>>` `.blueprintLists;`
+   - **read-only**
 
 ## AugmentBlueprint
 


### PR DESCRIPTION
Resolves following issues:
[API Request] Expose BlueprintManager methods #717
Expose Blueprint Constuctors #790

Implements `ProjectileFactory_Extend` structure, and `.cleanUpBlueprint` field which causes weapon to destroy its blueprint upon it's own destruction.
Alongside this it implements `:DetachFromGlobalBlueprint()` for the `ProjectileFactory` so that the projectile factory's blueprint can be edited from lua without affecting every other weapon of the same type.

Not implemented but would be a good idea, adding similar extensions and methods for other objects and their blueprints, such as drones, augments, and maybe crew.

Exposes the following methods:
- `ProjectileFactory:DetachFromGlobalBlueprint()`
- `BlueprintManager:GetRandomAugment(int count, bool demo_lock)`
- `BlueprintManager:GetRandomDrone(int count, bool demo_lock)`
- `BlueprintManager:GetRandomWeapon(int count, bool demo_lock)`

Exposes the following fields:
- `ProjectileFactory.extend`
- `BlueprintManager.shipBlueprints`
- `BlueprintManager.weaponBlueprints`
- `BlueprintManager.droneBlueprints`
- `BlueprintManager.augmentBlueprints`
- `BlueprintManager.crewBlueprints`
- `BlueprintManager.blueprintLists`

One possible extra addition would be implementing a persistant unique `selfId` for the `ProjectileFactory_Extend` which would allow mod developers to save things for specific in playerVariables, similar to that which can be done for `crewMember` structures.
This hasn't been done yet, but I would like to include it in this PR if possible.