### PR TITLE
Add template for savedStatBoostDefs

### DIFF
--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -348,6 +348,7 @@ namespace std {
     %template(vector_CrewPlacementDefinition) vector<CrewPlacementDefinition>;
     %template(vector_string) vector<string>;
     %template(vector_StatBoostDefinition) vector<StatBoostDefinition*>;
+    %template(unordered_map_string_StatBoostDefinition) unordered_map<string, StatBoostDefinition*>;
     %template(vector_TriggeredEventDefinition) vector<TriggeredEventDefinition>;
     %template(pair_Animation_int8_t) pair<Animation, int8_t>;
     %template(vector_pair_Animation_int8_t) vector<pair<Animation, int8_t>>;

--- a/lua/modules/hyperspace.i
+++ b/lua/modules/hyperspace.i
@@ -348,7 +348,7 @@ namespace std {
     %template(vector_CrewPlacementDefinition) vector<CrewPlacementDefinition>;
     %template(vector_string) vector<string>;
     %template(vector_StatBoostDefinition) vector<StatBoostDefinition*>;
-    %template(unordered_map_string_StatBoostDefinition) unordered_map<string, StatBoostDefinition*>;
+    %template(unordered_map_string_p_StatBoostDefinition) unordered_map<string, StatBoostDefinition*>;
     %template(vector_TriggeredEventDefinition) vector<TriggeredEventDefinition>;
     %template(pair_Animation_int8_t) pair<Animation, int8_t>;
     %template(vector_pair_Animation_int8_t) vector<pair<Animation, int8_t>>;


### PR DESCRIPTION
Add template for savedStatBoostDefs so that the exposed field is usable.
It was exposed but the template for `unordered_map<string, StatBoostDefinition*>` was never added, making the field unusable.