### PR TITLE
Expose Hotkey Getters

### DIFF
--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -4556,6 +4556,20 @@ We can expose them once the root cause is identified and the crash is fixed.
 %rename("%s") SettingValues::beamTutorial;
 %immutable SettingValues::beamTutorial;
 
+%rename("%s") SettingValues::GetHotkey;
+%rename("%s") SettingValues::GetHotkeyName;
+%extend SettingValues {
+    SDLKey GetHotkey(const std::string &hotkeyName)
+    {
+        return Settings::GetHotkey(hotkeyName);
+    }
+    std::string GetHotkeyName(const std::string &name)
+    {
+        return Settings::GetHotkeyName(name);
+    }
+}
+
+
 //Access PrintHelper singleton through Hyperspace.PrintHelper.GetInstance()
 %nodefaultctor PrintHelper;
 %nodefaultdtor PrintHelper;

--- a/wiki/Lua-Hyperspace-Module.md
+++ b/wiki/Lua-Hyperspace-Module.md
@@ -3729,6 +3729,12 @@ Accessed via `Projectile`'s `.extend` field
 
 ## SettingValues
 
+### Methods
+- [`SDLKey`](Lua-Defines-Module.md#SDLkeys) `:GetHotkey(const std::string &hotkeyName)`
+   - hotkeyName can be found by looking at text_tooltips.xml, the text entries `"hotkey_activate_cloak"` contain the relevant hotkey id, in this case that would be `activate_cloak`
+- `std::string :GetHotkeyName(const std::string &name)`
+   - returns the printable name of the key assigned to this hotkey, such as "SPACE" for `KEY_SPACE`
+
 ### Fields
 **All fields are read-only**
 - `int` `.fullscreen`


### PR DESCRIPTION
Add helper functions to SettingValue struct that call the hotkey getter functions.

```lua
    Hyperspace.Settings:GetHotkey("activate_cloak")
    Hyperspace.Settings:GetHotkeyName("activate_cloak")
```

`Settings` struct has not been exposed as `SettingValue` struct is already occupying the `Settings` namespace in lua.