### PR TITLE
Rework overhaul detection to warn on wrong patch order

### DIFF
--- a/Mod Files/data/hyperspace.xml
+++ b/Mod Files/data/hyperspace.xml
@@ -17,6 +17,17 @@
 -->
 <version>^1.22.2</version>
 
+<!--
+    Identifies this file as the Hyperspace base mod's own hyperspace.xml.
+    Mods that ship their own hyperspace.xml (overhauls like Multiverse) must set
+    <isBasemod>false</isBasemod>, or simply leave the tag out since it defaults to false.
+    
+    If this file is still the active one while overhaul data is present in ftl.dat,
+    hyperspace.ftl was patched after the overhaul and has overwritten some of its
+    files and Hyperspace will warn about this on startup.
+-->
+<isBasemod>true</isBasemod>
+
 <!-- Hyperspace defaults
 
 Allows some default parameters to be configured by the mod.

--- a/Resources.cpp
+++ b/Resources.cpp
@@ -39,6 +39,7 @@
 #include "CustomEquipment.h"
 #include "CustomTabbedWindow.h"
 #include "ArtillerySystem.h"
+#include "src/features/overhaul-detection/OverhaulDetection.h"
 
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/replace.hpp>
@@ -58,34 +59,13 @@ HOOK_METHOD(ResourceControl, PreloadResources, (bool unk) -> bool)
 {
     LOG_HOOK("HOOK_METHOD -> ResourceControl::PreloadResources -> Begin (Resources.cpp)\n")
 
-    /* Search for files unique to MV & HS FTL zips so we can determine if a user patched both files in error */
-    printf("Scanning for Multiverse & Hyperspace patching in ftl.dat\n");
-    typedef void (*list_files_start_funcptr)(PackageModuleInfo* info_arg);
-    typedef char* (*list_files_next_funcptr)(PackageModuleInfo* info_arg);
-    list_files_start_funcptr list_files_start = (list_files_start_funcptr) this->package->list_files_start;
-    list_files_next_funcptr list_files_next = (list_files_next_funcptr) this->package->list_files_next;
-
-    list_files_start(this->package);
-    bool mvDetected = false;
-    bool hsDetected = false;
-    for(char* pkgFile; pkgFile = list_files_next(this->package), pkgFile != (char*) 0x0;)
-    {
-        if(!mvDetected && strstr(pkgFile, "audio/music/mv_MUS_") == pkgFile)
-            mvDetected = true;
-        else if(!hsDetected && strcmp(pkgFile, "example_layout_syntax.xml") == 0)
-            hsDetected = true;
-        else if(hsDetected && mvDetected)
-            break;
-    }
-    printf("ftl.dat scan detection: Hyperspace.ftl: %s, Multiverse.zip: %s\n", hsDetected ? "YES" : "NO", mvDetected ? "YES" : "NO");
-
-    if(mvDetected && hsDetected)
-        ErrorMessage("Hyperspace & Multiverse both detected patched into ftl.dat!\nPlease patch only Multiverse and not hyperspace.ftl\n");
+    OverhaulDetection::ScanPackage(this);
 
     bool ret = super(unk);
     if (ret && G_)
     {
         G_->PreInitializeResources(this);
+        OverhaulDetection::CheckPatchOrder();
     }
     return ret;
 }
@@ -181,6 +161,11 @@ void Global::PreInitializeResources(ResourceControl *resources)
                             checkedVersion = v_major == HS_Version.major && (v_minor < HS_Version.minor || (v_minor == HS_Version.minor && v_patch <= HS_Version.patch));
                     }
                 }
+            }
+
+            if (strcmp(node->name(), "isBasemod") == 0)
+            {
+                OverhaulDetection::SetBasemodXml(EventsParser::ParseBoolean(node->value()));
             }
 
             if (strcmp(node->name(), "defaults") == 0)

--- a/src/features/overhaul-detection/OverhaulDetection.cpp
+++ b/src/features/overhaul-detection/OverhaulDetection.cpp
@@ -11,6 +11,7 @@ namespace {
     const char *const overhaulFingerprints[] = {
         "data/events_special_multiverse.xml", // Multiverse
         "img/achievements/insach_stonks.png", // Insurrection+
+        "data/alhazrad/arsenalVersion.lua",  // Arsenal+ for Hyperspace
         "data/is_overhaul_mod.xml", // Opt-in marker any overhaul can ship, see wiki/Hyperspace.xml.md
     };
 

--- a/src/features/overhaul-detection/OverhaulDetection.cpp
+++ b/src/features/overhaul-detection/OverhaulDetection.cpp
@@ -1,0 +1,48 @@
+#include "OverhaulDetection.h"
+#include "Global.h"
+
+#include <cstdio>
+#include <cstring>
+
+namespace {
+    // Files unique to known overhaul mods; any one present in ftl.dat proves an
+    // overhaul was patched in. Patching only adds or replaces files, so these
+    // survive any mods stacked on top.
+    const char *const overhaulFingerprints[] = {
+        "data/events_special_multiverse.xml", // Multiverse
+        "img/achievements/insach_stonks.png", // Insurrection+
+        "data/is_overhaul_mod.xml", // Opt-in marker any overhaul can ship, see wiki/Hyperspace.xml.md
+    };
+
+    bool overhaulDetected = false;
+    bool basemodXmlActive = false;
+}
+
+void OverhaulDetection::ScanPackage(ResourceControl *resources)
+{
+    PackageModuleInfo *package = resources->package;
+    if (!package || !package->list_files_start || !package->list_files_next) return;
+
+    package->list_files_start(package);
+    for (const char *pkgFile; !overhaulDetected && (pkgFile = package->list_files_next(package)) != nullptr;)
+    {
+        for (const char *fingerprint : overhaulFingerprints)
+        {
+            if (strcmp(pkgFile, fingerprint) == 0)
+                overhaulDetected = true;
+        }
+    }
+
+    printf("ftl.dat scan: overhaul mod: %s\n", overhaulDetected ? "detected" : "not found");
+}
+
+void OverhaulDetection::SetBasemodXml(bool isBasemod)
+{
+    basemodXmlActive = isBasemod;
+}
+
+void OverhaulDetection::CheckPatchOrder()
+{
+    if (overhaulDetected && basemodXmlActive)
+        ErrorMessage("Wrong mod patch order!\nhyperspace.ftl must be patched before overhaul mods like Multiverse or Insurrection+.\nRe-patch in the order given by your mod's install instructions.\n");
+}

--- a/src/features/overhaul-detection/OverhaulDetection.h
+++ b/src/features/overhaul-detection/OverhaulDetection.h
@@ -1,0 +1,18 @@
+#pragma once
+
+class ResourceControl;
+
+namespace OverhaulDetection {
+    // Fingerprint ftl.dat's file listing for patched mods. Called from the
+    // ResourceControl::PreloadResources hook before resources load.
+    void ScanPackage(ResourceControl *resources);
+
+    // Record the <isBasemod> value from the active hyperspace.xml. Called from
+    // hyperspace.xml early parsing; defaults to false when the tag is absent.
+    void SetBasemodXml(bool isBasemod);
+
+    // Warn if overhaul data is in the dat but the base mod's hyperspace.xml is
+    // the active one (hyperspace.ftl patched after the overhaul). Must be called
+    // after hyperspace.xml has been parsed.
+    void CheckPatchOrder();
+}

--- a/wiki/Hyperspace.xml.md
+++ b/wiki/Hyperspace.xml.md
@@ -3,6 +3,20 @@
 ## Other
 TODO: Document other parts of Hyperspace.xml as different sections here.
 
+## Overhaul detection
+
+On startup Hyperspace warns the player when an overhaul mod's files are present in `ftl.dat` but the Hyperspace base mod's own `hyperspace.xml` is the active config. This means `hyperspace.ftl` was patched *after* the overhaul, overwriting some of its files, and the player should re-patch with the overhaul last.
+
+Two signals are used for this:
+
+### `<isBasemod>`
+
+The base mod's `hyperspace.xml` declares `<isBasemod>true</isBasemod>`. Mods that ship their own full `hyperspace.xml` (overhauls like Multiverse) must set `<isBasemod>false</isBasemod>`, or simply leave the tag out since it defaults to false. When the overhaul is patched last (the correct order), its `hyperspace.xml` replaces the base mod's and the tag disappears, so no warning is shown.
+
+### `data/is_overhaul_mod.xml`
+
+If your mod is an overhaul (ships its own full `hyperspace.xml`), also include a file named `data/is_overhaul_mod.xml` (its contents don't matter, it can be empty). Its presence in `ftl.dat` tells Hyperspace that an overhaul was patched in, without your mod needing to be hardcoded in Hyperspace's fingerprint list. If it is present while the base mod's `hyperspace.xml` is still the active one, the patch-order warning is shown.
+
 ## Lua Scripts
 ### To load your script
 


### PR DESCRIPTION
New workflow supports patching both basemod and overhaul mods together, notifying only when the order is incorrect

- Move ftl.dat scanning into src/features/overhaul-detection
- Detect overhauls via fingerprint files: Multiverse, Insurrection+, or the data/is_overhaul_mod.xml opt-in marker
- Declare <isBasemod>true</isBasemod> in the basemod hyperspace.xml to detect if basemod was not overwritten.
- Show error message when both overhaulDetected and basemodXmlActive are true, which togehter mean wrong patch order
- Document the tag plus the marker file in wiki/Hyperspace.xml.md