### PR TITLE
Stamp pull request identity into CI builds

### DIFF
--- a/.github/workflows/build-linux-windows.yml
+++ b/.github/workflows/build-linux-windows.yml
@@ -16,6 +16,9 @@ jobs:
 
       - name: Build
         run: buildscripts/buildall-from-docker.sh
+        env:
+          HS_BUILD_BRANCH: ${{ github.head_ref || github.ref_name }}
+          HS_BUILD_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Store output
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -21,6 +21,9 @@ jobs:
 
       - name: Build all macOS variants
         run: buildscripts/buildall-darwin.sh
+        env:
+          HS_BUILD_BRANCH: ${{ github.head_ref || github.ref_name }}
+          HS_BUILD_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/buildscripts/docker-run-in-devcontainer.sh
+++ b/buildscripts/docker-run-in-devcontainer.sh
@@ -19,6 +19,11 @@ case "$(uname -m)" in
     arm64 | aarch64) DOCKER_ENV="-e VCPKG_FORCE_SYSTEM_BINARIES=1" ;;
 esac
 
+# generateVersion.sh runs inside the container and stamps these into the binary.
+for stamp in HS_BUILD_BRANCH HS_BUILD_HASH; do
+    if [ -n "${!stamp}" ]; then DOCKER_ENV="$DOCKER_ENV -e $stamp"; fi
+done
+
 case "$COMMAND" in
     buildscripts/windows/*) PLATFORMS="windows" ;;
     buildscripts/linux-*/*) PLATFORMS="linux" ;;

--- a/generateVersion.sh
+++ b/generateVersion.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
-version=$(git describe --always --dirty --match 'NOT A TAG')
-branch=$(git rev-parse --abbrev-ref HEAD)
+# On pull request CI uses a detached head so workflow needs to provide
+# HS_BUILD_HASH and HS_BUILD_BRANCH env variables in order for us to stamp the version
+if [ -n "$HS_BUILD_HASH" ]; then
+    version="${HS_BUILD_HASH:0:8}"
+else
+    version=$(git describe --always --dirty --match 'NOT A TAG')
+fi
+
+if [ -n "$HS_BUILD_BRANCH" ]; then
+    branch="$HS_BUILD_BRANCH"
+else
+    branch=$(git rev-parse --abbrev-ref HEAD)
+fi
+
 printf "#pragma once\n#undef BUILD_IDENTIFIER_HASH\n#define BUILD_IDENTIFIER_HASH \"$version\"\n#undef BUILD_BRANCH\n#define BUILD_BRANCH \"$branch\"\n" > Version.autogen.hpp.temp
-cmp Version.autogen.hpp Version.autogen.hpp.temp && rm Version.autogen.hpp.temp || mv -f Version.autogen.hpp.temp Version.autogen.hpp
+# -s because the file is missing on a clean build and cmp reports that as an error
+if cmp -s Version.autogen.hpp Version.autogen.hpp.temp; then
+    rm Version.autogen.hpp.temp
+else
+    mv -f Version.autogen.hpp.temp Version.autogen.hpp
+fi


### PR DESCRIPTION
GitHub builds a pull request from a detached ephemeral merge commit, so git reported the branch as "HEAD" and a hash that exists only on GitHub's side.

Players had no way to tell which build they were running.

- Prefer the workflow-supplied identity: HS_BUILD_HASH, HS_BUILD_BRANCH
- Fall back to git so local builds keep their current behaviour
- Forward both variables into the devcontainer, where the Linux and Windows build runs generateVersion.sh
- Silence cmp, which reports the missing file on every clean build