### PR TITLE
Remove trailing "(Change Lang)" from change_language string for parity

### DIFF
--- a/Mod Files/data/text-ko.xml
+++ b/Mod Files/data/text-ko.xml
@@ -249,7 +249,7 @@
 <text name="chance_of_fire" language="ko">방화</text>
 <text name="chance_of_separator" language="ko">,</text>
 <text name="chance_of_stun" language="ko">기절</text>
-<text name="change_language" language="ko">언어 변경(Change Lang)</text>
+<text name="change_language" language="ko">언어 변경</text>
 <text name="charge" language="ko">최대 탄수: \1</text>
 <text name="charge_time" language="ko">충전 시간: \1초</text>
 <text name="choose_language" language="ko">언어 선택</text>


### PR DESCRIPTION
Korean only:
<img width="278" height="83" alt="Bildschirmfoto 2026-08-09 um 00 58 56" src="https://github.com/user-attachments/assets/c59f7bf0-13f5-4021-a1c9-d2c523fcf3fe" />
Vanilla languages:
<img width="197" height="98" alt="Bildschirmfoto 2026-08-09 um 00 59 06" src="https://github.com/user-attachments/assets/cfcbc297-3565-43c6-b679-753d5e02c3c9" />
<img width="325" height="97" alt="Bildschirmfoto 2026-08-09 um 00 59 15" src="https://github.com/user-attachments/assets/f0a624f8-e13f-4416-8bff-76047e0dc1ec" />
<img width="254" height="100" alt="Bildschirmfoto 2026-08-09 um 00 59 22" src="https://github.com/user-attachments/assets/cf059b4a-a2fb-4ae0-95c0-39d5f0594a16" />
